### PR TITLE
catalogers: Python runtime is not a Python package itself, ignore it

### DIFF
--- a/syft/cataloger/python/package_cataloger.go
+++ b/syft/cataloger/python/package_cataloger.go
@@ -91,6 +91,12 @@ func (c *PackageCataloger) catalogEggOrWheel(entry *packageEntry) (*pkg.Package,
 		return nil, err
 	}
 
+	// This can happen for Python 2.7 where it is reported from an egg-info, but Python is
+	// the actual runtime, it isn't a "package". The special-casing here allows to skip it
+	if metadata.Name == "Python" {
+		return nil, nil
+	}
+
 	var licenses []string
 	if metadata.License != "" {
 		licenses = []string{metadata.License}

--- a/syft/cataloger/python/package_cataloger_test.go
+++ b/syft/cataloger/python/package_cataloger_test.go
@@ -284,3 +284,30 @@ func TestPythonPackageWheelCataloger(t *testing.T) {
 	}
 
 }
+
+func TestIgnorePackage(t *testing.T) {
+	tests := []struct {
+		MetadataFixture string
+	}{
+
+		{
+			MetadataFixture: "test-fixtures/Python-2.7.egg-info",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.MetadataFixture, func(t *testing.T) {
+			resolver := newTestResolver(test.MetadataFixture, "", "")
+
+			actual, err := NewPythonPackageCataloger().Catalog(resolver)
+			if err != nil {
+				t.Fatalf("failed to catalog python package: %+v", err)
+			}
+
+			if len(actual) != 0 {
+				t.Fatalf("Expected 0 packages but found: %d", len(actual))
+			}
+		})
+	}
+
+}

--- a/syft/cataloger/python/test-fixtures/Python-2.7.egg-info
+++ b/syft/cataloger/python/test-fixtures/Python-2.7.egg-info
@@ -1,0 +1,31 @@
+Metadata-Version: 1.1
+Name: Python
+Version: 2.7.13
+Summary: A high-level object-oriented programming language
+Home-page: http://www.python.org/2.7
+Author: Guido van Rossum and the Python community
+Author-email: python-dev@python.org
+License: PSF license
+Description: Python is an interpreted, interactive, object-oriented programming
+        language. It is often compared to Tcl, Perl, Scheme or Java.
+
+        Python combines remarkable power with very clear syntax. It has
+        modules, classes, exceptions, very high level dynamic data types, and
+        dynamic typing. There are interfaces to many system calls and
+        libraries, as well as to various windowing systems (X11, Motif, Tk,
+        Mac, MFC). New built-in modules are easily written in C or C++. Python
+        is also usable as an extension language for applications that need a
+        programmable interface.
+
+        The Python implementation is portable: it runs on many brands of UNIX,
+        on Windows, DOS, OS/2, Mac, Amiga... If your favorite system isn't
+        listed here, it may still be supported, if there's a C compiler for
+        it. Ask around on comp.lang.python -- or just try compiling Python
+        yourself.
+Platform: Many
+Classifier: Development Status :: 6 - Mature
+Classifier: License :: OSI Approved :: Python Software Foundation License
+Classifier: Natural Language :: English
+Classifier: Programming Language :: C
+Classifier: Programming Language :: Python
+Classifier: Topic :: Software Development


### PR DESCRIPTION
Ignores if the Python runtime is found as a package. Adds one test to verify this is the case as well as a fixture

Closes #300 