### PR TITLE
Remove duplicate rows from the summary table

### DIFF
--- a/syft/presenter/table/presenter.go
+++ b/syft/presenter/table/presenter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 
@@ -50,6 +51,7 @@ func (pres *Presenter) Present(output io.Writer) error {
 		}
 		return false
 	})
+	rows = removeDuplicateRows(rows)
 
 	table := tablewriter.NewWriter(output)
 
@@ -70,4 +72,22 @@ func (pres *Presenter) Present(output io.Writer) error {
 	table.Render()
 
 	return nil
+}
+
+func removeDuplicateRows(items [][]string) [][]string {
+	seen := map[string][]string{}
+	// nolint:prealloc
+	var result [][]string
+
+	for _, v := range items {
+		key := strings.Join(v, "|")
+		if seen[key] != nil {
+			// dup!
+			continue
+		}
+
+		seen[key] = v
+		result = append(result, v)
+	}
+	return result
 }

--- a/syft/presenter/table/presenter_test.go
+++ b/syft/presenter/table/presenter_test.go
@@ -3,6 +3,7 @@ package table
 import (
 	"bytes"
 	"flag"
+	"github.com/go-test/deep"
 	"testing"
 
 	"github.com/anchore/go-testutils"
@@ -62,4 +63,33 @@ func TestTablePresenter(t *testing.T) {
 		diffs := dmp.DiffMain(string(actual), string(expected), true)
 		t.Errorf("mismatched output:\n%s", dmp.DiffPrettyText(diffs))
 	}
+}
+
+func TestRemoveDuplicateRows(t *testing.T) {
+	data := [][]string{
+		{"1", "2", "3"},
+		{"a", "b", "c"},
+		{"1", "2", "3"},
+		{"a", "b", "c"},
+		{"1", "2", "3"},
+		{"4", "5", "6"},
+		{"1", "2", "1"},
+	}
+
+	expected := [][]string{
+		{"1", "2", "3"},
+		{"a", "b", "c"},
+		{"4", "5", "6"},
+		{"1", "2", "1"},
+	}
+
+	actual := removeDuplicateRows(data)
+
+	if diffs := deep.Equal(expected, actual); len(diffs) > 0 {
+		t.Errorf("found diffs!")
+		for _, d := range diffs {
+			t.Errorf("   diff: %+v", d)
+		}
+	}
+
 }


### PR DESCRIPTION
Prevents the summary table from showing duplicate rows.