### PR TITLE
Move docker login to after keychain creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,6 +96,10 @@ jobs:
     steps:
       - uses: docker-practice/actions-setup-docker@v1
 
+      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
+
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
@@ -124,9 +128,6 @@ jobs:
         if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
         run: make bootstrap
 
-      - name: Login to Docker Hub
-        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
-
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2
@@ -144,6 +145,8 @@ jobs:
       - name: Build & publish release artifacts
         run: make release
         env:
+          DOCKER_USERNAME: ${{ secrets.TOOLBOX_DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.TOOLBOX_DOCKER_PASS }}
           GITHUB_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.SIGNING_GPG_PRIVATE_KEY }}
           PASSPHRASE: ${{ secrets.SIGNING_GPG_PASSPHRASE }}

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,10 @@ release: clean-dist changelog-release ## Build and publish final binaries and pa
 	# Prepare for macOS-specific signing process
 	.github/scripts/mac-prepare-for-signing.sh
 
+	# login to docker
+	# note: the previous step creates a new keychain, so it is important to reauth into docker.io
+	@echo $${DOCKER_PASSWORD} | docker login docker.io -u $${DOCKER_USERNAME}  --password-stdin
+
 	# create a config with the dist dir overridden
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml


### PR DESCRIPTION
- We need to auth early the in release pipeline to prevent docker rate limiting while prepping for the release
- We need to auth again later in the pipeline within the release step since the mac code signing swaps out the default keychain