### PR TITLE
Add license validation

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -1,0 +1,5 @@
+permit:
+  - BSD.*
+  - MIT.*
+  - Apache.*
+  - MPL.*

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ TEMPDIR = ./.tmp
 RESULTSDIR = $(TEMPDIR)/results
 COVER_REPORT = $(RESULTSDIR)/cover.report
 COVER_TOTAL = $(RESULTSDIR)/cover.total
+LICENSES_REPORT = $(RESULTSDIR)/licenses.json
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --config .golangci.yaml
 BOLD := $(shell tput -T linux bold)
 PURPLE := $(shell tput -T linux setaf 5)
@@ -51,6 +52,8 @@ bootstrap: ## Download and install all project dependencies (+ prep tooling in t
 	go get ./...
 	# install golangci-lint
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b .tmp/ v1.26.0
+	# install bouncer
+	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b .tmp/ v0.1.0
 
 lint: ## Run gofmt + golangci lint checks
 	$(call title,Running linters)
@@ -100,3 +103,8 @@ build-release: ## Build final release binary
 				   -X main.commit="$(git describe --dirty --always)" \
 				   -X main.buildTime="$(date --rfc-3339=seconds --utc)"
 				   -o dist/imgbom
+
+# todo: this should by later used by goreleaser
+check-licenses:
+	$(TEMPDIR)/bouncer list -o json | tee $(LICENSES_REPORT)
+	$(TEMPDIR)/bouncer check

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.14
 
 require (
 	github.com/adrg/xdg v0.2.1
-	github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe
-	github.com/anchore/stereoscope v0.0.0-20200624175800-ef5dbfb7cae4
+	github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db
+	github.com/anchore/stereoscope v0.0.0-20200706164556-7cf39d7f4639
 	github.com/go-test/deep v1.0.6
 	github.com/google/go-containerregistry v0.1.1 // indirect
 	github.com/gookit/color v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -126,9 +126,13 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe h1:YMXe4RA3qy4Ri5fmGQii/Gn+Pxv3oBfiS/LqzeOVuwo=
 github.com/anchore/go-testutils v0.0.0-20200520222037-edc2bf1864fe/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
+github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db h1:LWKezJnFTFxNkZ4MzajVf+YWvJS0+7hwFr59u6SS7cw=
+github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db/go.mod h1:D3rc2L/q4Hcp9eeX6AIJH4Q+kPjOtJCFhG9za90j+nU=
 github.com/anchore/stereoscope v0.0.0-20200520221116-025e07f1c93e/go.mod h1:bkyLl5VITnrmgErv4S1vDfVz/TGAZ5il6161IQo7w2g=
 github.com/anchore/stereoscope v0.0.0-20200624175800-ef5dbfb7cae4 h1:bPd6YFo9VDyoTLVcawFNbW9Z8dQA3M/pCgdD22dR0VQ=
 github.com/anchore/stereoscope v0.0.0-20200624175800-ef5dbfb7cae4/go.mod h1:f4LZpPnN/5RpQnzcznDsYNeYavFCAW8CpbHN01G3Lh8=
+github.com/anchore/stereoscope v0.0.0-20200706164556-7cf39d7f4639 h1:J1oytkj+aBuACNF2whtEiVxRXIZ8zwT+EiPTqm/FvwA=
+github.com/anchore/stereoscope v0.0.0-20200706164556-7cf39d7f4639/go.mod h1:WntReQTI/I27FOQ87UgLVVzWgku6+ZsqfOTLxpIZFCs=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apex/log v1.1.4/go.mod h1:AlpoD9aScyQfJDVHmLMEcx4oU6LqzkWp4Mg9GdAcEvQ=
 github.com/apex/log v1.3.0 h1:1fyfbPvUwD10nMoh3hY6MXzvZShJQn9/ck7ATgAt5pA=


### PR DESCRIPTION
Run `make check-licenses` to ensure that the licenses from all dependencies meet the constraints as described in `.bouncer.yaml`. This will be added as a quality gate before cutting a release (when release support has been added).