### PR TITLE
Java cataloger miscellaneous fixes

### DIFF
--- a/schema/json/schema.json
+++ b/schema/json/schema.json
@@ -125,116 +125,109 @@
                                 "type": "string"
                             },
                             "manifest": {
-                                "anyOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
+                                "properties": {
+                                    "extraFields": {
                                         "properties": {
-                                            "extraFields": {
-                                                "properties": {
-                                                    "Archiver-Version": {
-                                                        "type": "string"
-                                                    },
-                                                    "Build-Jdk": {
-                                                        "type": "string"
-                                                    },
-                                                    "Built-By": {
-                                                        "type": "string"
-                                                    },
-                                                    "Created-By": {
-                                                        "type": "string"
-                                                    },
-                                                    "Extension-Name": {
-                                                        "type": "string"
-                                                    },
-                                                    "Group-Id": {
-                                                        "type": "string"
-                                                    },
-                                                    "Hudson-Version": {
-                                                        "type": "string"
-                                                    },
-                                                    "Jenkins-Version": {
-                                                        "type": "string"
-                                                    },
-                                                    "Long-Name": {
-                                                        "type": "string"
-                                                    },
-                                                    "Main-Class": {
-                                                        "type": "string"
-                                                    },
-                                                    "Minimum-Java-Version": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-Dependencies": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-Developers": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-License-Name": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-License-Url": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-ScmUrl": {
-                                                        "type": "string"
-                                                    },
-                                                    "Plugin-Version": {
-                                                        "type": "string"
-                                                    },
-                                                    "Short-Name": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "Archiver-Version",
-                                                    "Build-Jdk",
-                                                    "Built-By",
-                                                    "Created-By"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "implementationTitle": {
+                                            "Archiver-Version": {
                                                 "type": "string"
                                             },
-                                            "implementationVendor": {
+                                            "Build-Jdk": {
                                                 "type": "string"
                                             },
-                                            "implementationVersion": {
+                                            "Built-By": {
                                                 "type": "string"
                                             },
-                                            "manifestVersion": {
+                                            "Created-By": {
                                                 "type": "string"
                                             },
-                                            "name": {
+                                            "Extension-Name": {
                                                 "type": "string"
                                             },
-                                            "specificationTitle": {
+                                            "Group-Id": {
                                                 "type": "string"
                                             },
-                                            "specificationVendor": {
+                                            "Hudson-Version": {
                                                 "type": "string"
                                             },
-                                            "specificationVersion": {
+                                            "Jenkins-Version": {
+                                                "type": "string"
+                                            },
+                                            "Long-Name": {
+                                                "type": "string"
+                                            },
+                                            "Main-Class": {
+                                                "type": "string"
+                                            },
+                                            "Minimum-Java-Version": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-Dependencies": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-Developers": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-License-Name": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-License-Url": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-ScmUrl": {
+                                                "type": "string"
+                                            },
+                                            "Plugin-Version": {
+                                                "type": "string"
+                                            },
+                                            "Short-Name": {
                                                 "type": "string"
                                             }
                                         },
                                         "required": [
-                                            "extraFields",
-                                            "implementationTitle",
-                                            "implementationVendor",
-                                            "implementationVersion",
-                                            "manifestVersion",
-                                            "name",
-                                            "specificationTitle",
-                                            "specificationVendor",
-                                            "specificationVersion"
+                                            "Archiver-Version",
+                                            "Build-Jdk",
+                                            "Built-By",
+                                            "Created-By"
                                         ],
                                         "type": "object"
+                                    },
+                                    "implementationTitle": {
+                                        "type": "string"
+                                    },
+                                    "implementationVendor": {
+                                        "type": "string"
+                                    },
+                                    "implementationVersion": {
+                                        "type": "string"
+                                    },
+                                    "manifestVersion": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "specificationTitle": {
+                                        "type": "string"
+                                    },
+                                    "specificationVendor": {
+                                        "type": "string"
+                                    },
+                                    "specificationVersion": {
+                                        "type": "string"
                                     }
-                                ]
+                                },
+                                "required": [
+                                    "extraFields",
+                                    "implementationTitle",
+                                    "implementationVendor",
+                                    "implementationVersion",
+                                    "manifestVersion",
+                                    "name",
+                                    "specificationTitle",
+                                    "specificationVendor",
+                                    "specificationVersion"
+                                ],
+                                "type": "object"
                             },
                             "name": {
                                 "type": "string"
@@ -244,206 +237,6 @@
                             },
                             "package": {
                                 "type": "string"
-                            },
-                            "parentPackage": {
-                                "anyOf": [
-                                    {
-                                        "type": "null"
-                                    },
-                                    {
-                                        "properties": {
-                                            "foundBy": {
-                                                "type": "string"
-                                            },
-                                            "language": {
-                                                "type": "integer"
-                                            },
-                                            "licenses": {
-                                                "type": "null"
-                                            },
-                                            "manifest": {
-                                                "type": "string"
-                                            },
-                                            "metadata": {
-                                                "properties": {
-                                                    "manifest": {
-                                                        "properties": {
-                                                            "extraFields": {
-                                                                "properties": {
-                                                                    "Archiver-Version": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Build-Jdk": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Built-By": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Created-By": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Extension-Name": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Group-Id": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Hudson-Version": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Jenkins-Version": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Long-Name": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Main-Class": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Minimum-Java-Version": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-Dependencies": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-Developers": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-License-Name": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-License-Url": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-ScmUrl": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Plugin-Version": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "Short-Name": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "Archiver-Version",
-                                                                    "Build-Jdk",
-                                                                    "Built-By",
-                                                                    "Created-By"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "implementationTitle": {
-                                                                "type": "string"
-                                                            },
-                                                            "implementationVendor": {
-                                                                "type": "string"
-                                                            },
-                                                            "implementationVersion": {
-                                                                "type": "string"
-                                                            },
-                                                            "manifestVersion": {
-                                                                "type": "string"
-                                                            },
-                                                            "name": {
-                                                                "type": "string"
-                                                            },
-                                                            "specificationTitle": {
-                                                                "type": "string"
-                                                            },
-                                                            "specificationVendor": {
-                                                                "type": "string"
-                                                            },
-                                                            "specificationVersion": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "extraFields",
-                                                            "implementationTitle",
-                                                            "implementationVendor",
-                                                            "implementationVersion",
-                                                            "manifestVersion",
-                                                            "name",
-                                                            "specificationTitle",
-                                                            "specificationVendor",
-                                                            "specificationVersion"
-                                                        ],
-                                                        "type": "object"
-                                                    },
-                                                    "parentPackage": {
-                                                        "type": "null"
-                                                    },
-                                                    "pomProperties": {
-                                                        "properties": {
-                                                            "artifactId": {
-                                                                "type": "string"
-                                                            },
-                                                            "extraFields": {
-                                                                "type": "null"
-                                                            },
-                                                            "groupId": {
-                                                                "type": "string"
-                                                            },
-                                                            "name": {
-                                                                "type": "string"
-                                                            },
-                                                            "path": {
-                                                                "type": "string"
-                                                            },
-                                                            "version": {
-                                                                "type": "string"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "artifactId",
-                                                            "extraFields",
-                                                            "groupId",
-                                                            "name",
-                                                            "path",
-                                                            "version"
-                                                        ],
-                                                        "type": "object"
-                                                    },
-                                                    "virtualPath": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "manifest",
-                                                    "parentPackage",
-                                                    "pomProperties",
-                                                    "virtualPath"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "metadataType": {
-                                                "type": "string"
-                                            },
-                                            "sources": {
-                                                "type": "null"
-                                            },
-                                            "type": {
-                                                "type": "string"
-                                            },
-                                            "version": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "foundBy",
-                                            "language",
-                                            "licenses",
-                                            "manifest",
-                                            "metadata",
-                                            "metadataType",
-                                            "sources",
-                                            "type",
-                                            "version"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
                             },
                             "platform": {
                                 "type": "string"

--- a/schema/json/schema.json
+++ b/schema/json/schema.json
@@ -376,9 +376,6 @@
                                                     },
                                                     "pomProperties": {
                                                         "properties": {
-                                                            "Path": {
-                                                                "type": "string"
-                                                            },
                                                             "artifactId": {
                                                                 "type": "string"
                                                             },
@@ -391,25 +388,32 @@
                                                             "name": {
                                                                 "type": "string"
                                                             },
+                                                            "path": {
+                                                                "type": "string"
+                                                            },
                                                             "version": {
                                                                 "type": "string"
                                                             }
                                                         },
                                                         "required": [
-                                                            "Path",
                                                             "artifactId",
                                                             "extraFields",
                                                             "groupId",
                                                             "name",
+                                                            "path",
                                                             "version"
                                                         ],
                                                         "type": "object"
+                                                    },
+                                                    "virtualPath": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "manifest",
                                                     "parentPackage",
-                                                    "pomProperties"
+                                                    "pomProperties",
+                                                    "virtualPath"
                                                 ],
                                                 "type": "object"
                                             },
@@ -446,9 +450,6 @@
                             },
                             "pomProperties": {
                                 "properties": {
-                                    "Path": {
-                                        "type": "string"
-                                    },
                                     "artifactId": {
                                         "type": "string"
                                     },
@@ -461,16 +462,19 @@
                                     "name": {
                                         "type": "string"
                                     },
+                                    "path": {
+                                        "type": "string"
+                                    },
                                     "version": {
                                         "type": "string"
                                     }
                                 },
                                 "required": [
-                                    "Path",
                                     "artifactId",
                                     "extraFields",
                                     "groupId",
                                     "name",
+                                    "path",
                                     "version"
                                 ],
                                 "type": "object"
@@ -509,6 +513,9 @@
                                 "type": "string"
                             },
                             "version": {
+                                "type": "string"
+                            },
+                            "virtualPath": {
                                 "type": "string"
                             }
                         },

--- a/syft/cataloger/java/archive_filename.go
+++ b/syft/cataloger/java/archive_filename.go
@@ -70,10 +70,14 @@ func (a archiveFilename) version() string {
 }
 
 func (a archiveFilename) name() string {
-	// there should be only one name, if there is more or less then something is wrong
-	if len(a.fields) != 1 {
-		return ""
+	for _, fieldSet := range a.fields {
+		if name, ok := fieldSet["name"]; ok {
+			// return the first name
+			return name
+		}
 	}
 
-	return a.fields[0]["name"]
+	// derive the name from the archive name (no path or extension)
+	basename := filepath.Base(a.raw)
+	return strings.TrimSuffix(basename, filepath.Ext(basename))
 }

--- a/syft/cataloger/java/archive_parser.go
+++ b/syft/cataloger/java/archive_parser.go
@@ -148,7 +148,8 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		Type:         pkg.JavaPkg,
 		MetadataType: pkg.JavaMetadataType,
 		Metadata: pkg.JavaMetadata{
-			Manifest: manifest,
+			VirtualPath: j.virtualPath,
+			Manifest:    manifest,
 		},
 	}, nil
 }
@@ -184,6 +185,7 @@ func (j *archiveParser) discoverPkgsFromPomProperties(parentPkg *pkg.Package) ([
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
+						VirtualPath:   j.virtualPath,
 						PomProperties: propsObj,
 						Parent:        parentPkg,
 					},

--- a/syft/cataloger/java/archive_parser_test.go
+++ b/syft/cataloger/java/archive_parser_test.go
@@ -143,6 +143,7 @@ func TestParseJar(t *testing.T) {
 					Type:         pkg.JenkinsPluginPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
+						VirtualPath: "test-fixtures/java-builds/packages/example-jenkins-plugin.hpi",
 						Manifest: &pkg.JavaManifest{
 							ManifestVersion: "1.0",
 							SpecTitle:       "The Jenkins Plugins Parent POM Project",
@@ -188,6 +189,7 @@ func TestParseJar(t *testing.T) {
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
+						VirtualPath: "test-fixtures/java-builds/packages/example-java-app-gradle-0.1.0.jar",
 						Manifest: &pkg.JavaManifest{
 							ManifestVersion: "1.0",
 						},
@@ -208,6 +210,7 @@ func TestParseJar(t *testing.T) {
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
+						VirtualPath: "test-fixtures/java-builds/packages/example-java-app-maven-0.1.0.jar",
 						Manifest: &pkg.JavaManifest{
 							ManifestVersion: "1.0",
 							Extra: map[string]string{
@@ -233,6 +236,7 @@ func TestParseJar(t *testing.T) {
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
+						VirtualPath: "test-fixtures/java-builds/packages/example-java-app-maven-0.1.0.jar",
 						PomProperties: &pkg.PomProperties{
 							Path:       "META-INF/maven/joda-time/joda-time/pom.properties",
 							GroupID:    "joda-time",

--- a/syft/cataloger/java/java_manifest.go
+++ b/syft/cataloger/java/java_manifest.go
@@ -12,17 +12,29 @@ import (
 
 const manifestPath = "META-INF/MANIFEST.MF"
 
+// nolint:funlen
 func parseJavaManifest(reader io.Reader) (*pkg.JavaManifest, error) {
 	var manifest pkg.JavaManifest
-	manifestMap := make(map[string]string)
+	sections := []map[string]string{
+		make(map[string]string),
+	}
+	currentSection := 0
 	scanner := bufio.NewScanner(reader)
 	var lastKey string
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// ignore empty lines
+		// empty lines denote section separators
 		if strings.TrimSpace(line) == "" {
+			currentSection++
+			// we don't want to allocate a new section map that wont necessarily be used, do that once there is
+			// a non-empty line to process
+
+			// do not process line continuations after this
+			lastKey = ""
 			continue
+		} else if currentSection >= len(sections) {
+			sections = append(sections, make(map[string]string))
 		}
 
 		if line[0] == ' ' {
@@ -30,7 +42,7 @@ func parseJavaManifest(reader io.Reader) (*pkg.JavaManifest, error) {
 			if lastKey == "" {
 				return nil, fmt.Errorf("found continuation with no previous key (%s)", line)
 			}
-			manifestMap[lastKey] += strings.TrimSpace(line)
+			sections[currentSection][lastKey] += strings.TrimSpace(line)
 		} else {
 			// this is a new key-value pair
 			idx := strings.Index(line, ":")
@@ -40,9 +52,9 @@ func parseJavaManifest(reader io.Reader) (*pkg.JavaManifest, error) {
 
 			key := strings.TrimSpace(line[0:idx])
 			value := strings.TrimSpace(line[idx+1:])
-			manifestMap[key] = value
+			sections[currentSection][key] = value
 
-			// keep track of key for future continuations
+			// keep track of key for potential future continuations
 			lastKey = key
 		}
 	}
@@ -51,8 +63,13 @@ func parseJavaManifest(reader io.Reader) (*pkg.JavaManifest, error) {
 		return nil, fmt.Errorf("unable to read java manifest: %w", err)
 	}
 
-	if err := mapstructure.Decode(manifestMap, &manifest); err != nil {
+	if err := mapstructure.Decode(sections[0], &manifest); err != nil {
 		return nil, fmt.Errorf("unable to parse java manifest: %w", err)
+	}
+
+	// append on extra sections
+	if len(sections) > 1 {
+		manifest.Sections = sections[1:]
 	}
 
 	// clean select fields

--- a/syft/cataloger/java/java_manifest_test.go
+++ b/syft/cataloger/java/java_manifest_test.go
@@ -2,10 +2,11 @@ package java
 
 import (
 	"encoding/json"
-	"github.com/anchore/syft/syft/pkg"
-	"github.com/go-test/deep"
 	"os"
 	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/go-test/deep"
 )
 
 func TestParseJavaManifest(t *testing.T) {
@@ -38,10 +39,16 @@ func TestParseJavaManifest(t *testing.T) {
 				ManifestVersion: "1.0",
 				Extra: map[string]string{
 					"Archiver-Version": "Plexus Archiver",
-					"Build-Jdk":        "14.0.1",
-					"Built-By":         "?",
 					"Created-By":       "Apache Maven 3.6.3",
-					"Main-Class":       "hello.HelloWorld",
+				},
+				Sections: []map[string]string{
+					{
+						"Built-By": "?",
+					},
+					{
+						"Build-Jdk":  "14.0.1",
+						"Main-Class": "hello.HelloWorld",
+					},
 				},
 			},
 		},

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -7,7 +7,7 @@ type JavaMetadata struct {
 	VirtualPath   string         `json:"virtualPath"`
 	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest,omitempty"`
 	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties,omitempty"`
-	Parent        *Package       `json:"parentPackage,omitempty"` // TODO: should this be included in the json output?
+	Parent        *Package       `json:"-"`
 }
 
 // PomProperties represents the fields of interest extracted from a Java archive's pom.xml file.
@@ -31,7 +31,7 @@ type JavaManifest struct {
 	ImplVersion     string              `mapstructure:"Implementation-Version" json:"implementationVersion"`
 	ImplVendor      string              `mapstructure:"Implementation-Vendor" json:"implementationVendor"`
 	Extra           map[string]string   `mapstructure:",remain" json:"extraFields"`
-	Sections        []map[string]string `json:"sections"`
+	Sections        []map[string]string `json:"sections,omitempty"`
 }
 
 func (m JavaMetadata) PackageURL() string {

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -4,7 +4,7 @@ import "github.com/package-url/packageurl-go"
 
 // JavaMetadata encapsulates all Java ecosystem metadata for a package as well as an (optional) parent relationship.
 type JavaMetadata struct {
-	VirtualPath   string         `json:"virtual-path"`
+	VirtualPath   string         `json:"virtualPath"`
 	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest"`
 	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties"`
 	Parent        *Package       `json:"parentPackage"` // TODO: should this be included in the json output?

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -5,9 +5,9 @@ import "github.com/package-url/packageurl-go"
 // JavaMetadata encapsulates all Java ecosystem metadata for a package as well as an (optional) parent relationship.
 type JavaMetadata struct {
 	VirtualPath   string         `json:"virtualPath"`
-	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest"`
-	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties"`
-	Parent        *Package       `json:"parentPackage"` // TODO: should this be included in the json output?
+	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest,omitempty"`
+	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties,omitempty"`
+	Parent        *Package       `json:"parentPackage,omitempty"` // TODO: should this be included in the json output?
 }
 
 // PomProperties represents the fields of interest extracted from a Java archive's pom.xml file.
@@ -22,15 +22,16 @@ type PomProperties struct {
 
 // JavaManifest represents the fields of interest extracted from a Java archive's META-INF/MANIFEST.MF file.
 type JavaManifest struct {
-	Name            string            `mapstructure:"Name" json:"name"`
-	ManifestVersion string            `mapstructure:"Manifest-Version" json:"manifestVersion"`
-	SpecTitle       string            `mapstructure:"Specification-Title" json:"specificationTitle"`
-	SpecVersion     string            `mapstructure:"Specification-Version" json:"specificationVersion"`
-	SpecVendor      string            `mapstructure:"Specification-Vendor" json:"specificationVendor"`
-	ImplTitle       string            `mapstructure:"Implementation-Title" json:"implementationTitle"`
-	ImplVersion     string            `mapstructure:"Implementation-Version" json:"implementationVersion"`
-	ImplVendor      string            `mapstructure:"Implementation-Vendor" json:"implementationVendor"`
-	Extra           map[string]string `mapstructure:",remain" json:"extraFields"`
+	Name            string              `mapstructure:"Name" json:"name"`
+	ManifestVersion string              `mapstructure:"Manifest-Version" json:"manifestVersion"`
+	SpecTitle       string              `mapstructure:"Specification-Title" json:"specificationTitle"`
+	SpecVersion     string              `mapstructure:"Specification-Version" json:"specificationVersion"`
+	SpecVendor      string              `mapstructure:"Specification-Vendor" json:"specificationVendor"`
+	ImplTitle       string              `mapstructure:"Implementation-Title" json:"implementationTitle"`
+	ImplVersion     string              `mapstructure:"Implementation-Version" json:"implementationVersion"`
+	ImplVendor      string              `mapstructure:"Implementation-Vendor" json:"implementationVendor"`
+	Extra           map[string]string   `mapstructure:",remain" json:"extraFields"`
+	Sections        []map[string]string `json:"sections"`
 }
 
 func (m JavaMetadata) PackageURL() string {

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -4,6 +4,7 @@ import "github.com/package-url/packageurl-go"
 
 // JavaMetadata encapsulates all Java ecosystem metadata for a package as well as an (optional) parent relationship.
 type JavaMetadata struct {
+	VirtualPath   string         `json:"virtual-path"`
 	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest"`
 	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties"`
 	Parent        *Package       `json:"parentPackage"` // TODO: should this be included in the json output?
@@ -11,7 +12,7 @@ type JavaMetadata struct {
 
 // PomProperties represents the fields of interest extracted from a Java archive's pom.xml file.
 type PomProperties struct {
-	Path       string
+	Path       string            `mapstructure:"path" json:"path"`
 	Name       string            `mapstructure:"name" json:"name"`
 	GroupID    string            `mapstructure:"groupId" json:"groupId"`
 	ArtifactID string            `mapstructure:"artifactId" json:"artifactId"`


### PR DESCRIPTION
- Adds a `virtualPath` for java archives to indicate if the archive was found within another java archive (similar to Anchore engine). e.g. `hudson.war:WEB-INF/lib/args4j-2.0.16.jar`
- Removes the `parentPackage` from the json output for java archives
- Removes optional fields from json output when empty
- Parses java manifest sections separately; Fixes #220 
- Forces lowercase of pom properties `path` variable

Partially addresses findings from https://github.com/anchore/grype/issues/182 and https://github.com/anchore/grype/issues/192 as well as helps with https://github.com/anchore/anchore-engine/issues/681

