### PR TITLE
Use sorted artifacts for consistent SBoM output in table, cyclonedx, and json presenters

### DIFF
--- a/internal/presenter/packages/cyclonedx_document.go
+++ b/internal/presenter/packages/cyclonedx_document.go
@@ -34,7 +34,7 @@ func NewCycloneDxDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) Cyc
 	}
 
 	// attach components
-	for p := range catalog.Enumerate() {
+	for _, p := range catalog.Sorted() {
 		component := CycloneDxComponent{
 			Type:       "library", // TODO: this is not accurate
 			Name:       p.Name,

--- a/internal/presenter/packages/table_presenter.go
+++ b/internal/presenter/packages/table_presenter.go
@@ -25,7 +25,7 @@ func (pres *TablePresenter) Present(output io.Writer) error {
 	rows := make([][]string, 0)
 
 	columns := []string{"Name", "Version", "Type"}
-	for p := range pres.catalog.Enumerate() {
+	for _, p := range pres.catalog.Sorted() {
 		row := []string{
 			p.Name,
 			p.Version,

--- a/syft/pkg/catalog.go
+++ b/syft/pkg/catalog.go
@@ -164,6 +164,9 @@ func (c *Catalog) Sorted(types ...Type) []*Package {
 	sort.SliceStable(pkgs, func(i, j int) bool {
 		if pkgs[i].Name == pkgs[j].Name {
 			if pkgs[i].Version == pkgs[j].Version {
+				if pkgs[i].Type == pkgs[j].Type {
+					return pkgs[i].Locations[0].String() < pkgs[j].Locations[0].String()
+				}
 				return pkgs[i].Type < pkgs[j].Type
 			}
 			return pkgs[i].Version < pkgs[j].Version


### PR DESCRIPTION
Switches use of catalog.Enumerated() to catalog.Sorted() and adds the location as a component of the sort key.

Fixes #331 