### PR TITLE
make: add a bootstrap cache buster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ COVERAGE_THRESHOLD := 68
 # CI cache busting values; change these if you want CI to not use previous stored cache
 COMPARE_CACHE_BUSTER="f7e689d76a9"
 INTEGRATION_CACHE_BUSTER="789bacdf"
+BOOTSTRAP_CACHE="789bacdf"
 
 ## Build variables
 DISTDIR=./dist


### PR DESCRIPTION
Adding this entry to the `Makefile` will allow:

1. Busting the _current_ cache, which may solve build issues:

```
Error: /usr/local/bin/gtar: ../../../go/pkg/mod/dmitri.shuralyov.com/gpu/mtl@v0.0.0-20190408044501-666a987793e9/example/hellotriangle/main.go: Cannot open: No such file or directory
```

2. Allow for future cache busting, since the key for the cache is partially computed by changes to the `Makefile` itself