### PR TITLE
Bump go.mod minimum required go version to 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syft
 
-[![Validations](https://github.com/anchore/syft/workflows/validations.yaml/badge.svg)](https://github.com/anchore/syft/workflows/validations.yaml)
+[![Validations](https://github.com/anchore/syft/actions/workflows/validations.yaml/badge.svg)](https://github.com/anchore/syft/actions/workflows/validations.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/anchore/syft)](https://goreportcard.com/report/github.com/anchore/syft)
 [![GitHub release](https://img.shields.io/github/release/anchore/syft.svg)](https://github.com/anchore/syft/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/syft/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/anchore/syft)](https://goreportcard.com/report/github.com/anchore/syft)
 [![GitHub release](https://img.shields.io/github/release/anchore/syft.svg)](https://github.com/anchore/syft/releases/latest)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/anchore/syft/blob/main/LICENSE)
+[![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/anchore/syft.svg)](https://github.com/anchore/syft)
 
 A CLI tool and go library for generating a Software Bill of Materials (SBOM) from container images and filesystems.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/syft
 
-go 1.14
+go 1.16
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
Secrets cataloger requires crypto feature from the latest 1.16 version of go.