### PR TITLE
Ensure pkg.Catalog path index deduplicates real vs virtual paths

### DIFF
--- a/syft/pkg/catalog.go
+++ b/syft/pkg/catalog.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/anchore/syft/internal"
+
 	"github.com/anchore/syft/internal/log"
 )
 
@@ -82,12 +84,15 @@ func (c *Catalog) Add(p Package) {
 	c.idsByType[p.Type] = append(c.idsByType[p.Type], p.ID)
 
 	// store by file location paths
+	observedPaths := internal.NewStringSet()
 	for _, l := range p.Locations {
-		if l.RealPath != "" {
+		if l.RealPath != "" && !observedPaths.Contains(l.RealPath) {
 			c.idsByPath[l.RealPath] = append(c.idsByPath[l.RealPath], p.ID)
+			observedPaths.Add(l.RealPath)
 		}
-		if l.VirtualPath != "" {
+		if l.VirtualPath != "" && l.RealPath != l.VirtualPath && !observedPaths.Contains(l.VirtualPath) {
 			c.idsByPath[l.VirtualPath] = append(c.idsByPath[l.VirtualPath], p.ID)
+			observedPaths.Add(l.VirtualPath)
 		}
 	}
 }

--- a/syft/pkg/catalog_test.go
+++ b/syft/pkg/catalog_test.go
@@ -155,3 +155,51 @@ func assertIndexes(t *testing.T, c *Catalog, expectedIndexes expectedIndexes) {
 		}
 	}
 }
+
+func TestCatalog_PathIndexDeduplicatesRealVsVirtualPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  Package
+	}{
+		{
+			name: "multiple locations with shared path",
+			pkg: Package{
+				ID: "my-id",
+				Locations: []source.Location{
+					{
+						RealPath:    "/b/path",
+						VirtualPath: "/another/path",
+					},
+					{
+						RealPath:    "/b/path",
+						VirtualPath: "/b/path",
+					},
+				},
+				Type: RpmPkg,
+			},
+		},
+		{
+			name: "one location with shared path",
+			pkg: Package{
+				ID: "my-id",
+				Locations: []source.Location{
+					{
+						RealPath:    "/b/path",
+						VirtualPath: "/b/path",
+					},
+				},
+				Type: RpmPkg,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := NewCatalog(test.pkg).PackagesByPath("/b/path")
+			if len(actual) != 1 {
+				t.Errorf("expected exactly one package path, got %d", len(actual))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
For packages that have the same `RealPath` and `VirtualPath` for a given `Location` the `pkg.Catalog` is inserting duplicate entries (on for each path, even though they are the same). This PR ensures that duplicate paths for the same package are not added.