### PR TITLE
Add Docker image to release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,95 +1,89 @@
 name: "Release"
 on:
   push:
-#    # take no actions on push to any branch...
-#    branches-ignore:
-#      - "**"
-#    # ... only act on release tags
-#    tags:
-#      - "v*"
+    # take no actions on push to any branch...
+    branches-ignore:
+      - "**"
+    # ... only act on release tags
+    tags:
+      - "v*"
 
 env:
   GO_VERSION: "1.14.x"
 
 jobs:
-#  wait-for-checks:
-#    runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
-#      - name: Ensure tagged commit is on main
-#        run: |
-#          echo "Tag: ${GITHUB_REF##*/}"
-#          git fetch origin main
-#          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
-#
-#      - name: Check static analysis results
-#        uses: fountainhead/action-wait-for-check@v1.0.0
-#        id: static-analysis
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
-#          checkName: "Static-Analysis (1.x, ubuntu-latest)"
-#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-#
-#      - name: Check unit + integration results (latest go version)
-#        uses: fountainhead/action-wait-for-check@v1.0.0
-#        id: unit-integration
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
-#          checkName: "Tests (1.x, ubuntu-latest)"
-#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-#
-#      - name: Check acceptance test results (linux)
-#        uses: fountainhead/action-wait-for-check@v1.0.0
-#        id: acceptance-linux
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-#          checkName: "Acceptance-Linux"
-#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-#
-#      - name: Check acceptance test results (mac)
-#        uses: fountainhead/action-wait-for-check@v1.0.0
-#        id: acceptance-mac
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-#          checkName: "Acceptance-Mac"
-#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-#
-#      - name: Check inline comparison test results
-#        uses: fountainhead/action-wait-for-check@v1.0.0
-#        id: inline-compare
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-#          checkName: "Inline-Compare"
-#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-#
-#      - name: Quality gate
-#        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit-integration.outputs.conclusion != 'success' || steps.inline-compare.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
-#        run: |
-#          echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
-#          echo "Unit & Integration Test Status: ${{ steps.unit-integration.outputs.conclusion }}"
-#          echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"
-#          echo "Acceptance Test (Mac) Status: ${{ steps.acceptance-mac.outputs.conclusion }}"
-#          echo "Inline Compare Status: ${{ steps.inline-compare.outputs.conclusion }}"
-#          false
+  wait-for-checks:
+    runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
+    steps:
+      - uses: actions/checkout@v2
+
+      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
+      - name: Ensure tagged commit is on main
+        run: |
+          echo "Tag: ${GITHUB_REF##*/}"
+          git fetch origin main
+          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
+
+      - name: Check static analysis results
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: static-analysis
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
+          checkName: "Static-Analysis (1.x, ubuntu-latest)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check unit + integration results (latest go version)
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: unit-integration
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
+          checkName: "Tests (1.x, ubuntu-latest)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check acceptance test results (linux)
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: acceptance-linux
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+          checkName: "Acceptance-Linux"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check acceptance test results (mac)
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: acceptance-mac
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+          checkName: "Acceptance-Mac"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Check inline comparison test results
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: inline-compare
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+          checkName: "Inline-Compare"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Quality gate
+        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit-integration.outputs.conclusion != 'success' || steps.inline-compare.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
+        run: |
+          echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
+          echo "Unit & Integration Test Status: ${{ steps.unit-integration.outputs.conclusion }}"
+          echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"
+          echo "Acceptance Test (Mac) Status: ${{ steps.acceptance-mac.outputs.conclusion }}"
+          echo "Inline Compare Status: ${{ steps.inline-compare.outputs.conclusion }}"
+          false
 
   release:
-#    needs: [wait-for-checks]
+    needs: [wait-for-checks]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
       - uses: docker-practice/actions-setup-docker@master
-      - run: |
-          set -x
-
-          docker version
-
-          docker run --rm hello-world
 
       - uses: actions/setup-go@v2
         with:
@@ -130,30 +124,30 @@ jobs:
           echo "name:        ${{ steps.import_gpg.outputs.name }}"
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
-#      - name: Build & publish release artifacts
-#        run: make release
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
-#          GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
-#          PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
-#          SIGNING_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-#          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
-#          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }} # Used during macOS code signing.
-#          APPLE_DEVELOPER_ID_CERT_PASS: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASS }} # Used during macOS code signing.
-#          AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
-#          AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
+      - name: Build & publish release artifacts
+        run: make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
+          SIGNING_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
+          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }} # Used during macOS code signing.
+          APPLE_DEVELOPER_ID_CERT_PASS: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASS }} # Used during macOS code signing.
+          AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
+          AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
 
