### PR TITLE
Always return a cleanup function from scope

### DIFF
--- a/syft/scope/scope.go
+++ b/syft/scope/scope.go
@@ -54,11 +54,11 @@ func NewScope(userInput string, o Option) (Scope, func(), error) {
 	case directoryScheme:
 		fileMeta, err := fs.Stat(location)
 		if err != nil {
-			return Scope{}, nil, fmt.Errorf("unable to stat dir=%q: %w", location, err)
+			return Scope{}, func() {}, fmt.Errorf("unable to stat dir=%q: %w", location, err)
 		}
 
 		if !fileMeta.IsDir() {
-			return Scope{}, nil, fmt.Errorf("given path is not a directory (path=%q): %w", location, err)
+			return Scope{}, func() {}, fmt.Errorf("given path is not a directory (path=%q): %w", location, err)
 		}
 
 		s, err := NewScopeFromDir(location)


### PR DESCRIPTION
Should prevent panics on malformed input to scope:
```
grype -vv -o json --fail-on medium dir://tests/python
[0000] DEBUG Application config:
configpath: ""
presenteropt: 1
output: json
scopeopt: 1
scope: Squashed
quiet: false
log:
  structured: false
  levelopt: debug
  level: ""
  filelocation: ""
clioptions:
  configpath: ""
  verbosity: 2
db:
  dir: /Users/alfredo/Library/Caches/grype/db
  updateurl: https://toolbox-data.anchore.io/grype/databases/listing.json
  autoupdate: true
dev:
  profilecpu: false
checkforappupdate: true
failon: medium
failonseverity: 3
[0000] DEBUG No new grype update available
[0000]  INFO cataloging image from-lib=syft
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a1b756]
goroutine 16 [running]:
github.com/anchore/syft/syft.Catalog(0x7ffeefbff8e3, 0x12, 0x1, 0x0, 0x0, 0x0, 0x20a8ac0, 0xc00029d0a0)
	/Users/alfredo/go/pkg/mod/github.com/anchore/syft@v0.1.0-beta.4.0.20200925185305-576fbc898b98/syft/lib.go:37 +0x3d6
github.com/anchore/grype/cmd.startWorker.func1.2(0xc000225ee0, 0x7ffeefbff8e3, 0x12, 0xc0001402a0, 0xc0001402a8, 0xc0001402b0, 0xc0001e93d0, 0xc00010ab40)
	/Users/alfredo/python/grype/cmd/root.go:183 +0x82
created by github.com/anchore/grype/cmd.startWorker.func1
	/Users/alfredo/python/grype/cmd/root.go:181 +0x227`
```