### PR TITLE
Add config option for import timeout

### DIFF
--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -137,6 +137,11 @@ func setPackageFlags(flags *pflag.FlagSet) {
 		"overwrite-existing-image", false,
 		"overwrite an existing image during the upload to Anchore Enterprise",
 	)
+
+	flags.Uint(
+		"import-timeout", 30,
+		"set a timeout duration (in seconds) for the upload to Anchore Enterprise",
+	)
 }
 
 func bindPackagesConfigOptions(flags *pflag.FlagSet) error {
@@ -169,6 +174,10 @@ func bindPackagesConfigOptions(flags *pflag.FlagSet) error {
 	}
 
 	if err := viper.BindPFlag("anchore.overwrite-existing-image", flags.Lookup("overwrite-existing-image")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("anchore.import-timeout", flags.Lookup("import-timeout")); err != nil {
 		return err
 	}
 
@@ -262,6 +271,7 @@ func runPackageSbomUpload(src source.Source, s source.Metadata, catalog *pkg.Cat
 		Dockerfile:              dockerfileContents,
 		OverwriteExistingUpload: appConfig.Anchore.OverwriteExistingImage,
 		Scope:                   scope,
+		Timeout:                 appConfig.Anchore.ImportTimeout,
 	}
 
 	if err := c.Import(context.Background(), importCfg); err != nil {

--- a/internal/anchore/import.go
+++ b/internal/anchore/import.go
@@ -27,6 +27,7 @@ type ImportConfig struct {
 	Dockerfile              []byte
 	OverwriteExistingUpload bool
 	Scope                   source.Scope
+	Timeout                 uint
 }
 
 func importProgress(source string) (*progress.Stage, *progress.Manual) {
@@ -54,7 +55,8 @@ func importProgress(source string) (*progress.Stage, *progress.Manual) {
 func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 	stage, prog := importProgress(c.config.BaseURL)
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
+	timeout := time.Duration(cfg.Timeout) * time.Second
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	authedCtx := c.newRequestContext(ctxWithTimeout)

--- a/internal/config/anchore.go
+++ b/internal/config/anchore.go
@@ -12,6 +12,8 @@ type anchore struct {
 	Password               string `yaml:"-" json:"-" mapstructure:"password"`                                                               // -p , password to authenticate upload
 	Dockerfile             string `yaml:"dockerfile" json:"dockerfile" mapstructure:"dockerfile"`                                           // -d , dockerfile to attach for upload
 	OverwriteExistingImage bool   `yaml:"overwrite-existing-image" json:"overwrite-existing-image" mapstructure:"overwrite-existing-image"` // --overwrite-existing-image , if any of the SBOM components have already been uploaded this flag will ensure they are overwritten with the current upload
+	ImportTimeout          uint   `yaml:"import-timeout" json:"import-timeout" mapstructure:"import-timeout"`                               // --import-timeout
+	// , customize the number of seconds within which the SBOM import must be completed or canceled
 }
 
 func (cfg anchore) loadDefaultValues(v *viper.Viper) {

--- a/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
+++ b/internal/presenter/poweruser/test-fixtures/snapshot/TestJSONPresenter.golden
@@ -174,7 +174,8 @@
     "host": "",
     "path": "",
     "dockerfile": "",
-    "overwrite-existing-image": false
+    "overwrite-existing-image": false,
+    "import-timeout": 0
    },
    "dev": {
     "profile-cpu": false,


### PR DESCRIPTION
Closes #419 

Adds a new CLI flag (`--import-timeout`) and backing config option (`"anchore.import-timeout"`) to Syft. This allows the user to control the timeout duration applied to the image SBOM import operation. By default, this value is set to **30 seconds**.