-#      - uses: 8398a7/action-slack@v3
-#        with:
-#          status: ${{ job.status }}
-#          fields: repo,workflow,action,eventName
-#          text: "A new Syft release is ready to be manually published: https://github.com/anchore/syft/releases"
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-#        if: ${{ success() }}
-#
-#      - uses: actions/upload-artifact@v2
-#        with:
-#          name: artifacts
-#          path: dist/**/*
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,workflow,action,eventName
+          text: "A new Syft release is ready to be manually published: https://github.com/anchore/syft/releases"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+        if: ${{ success() }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: dist/**/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,7 +83,7 @@ jobs:
     needs: [wait-for-checks]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
-      - uses: docker-practice/actions-setup-docker@master
+      - uses: docker-practice/actions-setup-docker@v1
 
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,88 +1,96 @@
 name: "Release"
 on:
   push:
-    # take no actions on push to any branch...
-    branches-ignore:
-      - "**"
-    # ... only act on release tags
-    tags:
-      - "v*"
+#    # take no actions on push to any branch...
+#    branches-ignore:
+#      - "**"
+#    # ... only act on release tags
+#    tags:
+#      - "v*"
 
 env:
   GO_VERSION: "1.14.x"
 
 jobs:
-  wait-for-checks:
-    runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
-    steps:
-      - uses: actions/checkout@v2
-
-      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
-      - name: Ensure tagged commit is on main
-        run: |
-          echo "Tag: ${GITHUB_REF##*/}"
-          git fetch origin main
-          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
-
-      - name: Check static analysis results
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: static-analysis
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
-          checkName: "Static-Analysis (1.x, ubuntu-latest)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check unit + integration results (latest go version)
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: unit-integration
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
-          checkName: "Tests (1.x, ubuntu-latest)"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check acceptance test results (linux)
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: acceptance-linux
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-          checkName: "Acceptance-Linux"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check acceptance test results (mac)
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: acceptance-mac
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-          checkName: "Acceptance-Mac"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Check inline comparison test results
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: inline-compare
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
-          checkName: "Inline-Compare"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit-integration.outputs.conclusion != 'success' || steps.inline-compare.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
-        run: |
-          echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
-          echo "Unit & Integration Test Status: ${{ steps.unit-integration.outputs.conclusion }}"
-          echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"
-          echo "Acceptance Test (Mac) Status: ${{ steps.acceptance-mac.outputs.conclusion }}"
-          echo "Inline Compare Status: ${{ steps.inline-compare.outputs.conclusion }}"
-          false
+#  wait-for-checks:
+#    runs-on: ubuntu-latest # This OS choice is arbitrary. None of the steps in this job are specific to either Linux or macOS.
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      # we don't want to release commits that have been pushed and tagged, but not necessarily merged onto main
+#      - name: Ensure tagged commit is on main
+#        run: |
+#          echo "Tag: ${GITHUB_REF##*/}"
+#          git fetch origin main
+#          git merge-base --is-ancestor ${GITHUB_REF##*/} origin/main && echo "${GITHUB_REF##*/} is a commit on main!"
+#
+#      - name: Check static analysis results
+#        uses: fountainhead/action-wait-for-check@v1.0.0
+#        id: static-analysis
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
+#          checkName: "Static-Analysis (1.x, ubuntu-latest)"
+#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#
+#      - name: Check unit + integration results (latest go version)
+#        uses: fountainhead/action-wait-for-check@v1.0.0
+#        id: unit-integration
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          # This check name is defined as the circle-ci workflow name (in .circleci/config.yaml)
+#          checkName: "Tests (1.x, ubuntu-latest)"
+#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#
+#      - name: Check acceptance test results (linux)
+#        uses: fountainhead/action-wait-for-check@v1.0.0
+#        id: acceptance-linux
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+#          checkName: "Acceptance-Linux"
+#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#
+#      - name: Check acceptance test results (mac)
+#        uses: fountainhead/action-wait-for-check@v1.0.0
+#        id: acceptance-mac
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+#          checkName: "Acceptance-Mac"
+#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#
+#      - name: Check inline comparison test results
+#        uses: fountainhead/action-wait-for-check@v1.0.0
+#        id: inline-compare
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          # This check name is defined as the github action job name (in .github/workflows/acceptance-test.yaml)
+#          checkName: "Inline-Compare"
+#          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+#
+#      - name: Quality gate
+#        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit-integration.outputs.conclusion != 'success' || steps.inline-compare.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
+#        run: |
+#          echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
+#          echo "Unit & Integration Test Status: ${{ steps.unit-integration.outputs.conclusion }}"
+#          echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"
+#          echo "Acceptance Test (Mac) Status: ${{ steps.acceptance-mac.outputs.conclusion }}"
+#          echo "Inline Compare Status: ${{ steps.inline-compare.outputs.conclusion }}"
+#          false
 
   release:
-    needs: [wait-for-checks]
+#    needs: [wait-for-checks]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
+      - uses: docker-practice/actions-setup-docker@master
+      - run: |
+          set -x
+
+          docker version
+
+          docker run --rm hello-world
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -104,6 +112,10 @@ jobs:
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}-
             ${{ runner.os }}-go-${{ env.GO_VERSION }}-
 
