### PR TITLE
Add warning log level

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,7 +111,7 @@ func (cfg *Application) Build() error {
 			case v >= 2:
 				cfg.Log.LevelOpt = logrus.DebugLevel
 			default:
-				cfg.Log.LevelOpt = logrus.ErrorLevel
+				cfg.Log.LevelOpt = logrus.WarnLevel
 			}
 		}
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -8,6 +8,18 @@ func Errorf(format string, args ...interface{}) {
 	Log.Errorf(format, args...)
 }
 
+func Error(args ...interface{}) {
+	Log.Error(args...)
+}
+
+func Warnf(format string, args ...interface{}) {
+	Log.Warnf(format, args...)
+}
+
+func Warn(args ...interface{}) {
+	Log.Warn(args...)
+}
+
 func Infof(format string, args ...interface{}) {
 	Log.Infof(format, args...)
 }

--- a/internal/log/nop.go
+++ b/internal/log/nop.go
@@ -3,6 +3,9 @@ package log
 type nopLogger struct{}
 
 func (l *nopLogger) Errorf(format string, args ...interface{}) {}
+func (l *nopLogger) Error(args ...interface{})                 {}
+func (l *nopLogger) Warnf(format string, args ...interface{})  {}
+func (l *nopLogger) Warn(args ...interface{})                  {}
 func (l *nopLogger) Infof(format string, args ...interface{})  {}
 func (l *nopLogger) Info(args ...interface{})                  {}
 func (l *nopLogger) Debugf(format string, args ...interface{}) {}

--- a/internal/logger/logrus.go
+++ b/internal/logger/logrus.go
@@ -84,6 +84,14 @@ func (l *LogrusLogger) Infof(format string, args ...interface{}) {
 	l.Logger.Infof(format, args...)
 }
 
+func (l *LogrusLogger) Warnf(format string, args ...interface{}) {
+	l.Logger.Warnf(format, args...)
+}
+
+func (l *LogrusLogger) Errorf(format string, args ...interface{}) {
+	l.Logger.Errorf(format, args...)
+}
+
 func (l *LogrusLogger) Debug(args ...interface{}) {
 	l.Logger.Debug(args...)
 }
@@ -92,8 +100,12 @@ func (l *LogrusLogger) Info(args ...interface{}) {
 	l.Logger.Info(args...)
 }
 
