### PR TITLE
Update json schema to account for optional gemspec fields

### DIFF
--- a/schema/json/schema.json
+++ b/schema/json/schema.json
@@ -40,9 +40,6 @@
                             "architecture": {
                                 "type": "string"
                             },
-                            "authors": {
-                                "type": "null"
-                            },
                             "description": {
                                 "type": "string"
                             },
@@ -87,6 +84,9 @@
                                 "type": "array"
                             },
                             "gitCommitOfApkPort": {
+                                "type": "string"
+                            },
+                            "homepage": {
                                 "type": "string"
                             },
                             "installedSize": {


### PR DESCRIPTION
It seems that there is a cache-related problem in the PR check pipeline and main branch pipeline. The checks for https://github.com/anchore/syft/pull/218 passed, however, on main they failed. This PR updates the json schema appropriately relative to the changes in #218 .