### PR TITLE
Ignore apk xattr file checksum

### DIFF
--- a/internal/file/zip_file_manifest.go
+++ b/internal/file/zip_file_manifest.go
@@ -47,7 +47,7 @@ func NewZipFileManifest(archivePath string) (ZipFileManifest, error) {
 	defer func() {
 		err = zipReader.Close()
 		if err != nil {
-			log.Errorf("unable to close zip archive (%s): %w", archivePath, err)
+			log.Errorf("unable to close zip archive (%s): %+v", archivePath, err)
 		}
 	}()
 

--- a/internal/file/zip_file_traversal.go
+++ b/internal/file/zip_file_traversal.go
@@ -43,7 +43,7 @@ func TraverseFilesInZip(archivePath string, visitor func(*zip.File) error, paths
 	defer func() {
 		err = zipReader.Close()
 		if err != nil {
-			log.Errorf("unable to close zip archive (%s): %w", archivePath, err)
+			log.Errorf("unable to close zip archive (%s): %+v", archivePath, err)
 		}
 	}()
 

--- a/syft/cataloger/apkdb/parse_apk_db.go
+++ b/syft/cataloger/apkdb/parse_apk_db.go
@@ -93,7 +93,7 @@ func parseApkDBEntry(reader io.Reader) (*pkg.ApkMetadata, error) {
 			fileRecord = &files[len(files)-1]
 		case "a":
 			ownershipFields := strings.Split(value, ":")
-			if len(ownershipFields) != 3 {
+			if len(ownershipFields) < 3 {
 				log.Errorf("unexpected APK ownership field: %q", value)
 				continue
 			}
@@ -104,6 +104,8 @@ func parseApkDBEntry(reader io.Reader) (*pkg.ApkMetadata, error) {
 			fileRecord.OwnerUID = ownershipFields[0]
 			fileRecord.OwnerGUI = ownershipFields[1]
 			fileRecord.Permissions = ownershipFields[2]
+			// note: there are more optional fields available that we are not capturing, e.g.:
+			// "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
 		case "Z":
 			if fileRecord == nil {
 				log.Errorf("checksum field with no parent record: %q", value)

--- a/syft/cataloger/apkdb/test-fixtures/extra-file-attributes
+++ b/syft/cataloger/apkdb/test-fixtures/extra-file-attributes
@@ -1,0 +1,22 @@
+P:openjdk8-jre
+V:8.212.04-r0
+A:x86_64
+S:359029
+I:970752
+T:OpenJDK 8 Java Runtime
+U:https://icedtea.classpath.org/
+L:custom
+o:openjdk8
+m:Timo Teras <timo.teras@iki.fi>
+t:1556993127
+c:46badd1aabd3375ae4b41c7194bc448f74b2ea4a
+D:java-cacerts nss so:libX11.so.6 so:libXcomposite.so.1 so:libXext.so.6 so:libXi.so.6 so:libXrender.so.1 so:libXtst.so.6 so:libasound.so.2 so:libc.musl-x86_64.so.1 so:libfreetype.so.6 so:libgcc_s.so.1 so:libgif.so.7 so:libjpeg.so.8 so:libpng16.so.16 so:libstdc++.so.6 so:openjdk8:libawt.so so:openjdk8:libjava.so so:openjdk8:libjli.so so:openjdk8:libjvm.so
+p:so:openjdk8:libawt_xawt.so=0 so:openjdk8:libfontmanager.so=0 so:openjdk8:libjawt.so=0 so:openjdk8:libjsoundalsa.so=0 so:openjdk8:libsplashscreen.so=0
+F:usr
+F:usr/lib
+F:usr/lib/jvm
+F:usr/lib/jvm/java-1.8-openjdk
+F:usr/lib/jvm/java-1.8-openjdk/bin
+R:policytool
+a:0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4=
+Z:Q1M0C9qfC/+kdRiOodeihG2GMRtkE=

--- a/syft/cataloger/common/generic_cataloger.go
+++ b/syft/cataloger/common/generic_cataloger.go
@@ -51,7 +51,7 @@ func (a *GenericCataloger) SelectFiles(resolver scope.FileResolver) []file.Refer
 	for path, parser := range a.pathParsers {
 		files, err := resolver.FilesByPath(file.Path(path))
 		if err != nil {
-			log.Errorf("cataloger failed to select files by path: %w", err)
+			log.Errorf("cataloger failed to select files by path: %+v", err)
 		}
 		if files != nil {
 			a.register(files, parser)
@@ -88,7 +88,7 @@ func (a *GenericCataloger) Catalog(contents map[file.Reference]string, upstreamM
 		entries, err := parser(string(reference.Path), strings.NewReader(content))
 		if err != nil {
 			// TODO: should we fail? or only log?
-			log.Errorf("cataloger '%s' failed to parse entries (reference=%+v): %w", upstreamMatcher, reference, err)
+			log.Errorf("cataloger '%s' failed to parse entries (reference=%+v): %+v", upstreamMatcher, reference, err)
 			continue
 		}
 

--- a/syft/cataloger/java/save_archive_to_tmp.go
+++ b/syft/cataloger/java/save_archive_to_tmp.go
@@ -19,7 +19,7 @@ func saveArchiveToTmp(reader io.Reader) (string, string, func(), error) {
 	cleanupFn := func() {
 		err = os.RemoveAll(tempDir)
 		if err != nil {
-			log.Errorf("unable to cleanup jar tempdir: %w", err)
+			log.Errorf("unable to cleanup jar tempdir: %+v", err)
 		}
 	}
 

--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -4,7 +4,11 @@ import (
 	"github.com/package-url/packageurl-go"
 )
 
-// ApkMetadata represents all captured data for a Alpine DB package entry. See https://wiki.alpinelinux.org/wiki/Apk_spec for more information.
+// ApkMetadata represents all captured data for a Alpine DB package entry.
+// See the following sources for more information:
+// - https://wiki.alpinelinux.org/wiki/Apk_spec
+// - https://git.alpinelinux.org/apk-tools/tree/src/package.c
+// - https://git.alpinelinux.org/apk-tools/tree/src/database.c
 type ApkMetadata struct {
 	Package          string          `mapstructure:"P" json:"package"`
 	OriginPackage    string          `mapstructure:"o" json:"originPackage"`


### PR DESCRIPTION
Fixes the errors seen from this:
```
 bin syft docker:tomcat:alpine 
 ✔ Loaded image         
 ✔ Parsed image         
 ✔ Cataloged image      [52 packages]
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR unexpected APK ownership field: "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
[0003] ERROR cataloger 'apkdb-cataloger' failed to parse entries (reference={id:1937 Path:/lib/apk/db/installed}): %!w(*fmt.wrapError=&{failed to parse APK DB file: bufio.Scanner: token too long 0xc000188460})
```

Specifically:
- ignores the extra checksum in the file xattrs
- fixes log.Errorf error wraps