### PR TITLE
Add all package metadata types slice for use in downstream testing

### DIFF
--- a/syft/pkg/metadata.go
+++ b/syft/pkg/metadata.go
@@ -16,3 +16,15 @@ const (
 	RustCargoPackageMetadataType MetadataType = "RustCargoPackageMetadata"
 	KbPackageMetadataType        MetadataType = "KbPackageMetadata"
 )
+
+var AllMetadataTypes = []MetadataType{
+	ApkMetadataType,
+	DpkgMetadataType,
+	GemMetadataType,
+	JavaMetadataType,
+	NpmPackageJSONMetadataType,
+	RpmdbMetadataType,
+	PythonPackageMetadataType,
+	RustCargoPackageMetadataType,
+	KbPackageMetadataType,
+}


### PR DESCRIPTION
Adds a slice that lists all package metadata types, which is useful for downstream testing in grype (now in a test you can more easily answer "have I covered all possible metadata types with this test?" ).