### PR TITLE
cmd: replace Printf with a logging statement

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ func startWorker(userInput string) <-chan error {
 	go func() {
 		defer close(errs)
 		protocol := imgbom.NewProtocol(userInput)
-		fmt.Printf("protocol: %+v", protocol)
+		log.Debugf("protocol: %+v", protocol)
 
 		switch protocol.Type {
 		case imgbom.DirProtocol:


### PR DESCRIPTION
Somehow this made it through in the last PR. Making it a proper logging call