### PR TITLE
Ignore ownership for shared copyright resources

### DIFF
--- a/syft/pkg/catalog.go
+++ b/syft/pkg/catalog.go
@@ -7,12 +7,6 @@ import (
 	"github.com/anchore/syft/internal/log"
 )
 
-var globsForbiddenFromBeingOwned = []string{
-	ApkDbGlob,
-	DpkgDbGlob,
-	RpmDbGlob,
-}
-
 // Catalog represents a collection of Packages.
 type Catalog struct {
 	byID      map[ID]*Package

--- a/syft/pkg/ownership_by_files_relationship.go
+++ b/syft/pkg/ownership_by_files_relationship.go
@@ -6,6 +6,16 @@ import (
 	"github.com/scylladb/go-set/strset"
 )
 
+var globsForbiddenFromBeingOwned = []string{
+	// any OS DBs should automatically be ignored to prevent cyclic issues (e.g. the "rpm" RPM owns the path to the
+	// RPM DB, so if not ignored that package would own all other packages on the system).
+	ApkDbGlob,
+	DpkgDbGlob,
+	RpmDbGlob,
+	// DEB packages share common copyright info between, this does not mean that sharing these paths implies ownership.
+	"/usr/share/doc/**/copyright",
+}
+
 type ownershipByFilesMetadata struct {
 	Files []string `json:"files"`
 }


### PR DESCRIPTION
It may be possible for DPKG evidence locations to glean info from non-unique locations (such as `/usr/share/doc/**/copyright`) leading to relationships as so:

```
  "artifacts" : [
    {
      "id": "b7ccf459-e10b-40da-855a-55ad224885aa",
      "name": "libnettle7",
      "type": "deb",
      "locations": [
        ...
        {
          "path": "/usr/share/doc/libnettle7/copyright",
          "layerID": "sha256:bacd3af13903e13a43fe87b6944acd1ff21024132aad6e74b4452d984fb1a99a"
        },
        ...
      ],
    },
    ...
    {
      "id": "a2009b4f-58bd-4a37-a1b3-b7388890b08f",
      "name": "libhogweed5",
      "type": "deb",
      "foundBy": "dpkgdb-cataloger",
      "locations": [
        {
          "path": "/usr/share/doc/libnettle7/copyright",
          "layerID": "sha256:bacd3af13903e13a43fe87b6944acd1ff21024132aad6e74b4452d984fb1a99a"
        }
      ],
    },
    ....
  ]
  "artifactRelationships": [
    ....
    {
      "parent": "b7ccf459-e10b-40da-855a-55ad224885aa",
      "child": "a2009b4f-58bd-4a37-a1b3-b7388890b08f",
      "type": "ownership-by-file-overlap",
      "metadata": {
        "files": [
          "/usr/share/doc/libnettle7/copyright"
        ]
      }
    },
    ...
  ]
}
```
