### PR TITLE
Fixes #212 by increasing buffer size for scanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ unit: fixtures ## Run unit tests (with coverage)
 .PHONY: integration
 integration: ## Run integration tests
 	$(call title,Running integration tests)
-	go test -tags=integration ./test/integration
+	go test -tags=integration -v ./test/integration
 
 # note: this is used by CI to determine if the integration test fixture cache (docker image tars) should be busted
 integration-fingerprint:

--- a/syft/cataloger/apkdb/parse_apk_db.go
+++ b/syft/cataloger/apkdb/parse_apk_db.go
@@ -20,9 +20,14 @@ var _ common.ParserFn = parseApkDB
 // parseApkDb parses individual packages from a given Alpine DB file. For more information on specific fields
 // see https://wiki.alpinelinux.org/wiki/Apk_spec .
 func parseApkDB(_ string, reader io.Reader) ([]pkg.Package, error) {
+	// larger capacity for the scanner.
+	const maxScannerCapacity = 1024 * 1024
+	// a new larger buffer for the scanner
+	bufScan := make([]byte, maxScannerCapacity)
 	packages := make([]pkg.Package, 0)
 
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(bufScan, maxScannerCapacity)
 	onDoubleLF := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		for i := 0; i < len(data); i++ {
 			if i > 0 && data[i-1] == '\n' && data[i] == '\n' {

--- a/test/integration/regression_test.go
+++ b/test/integration/regression_test.go
@@ -1,0 +1,38 @@
+// +build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+
+	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/scope"
+)
+
+func TestRegression212ApkBufferSize(t *testing.T) {
+	// This is a regression test for issue #212 (https://github.com/anchore/syft/issues/212) in which the apk db could
+	// not be processed due to a scanner buffer that was too small
+
+	fixtureImageName := "image-large-apk-data"
+	_, cleanup := imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
+	tarPath := imagetest.GetFixtureImageTarPath(t, fixtureImageName)
+	defer cleanup()
+
+	catalog, _, _, err := syft.Catalog("docker-archive:"+tarPath, scope.SquashedScope)
+	if err != nil {
+		t.Fatalf("failed to catalog image: %+v", err)
+	}
+
+	expectedPkgs := 57
+	actualPkgs := 0
+	for range catalog.Enumerate(pkg.ApkPkg) {
+		actualPkgs += 1
+	}
+
+	if actualPkgs != expectedPkgs {
+		t.Errorf("unexpected number of APK packages: %d != %d", expectedPkgs, actualPkgs)
+	}
+}

--- a/test/integration/test-fixtures/image-large-apk-data/Dockerfile
+++ b/test/integration/test-fixtures/image-large-apk-data/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:latest
+RUN apk add tzdata vim alpine-sdk


### PR DESCRIPTION
Increases the buffer size to 1MB to accommodate large lines (ie the tzdata package, which is what was failing for me)

Signed-off-by: Jason Williams <jasonw@jhu.edu>