### PR TITLE
Add link destination to file metadata

### DIFF
--- a/cmd/power_user_tasks.go
+++ b/cmd/power_user_tasks.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"crypto"
+	"fmt"
+
 	"github.com/anchore/syft/internal/presenter/poweruser"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/file"
@@ -80,7 +83,26 @@ func catalogFileDigestTask() (powerUserTask, error) {
 		return nil, nil
 	}
 
-	digestsCataloger, err := file.NewDigestsCataloger(appConfig.FileMetadata.Digests)
+	supportedHashAlgorithms := make(map[string]crypto.Hash)
+	for _, h := range []crypto.Hash{
+		crypto.MD5,
+		crypto.SHA1,
+		crypto.SHA256,
+	} {
+		supportedHashAlgorithms[file.DigestAlgorithmName(h)] = h
+	}
+
+	var hashes []crypto.Hash
+	for _, hashStr := range appConfig.FileMetadata.Digests {
+		name := file.CleanDigestAlgorithmName(hashStr)
+		hashObj, ok := supportedHashAlgorithms[name]
+		if !ok {
+			return nil, fmt.Errorf("unsupported hash algorithm: %s", hashStr)
+		}
+		hashes = append(hashes, hashObj)
+	}
+
+	digestsCataloger, err := file.NewDigestsCataloger(hashes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/presenter/poweruser/json_presenter_test.go
+++ b/internal/presenter/poweruser/json_presenter_test.go
@@ -1,0 +1,172 @@
+package poweruser
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
+
+	"github.com/anchore/syft/syft/file"
+
+	"github.com/anchore/go-testutils"
+	"github.com/anchore/syft/internal/config"
+	"github.com/anchore/syft/syft/distro"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
+)
+
+var updateJSONGoldenFiles = flag.Bool("update-json", false, "update the *.golden files for json presenters")
+
+func must(c pkg.CPE, e error) pkg.CPE {
+	if e != nil {
+		panic(e)
+	}
+	return c
+}
+
+func TestJSONPresenter(t *testing.T) {
+	var buffer bytes.Buffer
+
+	catalog := pkg.NewCatalog()
+
+	catalog.Add(pkg.Package{
+		ID:      "package-1-id",
+		Name:    "package-1",
+		Version: "1.0.1",
+		Locations: []source.Location{
+			{
+				RealPath: "/a/place/a",
+			},
+		},
+		Type:         pkg.PythonPkg,
+		FoundBy:      "the-cataloger-1",
+		Language:     pkg.Python,
+		MetadataType: pkg.PythonPackageMetadataType,
+		Licenses:     []string{"MIT"},
+		Metadata: pkg.PythonPackageMetadata{
+			Name:    "package-1",
+			Version: "1.0.1",
+		},
+		PURL: "a-purl-1",
+		CPEs: []pkg.CPE{
+			must(pkg.NewCPE("cpe:2.3:*:some:package:1:*:*:*:*:*:*:*")),
+		},
+	})
+	catalog.Add(pkg.Package{
+		ID:      "package-2-id",
+		Name:    "package-2",
+		Version: "2.0.1",
+		Locations: []source.Location{
+			{
+				RealPath: "/b/place/b",
+			},
+		},
+		Type:         pkg.DebPkg,
+		FoundBy:      "the-cataloger-2",
+		MetadataType: pkg.DpkgMetadataType,
+		Metadata: pkg.DpkgMetadata{
+			Package: "package-2",
+			Version: "2.0.1",
+		},
+		PURL: "a-purl-2",
+		CPEs: []pkg.CPE{
+			must(pkg.NewCPE("cpe:2.3:*:some:package:2:*:*:*:*:*:*:*")),
+		},
+	})
+
+	cfg := JSONDocumentConfig{
+		ApplicationConfig: config.Application{},
+		PackageCatalog:    catalog,
+		FileMetadata: map[source.Location]source.FileMetadata{
+			source.NewLocation("/a/place"): {
+				Mode:    0775,
+				Type:    "directory",
+				UserID:  0,
+				GroupID: 0,
+			},
+			source.NewLocation("/a/place/a"): {
+				Mode:    0775,
+				Type:    "regularFile",
+				UserID:  0,
+				GroupID: 0,
+			},
+			source.NewLocation("/b"): {
+				Mode:            0775,
+				Type:            "symbolicLink",
+				LinkDestination: "/c",
+				UserID:          0,
+				GroupID:         0,
+			},
+			source.NewLocation("/b/place/b"): {
+				Mode:    0644,
+				Type:    "regularFile",
+				UserID:  1,
+				GroupID: 2,
+			},
+		},
+		FileDigests: map[source.Location][]file.Digest{
+			source.NewLocation("/a/place/a"): {
+				{
+					Algorithm: "sha256",
+					Value:     "366a3f5653e34673b875891b021647440d0127c2ef041e3b1a22da2a7d4f3703",
+				},
+			},
+			source.NewLocation("/b/place/b"): {
+				{
+					Algorithm: "sha256",
+					Value:     "1b3722da2a7d90d033b87581a2a3f12021647445653e34666ef041e3b4f3707c",
+				},
+			},
+		},
+		Distro: &distro.Distro{
+			Type:       distro.RedHat,
+			RawVersion: "7",
+			IDLike:     "rhel",
+		},
+		SourceMetadata: source.Metadata{
+			Scheme: source.ImageScheme,
+			ImageMetadata: source.ImageMetadata{
+				UserInput:      "user-image-input",
+				ID:             "sha256:c2b46b4eb06296933b7cf0722683964e9ecbd93265b9ef6ae9642e3952afbba0",
+				ManifestDigest: "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
+				MediaType:      "application/vnd.docker.distribution.manifest.v2+json",
+				Tags: []string{
+					"stereoscope-fixture-image-simple:85066c51088bdd274f7a89e99e00490f666c49e72ffc955707cd6e18f0e22c5b",
+				},
+				Size: 38,
+				Layers: []source.LayerMetadata{
+					{
+						MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+						Digest:    "sha256:3de16c5b8659a2e8d888b8ded8427be7a5686a3c8c4e4dd30de20f362827285b",
+						Size:      22,
+					},
+					{
+						MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+						Digest:    "sha256:366a3f5653e34673b875891b021647440d0127c2ef041e3b1a22da2a7d4f3703",
+						Size:      16,
+					},
+				},
+				RawManifest: []byte("eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJh..."),
+				RawConfig:   []byte("eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZp..."),
+			},
+		},
+	}
+
+	if err := NewJSONPresenter(cfg).Present(&buffer); err != nil {
+		t.Fatal(err)
+	}
+	actual := buffer.Bytes()
+
+	if *updateJSONGoldenFiles {
+		testutils.UpdateGoldenFileContents(t, actual)
+	}
+
+	var expected = testutils.GetGoldenFileContents(t)
+
+	if !bytes.Equal(expected, actual) {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(string(expected), string(actual), true)
+		t.Errorf("mismatched output:\n%s", dmp.DiffPrettyText(diffs))
+	}
+}

