### PR TITLE
Add changelog generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+CHANGELOG.md
 /dist
 /snapshot
 .server/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,10 @@
 release:
-  # If set to auto, will mark the release as not ready for production
-  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
-  # If set to true, will mark the release as not ready for production.
+  # If set to auto, will mark the release as not ready for production in case there is an indicator for this in the
+  # tag e.g. v1.0.0-rc1 .If set to true, will mark the release as not ready for production.
   prerelease: false
+
+  # If set to true, will not auto-publish the release. This is done to allow us to review the changelog before publishing.
+  draft: true
 
 signs:
   - artifacts: checksum


### PR DESCRIPTION
Adds a new make target `make changelog` to generate a changelog in the root of the repo. Additionally adds this changelog to the GitHub Releases page on release in the form of a draft.

Closes #159 