### PR TITLE
Improve package.json license parsing

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -101,7 +101,7 @@ func initLogging() {
 	logWrapper := logger.NewLogrusLogger(cfg)
 	syft.SetLogger(logWrapper)
 	stereoscope.SetLogger(&logger.LogrusNestedLogger{
-		Logger: logWrapper.Logger.WithField("from-lib", "steroscope"),
+		Logger: logWrapper.Logger.WithField("from-lib", "stereoscope"),
 	})
 }
 

--- a/syft/cataloger/javascript/parse_package_json.go
+++ b/syft/cataloger/javascript/parse_package_json.go
@@ -133,6 +133,11 @@ func licenseFromJSON(b []byte) (string, error) {
 }
 
 func licensesFromJSON(p PackageJSON) ([]string, error) {
+	if p.License == nil && p.Licenses == nil {
+		// This package.json doesn't specify any licenses whatsoever
+		return []string{}, nil
+	}
+
 	singleLicense, err := licenseFromJSON(p.License)
 	if err == nil {
 		return []string{singleLicense}, nil

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -124,7 +124,7 @@ func TestParsePackageJSON(t *testing.T) {
 				t.Fatalf("failed to open fixture: %+v", err)
 			}
 
-			actual, err := parsePackageJSON(fixture.Name(), fixture)
+			actual, err := parsePackageJSON("", fixture)
 			if err != nil {
 				t.Fatalf("failed to parse package-lock.json: %+v", err)
 			}

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -65,6 +65,23 @@ func TestParsePackageJSON(t *testing.T) {
 			},
 		},
 		{
+			Fixture: "test-fixtures/pkg-json/package-no-license.json",
+			ExpectedPkg: pkg.Package{
+				Name:         "npm",
+				Version:      "6.14.6",
+				Type:         pkg.NpmPkg,
+				Licenses:     []string{},
+				Language:     pkg.JavaScript,
+				MetadataType: pkg.NpmPackageJSONMetadataType,
+				Metadata: pkg.NpmPackageJSONMetadata{
+					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+					Homepage: "https://docs.npmjs.com/",
+					URL:      "https://github.com/npm/cli",
+					Licenses: []string{},
+				},
+			},
+		},
+		{
 			Fixture: "test-fixtures/pkg-json/package-nested-author.json",
 			ExpectedPkg: pkg.Package{
 				Name:         "npm",

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -48,6 +48,23 @@ func TestParsePackageJSON(t *testing.T) {
 			},
 		},
 		{
+			Fixture: "test-fixtures/pkg-json/package-license-objects.json",
+			ExpectedPkg: pkg.Package{
+				Name:         "npm",
+				Version:      "6.14.6",
+				Type:         pkg.NpmPkg,
+				Licenses:     []string{"MIT", "Apache-2.0"},
+				Language:     pkg.JavaScript,
+				MetadataType: pkg.NpmPackageJSONMetadataType,
+				Metadata: pkg.NpmPackageJSONMetadata{
+					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+					Homepage: "https://docs.npmjs.com/",
+					URL:      "https://github.com/npm/cli",
+					Licenses: []string{"MIT", "Apache-2.0"},
+				},
+			},
+		},
+		{
 			Fixture: "test-fixtures/pkg-json/package-nested-author.json",
 			ExpectedPkg: pkg.Package{
 				Name:         "npm",

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -31,6 +31,23 @@ func TestParsePackageJSON(t *testing.T) {
 			},
 		},
 		{
+			Fixture: "test-fixtures/pkg-json/package-license-object.json",
+			ExpectedPkg: pkg.Package{
+				Name:         "npm",
+				Version:      "6.14.6",
+				Type:         pkg.NpmPkg,
+				Licenses:     []string{"ISC"},
+				Language:     pkg.JavaScript,
+				MetadataType: pkg.NpmPackageJSONMetadataType,
+				Metadata: pkg.NpmPackageJSONMetadata{
+					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+					Homepage: "https://docs.npmjs.com/",
+					URL:      "https://github.com/npm/cli",
+					Licenses: []string{"ISC"},
+				},
+			},
+		},
+		{
 			Fixture: "test-fixtures/pkg-json/package-nested-author.json",
 			ExpectedPkg: pkg.Package{
 				Name:         "npm",

--- a/syft/cataloger/javascript/test-fixtures/pkg-json/package-license-object.json
+++ b/syft/cataloger/javascript/test-fixtures/pkg-json/package-license-object.json
@@ -1,0 +1,22 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "bugs": {
+    "url": "https://npm.community/c/bugs"
+  },
+  "main": "./lib/npm.js",
+  "license": {
+    "type" : "ISC",
+    "url" : "https://opensource.org/licenses/ISC"
+  },
+  "engines": {
+    "node": "6 >=6.2.0 || 8 || >=9.3.0"
+  }
+}

--- a/syft/cataloger/javascript/test-fixtures/pkg-json/package-license-objects.json
+++ b/syft/cataloger/javascript/test-fixtures/pkg-json/package-license-objects.json
@@ -1,0 +1,26 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "bugs": {
+    "url": "https://npm.community/c/bugs"
+  },
+  "main": "./lib/npm.js",
+  "licenses": [
+    { "type": "MIT",
+      "url": "https://www.opensource.org/licenses/mit-license.php"
+    },
+    { "type": "Apache-2.0",
+      "url": "https://opensource.org/licenses/apache2.0.php"
+    }
+  ],
+  "engines": {
+    "node": "6 >=6.2.0 || 8 || >=9.3.0"
+  }
+}

--- a/syft/cataloger/javascript/test-fixtures/pkg-json/package-no-license.json
+++ b/syft/cataloger/javascript/test-fixtures/pkg-json/package-no-license.json
@@ -1,0 +1,18 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "bugs": {
+    "url": "https://npm.community/c/bugs"
+  },
+  "main": "./lib/npm.js",
+  "engines": {
+    "node": "6 >=6.2.0 || 8 || >=9.3.0"
+  }
+}


### PR DESCRIPTION
- Closes #253 
- Adds support for [alternative/deprecated formats for the `license` property](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#license) in `package.json` (e.g. a license object, an array of license objects)
- Adds support for the absence of a `license` property
- Adds tests to cover the above scenarios