### PR TITLE
Sort generated CPEs by specificity

### DIFF
--- a/syft/cataloger/cpe_specificity.go
+++ b/syft/cataloger/cpe_specificity.go
@@ -1,0 +1,31 @@
+package cataloger
+
+import "github.com/facebookincubator/nvdtools/wfn"
+
+type ByCPESpecificity []wfn.Attributes
+
+// Implementing sort.Interface
+func (c ByCPESpecificity) Len() int      { return len(c) }
+func (c ByCPESpecificity) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c ByCPESpecificity) Less(i, j int) bool {
+	return countSpecifiedFields(c[i]) > countSpecifiedFields(c[j])
+}
+
+func countSpecifiedFields(cpe wfn.Attributes) int {
+	checksForSpecifiedField := []func(cpe wfn.Attributes) bool{
+		func(cpe wfn.Attributes) bool { return cpe.Part != "" },
+		func(cpe wfn.Attributes) bool { return cpe.Product != "" },
+		func(cpe wfn.Attributes) bool { return cpe.Vendor != "" },
+		func(cpe wfn.Attributes) bool { return cpe.Version != "" },
+		func(cpe wfn.Attributes) bool { return cpe.TargetSW != "" },
+	}
+
+	count := 0
+	for _, fieldIsSpecified := range checksForSpecifiedField {
+		if fieldIsSpecified(cpe) {
+			count++
+		}
+	}
+
+	return count
+}


### PR DESCRIPTION
- Sorts generated CPEs by specificity (measured by number of CPE fields that **aren't** set to `*`)
- Makes progress toward the implementation mentioned in @wagoodman's [comment](https://github.com/anchore/syft/issues/268#issuecomment-741829842) on #268 