### PR TITLE
Ignore prerelease versions when uploading version file on release

### DIFF
--- a/.github/scripts/update-version-file.sh
+++ b/.github/scripts/update-version-file.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -ue
+
+BIN="syft"
+DISTDIR=$1
+VERSION=$2
+
+if [[ $VERSION == *-* ]] ; then
+   echo "skipping publishing a version file (this is a pre-release: ${VERSION})"
+   exit 0
+fi
+
+echo "creating and publishing version file"
+
+# create a version file for version-update checks
+echo "${VERSION}" | tee ${DISTDIR}/VERSION
+
+# upload the version file that supports the application version update check
+docker run --rm \
+    -i \
+    -e AWS_DEFAULT_REGION=us-west-2 \
+    -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+    -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+    -v $(pwd)/${DISTDIR}/:/distmount \
+    amazon/aws-cli \
+        s3 cp /distmount/VERSION s3://toolbox-data.anchore.io/${BIN}/releases/latest/VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,8 +112,8 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
           SIGNING_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          TOOLBOX_AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
-          TOOLBOX_AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -211,18 +211,8 @@ release: clean-dist ## Build and publish final binaries and packages
 	# verify checksum signatures
 	.github/scripts/verify-signature.sh "$(DISTDIR)"
 
-	# create a version file for version-update checks
-	echo "$(VERSION)" > $(DISTDIR)/VERSION
-
-	# upload the version file that supports the application version update check
-	@docker run --rm \
-		-i \
-		-e AWS_DEFAULT_REGION=us-west-2 \
-		-e AWS_ACCESS_KEY_ID=${TOOLBOX_AWS_ACCESS_KEY_ID} \
-		-e AWS_SECRET_ACCESS_KEY=${TOOLBOX_AWS_SECRET_ACCESS_KEY} \
-		-v $(shell pwd)/$(DISTDIR)/:/distmount \
-		amazon/aws-cli --debug \
-			s3 cp /distmount/VERSION s3://toolbox-data.anchore.io/$(BIN)/releases/latest/VERSION
+	# upload the version file that supports the application version update check (excluding pre-releases)
+	.github/scripts/update-version-file.sh "$(DISTDIR)" "$(VERSION)"
 
 .PHONY: clean
 clean: clean-dist clean-snapshot  ## Remove previous builds and result reports


### PR DESCRIPTION
Today on release the pipeline uploads a flat file to S3 to indicate the latest released version. Currently the release process publishes a new version file on each release, even if it is marked for pre-release. This PR enables the pipeline to not update this version file on pre-releases (semver tags with `-`).

Closes #93 