### PR TITLE
Bootstrap cached dependencies and CI dependencies separately for acceptance tests

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -35,8 +35,11 @@ jobs:
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
 
-      - name: Bootstrap dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Bootstrap project dependencies
+        if: steps.bootstrap-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
+
+      - name: Bootstrap CI dependencies
         run: make ci-bootstrap
 
       - name: Import GPG key


### PR DESCRIPTION
This was missed during the migration from CircleCI to GHA, specifically, the pipeline was depending only on cache to load the `.tmp` dir instead of invoking `make bootstrap` to explicitly populate it on a cache miss.