### PR TITLE
Allow for gemspec metadata fields to be optional

### DIFF
--- a/syft/pkg/gem_metadata.go
+++ b/syft/pkg/gem_metadata.go
@@ -3,8 +3,8 @@ package pkg
 type GemMetadata struct {
 	Name     string   `mapstructure:"name" json:"name"`
 	Version  string   `mapstructure:"version" json:"version"`
-	Files    []string `mapstructure:"files" json:"files"`
-	Authors  []string `mapstructure:"authors" json:"authors"`
-	Licenses []string `mapstructure:"licenses" json:"licenses"`
-	Homepage string   `mapstructure:"homepage" json:"homepage"`
+	Files    []string `mapstructure:"files" json:"files,omitempty"`
+	Authors  []string `mapstructure:"authors" json:"authors,omitempty"`
+	Licenses []string `mapstructure:"licenses" json:"licenses,omitempty"`
+	Homepage string   `mapstructure:"homepage" json:"homepage,omitempty"`
 }


### PR DESCRIPTION
Prevent `null` and empty gemspec fields when rendering JSON.