### PR TITLE
Duplicate reference readers for duplicate location resolutions

### DIFF
--- a/syft/presenter/cyclonedx/presenter_test.go
+++ b/syft/presenter/cyclonedx/presenter_test.go
@@ -104,7 +104,7 @@ func TestCycloneDxImgsPresenter(t *testing.T) {
 		Name:    "package1",
 		Version: "1.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref1, img),
+			source.NewLocationFromImage(string(ref1.RealPath), *ref1, img),
 		},
 		Type:    pkg.RpmPkg,
 		FoundBy: "the-cataloger-1",
@@ -114,7 +114,7 @@ func TestCycloneDxImgsPresenter(t *testing.T) {
 		Name:    "package2",
 		Version: "2.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref2, img),
+			source.NewLocationFromImage(string(ref2.RealPath), *ref2, img),
 		},
 		Type:    pkg.RpmPkg,
 		FoundBy: "the-cataloger-2",

--- a/syft/presenter/json/presenter_test.go
+++ b/syft/presenter/json/presenter_test.go
@@ -116,7 +116,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 		Name:    "package-1",
 		Version: "1.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref1, img),
+			source.NewLocationFromImage(string(ref1.RealPath), *ref1, img),
 		},
 		Type:         pkg.PythonPkg,
 		FoundBy:      "the-cataloger-1",
@@ -136,7 +136,7 @@ func TestJsonImgsPresenter(t *testing.T) {
 		Name:    "package-2",
 		Version: "2.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref2, img),
+			source.NewLocationFromImage(string(ref2.RealPath), *ref2, img),
 		},
 		Type:         pkg.DebPkg,
 		FoundBy:      "the-cataloger-2",

--- a/syft/presenter/table/presenter_test.go
+++ b/syft/presenter/table/presenter_test.go
@@ -35,7 +35,7 @@ func TestTablePresenter(t *testing.T) {
 		Name:    "package-1",
 		Version: "1.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref1, img),
+			source.NewLocationFromImage(string(ref1.RealPath), *ref1, img),
 		},
 		Type: pkg.DebPkg,
 	})
@@ -43,7 +43,7 @@ func TestTablePresenter(t *testing.T) {
 		Name:    "package-2",
 		Version: "2.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref2, img),
+			source.NewLocationFromImage(string(ref2.RealPath), *ref2, img),
 		},
 		Type: pkg.DebPkg,
 	})

--- a/syft/presenter/text/presenter_test.go
+++ b/syft/presenter/text/presenter_test.go
@@ -80,7 +80,7 @@ func TestTextImgPresenter(t *testing.T) {
 		Name:    "package-1",
 		Version: "1.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref1, img),
+			source.NewLocationFromImage(string(ref1.RealPath), *ref1, img),
 		},
 		FoundBy: "dpkg",
 		Type:    pkg.DebPkg,
@@ -89,7 +89,7 @@ func TestTextImgPresenter(t *testing.T) {
 		Name:    "package-2",
 		Version: "2.0.1",
 		Locations: []source.Location{
-			source.NewLocationFromImage(*ref2, img),
+			source.NewLocationFromImage(string(ref2.RealPath), *ref2, img),
 		},
 		FoundBy:  "dpkg",
 		Metadata: PackageInfo{Name: "package-2", Version: "1.0.2"},

--- a/syft/source/all_layers_resolver_test.go
+++ b/syft/source/all_layers_resolver_test.go
@@ -113,8 +113,8 @@ func TestAllLayersResolver_FilesByPath(t *testing.T) {
 			for idx, actual := range refs {
 				expected := c.resolutions[idx]
 
-				if actual.Path != expected.path {
-					t.Errorf("bad resolve path: '%s'!='%s'", actual.Path, expected.path)
+				if string(actual.ref.RealPath) != expected.path {
+					t.Errorf("bad resolve path: '%s'!='%s'", string(actual.ref.RealPath), expected.path)
 				}
 
 				entry, err := img.FileCatalog.Get(actual.ref)
@@ -217,8 +217,8 @@ func TestAllLayersResolver_FilesByGlob(t *testing.T) {
 			for idx, actual := range refs {
 				expected := c.resolutions[idx]
 
-				if actual.Path != expected.path {
-					t.Errorf("bad resolve path: '%s'!='%s'", actual.Path, expected.path)
+				if string(actual.ref.RealPath) != expected.path {
+					t.Errorf("bad resolve path: '%s'!='%s'", string(actual.ref.RealPath), expected.path)
 				}
 
 				entry, err := img.FileCatalog.Get(actual.ref)

--- a/syft/source/image_squash_resolver.go
+++ b/syft/source/image_squash_resolver.go
@@ -66,7 +66,7 @@ func (r *ImageSquashResolver) FilesByPath(paths ...string) ([]Location, error) {
 
 		if resolvedRef != nil && !uniqueFileIDs.Contains(*resolvedRef) {
 			uniqueFileIDs.Add(*resolvedRef)
-			uniqueLocations = append(uniqueLocations, NewLocationFromImage(*resolvedRef, r.img))
+			uniqueLocations = append(uniqueLocations, NewLocationFromImage(path, *resolvedRef, r.img))
 		}
 	}
 

--- a/syft/source/image_squash_resolver_test.go
+++ b/syft/source/image_squash_resolver_test.go
@@ -102,8 +102,8 @@ func TestImageSquashResolver_FilesByPath(t *testing.T) {
 
 			actual := refs[0]
 
-			if actual.Path != c.resolvePath {
-				t.Errorf("bad resolve path: '%s'!='%s'", actual.Path, c.resolvePath)
+			if string(actual.ref.RealPath) != c.resolvePath {
+				t.Errorf("bad resolve path: '%s'!='%s'", string(actual.ref.RealPath), c.resolvePath)
 			}
 
 			entry, err := img.FileCatalog.Get(actual.ref)
@@ -204,8 +204,8 @@ func TestImageSquashResolver_FilesByGlob(t *testing.T) {
 
 			actual := refs[0]
 
-			if actual.Path != c.resolvePath {
-				t.Errorf("bad resolve path: '%s'!='%s'", actual.Path, c.resolvePath)
+			if string(actual.ref.RealPath) != c.resolvePath {
+				t.Errorf("bad resolve path: '%s'!='%s'", string(actual.ref.RealPath), c.resolvePath)
 			}
 
 			entry, err := img.FileCatalog.Get(actual.ref)

--- a/syft/source/location.go
+++ b/syft/source/location.go
@@ -22,18 +22,18 @@ func NewLocation(path string) Location {
 }
 
 // NewLocationFromImage creates a new Location representing the given path (extracted from the ref) relative to the given image.
-func NewLocationFromImage(ref file.Reference, img *image.Image) Location {
+func NewLocationFromImage(path string, ref file.Reference, img *image.Image) Location {
 	entry, err := img.FileCatalog.Get(ref)
 	if err != nil {
 		log.Warnf("unable to find file catalog entry for ref=%+v", ref)
 		return Location{
-			Path: string(ref.RealPath),
+			Path: path,
 			ref:  ref,
 		}
 	}
 
 	return Location{
-		Path:         string(ref.RealPath),
+		Path:         path,
 		FileSystemID: entry.Layer.Metadata.Digest,
 		ref:          ref,
 	}


### PR DESCRIPTION
With the new content API + link resolution changes it is possible for a bulk request to have multiple locations share the same file.Reference. This means that stereoscope will return a single reader for multiple callers. This PR duplicates the reader as necessary so Resolver callers get individual readers for paths that match the request (not necessarily the real path from the file.Reference).