### PR TITLE
Show message when no packages are discovered

### DIFF
--- a/syft/presenter/table/presenter.go
+++ b/syft/presenter/table/presenter.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"fmt"
 	"io"
 	"sort"
 
@@ -35,6 +36,11 @@ func (pres *Presenter) Present(output io.Writer) error {
 		rows = append(rows, row)
 	}
 
+	if len(rows) == 0 {
+		fmt.Fprintln(output, "No packages discovered")
+		return nil
+	}
+
 	// sort by name, version, then type
 	sort.SliceStable(rows, func(i, j int) bool {
 		for col := 0; col < len(columns); col++ {
@@ -57,7 +63,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
 	table.SetRowSeparator("")
-	table.SetTablePadding("\t")
+	table.SetTablePadding("  ")
 	table.SetNoWhiteSpace(true)
 
 	table.AppendBulk(rows)

--- a/syft/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
+++ b/syft/presenter/table/test-fixtures/snapshot/TestTablePresenter.golden
@@ -1,3 +1,3 @@
-NAME     	VERSION	TYPE 
-package-1	1.0.1  	deb 	
-package-2	2.0.1  	deb 	
+NAME       VERSION  TYPE 
+package-1  1.0.1    deb   
+package-2  2.0.1    deb   

--- a/syft/presenter/text/presenter.go
+++ b/syft/presenter/text/presenter.go
@@ -48,6 +48,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 	}
 
 	// populate artifacts...
+	rows := 0
 	for _, p := range pres.catalog.Sorted() {
 		fmt.Fprintln(w, fmt.Sprintf("[%s]", p.Name))
 		fmt.Fprintln(w, " Version:\t", p.Version)
@@ -55,6 +56,12 @@ func (pres *Presenter) Present(output io.Writer) error {
 		fmt.Fprintln(w, " Found by:\t", p.FoundBy)
 		fmt.Fprintln(w)
 		w.Flush()
+		rows++
+	}
+
+	if rows == 0 {
+		fmt.Fprintln(output, "No packages discovered")
+		return nil
 	}
 
 	return nil


### PR DESCRIPTION
Currently the table output shows a header and no rows when no packages are discovered. This PR updates both the table and text presenters to handle this case more explicitly with a message. Also, this PR tweaks the table padding.