### PR TITLE
Pin actions/cache to v2.1.3

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -1,4 +1,4 @@
-name: 'Acceptance'
+name: "Acceptance"
 on:
   workflow_dispatch:
   push:
@@ -16,7 +16,6 @@ jobs:
   Build-Snapshot-Artifacts:
     runs-on: macos-latest # We're creating these snapshot builds on macOS to be consistent with our release workflow's build process, which also takes place on macOS (due to code signing requirements).
     steps:
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -25,7 +24,7 @@ jobs:
 
       - name: Restore bootstrap cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: |
             ~/go/pkg/mod
@@ -75,11 +74,10 @@ jobs:
 
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Linux:
-    needs: [ Build-Snapshot-Artifacts ]
+    needs: [Build-Snapshot-Artifacts]
     # come Nov 30 2020 ubuntu-latest will be ubuntu-20.04, until then it needs to be explicitly referenced due to python 3.7 specific features being used
     runs-on: ubuntu-20.04
     steps:
-
       - uses: actions/checkout@v2
 
       - uses: actions/download-artifact@v2
@@ -101,10 +99,9 @@ jobs:
 
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Mac:
-    needs: [ Build-Snapshot-Artifacts ]
+    needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
     steps:
-
       - uses: actions/checkout@v2
 
       - uses: actions/download-artifact@v2
@@ -126,11 +123,10 @@ jobs:
 
   # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Inline-Compare:
-    needs: [ Build-Snapshot-Artifacts ]
+    needs: [Build-Snapshot-Artifacts]
     # come Nov 30 2020 ubuntu-latest will be ubuntu-20.04, until then it needs to be explicitly referenced due to python 3.7 specific features being used
     runs-on: ubuntu-20.04
     steps:
-
       - uses: actions/checkout@v2
 
       - name: Fingerprint inline-compare sources
@@ -138,7 +134,7 @@ jobs:
 
       - name: Restore inline reports cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: ${{ github.workspace }}/test/inline-compare/inline-reports
           key: inline-reports-${{ hashFiles('**/inline-compare.fingerprint') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
-name: 'Release'
+name: "Release"
 on:
   push:
     # take no actions on push to any branch...
     branches-ignore:
-      - '**'
+      - "**"
     # ... only act on release tags
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   GO_VERSION: "1.14.x"
@@ -15,7 +15,6 @@ jobs:
   wait-for-checks:
     runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
     steps:
-
       - uses: actions/checkout@v2
 
       # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
@@ -81,10 +80,9 @@ jobs:
           false
 
   release:
-    needs: [ wait-for-checks ]
+    needs: [wait-for-checks]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -96,7 +94,7 @@ jobs:
       # We are expecting this cache to have been created during the "Build-Snapshot-Artifacts" job in the "Acceptance" workflow.
       - name: Restore bootstrap cache
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/static-unit-integration.yaml
+++ b/.github/workflows/static-unit-integration.yaml
@@ -1,10 +1,9 @@
-name: 'Static Analysis + Unit + Integration'
+name: "Static Analysis + Unit + Integration"
 on:
   workflow_dispatch:
   push:
   pull_request:
 jobs:
-
   Static-Analysis:
     strategy:
       matrix:
@@ -12,7 +11,6 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
@@ -21,7 +19,7 @@ jobs:
 
       - name: Restore bootstrap cache
         id: bootstrap-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: |
             ~/go/pkg/mod
@@ -49,7 +47,6 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
@@ -58,7 +55,7 @@ jobs:
 
       - name: Restore bootstrap cache
         id: bootstrap-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: |
             ~/go/pkg/mod
@@ -80,7 +77,7 @@ jobs:
 
       - name: Restore Java test-fixture cache
         id: unit-java-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: syft/cataloger/java/test-fixtures/java-builds/packages
           key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/cataloger/java/test-fixtures/java-builds/packages.fingerprint' ) }}
@@ -95,7 +92,7 @@ jobs:
         run: make integration-fingerprint
 
       - name: Restore integration test cache
-        uses: actions/cache@v2
+        uses: actions/cache@v2.1.3
         with:
           path: ${{ github.workspace }}/integration/test-fixtures/cache
           key: ${{ runner.os }}-integration-test-cache-${{ hashFiles('integration/test-fixtures/cache.fingerprint') }}


### PR DESCRIPTION
Pinning GitHub's "cache" action to avoid an error caused by the latest release: https://github.com/actions/cache/issues/527