### PR TITLE
Fix go mod tidy release problem

### DIFF
--- a/.github/scripts/go-mod-tidy-check.sh
+++ b/.github/scripts/go-mod-tidy-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -u
+
+TMP_GOMOD=$(mktemp)
+TMP_GOSUM=$(mktemp)
+
+trap "rm -f ${TMP_GOSUM} ${TMP_GOMOD}" EXIT
+
+cp go.mod "${TMP_GOMOD}"
+cp go.sum "${TMP_GOSUM}"
+
+go mod tidy
+
+DIFF_MOD=$(diff -u "${TMP_GOMOD}" go.mod)
+DIFF_SUM=$(diff -u "${TMP_GOSUM}" go.sum)
+
+cp "${TMP_GOMOD}" go.mod
+cp "${TMP_GOSUM}" go.sum
+
+if [[ -n "${DIFF_MOD}" || -n "${DIFF_SUM}" ]]; then
+    echo "go.mod and/or go.sum are not tidy; please run go mod tidy"
+    echo "go.mod diff:"
+    echo "${DIFF_MOD}"
+    echo "go.sum diff:"
+    echo "${DIFF_SUM}"
+    exit 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ bootstrap: $(RESULTSDIR) bootstrap-go bootstrap-tools ## Download and install al
 	$(call title,Bootstrapping dependencies)
 
 .PHONY: static-analysis
-static-analysis: lint check-licenses
+static-analysis: lint check-go-mod-tidy check-licenses
 
 .PHONY: lint
 lint: ## Run gofmt + golangci lint checks
@@ -136,10 +136,14 @@ lint-fix: ## Auto-format all source code + run golangci lint fixers
 	$(call title,Running lint fixers)
 	gofmt -w -s .
 	$(LINTCMD) --fix
+	go mod tidy
 
 .PHONY: check-licenses
 check-licenses:
 	$(TEMPDIR)/bouncer check
+
+check-go-mod-tidy:
+	@ .github/scripts/go-mod-tidy-check.sh && echo "go.mod and go.sum are tidy!"
 
 .PHONY: validate-cyclonedx-schema
 validate-cyclonedx-schema:

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6 h1:g9ZS2V/T0wxseccI4t1hQTqWBek5DVOQZOzzdWBjwnU=
-github.com/anchore/stereoscope v0.0.0-20210413221244-d577f30b19e6/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f h1:bFadyOLOkzME3BrZFZ5m8cf/b2hsn3aMSS9s+SKubRk=
 github.com/anchore/stereoscope v0.0.0-20210524175238-3b7662f3a66f/go.mod h1:vhh1M99rfWx5ejMvz1lkQiFZUrC5wu32V12R4JXH+ZI=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=


### PR DESCRIPTION
Brings in `go mod tidy` fix from https://github.com/anchore/grype/pull/323 (with minor update)
