### PR TITLE
Handle site packages based on which egg file is parsed

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,7 +31,6 @@ linters:
     - misspell
     - nakedret
     - nolintlint
-    - prealloc
     - rowserrcheck
     - scopelint
     - staticcheck
@@ -55,5 +54,6 @@ linters:
 #    - lll         # without a way to specify per-line exception cases, this is not usable
 #    - maligned    # this is an excellent linter, but tricky to optimize and we are not sensitive to memory layout optimizations
 #    - nestif
+#    - prealloc    # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
 #    - testpackage
 #    - wsl

--- a/syft/cataloger/python/parse_wheel_egg_metadata.go
+++ b/syft/cataloger/python/parse_wheel_egg_metadata.go
@@ -3,10 +3,11 @@ package python
 import (
 	"bufio"
 	"fmt"
-	"github.com/anchore/syft/internal/file"
 	"io"
 	"path/filepath"
 	"strings"
+
+	"github.com/anchore/syft/internal/file"
 
 	"github.com/mitchellh/mapstructure"
 

--- a/syft/cataloger/python/parse_wheel_egg_metadata.go
+++ b/syft/cataloger/python/parse_wheel_egg_metadata.go
@@ -3,6 +3,7 @@ package python
 import (
 	"bufio"
 	"fmt"
+	"github.com/anchore/syft/internal/file"
 	"io"
 	"path/filepath"
 	"strings"
@@ -70,9 +71,26 @@ func parseWheelOrEggMetadata(path string, reader io.Reader) (pkg.PythonPackageMe
 
 	// add additional metadata not stored in the egg/wheel metadata file
 
-	metadata.SitePackagesRootPath = filepath.Clean(filepath.Join(filepath.Dir(path), ".."))
+	metadata.SitePackagesRootPath = determineSitePackagesRootPath(path)
 
 	return metadata, nil
+}
+
+// isEggRegularFile determines if the specified path is the regular file variant
+// of egg metadata (as opposed to a directory that contains more metadata
+// files).
+func isEggRegularFile(path string) bool {
+	return file.GlobMatch(eggFileMetadataGlob, path)
+}
+
+// determineSitePackagesRootPath returns the path of the site packages root,
+// given the egg metadata file or directory specified in the path.
+func determineSitePackagesRootPath(path string) string {
+	if isEggRegularFile(path) {
+		return filepath.Clean(filepath.Dir(path))
+	}
+
+	return filepath.Clean(filepath.Dir(filepath.Dir(path)))
 }
 
 // handleFieldBodyContinuation returns the updated value for the specified field after processing the specified line.

--- a/syft/cataloger/python/parse_wheel_egg_metadata_test.go
+++ b/syft/cataloger/python/parse_wheel_egg_metadata_test.go
@@ -56,5 +56,64 @@ func TestParseWheelEggMetadata(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestIsRegularEggFile(t *testing.T) {
+	cases := []struct {
+		path     string
+		expected bool
+	}{
+		{
+			"/usr/lib64/python2.6/site-packages/M2Crypto-0.20.2-py2.6.egg-info",
+			true,
+		},
+		{
+			"/usr/lib64/python2.6/site-packages/M2Crypto-0.20.2-py2.6.egg-info/PKG-INFO",
+			false,
+		},
+		{
+			"/usr/lib64/python2.6/site-packages/M2Crypto-0.20.2-py2.6.dist-info/METADATA",
+			false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			actual := isEggRegularFile(c.path)
+
+			if actual != c.expected {
+				t.Errorf("expected %t but got %t", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestDetermineSitePackagesRootPath(t *testing.T) {
+	cases := []struct {
+		inputPath string
+		expected  string
+	}{
+		{
+			inputPath: "/usr/lib64/python2.6/site-packages/ethtool-0.6-py2.6.egg-info",
+			expected:  "/usr/lib64/python2.6/site-packages",
+		},
+		{
+			inputPath: "/usr/lib/python2.7/dist-packages/configobj-5.0.6.egg-info/top_level.txt",
+			expected:  "/usr/lib/python2.7/dist-packages",
+		},
+		{
+			inputPath: "/usr/lib/python2.7/dist-packages/six-1.10.0.egg-info/PKG-INFO",
+			expected:  "/usr/lib/python2.7/dist-packages",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.inputPath, func(t *testing.T) {
+			actual := determineSitePackagesRootPath(c.inputPath)
+
+			if actual != c.expected {
+				t.Errorf("expected %s but got %s", c.expected, actual)
+			}
+		})
+	}
 }

--- a/syft/source/mock_resolver.go
+++ b/syft/source/mock_resolver.go
@@ -1,0 +1,115 @@
+package source
+
+import (
+	"fmt"
+	"github.com/anchore/syft/internal/file"
+	"io/ioutil"
+	"os"
+)
+
+var _ Resolver = (*MockResolver)(nil)
+
+// MockResolver implements the Resolver interface and is intended for use *only in test code*.
+// It provides an implementation that can resolve local filesystem paths using only a provided discrete list of file
+// paths, which are typically paths to test fixtures.
+type MockResolver struct {
+	Locations []Location
+}
+
+// NewMockResolverForPaths creates a new MockResolver, where the only resolvable
+// files are those specified by the supplied paths.
+func NewMockResolverForPaths(paths ...string) *MockResolver {
+	var locations []Location
+	for _, p := range paths {
+		locations = append(locations, NewLocation(p))
+	}
+
+	return &MockResolver{Locations: locations}
+}
+
+// String returns the string representation of the MockResolver.
+func (r MockResolver) String() string {
+	return fmt.Sprintf("mock:(%s,...)", r.Locations[0].Path)
+}
+
+// FileContentsByLocation fetches file contents for a single location. If the
+// path does not exist, an error is returned.
+func (r MockResolver) FileContentsByLocation(location Location) (string, error) {
+	for _, l := range r.Locations {
+		if l == location {
+			return stringContent(location.Path)
+		}
+	}
+
+	return "", fmt.Errorf("no file for location: %v", location)
+}
+
+// MultipleFileContentsByLocation returns the file contents for all specified Locations.
+func (r MockResolver) MultipleFileContentsByLocation(locations []Location) (map[Location]string, error) {
+	results := make(map[Location]string)
+	for _, l := range locations {
+		contents, err := r.FileContentsByLocation(l)
+		if err != nil {
+			return nil, err
+		}
+		results[l] = contents
+	}
+
+	return results, nil
+}
+
+// FilesByPath returns all Locations that match the given paths.
+func (r MockResolver) FilesByPath(paths ...string) ([]Location, error) {
+	var results []Location
+	for _, p := range paths {
+		for _, location := range r.Locations {
+			if p == location.Path {
+				results = append(results, NewLocation(p))
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// FilesByGlob returns all Locations that match the given path glob pattern.
+func (r MockResolver) FilesByGlob(patterns ...string) ([]Location, error) {
+	var results []Location
+	for _, pattern := range patterns {
+		for _, location := range r.Locations {
+			if file.GlobMatch(pattern, location.Path) {
+				results = append(results, location)
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// RelativeFileByPath returns a single Location for the given path.
+func (r MockResolver) RelativeFileByPath(_ Location, path string) *Location {
+	paths, err := r.FilesByPath(path)
+	if err != nil {
+		return nil
+	}
+
+	if len(paths) < 1 {
+		return nil
+	}
+
+	return &paths[0]
+}
+
+func stringContent(path string) (string, error) {
+	reader, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/syft/source/mock_resolver.go
+++ b/syft/source/mock_resolver.go
@@ -2,9 +2,10 @@ package source
 
 import (
 	"fmt"
-	"github.com/anchore/syft/internal/file"
 	"io/ioutil"
 	"os"
+
+	"github.com/anchore/syft/internal/file"
 )
 
 var _ Resolver = (*MockResolver)(nil)


### PR DESCRIPTION
- Accounts for the possibility of the parsed file's parent directory being `site-packages` itself (a possibility that was introduced in https://github.com/anchore/syft/pull/296) as opposed to an `...egg-info` directory
- Adds a new resolver: `MockResolver` — this can be used when you need a `source.Resolver` but you want to explicitly only use a set of test fixture files