-func (l *LogrusLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+func (l *LogrusLogger) Warn(args ...interface{}) {
+	l.Logger.Warn(args...)
+}
+
+func (l *LogrusLogger) Error(args ...interface{}) {
+	l.Logger.Error(args...)
 }
 
 func (l *LogrusNestedLogger) Debugf(format string, args ...interface{}) {
@@ -104,6 +116,14 @@ func (l *LogrusNestedLogger) Infof(format string, args ...interface{}) {
 	l.Logger.Infof(format, args...)
 }
 
+func (l *LogrusNestedLogger) Warnf(format string, args ...interface{}) {
+	l.Logger.Warnf(format, args...)
+}
+
+func (l *LogrusNestedLogger) Errorf(format string, args ...interface{}) {
+	l.Logger.Errorf(format, args...)
+}
+
 func (l *LogrusNestedLogger) Debug(args ...interface{}) {
 	l.Logger.Debug(args...)
 }
@@ -112,6 +132,10 @@ func (l *LogrusNestedLogger) Info(args ...interface{}) {
 	l.Logger.Info(args...)
 }
 
-func (l *LogrusNestedLogger) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+func (l *LogrusNestedLogger) Warn(args ...interface{}) {
+	l.Logger.Warn(args...)
+}
+
+func (l *LogrusNestedLogger) Error(args ...interface{}) {
+	l.Logger.Error(args...)
 }

--- a/syft/cataloger/apkdb/parse_apk_db.go
+++ b/syft/cataloger/apkdb/parse_apk_db.go
@@ -109,11 +109,11 @@ func parseApkDBEntry(reader io.Reader) (*pkg.ApkMetadata, error) {
 		case "a", "M":
 			ownershipFields := strings.Split(value, ":")
 			if len(ownershipFields) < 3 {
-				log.Errorf("unexpected APK ownership field: %q", value)
+				log.Warnf("unexpected APK ownership field: %q", value)
 				continue
 			}
 			if fileRecord == nil {
-				log.Errorf("ownership field with no parent record: %q", value)
+				log.Warnf("ownership field with no parent record: %q", value)
 				continue
 			}
 			fileRecord.OwnerUID = ownershipFields[0]
@@ -123,7 +123,7 @@ func parseApkDBEntry(reader io.Reader) (*pkg.ApkMetadata, error) {
 			// "0:0:755:Q1JaDEHQHBbizhEzoWK1YxuraNU/4="
 		case "Z":
 			if fileRecord == nil {
-				log.Errorf("checksum field with no parent record: %q", value)
+				log.Warnf("checksum field with no parent record: %q", value)
 				continue
 			}
 			fileRecord.Checksum = value

--- a/syft/cataloger/common/generic_cataloger.go
+++ b/syft/cataloger/common/generic_cataloger.go
@@ -68,7 +68,7 @@ func (c *GenericCataloger) selectFiles(resolver scope.FileResolver) []file.Refer
 	for path, parser := range c.pathParsers {
 		files, err := resolver.FilesByPath(file.Path(path))
 		if err != nil {
-			log.Errorf("cataloger failed to select files by path: %+v", err)
+			log.Warnf("cataloger failed to select files by path: %+v", err)
 		}
 		if files != nil {
 			c.register(files, parser)
@@ -79,7 +79,7 @@ func (c *GenericCataloger) selectFiles(resolver scope.FileResolver) []file.Refer
 	for globPattern, parser := range c.globParsers {
 		fileMatches, err := resolver.FilesByGlob(globPattern)
 		if err != nil {
-			log.Errorf("failed to find files by glob: %s", globPattern)
+			log.Warnf("failed to find files by glob: %s", globPattern)
 		}
 		if fileMatches != nil {
 			c.register(fileMatches, parser)
@@ -98,14 +98,14 @@ func (c *GenericCataloger) catalog(contents map[file.Reference]string) ([]pkg.Pa
 	for reference, parser := range c.parsers {
 		content, ok := contents[reference]
 		if !ok {
-			log.Errorf("cataloger '%s' missing file content: %+v", c.upstreamCataloger, reference)
+			log.Warnf("cataloger '%s' missing file content: %+v", c.upstreamCataloger, reference)
 			continue
 		}
 
 		entries, err := parser(string(reference.Path), strings.NewReader(content))
 		if err != nil {
 			// TODO: should we fail? or only log?
-			log.Errorf("cataloger '%s' failed to parse entries (reference=%+v): %+v", c.upstreamCataloger, reference, err)
+			log.Warnf("cataloger '%s' failed to parse entries (reference=%+v): %+v", c.upstreamCataloger, reference, err)
 			continue
 		}
 

--- a/syft/cataloger/java/archive_filename.go
+++ b/syft/cataloger/java/archive_filename.go
@@ -69,7 +69,7 @@ func (a archiveFilename) pkgType() pkg.Type {
 
 func (a archiveFilename) version() string {
 	if len(a.fields) > 1 {
-		log.Errorf("discovered multiple name-version pairings from %q: %+v", a.raw, a.fields)
+		log.Warnf("discovered multiple name-version pairings from %q: %+v", a.raw, a.fields)
 		return ""
 	} else if len(a.fields) < 1 {
 		return ""

--- a/syft/cataloger/java/archive_parser.go
+++ b/syft/cataloger/java/archive_parser.go
@@ -266,7 +266,7 @@ func (j *archiveParser) discoverPkgsFromNestedArchives(parentPkg *pkg.Package) (
 		nestedPkgs, err := parseJavaArchive(nestedPath, archiveReadCloser)
 		if err != nil {
 			if closeErr := archiveReadCloser.Close(); closeErr != nil {
-				log.Errorf("unable to close archived file from tempdir: %+v", closeErr)
+				log.Warnf("unable to close archived file from tempdir: %+v", closeErr)
 			}
 			return nil, fmt.Errorf("unable to process nested java archive (%s): %w", archivePath, err)
 		}

--- a/syft/cataloger/java/java_manifest.go
+++ b/syft/cataloger/java/java_manifest.go
@@ -77,7 +77,7 @@ func parseJavaManifest(path string, reader io.Reader) (*pkg.JavaManifest, error)
 					// per the manifest spec (https://docs.oracle.com/en/java/javase/11/docs/specs/jar/jar.html#jar-manifest)
 					// this should never happen. If it does we want to know about it, but not necessarily stop
 					// cataloging entirely... for this reason we only log.
-					log.Errorf("java manifest section found without a name: %s", path)
+					log.Warnf("java manifest section found without a name: %s", path)
 					name = strconv.Itoa(i)
 				} else {
 					delete(s, "Name")

--- a/syft/cataloger/javascript/parse_yarn_lock.go
+++ b/syft/cataloger/javascript/parse_yarn_lock.go
@@ -40,7 +40,7 @@ func parseYarnLock(_ string, reader io.Reader) ([]pkg.Package, error) {
 		case composedNameExp.MatchString(line):
 			name := composedNameExp.FindString(line)
 			if len(name) == 0 {
-				log.Errorf("unable to parse line: '%s'", line)
+				log.Warnf("unable to parse yarn.lock line: %q", line)
 			}
 			currentName = strings.TrimLeft(name, "\"")
 		case simpleNameExp.MatchString(line):

--- a/syft/cataloger/python/package_cataloger.go
+++ b/syft/cataloger/python/package_cataloger.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/anchore/syft/internal/log"
+
 	"github.com/anchore/stereoscope/pkg/file"
 
 	"github.com/anchore/syft/syft/pkg"
@@ -123,7 +125,8 @@ func (c *PackageCataloger) fetchTopLevelPackages(resolver scope.Resolver, metada
 		return nil, nil, err
 	}
 	if topLevelRef == nil {
-		return nil, nil, fmt.Errorf("missing python package top_level.txt (package=%q)", string(metadataRef.Path))
+		log.Warnf("missing python package top_level.txt (package=%q)", string(metadataRef.Path))
+		return nil, nil, nil
 	}
 
 	sources = append(sources, *topLevelRef)

--- a/syft/cataloger/python/package_cataloger_test.go
+++ b/syft/cataloger/python/package_cataloger_test.go
@@ -69,20 +69,20 @@ func newTestResolver(metaPath, recordPath, topPath string) *pythonTestResolverMo
 }
 
 func (r *pythonTestResolverMock) FileContentsByRef(ref file.Reference) (string, error) {
-	switch ref.Path {
-	case r.topLevelRef.Path:
+	switch {
+	case r.topLevelRef != nil && ref.Path == r.topLevelRef.Path:
 		b, err := ioutil.ReadAll(r.topLevelReader)
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
-	case r.metadataRef.Path:
+	case ref.Path == r.metadataRef.Path:
 		b, err := ioutil.ReadAll(r.metadataReader)
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
-	case r.recordRef.Path:
+	case ref.Path == r.recordRef.Path:
 		b, err := ioutil.ReadAll(r.recordReader)
 		if err != nil {
 			return "", err
@@ -188,7 +188,6 @@ func TestPythonPackageWheelCataloger(t *testing.T) {
 			// in cases where the metadata file is available and the record is not we should still record there is a package
 			// additionally empty top_level.txt files should not result in an error
 			MetadataFixture: "test-fixtures/partial.dist-info/METADATA",
-			TopLevelFixture: "test-fixtures/partial.dist-info/top_level.txt",
 			ExpectedPackage: pkg.Package{
 				Name:         "Pygments",
 				Version:      "2.6.1",

--- a/syft/logger/logger.go
+++ b/syft/logger/logger.go
@@ -5,6 +5,9 @@ package logger
 
 type Logger interface {
 	Errorf(format string, args ...interface{})
+	Error(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warn(args ...interface{})
 	Infof(format string, args ...interface{})
 	Info(args ...interface{})
 	Debugf(format string, args ...interface{})


### PR DESCRIPTION
- Adds `Error` log level helper (mirrors existing pattern of other levels)
- Adds `Warn*` log level helpers
- Replaces a few `log.Errorf` uses that should be `log.Warnf`
- Fixes https://github.com/anchore/syft/issues/259