### PR TITLE
Add signed and notarized ZIP release asset

### DIFF
--- a/.github/scripts/mac-sign-and-notarize.sh
+++ b/.github/scripts/mac-sign-and-notarize.sh
@@ -8,9 +8,12 @@ if [[ "${IS_SNAPSHOT}" == "true" ]]; then
   exit 0
 fi
 
-GON_CONFIG="$2"                         # e.g. "gon.hcl"
-NEW_DMG_NAME="$3"                       # e.g. "./dist/syft-0.1.0.dmg"
-ORIGINAL_DMG_NAME="./dist/output.dmg"   # This should match dmg output_path in the gon config file.
+GON_CONFIG="$2"                                       # e.g. "gon.hcl"
+NEW_NAME_WITHOUT_EXTENSION="$3"                       # e.g. "./dist/syft-0.1.0"
+ORIGINAL_NAME_WITHOUT_EXTENSION="./dist/output"       # This should match dmg and zip output_path in the gon config file, without the extension.
 
 gon "${GON_CONFIG}"
-mv -v "${ORIGINAL_DMG_NAME}" "${NEW_DMG_NAME}"
+
+# Rename outputs with specified desired name
+mv -v "${ORIGINAL_NAME_WITHOUT_EXTENSION}.dmg" "${NEW_NAME_WITHOUT_EXTENSION}.dmg"
+mv -v "${ORIGINAL_NAME_WITHOUT_EXTENSION}.zip" "${NEW_NAME_WITHOUT_EXTENSION}.zip"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,12 +50,31 @@ builds:
       -X github.com/anchore/syft/internal/version.gitCommit={{.Commit}}
       -X github.com/anchore/syft/internal/version.buildDate={{.Date}}
       -X github.com/anchore/syft/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}
-    hooks:
-      post: ./.github/scripts/mac-sign-and-notarize.sh "{{.IsSnapshot}}" "gon.hcl" "./dist/syft_{{.Version}}_{{.Target}}.dmg"
+
+archives:
+  - format: tar.gz
+    builds:
+      - syft # i.e. Linux only
+  - format: zip # This is a hack! We don't actually intend to use _this_ ZIP file, we just need goreleaser to consider the ZIP file produced by gon (which will have the same file name) to be an artifact so we can use it downstream in publishing (e.g. to a homebrew tap)
+    id: syft-zip
+    builds:
+      - syft-macos
 
 signs:
   - artifacts: checksum
+    ids:
+      - syft # i.e. Linux only
     args: ["--output", "${signature}", "--detach-sign", "${artifact}"]
+  - id: syft-macos-signing
+    signature: "./dist/syft_{{ .Version }}_darwin_amd64.dmg"
+    ids:
+      - syft-macos
+    cmd: ./.github/scripts/mac-sign-and-notarize.sh
+    args:
+      - "{{ .IsSnapshot }}"
+      - "gon.hcl"
+      - "./dist/syft_{{ .Version }}_darwin_amd64"
+    artifacts: all
 
 nfpms:
   - license: "Apache 2.0"
@@ -72,11 +91,3 @@ brews:
       name: homebrew-syft
     homepage: *website
     description: *description
-
-archives:
-  - format: tar.gz
-    builds:
-      - syft # i.e. Linux only
-    format_overrides:
-      - goos: windows
-        format: zip

--- a/gon.hcl
+++ b/gon.hcl
@@ -9,3 +9,7 @@ dmg {
   output_path = "./dist/output.dmg"
   volume_name = "Syft"
 }
+
+zip {
+  output_path = "./dist/output.zip"
+}

--- a/install.sh
+++ b/install.sh
@@ -243,7 +243,7 @@ unpack() {
 extract_from_dmg() {
   dmg_file=$1
   mount_point="/Volumes/tmp-dmg"
-  hdiutil attach -quiet -mountpoint "${mount_point}" "${dmg_file}"
+  hdiutil attach -quiet -nobrowse -mountpoint "${mount_point}" "${dmg_file}"
   cp -fR "${mount_point}/" ./
   hdiutil detach -quiet -force "${mount_point}"
 }


### PR DESCRIPTION
- Adds "zip" as a `gon` output
- Ensures that this ZIP file is a goreleaser artifact, so it's used in the brew publish step and included as a release asset
- Removes the "flash" of a Finder window during the execution of `install.sh`

This is also intended to address https://github.com/anchore/grype/issues/203... Once this solution is confirmed, similar changes will be made to Grype.