### PR TITLE
Fix py globs to include partial matches

### DIFF
--- a/syft/cataloger/python/cataloger.go
+++ b/syft/cataloger/python/cataloger.go
@@ -12,10 +12,13 @@ type Cataloger struct {
 }
 
 func NewCataloger() *Cataloger {
+	// we want to match on partial dir names
+	// 	/home/user/requests-2.10.0.dist-info/METADATA
+	//	/home/user/requests-2.10.0/dist-info/METADATA
 	globParsers := map[string]common.ParserFn{
-		"**/egg-info/PKG-INFO":  parseEggMetadata,
-		"**/dist-info/METADATA": parseWheelMetadata,
-		"**/requirements.txt":   parseRequirementsTxt,
+		"**/*egg-info/PKG-INFO":  parseEggMetadata,
+		"**/*dist-info/METADATA": parseWheelMetadata,
+		"**/requirements.txt":    parseRequirementsTxt,
 	}
 
 	return &Cataloger{

--- a/test/integration/fixture_pkg_coverage_test.go
+++ b/test/integration/fixture_pkg_coverage_test.go
@@ -57,6 +57,7 @@ var cases = []struct {
 		pkgLanguage: pkg.Python,
 		pkgInfo: map[string]string{
 			"Pygments": "2.6.1",
+			"requests": "2.10.0",
 		},
 	},
 	{
@@ -73,6 +74,7 @@ var cases = []struct {
 		pkgLanguage: pkg.Python,
 		pkgInfo: map[string]string{
 			"requests": "2.22.0",
+			"otherpkg": "2.19.0",
 		},
 	},
 	{

--- a/test/integration/test-fixtures/image-pkg-coverage/python/otherpkg-2.19.0-py3.8.egg-info/PKG-INFO
+++ b/test/integration/test-fixtures/image-pkg-coverage/python/otherpkg-2.19.0-py3.8.egg-info/PKG-INFO
@@ -1,0 +1,8 @@
+Metadata-Version: 2.1
+Name: otherpkg
+Version: 2.19.0
+Summary: Python HTTP for Humans.
+Home-page: http://python-requests.org
+Author: Kenneth Reitz
+Author-email: me@kennethreitz.org
+License: Apache 2.0

--- a/test/integration/test-fixtures/image-pkg-coverage/python/requests-2.10.0.dist-info/METADATA
+++ b/test/integration/test-fixtures/image-pkg-coverage/python/requests-2.10.0.dist-info/METADATA
@@ -1,0 +1,26 @@
+Metadata-Version: 2.1
+Name: requests
+Version: 2.10.0
+Summary: stuff
+Home-page: stuff
+Author: Georg Brandl
+Author-email: georg@python.org
+License: BSD License
+Platform: any
+Classifier: License :: OSI Approved :: BSD License
+Classifier: Intended Audience :: Developers
+Classifier: Intended Audience :: End Users/Desktop
+Classifier: Intended Audience :: System Administrators
+Classifier: Development Status :: 6 - Mature
+Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 3
+Classifier: Programming Language :: Python :: 3.5
+Classifier: Programming Language :: Python :: 3.6
+Classifier: Programming Language :: Python :: 3.7
+Classifier: Programming Language :: Python :: 3.8
+Classifier: Programming Language :: Python :: Implementation :: CPython
+Classifier: Programming Language :: Python :: Implementation :: PyPy
+Classifier: Operating System :: OS Independent
+Classifier: Topic :: Text Processing :: Filters
+Classifier: Topic :: Utilities
+Requires-Python: >=3.5


### PR DESCRIPTION
Currently we are matching on egg/wheel paths of `**/dist-info/...` and `**/egg-info/...`, however this will not match cases such as `site-packages/requests-2.22.0.dist-info/...`. This PR adds these cases + int tests to cover.