### PR TITLE
Allow path prefixes

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -159,12 +159,12 @@ func doImport(src source.Source, s source.Metadata, catalog *pkg.Catalog, d *dis
 	}
 
 	c, err := anchore.NewClient(anchore.Configuration{
-		BasePath: appConfig.Anchore.Host,
+		BaseURL:  appConfig.Anchore.Host,
 		Username: appConfig.Anchore.Username,
 		Password: appConfig.Anchore.Password,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create anchore client: %+v", err)
+		return fmt.Errorf("unable to upload results: %w", err)
 	}
 
 	importCfg := anchore.ImportConfig{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,19 +158,10 @@ func doImport(src source.Source, s source.Metadata, catalog *pkg.Catalog, d *dis
 		}
 	}
 
-	var scheme string
-	var hostname = appConfig.Anchore.Host
-	urlFields := strings.Split(hostname, "://")
-	if len(urlFields) > 1 {
-		scheme = urlFields[0]
-		hostname = urlFields[1]
-	}
-
 	c, err := anchore.NewClient(anchore.Configuration{
-		Hostname: hostname,
+		BasePath: appConfig.Anchore.Host,
 		Username: appConfig.Anchore.Username,
 		Password: appConfig.Anchore.Password,
-		Scheme:   scheme,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create anchore client: %+v", err)

--- a/internal/anchore/client.go
+++ b/internal/anchore/client.go
@@ -31,6 +31,9 @@ func NewClient(cfg Configuration) (*Client, error) {
 
 	basePath := ensureURLHasScheme(cfg.BasePath) // we can rely on the built-in URL parsing for the scheme, host,
 	// port, and path prefix, as long as a scheme is present
+	basePath = strings.TrimSuffix(basePath, "/")
+	basePath = ensureURLHasSuffix(basePath,
+		"/v1") // We need some mechanism to ensure Syft doesn't try to communicate with the wrong API version.
 
 	return &Client{
 		config: cfg,
@@ -66,6 +69,14 @@ func ensureURLHasScheme(url string) string {
 
 	if !hasScheme(url) {
 		return fmt.Sprintf("%s://%s", defaultScheme, url)
+	}
+
+	return url
+}
+
+func ensureURLHasSuffix(url, suffix string) string {
+	if !strings.HasSuffix(url, suffix) {
+		return url + suffix
 	}
 
 	return url

--- a/internal/anchore/client_test.go
+++ b/internal/anchore/client_test.go
@@ -1,0 +1,71 @@
+package anchore
+
+import "testing"
+
+func TestHasScheme(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected bool
+	}{
+		{
+			url:      "http://localhost",
+			expected: true,
+		},
+		{
+			url:      "https://anchore.com:8443",
+			expected: true,
+		},
+		{
+			url:      "google.com",
+			expected: false,
+		},
+		{
+			url:      "",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.url, func(t *testing.T) {
+			result := hasScheme(testCase.url)
+
+			if testCase.expected != result {
+				t.Errorf("expected %t but got %t", testCase.expected, result)
+			}
+		})
+	}
+}
+
+func TestEnsureURLHasScheme(t *testing.T) {
+	cases := []struct {
+		url      string
+		expected string
+	}{
+		{
+			url:      "http://localhost",
+			expected: "http://localhost",
+		},
+		{
+			url:      "https://anchore.com:8443",
+			expected: "https://anchore.com:8443",
+		},
+		{
+			url:      "google.com:1234/v1/",
+			expected: "http://google.com:1234/v1/",
+		},
+		{
+			url:      "localhost",
+			expected: "http://localhost",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.url, func(t *testing.T) {
+			result := ensureURLHasScheme(testCase.url)
+
+			if testCase.expected != result {
+				t.Errorf("expected '%s' but got '%s'", testCase.expected, result)
+			}
+		})
+	}
+}

--- a/internal/anchore/client_test.go
+++ b/internal/anchore/client_test.go
@@ -69,3 +69,41 @@ func TestEnsureURLHasScheme(t *testing.T) {
 		})
 	}
 }
+func TestEnsureURLHasSuffix(t *testing.T) {
+	cases := []struct {
+		url      string
+		suffix   string
+		expected string
+	}{
+		{
+			url:      "http://localhost",
+			suffix:   "/v1",
+			expected: "http://localhost/v1",
+		},
+		{
+			url:      "http://localhost/v1",
+			suffix:   "/v1",
+			expected: "http://localhost/v1",
+		},
+		{
+			url:      "http://localhost/v1/",
+			suffix:   "/v1",
+			expected: "http://localhost/v1//v1",
+		},
+		{
+			url:      "http://localhost-v1",
+			suffix:   "/v1",
+			expected: "http://localhost-v1/v1",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.url, func(t *testing.T) {
+			result := ensureURLHasSuffix(testCase.url, testCase.suffix)
+
+			if testCase.expected != result {
+				t.Errorf("expected '%s' but got '%s'", testCase.expected, result)
+			}
+		})
+	}
+}

--- a/internal/anchore/import.go
+++ b/internal/anchore/import.go
@@ -51,7 +51,7 @@ func importProgress(source string) (*progress.Stage, *progress.Manual) {
 
 // nolint:funlen
 func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
-	stage, prog := importProgress(c.config.Hostname)
+	stage, prog := importProgress(c.config.BasePath)
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()

--- a/internal/anchore/import.go
+++ b/internal/anchore/import.go
@@ -51,7 +51,7 @@ func importProgress(source string) (*progress.Stage, *progress.Manual) {
 
 // nolint:funlen
 func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
-	stage, prog := importProgress(c.config.BasePath)
+	stage, prog := importProgress(c.config.BaseURL)
 
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()


### PR DESCRIPTION
Closes #315 

This PR:

- broadens what users can specify using the `--host` / `-H` configuration value (adds support for path prefixes, e.g. `-H localhost:8000/v1`)
- ensures that, for now, our base paths for API requests end with `/v1`