### PR TITLE
Omit empty packages

### DIFF
--- a/syft/cataloger/javascript/parse_package_json.go
+++ b/syft/cataloger/javascript/parse_package_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/anchore/syft/internal/log"
 	"io"
 	"regexp"
 
@@ -172,6 +173,12 @@ func parsePackageJSON(_ string, reader io.Reader) ([]pkg.Package, error) {
 			return nil, fmt.Errorf("failed to parse package.json file: %w", err)
 		}
 
+		if !p.hasMinimumRequiredValues() {
+			log.Debug("encountered package.json file without the minimum number of field values required for" +
+				" consideration as a package")
+			return nil, nil
+		}
+
 		licenses, err := licensesFromJSON(p)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse package.json file: %w", err)
@@ -194,4 +201,8 @@ func parsePackageJSON(_ string, reader io.Reader) ([]pkg.Package, error) {
 	}
 
 	return packages, nil
+}
+
+func (p PackageJSON) hasMinimumRequiredValues() bool {
+	return p.Name != "" && p.Version != ""
 }

--- a/syft/cataloger/javascript/parse_package_json.go
+++ b/syft/cataloger/javascript/parse_package_json.go
@@ -174,9 +174,8 @@ func parsePackageJSON(_ string, reader io.Reader) ([]pkg.Package, error) {
 			return nil, fmt.Errorf("failed to parse package.json file: %w", err)
 		}
 
-		if !p.hasMinimumRequiredValues() {
-			log.Debug("encountered package.json file without the minimum number of field values required for" +
-				" consideration as a package")
+		if !p.hasNameAndVersionValues() {
+			log.Debug("encountered package.json file without a name and/or version field, ignoring this file")
 			return nil, nil
 		}
 
@@ -204,6 +203,6 @@ func parsePackageJSON(_ string, reader io.Reader) ([]pkg.Package, error) {
 	return packages, nil
 }
 
-func (p PackageJSON) hasMinimumRequiredValues() bool {
+func (p PackageJSON) hasNameAndVersionValues() bool {
 	return p.Name != "" && p.Version != ""
 }

--- a/syft/cataloger/javascript/parse_package_json.go
+++ b/syft/cataloger/javascript/parse_package_json.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/anchore/syft/internal/log"
 	"io"
 	"regexp"
+
+	"github.com/anchore/syft/internal/log"
 
 	"github.com/anchore/syft/internal"
 

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -155,7 +155,7 @@ func TestParsePackageJSON_Partial(t *testing.T) { // see https://github.com/anch
 		t.Fatalf("failed to parse package-lock.json: %+v", err)
 	}
 
-	if len(actual) != 0 {
-		t.Errorf("no packages should've been returned")
+	if actualCount := len(actual); actualCount != 0 {
+		t.Errorf("no packages should've been returned (but got %d packages)", actualCount)
 	}
 }

--- a/syft/cataloger/javascript/parse_package_json_test.go
+++ b/syft/cataloger/javascript/parse_package_json_test.go
@@ -142,3 +142,20 @@ func TestParsePackageJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePackageJSON_Partial(t *testing.T) { // see https://github.com/anchore/syft/issues/311
+	const fixtureFile = "test-fixtures/pkg-json/package-partial.json"
+	fixture, err := os.Open(fixtureFile)
+	if err != nil {
+		t.Fatalf("failed to open fixture: %+v", err)
+	}
+
+	actual, err := parsePackageJSON("", fixture)
+	if err != nil {
+		t.Fatalf("failed to parse package-lock.json: %+v", err)
+	}
+
+	if len(actual) != 0 {
+		t.Errorf("no packages should've been returned")
+	}
+}

--- a/syft/cataloger/javascript/test-fixtures/pkg-json/package-partial.json
+++ b/syft/cataloger/javascript/test-fixtures/pkg-json/package-partial.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": false,
+  "module": "../../esm/fp/isSaturday/index.js",
+  "typings": "../../typings.d.ts"
+}

--- a/test/integration/regression_test.go
+++ b/test/integration/regression_test.go
@@ -24,7 +24,7 @@ func TestRegression212ApkBufferSize(t *testing.T) {
 		t.Fatalf("failed to catalog image: %+v", err)
 	}
 
-	expectedPkgs := 57
+	expectedPkgs := 58
 	actualPkgs := 0
 	for range catalog.Enumerate(pkg.ApkPkg) {
 		actualPkgs += 1

--- a/test/integration/test-fixtures/image-large-apk-data/Dockerfile
+++ b/test/integration/test-fixtures/image-large-apk-data/Dockerfile
@@ -1,2 +1,5 @@
-FROM alpine:latest
-RUN apk add tzdata vim alpine-sdk
+FROM alpine@sha256:d9a7354e3845ea8466bb00b22224d9116b183e594527fb5b6c3d30bc01a20378
+RUN apk add --no-cache \
+            tzdata=2020f-r0 \
+            vim=8.2.2320-r0 \
+            alpine-sdk=1.0-r0


### PR DESCRIPTION
Closes #311 

This PR changes the parsing of `package.json` such that files that don't include the minimally required fields (currently `name` and `version`) will not be surfaced as packages. A `DEBUG` level message is logged in this case.