### PR TITLE
Fix acceptance tests & add notification upon failures

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -64,6 +64,15 @@ jobs:
           name: artifacts
           path: snapshot/**/*
 
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,job,commit,message,author
+          text: The syft acceptance tests have failed tragically!
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() }}
+
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Linux:
     needs: [ Build-Snapshot-Artifacts ]
@@ -80,6 +89,15 @@ jobs:
       - name: Run Acceptance Tests (Linux)
         run: make acceptance-linux
 
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,job,commit,message,author
+          text: The syft acceptance tests have failed tragically!
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() }}
+
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Mac:
     needs: [ Build-Snapshot-Artifacts ]
@@ -95,6 +113,15 @@ jobs:
 
       - name: Run Acceptance Tests (Mac)
         run: make acceptance-mac
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,job,commit,message,author
+          text: The syft acceptance tests have failed tragically!
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() }}
 
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Inline-Compare:
@@ -121,3 +148,12 @@ jobs:
 
       - name: Compare Anchore inline-scan results against snapshot build output
         run: make compare-snapshot
+
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,job,commit,message,author
+          text: The syft acceptance tests have failed tragically!
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ failure() }}

--- a/test/acceptance/deb.sh
+++ b/test/acceptance/deb.sh
@@ -41,7 +41,7 @@ docker run --rm \
     ubuntu:latest \
         /bin/bash -x -c "\
             DEBIAN_FRONTEND=noninteractive apt install ${DISTDIR}/syft_*_linux_amd64.deb -y && \
-            syft version -v && \
+            syft version && \
             syft ${TEST_IMAGE} -vv -o json > ${REPORT} \
         "
 

--- a/test/acceptance/mac.sh
+++ b/test/acceptance/mac.sh
@@ -38,7 +38,7 @@ ls -alh ${TEST_IMAGE_TAR}
 
 # run syft
 chmod 755 ${DISTDIR}/syft_darwin_amd64/syft
-${DISTDIR}/syft_darwin_amd64/syft version -v
+${DISTDIR}/syft_darwin_amd64/syft version
 SYFT_CHECK_FOR_APP_UPDATE=0 ${DISTDIR}/syft_darwin_amd64/syft docker-archive://${TEST_IMAGE_TAR} -vv -o json > ${REPORT}
 
 # keep the generated report around

--- a/test/acceptance/rpm.sh
+++ b/test/acceptance/rpm.sh
@@ -40,7 +40,7 @@ docker run --rm \
     centos:latest \
         /bin/bash -x -c "\
             rpm -ivh ${DISTDIR}/syft_*_linux_amd64.rpm && \
-            syft version -v && \
+            syft version && \
             syft ${TEST_IMAGE} -vv -o json > ${REPORT} \
         "
 


### PR DESCRIPTION
Acceptance tests do not occur within the PR checks, which means it is possible for a passing PR to fail after being merged to main (when acceptance tests run). This PR fixes the existing failures and adds notifications to the toolbox channel when a failure is seen.