### PR TITLE
Use xml encoder for CycloneDX presenter

### DIFF
--- a/syft/presenter/cyclonedx/presenter.go
+++ b/syft/presenter/cyclonedx/presenter.go
@@ -66,16 +66,15 @@ func (pres *Presenter) Present(output io.Writer) error {
 		return fmt.Errorf("unsupported source: %T", src)
 	}
 
-	xmlOut, err := xml.MarshalIndent(bom, " ", "  ")
+	encoder := xml.NewEncoder(output)
+	encoder.Indent("", "  ")
+
+	_, err := output.Write([]byte(xml.Header))
 	if err != nil {
 		return err
 	}
 
-	_, err = output.Write([]byte(xml.Header))
-	if err != nil {
-		return err
-	}
-	_, err = output.Write(xmlOut)
+	err = encoder.Encode(bom)
 	if err != nil {
 		return err
 	}

--- a/syft/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxDirsPresenter.golden
+++ b/syft/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxDirsPresenter.golden
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" version="1" serialNumber="urn:uuid:88c9a559-fb74-45a1-9dbb-a3d8bcbcacc8">
-   <components>
-     <component type="library">
-       <name>package1</name>
-       <version>1.0.1</version>
-       <purl>pkg:deb/ubuntu/package1@1.0.1?arch=amd64</purl>
-     </component>
-     <component type="library">
-       <name>package2</name>
-       <version>2.0.1</version>
-       <licenses>
-         <license>
-           <name>MIT</name>
-         </license>
-         <license>
-           <name>Apache-v2</name>
-         </license>
-       </licenses>
-       <purl>pkg:deb/ubuntu/package2@1.0.2?arch=amd64</purl>
-     </component>
-   </components>
-   <bd:metadata>
-     <bd:timestamp>2020-08-29T20:17:49-04:00</bd:timestamp>
-     <bd:tool>
-       <bd:vendor>anchore</bd:vendor>
-       <bd:name>syft</bd:name>
-       <bd:version>[not provided]</bd:version>
-     </bd:tool>
-     <bd:component type="file">
-       <name>/some/path</name>
-       <version></version>
-     </bd:component>
-   </bd:metadata>
- </bom>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" version="1" serialNumber="urn:uuid:b3b1786a-2de3-4501-b902-58b701b8ad0e">
+  <components>
+    <component type="library">
+      <name>package1</name>
+      <version>1.0.1</version>
+      <purl>pkg:deb/ubuntu/package1@1.0.1?arch=amd64</purl>
+    </component>
+    <component type="library">
+      <name>package2</name>
+      <version>2.0.1</version>
+      <licenses>
+        <license>
+          <name>MIT</name>
+        </license>
+        <license>
+          <name>Apache-v2</name>
+        </license>
+      </licenses>
+      <purl>pkg:deb/ubuntu/package2@1.0.2?arch=amd64</purl>
+    </component>
+  </components>
+  <bd:metadata>
+    <bd:timestamp>2020-08-30T21:50:50-04:00</bd:timestamp>
+    <bd:tool>
+      <bd:vendor>anchore</bd:vendor>
+      <bd:name>syft</bd:name>
+      <bd:version>[not provided]</bd:version>
+    </bd:tool>
+    <bd:component type="file">
+      <name>/some/path</name>
+      <version></version>
+    </bd:component>
+  </bd:metadata>
+</bom>

--- a/syft/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxImgsPresenter.golden
+++ b/syft/presenter/cyclonedx/test-fixtures/snapshot/TestCycloneDxImgsPresenter.golden
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" version="1" serialNumber="urn:uuid:6da957f1-3337-4128-870c-fe271aa195d1">
-   <components>
-     <component type="library">
-       <name>package1</name>
-       <version>1.0.1</version>
-       <purl>pkg:rpm/redhat/package1@0:1.0.1-1?arch=x86_64</purl>
-     </component>
-     <component type="library">
-       <name>package2</name>
-       <version>2.0.1</version>
-       <licenses>
-         <license>
-           <name>MIT</name>
-         </license>
-         <license>
-           <name>Apache-v2</name>
-         </license>
-       </licenses>
-       <purl>pkg:rpm/redhat/package2@0:1.0.2-1?arch=x86_64</purl>
-     </component>
-   </components>
-   <bd:metadata>
-     <bd:timestamp>2020-08-29T20:17:49-04:00</bd:timestamp>
-     <bd:tool>
-       <bd:vendor>anchore</bd:vendor>
-       <bd:name>syft</bd:name>
-       <bd:version>[not provided]</bd:version>
-     </bd:tool>
-     <bd:component type="container">
-       <name>index.docker.io/library/anchore-fixture-image-simple</name>
-       <version>04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7</version>
-     </bd:component>
-   </bd:metadata>
- </bom>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" xmlns:bd="http://cyclonedx.org/schema/ext/bom-descriptor/1.0" version="1" serialNumber="urn:uuid:ab970429-e6a2-44a1-810c-f9ed2b7c3147">
+  <components>
+    <component type="library">
+      <name>package1</name>
+      <version>1.0.1</version>
+      <purl>pkg:rpm/redhat/package1@0:1.0.1-1?arch=x86_64</purl>
+    </component>
+    <component type="library">
+      <name>package2</name>
+      <version>2.0.1</version>
+      <licenses>
+        <license>
+          <name>MIT</name>
+        </license>
+        <license>
+          <name>Apache-v2</name>
+        </license>
+      </licenses>
+      <purl>pkg:rpm/redhat/package2@0:1.0.2-1?arch=x86_64</purl>
+    </component>
+  </components>
+  <bd:metadata>
+    <bd:timestamp>2020-08-30T21:50:50-04:00</bd:timestamp>
+    <bd:tool>
+      <bd:vendor>anchore</bd:vendor>
+      <bd:name>syft</bd:name>
+      <bd:version>[not provided]</bd:version>
+    </bd:tool>
+    <bd:component type="container">
+      <name>index.docker.io/library/anchore-fixture-image-simple</name>
+      <version>04e16e44161c8888a1a963720fd0443cbf7eef8101434c431de8725cd98cc9f7</version>
+    </bd:component>
+  </bd:metadata>
+</bom>


### PR DESCRIPTION
In response to https://github.com/anchore/grype/pull/143/files#r479703994 .

Additionally noticed that there was a single space prefix for the document, which is unnecessary (thus removed).