### PR TITLE
Remove metadata from text presenter

### DIFF
--- a/imgbom/presenter/text/presenter.go
+++ b/imgbom/presenter/text/presenter.go
@@ -52,9 +52,6 @@ func (pres *Presenter) Present(output io.Writer) error {
 		fmt.Fprintln(w, fmt.Sprintf("[%s]", p.Name))
 		fmt.Fprintln(w, " Version:\t", p.Version)
 		fmt.Fprintln(w, " Type:\t", p.Type.String())
-		if p.Metadata != nil {
-			fmt.Fprintf(w, " Metadata:\t%+v\n", p.Metadata)
-		}
 		fmt.Fprintln(w, " Found by:\t", p.FoundBy)
 		fmt.Fprintln(w)
 		w.Flush()

--- a/imgbom/presenter/text/test-fixtures/snapshot/TestTextImgPresenter.golden
+++ b/imgbom/presenter/text/test-fixtures/snapshot/TestTextImgPresenter.golden
@@ -17,6 +17,5 @@
 [package-2]
  Version:	 2.0.1
  Type:		 deb
- Metadata:	{Name:package-2 Version:1.0.2}
  Found by:	 dpkg
 


### PR DESCRIPTION
Currently the text presenter is formatting the package metadata via `%+v`, however, this does not show nested fields and additionally shows memory addresses for pointer types (discovered while @alfredodeza was working on https://github.com/anchore/imgbom/issues/75). 

Showing all of the metadata for some packages will be quite verbose, so it has been decided to remove this field from the text output.