### PR TITLE
Ensure consistent go.sum state during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ bootstrap-tools: $(TEMPDIR)
 .PHONY: bootstrap-go
 bootstrap-go:
 	go mod download
+	go mod tidy # note: it is important that the go.sum is kept in a consistent state at all times (especially during release)
 
 .PHONY: bootstrap
 bootstrap: $(RESULTSDIR) bootstrap-go bootstrap-tools ## Download and install all go dependencies (+ prep tooling in the ./tmp dir)


### PR DESCRIPTION
The release pipeline downloads the required go modules, however, this may modify the go.sum. The state of the sum may be equivalent to that of what is checked into git, however, to ensure this is the case `go mod tidy` must be run to get the reduced state. If the state differs, then there is a problem and the release should be halted (goreleaser does this), otherwise it is safe to continue.

```
❯ go clean --modcache
❯ git status
On branch bootstrap-go-mod-tidy
nothing to commit, working tree clean
❯ go mod download
❯ git status
On branch bootstrap-go-mod-tidy
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   go.sum
no changes added to commit (use "git add" and/or "git commit -a")
❯ git diff --stat
go.sum | 358 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 358 insertions(+)
❯ go mod tidy -v
❯ git status
On branch bootstrap-go-mod-tidy
nothing to commit, working tree clean
❯
```