### PR TITLE
Change mac acceptance test image.tar path

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -311,7 +311,7 @@ jobs:
         id: go-cache
         uses: actions/cache@v2.1.3
         with:
-          path: /tmp/image.tar
+          path: image.tar
           key: ${{ runner.os }}-${{ hashFiles('test/acceptance/mac.sh') }}
 
       - name: Run Acceptance Tests (Mac)


### PR DESCRIPTION
Today the `/tmp/image.tar` file used for mac acceptance testing is cached, however, the system used for CI is unable to untar into /tmp:
<img width="1241" alt="Screen Shot 2021-04-16 at 9 18 17 AM" src="https://user-images.githubusercontent.com/590471/115030459-1c79eb80-9e95-11eb-8099-b2be7f297a3a.png">

Resulting in docker pull rate limits over time:
<img width="1452" alt="Screen Shot 2021-04-16 at 9 16 42 AM" src="https://user-images.githubusercontent.com/590471/115030494-26035380-9e95-11eb-901d-12aabe3b5676.png">

This PR moves the image to a location which can be restore to by the cache (not in /tmp)

Additionally this PR fixes a bad image reference given to syft (`docker-archive://` vs `docker-archive:`) and now only installs skopeo on a cache miss.