### PR TITLE
Unpin skopeo during mac acceptance tests

### DIFF
--- a/test/acceptance/mac.sh
+++ b/test/acceptance/mac.sh
@@ -29,8 +29,8 @@ function cleanup {
 
 trap cleanup EXIT
 
-# install skopeo (pinned to 1.1.0)
-skopeo --version || brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/75e8d7a40af77b48cc91f4bdb7d669f891a6de60/Formula/skopeo.rb
+# install skopeo
+skopeo --version || brew install skopeo
 
 # fetch test image
 skopeo --override-os linux copy docker://docker.io/${TEST_IMAGE} docker-archive:${TEST_IMAGE_TAR}


### PR DESCRIPTION
Fixes acceptance test failures by unpinning skopeo:
```
./test/acceptance/mac.sh: line 33: skopeo: command not found
+ brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/75e8d7a40af77b48cc91f4bdb7d669f891a6de60/Formula/skopeo.rb
Error: Calling Installation of skopeo from a GitHub commit URL is disabled! Use 'brew extract skopeo' to stable tap on GitHub instead.
```

From https://github.com/anchore/syft/runs/1127902909?check_suite_focus=true