### PR TITLE
Replace links to Slack channels with public signup link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,6 @@
 contact_links:
 
-  - name: Help & Support Slack Channel ⛑️
-    # link to toolbox-help channel
-    url: https://anchorecommunity.slack.com/archives/C019BUXV7R6
-    about: Ask a questions and get answers
-
-  - name: Developer Slack Channel 💬
-    # link to toolbox-dev channel
-    url: https://anchorecommunity.slack.com/archives/C0190NF9TSM
-    about: Participate in design discussions and feature development
+  - name: Join the Slack community 💬
+    # link to our community Slack registration page
+    url: https://anchore.com/slack
+    about: 'Be sure to check out the channels #toolbox-help (ask us questions) and #toolbox-dev (collaborate with us on design and development)!'


### PR DESCRIPTION
Fixes #423 

For why this is needed, see https://github.com/anchore/syft/issues/423#issuecomment-848738330.

Next, I'll open an equivalent PR in [Grype](https://github.com/anchore/grype).