+      - name: Bootstrap project dependencies
+        if: steps.bootstrap-cache.outputs.cache-hit != 'true'
+        run: make bootstrap
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -118,30 +130,30 @@ jobs:
           echo "name:        ${{ steps.import_gpg.outputs.name }}"
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
-      - name: Build & publish release artifacts
-        run: make release
-        env:
-          GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
-          SIGNING_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
-          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }} # Used during macOS code signing.
-          APPLE_DEVELOPER_ID_CERT_PASS: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASS }} # Used during macOS code signing.
-          AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
-          AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
+#      - name: Build & publish release artifacts
+#        run: make release
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
+#          GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
+#          PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}
+#          SIGNING_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+#          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
+#          APPLE_DEVELOPER_ID_CERT: ${{ secrets.APPLE_DEVELOPER_ID_CERT }} # Used during macOS code signing.
+#          APPLE_DEVELOPER_ID_CERT_PASS: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASS }} # Used during macOS code signing.
+#          AC_USERNAME: ${{ secrets.ENG_CI_APPLE_ID }} # Used during macOS notarization.
+#          AC_PASSWORD: ${{ secrets.ENG_CI_APPLE_ID_PASS }} # Used during macOS notarization.
 
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,workflow,action,eventName
-          text: "A new Syft release is ready to be manually published: https://github.com/anchore/syft/releases"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
-        if: ${{ success() }}
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: artifacts
-          path: dist/**/*
+#      - uses: 8398a7/action-slack@v3
+#        with:
+#          status: ${{ job.status }}
+#          fields: repo,workflow,action,eventName
+#          text: "A new Syft release is ready to be manually published: https://github.com/anchore/syft/releases"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
+#        if: ${{ success() }}
+#
+#      - uses: actions/upload-artifact@v2
+#        with:
+#          name: artifacts
+#          path: dist/**/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -90,3 +90,14 @@ brews:
       name: homebrew-syft
     homepage: *website
     description: *description
+
+dockers:
+  -
+    binaries:
+      - syft
+    dockerfile: Dockerfile
+    image_templates:
+      - "anchore/syft:latest"
+      - "anchore/syft:{{ .Tag }}"
+      - "anchore/syft:v{{ .Major }}"
+      - "anchore/syft:v{{ .Major }}.{{ .Minor }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,3 +101,9 @@ dockers:
       - "anchore/syft:{{ .Tag }}"
       - "anchore/syft:v{{ .Major }}"
       - "anchore/syft:v{{ .Major }}.{{ .Minor }}"
+
+    build_flag_templates:
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,18 @@ WORKDIR /tmp
 
 COPY syft /
 
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+ARG VCS_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.name="syft"
+LABEL org.label-schema.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
+LABEL org.label-schema.vcs-url=$VCS_URL
+LABEL org.label-schema.vcs-ref=$VCS_REF
+LABEL org.label-schema.vendor="Anchore, Inc."
+LABEL org.label-schema.version=$BUILD_VERSION
+
 ENTRYPOINT ["/syft"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest AS build
+
+RUN apk --no-cache add ca-certificates
+
+FROM scratch
+# needed for version check HTTPS request
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# create the /tmp dir, which is needed for image content cache
+WORKDIR /tmp
+
+COPY syft /
+
+ENTRYPOINT ["/syft"]


### PR DESCRIPTION
This adds a docker image build step to goreleaser (publishing to `anchore/syft`). This work does NOT replace the additional work proposed in https://github.com/anchore/syft/pull/310 but instead only delivers the docker image portion for now. 

Note: this adds docker to the mac instance in CI during release.

Closes #228