### PR TITLE
Fix cache key for java packages 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
       - image: circleci/golang:<< parameters.version >>
         environment:
           GO111MODULE: "on"
+          # work around for recent circle CI breaking change
+          # Error: "Error response from daemon: client version 1.39 is too new. Maximum supported API version is 1.38"
+          DOCKER_API_VERSION: "1.38"
     # 1CPU / 2GB RAM
     resource_class: small
     steps:
@@ -39,6 +42,9 @@ jobs:
       - image: circleci/golang:<< parameters.version >>
         environment:
           GO111MODULE: "on"
+          # work around for recent circle CI breaking change
+          # Error: "Error response from daemon: client version 1.39 is too new. Maximum supported API version is 1.38"
+          DOCKER_API_VERSION: "1.38"
     # 1CPU / 2GB RAM
     resource_class: small
     steps:
@@ -75,9 +81,7 @@ jobs:
 
       - run:
           name: build cache key for java test-fixture blobs
-          command: |
-            cd imgbom/cataloger/java/test-fixtures/java-builds &&\
-            make packages.fingerprint
+          command: make java-packages-fingerprint
 
       - restore_cache:
           keys:

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ integration: ## Run integration tests
 integration/test-fixtures/tar-cache.key, integration-fingerprint:
 	find integration/test-fixtures/image-* -type f -exec md5sum {} + | awk '{print $1}' | sort | md5sum | tee integration/test-fixtures/tar-cache.fingerprint
 
+java-packages-fingerprint:
+	@cd imgbom/cataloger/java/test-fixtures/java-builds && \
+	make packages.fingerprint
+
 clear-test-cache: ## Delete all test cache (built docker image tars)
 	find . -type f -wholename "**/test-fixtures/tar-cache/*.tar" -delete
 

--- a/imgbom/cataloger/java/test-fixtures/java-builds/Makefile
+++ b/imgbom/cataloger/java/test-fixtures/java-builds/Makefile
@@ -18,7 +18,8 @@ $(PKGSDIR)/example-java-app-maven-0.1.0.jar:
 	./build-example-java-app-maven.sh $(PKGSDIR)
 
 clean-maven:
-	rm -rf	example-java-app/target \
+	rm -rf	example-java-app/\? \
+			example-java-app/target \
 			example-java-app/dependency-reduced-pom.xml
 
 # Gradle...
@@ -41,5 +42,5 @@ clean-jenkins:
 # we need a way to determine if CI should bust the test cache based on the source material
 $(PKGSDIR).fingerprint: clean-examples
 	mkdir -p $(PKGSDIR)
-	find example-* -type f -exec sha256sum {} \; > $(PKGSDIR).fingerprint
+	find example-* -type f -exec sha256sum {} \; | sort | tee $(PKGSDIR).fingerprint
 	sha256sum $(PKGSDIR).fingerprint


### PR DESCRIPTION
The shasums that made up the java cache key were not sorted, which caused a cache miss on every commit. This sorts the cache key dependencies for consistent results.

Additionally, it seems that there are intermittent failures due to an unexpected docker API version --fixing the docker API version via env var was added to fix this.