### PR TITLE
Add additional cases for categorizing jenkins package type by group id

### DIFF
--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"strings"
+
 	"github.com/anchore/syft/internal"
 	"github.com/package-url/packageurl-go"
 )
@@ -35,7 +37,7 @@ type PomProperties struct {
 
 // PkgTypeIndicated returns the package Type indicated by the data contained in the PomProperties.
 func (p PomProperties) PkgTypeIndicated() Type {
-	if internal.HasAnyOfPrefixes(p.GroupID, JenkinsPluginPomPropertiesGroupIDs...) {
+	if internal.HasAnyOfPrefixes(p.GroupID, JenkinsPluginPomPropertiesGroupIDs...) || strings.Contains(p.GroupID, ".jenkins.plugin") {
 		return JenkinsPluginPkg
 	}
 

--- a/syft/pkg/java_metadata_test.go
+++ b/syft/pkg/java_metadata_test.go
@@ -90,6 +90,17 @@ func TestPomProperties_PkgTypeIndicated(t *testing.T) {
 			},
 			expectedType: JenkinsPluginPkg,
 		},
+		{
+			name: "jenkins.plugin somewhere in group id",
+			pomProperties: PomProperties{
+				Path:       "some path",
+				Name:       "some name",
+				GroupID:    "org.wagoodman.jenkins.plugins.something",
+				ArtifactID: "some artifact ID",
+				Version:    "1",
+			},
+			expectedType: JenkinsPluginPkg,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
There are several examples in the `cloudbees-mm-core` image for jenkins plugin jars that have `jenkins.plugin` or `jenkins.plugins` in the group ID, but are specifically for their org, thus, a full or prefix group id match will not work.