### PR TITLE
Update gemspec glob to include named nested specification directories

### DIFF
--- a/syft/cataloger/ruby/catalogers.go
+++ b/syft/cataloger/ruby/catalogers.go
@@ -19,7 +19,7 @@ func NewGemFileLockCataloger() *common.GenericCataloger {
 // NewGemSpecCataloger returns a new Bundler cataloger object tailored for detecting installations of gems (e.g. Gemspec).
 func NewGemSpecCataloger() *common.GenericCataloger {
 	globParsers := map[string]common.ParserFn{
-		"**/specifications/*.gemspec": parseGemSpecEntries,
+		"**/specifications/**/*.gemspec": parseGemSpecEntries,
 	}
 
 	return common.NewGenericCataloger(nil, globParsers, "ruby-gemspec-cataloger")

--- a/test/integration/pkg_cases_test.go
+++ b/test/integration/pkg_cases_test.go
@@ -15,7 +15,10 @@ var imageOnlyTestCases = []testCase{
 		pkgType:     pkg.GemPkg,
 		pkgLanguage: pkg.Ruby,
 		pkgInfo: map[string]string{
+			// specifications in the root specification directory
 			"bundler": "2.1.4",
+			// specifications in named directories
+			"unbundler": "3.1.4",
 		},
 	},
 	{

--- a/test/integration/test-fixtures/image-pkg-coverage/ruby/specifications/default/unbundler.gemspec
+++ b/test/integration/test-fixtures/image-pkg-coverage/ruby/specifications/default/unbundler.gemspec
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# -*- encoding: utf-8 -*-                                                                                                                                         
+# stub: unbundler 2.1.4 ruby lib                                                                                                                                    
+                                                                                                                                                                  
+Gem::Specification.new do |s|                                                                                                                                     
+    s.name = "unbundler".freeze
+    s.version = "3.1.4"
+                                                                                                                                                                    
+    s.required_rubygems_version = Gem::Requirement.new(">= 2.5.2".freeze) if s.respond_to? :required_rubygems_version=                                              
+    s.require_paths = ["lib".freeze]                                                                                                                                
+    s.authors = ["Andr\u00E9 Arko".freeze, "Samuel Giddins".freeze, "Colby Swandale".freeze, "Hiroshi Shibata".freeze, "David Rodr\u00EDguez".freeze, "Grey Baker".f
+    s.bindir = "exe".freeze                                                                                                                                         
+    s.date = "2020-01-05"                                                                                                                                           
+    s.description = "Bundler manages an application's dependencies through its entire life, across many machines, systematically and repeatably".freeze             
+    s.email = ["team@unbundler.io".freeze]                                                                                                                            
+    s.executables = ["unbundle".freeze, "unbundler".freeze]                                                                                                             
+    s.files = ["exe/unbundle".freeze, "exe/unbundler".freeze]                                                                                                           
+    s.homepage = "https://unbundler.io".freeze                                                                                                                        
+    s.licenses = ["MIT".freeze]                                                                                                                                     
+    s.required_ruby_version = Gem::Requirement.new(">= 2.3.0".freeze)                                                                                               
+    s.rubygems_version = "3.1.2".freeze                                                                                                                             
+    s.summary = "The best way to manage your application's dependencies".freeze                                                                                     
+                                                                                                                                                                    
+    s.installed_by_version = "3.1.2" if s.respond_to? :installed_by_version                                                                                         
+  end 


### PR DESCRIPTION
The previous glob implementation had slightly different glob pattern rules. This PR updates the gemspec glob pattern to account for nested named directories within the `specification` installation directory.