### PR TITLE
Ignore failures on benchmark sticky comment

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -216,6 +216,7 @@ jobs:
 
       - name: Update PR benchmark results comment
         uses: marocchino/sticky-pull-request-comment@v2
+        continue-on-error: true
         with:
           header: benchmark
           message: |


### PR DESCRIPTION
PRs from forks will not be able to add a sticky comment to PRs, so this step should be allowed to run without indicating a failure if the post fails (for any reason, not just the single reason listed here).