--- a/internal/presenter/poweruser/json_presenter_test.go
+++ b/internal/presenter/poweruser/json_presenter_test.go
@@ -47,6 +47,7 @@ func TestJSONPresenter(t *testing.T) {
 		Metadata: pkg.PythonPackageMetadata{
 			Name:    "package-1",
 			Version: "1.0.1",
+			Files:   []pkg.PythonFileRecord{},
 		},
 		PURL: "a-purl-1",
 		CPEs: []pkg.CPE{
@@ -68,6 +69,7 @@ func TestJSONPresenter(t *testing.T) {
 		Metadata: pkg.DpkgMetadata{
 			Package: "package-2",
 			Version: "2.0.1",
+			Files:   []pkg.DpkgFileRecord{},
 		},
 		PURL: "a-purl-2",
 		CPEs: []pkg.CPE{
@@ -76,8 +78,12 @@ func TestJSONPresenter(t *testing.T) {
 	})
 
 	cfg := JSONDocumentConfig{
-		ApplicationConfig: config.Application{},
-		PackageCatalog:    catalog,
+		ApplicationConfig: config.Application{
+			FileMetadata: config.FileMetadata{
+				Digests: []string{"sha256"},
+			},
+		},
+		PackageCatalog: catalog,
 		FileMetadata: map[source.Location]source.FileMetadata{
 			source.NewLocation("/a/place"): {
 				Mode:    0775,
@@ -149,6 +155,7 @@ func TestJSONPresenter(t *testing.T) {
 				},
 				RawManifest: []byte("eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJh..."),
 				RawConfig:   []byte("eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZp..."),
+				RepoDigests: []string{},
 			},
 		},
 	}
@@ -162,7 +169,7 @@ func TestJSONPresenter(t *testing.T) {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
-	var expected = testutils.GetGoldenFileContents(t)
+	expected := testutils.GetGoldenFileContents(t)
 
 	if !bytes.Equal(expected, actual) {
 		dmp := diffmatchpatch.New()

--- a/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
+++ b/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
@@ -1,0 +1,198 @@
+{
+ "fileMetadata": [
+  {
+   "location": {
+    "path": "/a/place"
+   },
+   "metadata": {
+    "mode": 775,
+    "type": "directory",
+    "userID": 0,
+    "groupID": 0
+   }
+  },
+  {
+   "location": {
+    "path": "/a/place/a"
+   },
+   "metadata": {
+    "mode": 775,
+    "type": "regularFile",
+    "userID": 0,
+    "groupID": 0,
+    "digests": [
+     {
+      "algorithm": "sha256",
+      "value": "366a3f5653e34673b875891b021647440d0127c2ef041e3b1a22da2a7d4f3703"
+     }
+    ]
+   }
+  },
+  {
+   "location": {
+    "path": "/b"
+   },
+   "metadata": {
+    "mode": 775,
+    "type": "symbolicLink",
+    "linkDestination": "/c",
+    "userID": 0,
+    "groupID": 0
+   }
+  },
+  {
+   "location": {
+    "path": "/b/place/b"
+   },
+   "metadata": {
+    "mode": 644,
+    "type": "regularFile",
+    "userID": 1,
+    "groupID": 2,
+    "digests": [
+     {
+      "algorithm": "sha256",
+      "value": "1b3722da2a7d90d033b87581a2a3f12021647445653e34666ef041e3b4f3707c"
+     }
+    ]
+   }
+  }
+ ],
+ "artifacts": [
+  {
+   "id": "package-1-id",
+   "name": "package-1",
+   "version": "1.0.1",
+   "type": "python",
+   "foundBy": "the-cataloger-1",
+   "locations": [
+    {
+     "path": "/a/place/a"
+    }
+   ],
+   "licenses": [
+    "MIT"
+   ],
+   "language": "python",
+   "cpes": [
+    "cpe:2.3:*:some:package:1:*:*:*:*:*:*:*"
+   ],
+   "purl": "a-purl-1",
+   "metadataType": "PythonPackageMetadata",
+   "metadata": {
+    "name": "package-1",
+    "version": "1.0.1",
+    "license": "",
+    "author": "",
+    "authorEmail": "",
+    "platform": "",
+    "sitePackagesRootPath": ""
+   }
+  },
+  {
+   "id": "package-2-id",
+   "name": "package-2",
+   "version": "2.0.1",
+   "type": "deb",
+   "foundBy": "the-cataloger-2",
+   "locations": [
+    {
+     "path": "/b/place/b"
+    }
+   ],
+   "licenses": [],
+   "language": "",
+   "cpes": [
+    "cpe:2.3:*:some:package:2:*:*:*:*:*:*:*"
+   ],
+   "purl": "a-purl-2",
+   "metadataType": "DpkgMetadata",
+   "metadata": {
+    "package": "package-2",
+    "source": "",
+    "version": "2.0.1",
+    "sourceVersion": "",
+    "architecture": "",
+    "maintainer": "",
+    "installedSize": 0,
+    "files": null
+   }
+  }
+ ],
+ "artifactRelationships": [],
+ "source": {
+  "type": "image",
+  "target": {
+   "userInput": "user-image-input",
+   "imageID": "sha256:c2b46b4eb06296933b7cf0722683964e9ecbd93265b9ef6ae9642e3952afbba0",
+   "manifestDigest": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
+   "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+   "tags": [
+    "stereoscope-fixture-image-simple:85066c51088bdd274f7a89e99e00490f666c49e72ffc955707cd6e18f0e22c5b"
+   ],
+   "imageSize": 38,
+   "layers": [
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:3de16c5b8659a2e8d888b8ded8427be7a5686a3c8c4e4dd30de20f362827285b",
+     "size": 22
+    },
+    {
+     "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+     "digest": "sha256:366a3f5653e34673b875891b021647440d0127c2ef041e3b1a22da2a7d4f3703",
+     "size": 16
+    }
+   ],
+   "manifest": "ZXlKelkyaGxiV0ZXWlhKemFXOXVJam95TENKdFpXUnBZVlI1Y0dVaU9pSmguLi4=",
+   "config": "ZXlKaGNtTm9hWFJsWTNSMWNtVWlPaUpoYldRMk5DSXNJbU52Ym1acC4uLg==",
+   "scope": ""
+  }
+ },
+ "distro": {
+  "name": "redhat",
+  "version": "7",
+  "idLike": "rhel"
+ },
+ "descriptor": {
+  "name": "syft",
+  "version": "[not provided]",
+  "configuration": {
+   "configPath": "",
+   "output": "",
+   "quiet": false,
+   "log": {
+    "structured": false,
+    "level": "",
+    "file-location": ""
+   },
+   "dev": {
+    "profile-cpu": false,
+    "profile-mem": false
+   },
+   "check-for-app-update": false,
+   "anchore": {
+    "host": "",
+    "path": "",
+    "dockerfile": "",
+    "overwrite-existing-image": false
+   },
+   "package": {
+    "cataloger": {
+     "enabled": false,
+     "scope": ""
+    }
+   },
+   "file-metadata": {
+    "cataloger": {
+     "enabled": false,
+     "scope": ""
+    },
+    "digests": null
+   }
+  }
+ },
+ "schema": {
+  "version": "1.0.4",
+  "url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-1.0.4.json"
+ }
+}

--- a/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
+++ b/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
@@ -115,7 +115,7 @@
     "architecture": "",
     "maintainer": "",
     "installedSize": 0,
-    "files": null
+    "files": []
    }
   }
  ],
