### PR TITLE
Fix release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,6 +57,13 @@ archives:
       - syft-macos
 
 signs:
+  - artifacts: checksum
+    cmd: sh
+    args:
+      - '-c'
+      # we should not include the zip artifact, as the artifact is mutated throughout the next macOS notarization step
+      # note: sed -i is not portable
+      - 'sed "/.*\.zip/d" ${artifact} > tmpfile && mv tmpfile ${artifact} && gpg --output ${signature} --detach-sign ${artifact}'
   - id: syft-macos-signing
     ids:
       - syft-macos

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,10 +6,6 @@ release:
   # If set to true, will not auto-publish the release. This is done to allow us to review the changelog before publishing.
   draft: true
 
-  # This ensures any macOS signed artifacts get included with the release.
-  extra_files:
-    - glob: "./dist/*.dmg"
-
 builds:
   - binary: syft
     id: syft
@@ -61,15 +57,11 @@ archives:
       - syft-macos
 
 signs:
-  - artifacts: checksum
-    ids:
-      - syft # i.e. Linux only
-    args: ["--output", "${signature}", "--detach-sign", "${artifact}"]
   - id: syft-macos-signing
-    signature: "./dist/syft_{{ .Version }}_darwin_amd64.dmg"
     ids:
       - syft-macos
     cmd: ./.github/scripts/mac-sign-and-notarize.sh
+    signature: "syft_${VERSION}_darwin_amd64.dmg" # This is somewhat unintuitive. This gets the DMG file recognized as an artifact. In fact, both a DMG and a ZIP file are being produced by this signing step.
     args:
       - "{{ .IsSnapshot }}"
       - "gon.hcl"

--- a/Makefile
+++ b/Makefile
@@ -273,10 +273,13 @@ release: clean-dist ci-bootstrap-mac changelog-release ## Build and publish fina
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml
 
 	# release
-	bash -c "BUILD_GIT_TREE_STATE=$(GITTREESTATE) $(TEMPDIR)/goreleaser \
-		--rm-dist \
-		--config $(TEMPDIR)/goreleaser.yaml \
-		--release-notes <(cat CHANGELOG.md)"
+	bash -c "\
+		BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
+		VERSION=$(VERSION) \
+		$(TEMPDIR)/goreleaser \
+			--rm-dist \
+			--config $(TEMPDIR)/goreleaser.yaml \
+			--release-notes <(cat CHANGELOG.md)"
 
 	# verify checksum signatures
 	.github/scripts/verify-signature.sh "$(DISTDIR)"

--- a/Makefile
+++ b/Makefile
@@ -272,10 +272,10 @@ release: clean-dist ci-bootstrap-mac changelog-release ## Build and publish fina
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml
 
-	# release
+	# release (note the version transformation from v0.7.0 --> 0.7.0)
 	bash -c "\
 		BUILD_GIT_TREE_STATE=$(GITTREESTATE) \
-		VERSION=$(VERSION) \
+		VERSION=$(VERSION:v%=%) \
 		$(TEMPDIR)/goreleaser \
 			--rm-dist \
 			--config $(TEMPDIR)/goreleaser.yaml \


### PR DESCRIPTION
- augment the macOS signing step to denote creation of the DMG file
- augment the linux signing step to remove the zip checksum, which will always be incorrect
- provide goreleaser with the artifact version via an environment variable