### PR TITLE
Replace fetching->loading and reading->parsing in UI

### DIFF
--- a/syft/scope/scope.go
+++ b/syft/scope/scope.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
-	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/scope/resolvers"
 )
 
@@ -45,7 +44,6 @@ func NewScope(userInput string, o Option) (Scope, func(), error) {
 		return s, func() {}, nil
 
 	case imageProtocol:
-		log.Infof("Fetching image '%s'", userInput)
 		img, err := stereoscope.GetImage(userInput)
 		cleanup := func() {
 			stereoscope.Cleanup()

--- a/ui/event_handlers.go
+++ b/ui/event_handlers.go
@@ -189,7 +189,7 @@ func FetchImageHandler(ctx context.Context, fr *frame.Frame, event partybus.Even
 
 	formatter, spinner := startProcess()
 	stream := progress.Stream(ctx, prog, interval)
-	title := tileFormat.Sprint("Fetching image")
+	title := tileFormat.Sprint("Loading image")
 
 	formatFn := func(p progress.Progress) {
 		progStr, err := formatter.Format(p)
@@ -211,7 +211,7 @@ func FetchImageHandler(ctx context.Context, fr *frame.Frame, event partybus.Even
 		}
 
 		spin := color.Green.Sprint(completedStatus)
-		title = tileFormat.Sprint("Fetched image")
+		title = tileFormat.Sprint("Loaded image")
 		_, _ = io.WriteString(line, fmt.Sprintf(statusTitleTemplate, spin, title))
 	}()
 	return err
@@ -232,7 +232,7 @@ func ReadImageHandler(ctx context.Context, fr *frame.Frame, event partybus.Event
 
 	formatter, spinner := startProcess()
 	stream := progress.Stream(ctx, prog, interval)
-	title := tileFormat.Sprint("Reading image")
+	title := tileFormat.Sprint("Parsing image")
 
 	formatFn := func(p progress.Progress) {
 		progStr, err := formatter.Format(p)
@@ -253,7 +253,7 @@ func ReadImageHandler(ctx context.Context, fr *frame.Frame, event partybus.Event
 		}
 
 		spin := color.Green.Sprint(completedStatus)
-		title = tileFormat.Sprint("Read image")
+		title = tileFormat.Sprint("Parsed image")
 		_, _ = io.WriteString(line, fmt.Sprintf(statusTitleTemplate, spin, title))
 	}()
 


### PR DESCRIPTION
Given the set of actions that have been added to the UI, swapping out "fetching" for "loading" makes more sense in context of what it's doing (docker image save and writing to a temp file) and "reading" to "parsing" (read temp file, parse image, build tree cache, and create squash tree). 

Additionally moves some logging that belongs in stereoscope.