@@ -145,6 +145,7 @@
    ],
    "manifest": "ZXlKelkyaGxiV0ZXWlhKemFXOXVJam95TENKdFpXUnBZVlI1Y0dVaU9pSmguLi4=",
    "config": "ZXlKaGNtTm9hWFJsWTNSMWNtVWlPaUpoYldRMk5DSXNJbU52Ym1acC4uLg==",
+   "repoDigests": [],
    "scope": ""
   }
  },
@@ -187,7 +188,9 @@
      "enabled": false,
      "scope": ""
     },
-    "digests": null
+    "digests": [
+     "sha256"
+    ]
    }
   }
  },

--- a/schema/json/schema-1.0.4.json
+++ b/schema/json/schema-1.0.4.json
@@ -345,14 +345,16 @@
         "mode",
         "type",
         "userID",
-        "groupID",
-        "digests"
+        "groupID"
       ],
       "properties": {
         "mode": {
           "type": "integer"
         },
         "type": {
+          "type": "string"
+        },
+        "linkDestination": {
           "type": "string"
         },
         "userID": {

--- a/syft/file/digest_cataloger.go
+++ b/syft/file/digest_cataloger.go
@@ -74,16 +74,18 @@ func (i *DigestsCataloger) catalogLocation(resolver source.FileResolver, locatio
 		return nil, fmt.Errorf("unable to observe contents of %+v: %+v", location.RealPath, err)
 	}
 
+	if size == 0 {
+		return make([]Digest, 0), nil
+	}
+
 	result := make([]Digest, len(i.hashes))
-	if size > 0 {
-		// only capture digests when there is content. It is important to do this based on SIZE and not
-		// FILE TYPE. The reasoning is that it is possible for a tar to be crafted with a header-only
-		// file type but a body is still allowed.
-		for idx, hasher := range hashers {
-			result[idx] = Digest{
-				Algorithm: cleanAlgorithmName(i.hashes[idx].String()),
-				Value:     fmt.Sprintf("%+x", hasher.Sum(nil)),
-			}
+	// only capture digests when there is content. It is important to do this based on SIZE and not
+	// FILE TYPE. The reasoning is that it is possible for a tar to be crafted with a header-only
+	// file type but a body is still allowed.
+	for idx, hasher := range hashers {
+		result[idx] = Digest{
+			Algorithm: cleanAlgorithmName(i.hashes[idx].String()),
+			Value:     fmt.Sprintf("%+x", hasher.Sum(nil)),
 		}
 	}
 

--- a/syft/file/metadata_cataloger_test.go
+++ b/syft/file/metadata_cataloger_test.go
@@ -50,7 +50,7 @@ func TestFileMetadataCataloger(t *testing.T) {
 			exists: true,
 			expected: source.FileMetadata{
 				Mode:    0644,
-				Type:    "regularFile",
+				Type:    "RegularFile",
 				UserID:  1,
 				GroupID: 2,
 			},
@@ -59,20 +59,22 @@ func TestFileMetadataCataloger(t *testing.T) {
 			path:   "/hardlink-1",
 			exists: true,
 			expected: source.FileMetadata{
-				Mode:    0644,
-				Type:    "hardLink",
-				UserID:  1,
-				GroupID: 2,
+				Mode:            0644,
+				Type:            "HardLink",
+				LinkDestination: "file-1.txt",
+				UserID:          1,
+				GroupID:         2,
 			},
 		},
 		{
 			path:   "/symlink-1",
 			exists: true,
 			expected: source.FileMetadata{
-				Mode:    0777 | os.ModeSymlink,
-				Type:    "symbolicLink",
-				UserID:  0,
-				GroupID: 0,
+				Mode:            0777 | os.ModeSymlink,
+				Type:            "SymbolicLink",
+				LinkDestination: "file-1.txt",
+				UserID:          0,
+				GroupID:         0,
 			},
 		},
 		{
@@ -80,7 +82,7 @@ func TestFileMetadataCataloger(t *testing.T) {
 			exists: true,
 			expected: source.FileMetadata{
 				Mode:    0644 | os.ModeDevice | os.ModeCharDevice,
-				Type:    "characterDevice",
+				Type:    "CharacterDevice",
 				UserID:  0,
 				GroupID: 0,
 			},
@@ -90,7 +92,7 @@ func TestFileMetadataCataloger(t *testing.T) {
 			exists: true,
 			expected: source.FileMetadata{
 				Mode:    0644 | os.ModeDevice,
-				Type:    "blockDevice",
+				Type:    "BlockDevice",
 				UserID:  0,
 				GroupID: 0,
 			},
@@ -100,7 +102,7 @@ func TestFileMetadataCataloger(t *testing.T) {
 			exists: true,
 			expected: source.FileMetadata{
 				Mode:    0644 | os.ModeNamedPipe,
-				Type:    "fifoNode",
+				Type:    "FIFONode",
 				UserID:  0,
 				GroupID: 0,
 			},
@@ -110,7 +112,7 @@ func TestFileMetadataCataloger(t *testing.T) {
 			exists: true,
 			expected: source.FileMetadata{
 				Mode:    0755 | os.ModeDir,
-				Type:    "directory",
+				Type:    "Directory",
 				UserID:  0,
 				GroupID: 0,
 			},

--- a/syft/source/file_metadata.go
+++ b/syft/source/file_metadata.go
@@ -7,10 +7,11 @@ import (
 )
 
 type FileMetadata struct {
-	Mode    os.FileMode
-	Type    FileType
-	UserID  int
-	GroupID int
+	Mode            os.FileMode
+	Type            FileType
+	UserID          int
+	GroupID         int
+	LinkDestination string
 }
 
 func fileMetadataByLocation(img *image.Image, location Location) (FileMetadata, error) {
@@ -20,9 +21,10 @@ func fileMetadataByLocation(img *image.Image, location Location) (FileMetadata, 
 	}
 
 	return FileMetadata{
-		Mode:    entry.Metadata.Mode,
-		Type:    newFileTypeFromTarHeaderTypeFlag(entry.Metadata.TypeFlag),
-		UserID:  entry.Metadata.UserID,
-		GroupID: entry.Metadata.GroupID,
+		Mode:            entry.Metadata.Mode,
+		Type:            newFileTypeFromTarHeaderTypeFlag(entry.Metadata.TypeFlag),
+		UserID:          entry.Metadata.UserID,
+		GroupID:         entry.Metadata.GroupID,
+		LinkDestination: entry.Metadata.Linkname,
 	}, nil
 }

--- a/syft/source/file_type.go
+++ b/syft/source/file_type.go
@@ -1,33 +1,35 @@
 package source
 
+import "archive/tar"
+
 const (
-	UnknownFileType FileType = "unknownFileType"
-	RegularFile     FileType = "regularFile"
-	HardLink        FileType = "hardLink"
-	SymbolicLink    FileType = "symbolicLink"
-	CharacterDevice FileType = "characterDevice"
-	BlockDevice     FileType = "blockDevice"
-	Directory       FileType = "directory"
-	FIFONode        FileType = "fifoNode"
+	UnknownFileType FileType = "UnknownFileType"
+	RegularFile     FileType = "RegularFile"
+	HardLink        FileType = "HardLink"
+	SymbolicLink    FileType = "SymbolicLink"
+	CharacterDevice FileType = "CharacterDevice"
+	BlockDevice     FileType = "BlockDevice"
+	Directory       FileType = "Directory"
+	FIFONode        FileType = "FIFONode"
 )
 
 type FileType string
 
 func newFileTypeFromTarHeaderTypeFlag(flag byte) FileType {
 	switch flag {
-	case '0', '\x00':
+	case tar.TypeReg, tar.TypeRegA:
 		return RegularFile
-	case '1':
+	case tar.TypeLink:
 		return HardLink
-	case '2':
+	case tar.TypeSymlink:
 		return SymbolicLink
-	case '3':
+	case tar.TypeChar:
 		return CharacterDevice
-	case '4':
+	case tar.TypeBlock:
 		return BlockDevice
-	case '5':
+	case tar.TypeDir:
 		return Directory
-	case '6':
+	case tar.TypeFifo:
 		return FIFONode
 	}
 	return UnknownFileType

--- a/test/cli/power_user_cmd_test.go
+++ b/test/cli/power_user_cmd_test.go
@@ -26,7 +26,7 @@ func TestPowerUserCmdFlags(t *testing.T) {
 			args: []string{"power-user", request},
 			assertions: []traitAssertion{
 				assertNotInOutput(" command is deprecated"),     // only the root command should be deprecated
-				assertInOutput(`"type": "regularFile"`),         // proof of file-metadata data
+				assertInOutput(`"type": "RegularFile"`),         // proof of file-metadata data
 				assertInOutput(`"algorithm": "sha256"`),         // proof of file-metadata default digest algorithm of sha256
 				assertInOutput(`"metadataType": "ApkMetadata"`), // proof of package artifacts data
 				assertSuccessfulReturnCode,


### PR DESCRIPTION
- Added `LinkDestination` to `source.FileMetadata`, which is shown in the json output only when there is a value
- Makes `digests` an optional field in the json output
- Adds tests for the power-user presenter
- Renames `source.FileType` strings to be capitalized (consistent with similar fields)
- Fixes a bug where there are digests with a single value which have empty `algorithm` and `value` fields.
- Fixed a bug where sorting file metadata was not stable

Related to https://github.com/anchore/syft/issues/335