### PR TITLE
Align check names to release quality gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Static-Analysis"
+          checkName: "Static analysis"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check unit test results
@@ -40,7 +40,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Unit-Test"
+          checkName: "Unit tests"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check integration test results
@@ -49,7 +49,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Integration-Test"
+          checkName: "Integration tests"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check acceptance test results (linux)
@@ -58,7 +58,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Acceptance-Linux"
+          checkName: "Acceptance tests (Linux)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check acceptance test results (mac)
@@ -67,7 +67,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Acceptance-Mac"
+          checkName: "Acceptance tests (Mac)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check cli test results (linux)
@@ -76,7 +76,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Cli-Linux"
+          checkName: "CLI tests (Linux)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Quality gate

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -9,8 +9,8 @@ env:
 
 jobs:
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Static-Analysis:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-20.04
     # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
@@ -49,8 +49,8 @@ jobs:
       - name: Run static analysis
         run: make static-analysis
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Unit-Test:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-20.04
     # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
@@ -104,8 +104,8 @@ jobs:
           name: unit-test-results
           path: test/results/**/*
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Integration-Test:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Integration tests"
     runs-on: ubuntu-20.04
     # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
@@ -272,8 +272,8 @@ jobs:
           name: artifacts
           path: snapshot/**/*
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Linux:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Acceptance tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04
@@ -291,8 +291,8 @@ jobs:
       - name: Run Acceptance Tests (Linux)
         run: make acceptance-linux
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Acceptance-Mac:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Acceptance tests (Mac)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
@@ -317,8 +317,8 @@ jobs:
       - name: Run Acceptance Tests (Mac)
         run: make acceptance-mac
 
-  # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
   Cli-Linux:
+    # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "CLI tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Currently the release pipeline will not complete; the job names are tied to the `name:` attribute, not the yaml section name, which means the quality gate checks need to be adjusted to match.