### PR TITLE
Add source to packages found by RPMdb cataloger

### DIFF
--- a/syft/cataloger/rpmdb/cataloger.go
+++ b/syft/cataloger/rpmdb/cataloger.go
@@ -35,15 +35,15 @@ func (c *Cataloger) Catalog(resolver scope.Resolver) ([]pkg.Package, error) {
 	}
 
 	var pkgs []pkg.Package
-	for _, ref := range fileMatches {
-		dbContents, err := resolver.FileContentsByRef(ref)
+	for _, dbRef := range fileMatches {
+		dbContents, err := resolver.FileContentsByRef(dbRef)
 		if err != nil {
 			return nil, err
 		}
 
-		pkgs, err = parseRpmDB(resolver, strings.NewReader(dbContents))
+		pkgs, err = parseRpmDB(resolver, dbRef, strings.NewReader(dbContents))
 		if err != nil {
-			return nil, fmt.Errorf("unable to catalog rpmdb package=%+v: %w", ref.Path, err)
+			return nil, fmt.Errorf("unable to catalog rpmdb package=%+v: %w", dbRef.Path, err)
 		}
 	}
 	return pkgs, nil

--- a/syft/cataloger/rpmdb/parse_rpmdb.go
+++ b/syft/cataloger/rpmdb/parse_rpmdb.go
@@ -17,7 +17,7 @@ import (
 )
 
 // parseApkDb parses an "Packages" RPM DB and returns the Packages listed within it.
-func parseRpmDB(resolver scope.FileResolver, reader io.Reader) ([]pkg.Package, error) {
+func parseRpmDB(resolver scope.FileResolver, dbRef file.Reference, reader io.Reader) ([]pkg.Package, error) {
 	f, err := ioutil.TempFile("", internal.ApplicationName+"-rpmdb")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp rpmdb file: %w", err)
@@ -57,6 +57,7 @@ func parseRpmDB(resolver scope.FileResolver, reader io.Reader) ([]pkg.Package, e
 			Name:    entry.Name,
 			Version: fmt.Sprintf("%s-%s", entry.Version, entry.Release), // this is what engine does
 			//Version: fmt.Sprintf("%d:%s-%s.%s", entry.Epoch, entry.Version, entry.Release, entry.Arch),
+			Source:       []file.Reference{dbRef},
 			Type:         pkg.RpmPkg,
 			MetadataType: pkg.RpmdbMetadataType,
 			Metadata: pkg.RpmdbMetadata{

--- a/syft/cataloger/rpmdb/parse_rpmdb_test.go
+++ b/syft/cataloger/rpmdb/parse_rpmdb_test.go
@@ -41,6 +41,8 @@ func (r *rpmdbTestFileResolverMock) RelativeFileByPath(file.Reference, string) (
 }
 
 func TestParseRpmDB(t *testing.T) {
+	dbRef := file.NewFileReference("test-path")
+
 	tests := []struct {
 		fixture     string
 		expected    map[string]pkg.Package
@@ -54,6 +56,7 @@ func TestParseRpmDB(t *testing.T) {
 				"dive": {
 					Name:         "dive",
 					Version:      "0.9.2-1",
+					Source:       []file.Reference{dbRef},
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmdbMetadataType,
 					Metadata: pkg.RpmdbMetadata{
@@ -79,6 +82,7 @@ func TestParseRpmDB(t *testing.T) {
 				"dive": {
 					Name:         "dive",
 					Version:      "0.9.2-1",
+					Source:       []file.Reference{dbRef},
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmdbMetadataType,
 					Metadata: pkg.RpmdbMetadata{
@@ -114,7 +118,7 @@ func TestParseRpmDB(t *testing.T) {
 
 			fileResolver := newTestFileResolver(test.ignorePaths)
 
-			actual, err := parseRpmDB(fileResolver, fixture)
+			actual, err := parseRpmDB(fileResolver, dbRef, fixture)
 			if err != nil {
 				t.Fatalf("failed to parse rpmdb: %+v", err)
 			}


### PR DESCRIPTION
Today we should be attaching the file source to the packages discovered --this PR does this for the RPMDB cataloger.