### PR TITLE
Disable prerelease version update check

### DIFF
--- a/.github/scripts/update-version-file.sh
+++ b/.github/scripts/update-version-file.sh
@@ -5,10 +5,13 @@ BIN="syft"
 DISTDIR=$1
 VERSION=$2
 
-if [[ $VERSION == *-* ]] ; then
-   echo "skipping publishing a version file (this is a pre-release: ${VERSION})"
-   exit 0
-fi
+# TODO: after v0.1.0 release, add the pre-release check back in. Currently we are only cutting beta releases so we want
+# to let user's know when there is a new beta available, however, after v0.1.0 we will rarely be cutting beta releases.
+# At that point we do not want to update the version file for new betas.
+# if [[ $VERSION == *-* ]] ; then
+#    echo "skipping publishing a version file (this is a pre-release: ${VERSION})"
+#    exit 0
+# fi
 
 echo "creating and publishing version file"
 

--- a/.github/scripts/update-version-file.sh
+++ b/.github/scripts/update-version-file.sh
@@ -5,13 +5,12 @@ BIN="syft"
 DISTDIR=$1
 VERSION=$2
 
-# TODO: after v0.1.0 release, add the pre-release check back in. Currently we are only cutting beta releases so we want
-# to let user's know when there is a new beta available, however, after v0.1.0 we will rarely be cutting beta releases.
-# At that point we do not want to update the version file for new betas.
-# if [[ $VERSION == *-* ]] ; then
-#    echo "skipping publishing a version file (this is a pre-release: ${VERSION})"
-#    exit 0
-# fi
+# the source of truth as to whether we want to notify users of an update is if the release just created is NOT
+# flagged as a pre-release on github
+if [[ "$(curl -SsL https://api.github.com/repos/anchore/${BIN}/releases/tags/${VERSION} | jq .prerelease)" == "true" ]] ; then
+   echo "skipping publishing a version file (this is a pre-release: ${VERSION})"
+   exit 0
+fi
 
 echo "creating and publishing version file"
 

--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -17,12 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # TODO: remove me after release
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
-        run: git config --global url."https://anchore:${TOKEN}@github.com".insteadOf "https://github.com"
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,12 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      # TODO: remove me after release
-      - name: Configure git for private modules
-        env:
-          TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
-        run: git config --global url."https://anchore:${TOKEN}@github.com".insteadOf "https://github.com"
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ help:
 
 .PHONY: ci-bootstrap
 ci-bootstrap: bootstrap
-	sudo apt install -y bc
+	sudo apt update && sudo apt install -y bc jq
 
 .PHONY: bootstrap
 bootstrap: ## Download and install all go dependencies (+ prep tooling in the ./tmp dir)


### PR DESCRIPTION
Since we will be cutting betas for a while longer, we want to let users know when there is another beta available. However, after v0.1.0 release, we will not be creating betas that often, but when we do we do not want to let users know there is another version available if the new version is a pre-release (e.g. `v#.#.#-<prerelease>`).

This PR switches the source of truth for when to notify users from the semver on the git tag to using the github releases "prerelease" indicator.