### PR TITLE
Modify registry credential verification

### DIFF
--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -37,7 +37,7 @@ func (cfg *registry) parseConfigValues() error {
 		os.Getenv("SYFT_REGISTRY_AUTH_PASSWORD"),
 		os.Getenv("SYFT_REGISTRY_AUTH_TOKEN")
 
-	if hasNonEmptyCredentials(authority, password, token) {
+	if hasNonEmptyCredentials(authority, username, password, token) {
 		// note: we prepend the credentials such that the environment variables take precedence over on-disk configuration.
 		cfg.Auth = append([]RegistryCredentials{
 			{
@@ -51,8 +51,8 @@ func (cfg *registry) parseConfigValues() error {
 	return nil
 }
 
-func hasNonEmptyCredentials(authority, password, token string) bool {
-	return authority != "" && password != "" || authority != "" && token != ""
+func hasNonEmptyCredentials(authority, username, password, token string) bool {
+	return authority != "" && password != "" && username != "" || authority != "" && token != ""
 }
 
 func (cfg *registry) ToOptions() *image.RegistryOptions {

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasNonEmptyCredentials(t *testing.T) {
+	tests := []struct {
+		auth, username, password, token string
+		expected                        bool
+	}{
+		{
+			"", "", "", "",
+			false,
+		},
+		{
+			"auth", "", "", "",
+			false,
+		},
+		{
+			"auth", "user", "", "",
+			false,
+		},
+		{
+			"auth", "", "pass", "",
+			false,
+		},
+		{
+			"auth", "", "pass", "tok",
+			true,
+		},
+		{
+			"auth", "user", "", "tok",
+			true,
+		},
+		{
+			"auth", "", "", "tok",
+			true,
+		},
+		{
+			"auth", "user", "pass", "tok",
+			true,
+		},
+
+		{
+			"auth", "user", "pass", "",
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
+			assert.Equal(t, test.expected, hasNonEmptyCredentials(test.auth, test.username, test.password, test.token))
+		})
+	}
+}


### PR DESCRIPTION
Enforces that user and password OR a token must be present --no partial values allowed now. Sister PR to https://github.com/anchore/grype/pull/293

Closes #385 