### PR TITLE
Allow registry auth config without authority value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/anchore/go-rpmdb v0.0.0-20210415132930-2460011e83c6
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6
+	github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f
 	github.com/antihax/optional v1.0.0
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200309214505-aa6a9891b09c+incompatible

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
 github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
+github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -37,7 +37,7 @@ func (cfg *registry) parseConfigValues() error {
 		os.Getenv("SYFT_REGISTRY_AUTH_PASSWORD"),
 		os.Getenv("SYFT_REGISTRY_AUTH_TOKEN")
 
-	if hasNonEmptyCredentials(authority, username, password, token) {
+	if hasNonEmptyCredentials(username, password, token) {
 		// note: we prepend the credentials such that the environment variables take precedence over on-disk configuration.
 		cfg.Auth = append([]RegistryCredentials{
 			{
@@ -51,8 +51,8 @@ func (cfg *registry) parseConfigValues() error {
 	return nil
 }
 
-func hasNonEmptyCredentials(authority, username, password, token string) bool {
-	return authority != "" && password != "" && username != "" || authority != "" && token != ""
+func hasNonEmptyCredentials(username, password, token string) bool {
+	return password != "" && username != "" || token != ""
 }
 
 func (cfg *registry) ToOptions() *image.RegistryOptions {

--- a/internal/config/registry_test.go
+++ b/internal/config/registry_test.go
@@ -9,51 +9,48 @@ import (
 
 func TestHasNonEmptyCredentials(t *testing.T) {
 	tests := []struct {
-		auth, username, password, token string
-		expected                        bool
+		username, password, token string
+		expected                  bool
 	}{
+
 		{
-			"", "", "", "",
+			"", "", "",
 			false,
 		},
 		{
-			"auth", "", "", "",
+			"user", "", "",
 			false,
 		},
 		{
-			"auth", "user", "", "",
+			"", "pass", "",
 			false,
 		},
 		{
-			"auth", "", "pass", "",
-			false,
-		},
-		{
-			"auth", "", "pass", "tok",
+			"", "pass", "tok",
 			true,
 		},
 		{
-			"auth", "user", "", "tok",
+			"user", "", "tok",
 			true,
 		},
 		{
-			"auth", "", "", "tok",
+			"", "", "tok",
 			true,
 		},
 		{
-			"auth", "user", "pass", "tok",
+			"user", "pass", "tok",
 			true,
 		},
 
 		{
-			"auth", "user", "pass", "",
+			"user", "pass", "",
 			true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
-			assert.Equal(t, test.expected, hasNonEmptyCredentials(test.auth, test.username, test.password, test.token))
+			assert.Equal(t, test.expected, hasNonEmptyCredentials(test.username, test.password, test.token))
 		})
 	}
 }

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -165,7 +165,7 @@ func TestRegistryAuth(t *testing.T) {
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
 				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using registry credentials for "localhost:5000"`),
+				assertInOutput(`using basic auth for registry "localhost:5000"`),
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestRegistryAuth(t *testing.T) {
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
 				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using registry token for "localhost:5000"`),
+				assertInOutput(`using token for registry "localhost:5000"`),
 			},
 		},
 		{


### PR DESCRIPTION
Related to https://github.com/anchore/stereoscope/issues/68

Allows Syft to use registry credentials in cases where the user hasn't provided an "authority" config value