### PR TITLE
Ensure java parent pkg ref isn't nil when looking for parent matches

### DIFF
--- a/test/integration/java_no_main_package_test.go
+++ b/test/integration/java_no_main_package_test.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/source"
+	"testing"
+)
+
+func TestJavaNoMainPackage(t *testing.T) { // Regression: https://github.com/anchore/syft/issues/252
+	fixtureImageName := "image-java-no-main-package"
+	_, cleanup := imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
+	tarPath := imagetest.GetFixtureImageTarPath(t, fixtureImageName)
+	defer cleanup()
+
+	_, _, _, err := syft.Catalog("docker-archive:"+tarPath, source.SquashedScope)
+	if err != nil {
+		t.Fatalf("failed to catalog image: %+v", err)
+	}
+}

--- a/test/integration/test-fixtures/image-java-no-main-package/Dockerfile
+++ b/test/integration/test-fixtures/image-java-no-main-package/Dockerfile
@@ -1,0 +1,23 @@
+FROM jenkins:2.60.3
+
+USER root
+
+WORKDIR /usr/share/jenkins
+
+RUN mkdir tmp
+
+WORKDIR /usr/share/jenkins/tmp
+
+RUN apt-get update 2>&1 > /dev/null && apt-get install -y less zip 2>&1 > /dev/null
+
+RUN unzip ../jenkins.war 2>&1 > /dev/null
+
+RUN rm -f ./META-INF/MANIFEST.MF
+
+WORKDIR /usr/share/jenkins
+
+RUN rm -rf jenkins.war
+
+RUN cd ./tmp && zip -r ../jenkins.war . && cd ..
+
+RUN rm -rf ./tmp

--- a/test/integration/test-fixtures/image-large-apk-data/Dockerfile
+++ b/test/integration/test-fixtures/image-large-apk-data/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine@sha256:d9a7354e3845ea8466bb00b22224d9116b183e594527fb5b6c3d30bc01a20378
 RUN apk add --no-cache \
-            tzdata=2020f-r0 \
+            tzdata=2021a-r0 \
             vim=8.2.2320-r0 \
             alpine-sdk=1.0-r0


### PR DESCRIPTION
Fixes #252 (and duplicate issue #291)

(this fix was provided by @wagoodman)

Signed-off-by: Alex Goodman <alex.goodman@anchore.com>