### PR TITLE
Minimal changes to use ID_LIKE

### DIFF
--- a/syft/distro/identify.go
+++ b/syft/distro/identify.go
@@ -97,8 +97,7 @@ func assemble(name, version, like string) *Distro {
 
 	// If it's an unknown distro, try mapping the ID_LIKE
 	if !ok && len(like) != 0 {
-		name = like
-		distroType, ok = IDMapping[name]
+		distroType, ok = IDMapping[like]
 	}
 
 	if ok {

--- a/syft/distro/identify.go
+++ b/syft/distro/identify.go
@@ -95,6 +95,12 @@ func assemble(name, version, like string) *Distro {
 		return nil
 	}
 
+	// If it's an unknown distro, try mapping the ID_LIKE
+	if !ok && len(like) != 0 {
+		name = like
+		distroType, ok = IDMapping[name]
+	}
+
 	if ok {
 		distro, err := NewDistro(distroType, version, like)
 		if err != nil {

--- a/syft/distro/identify.go
+++ b/syft/distro/identify.go
@@ -91,7 +91,7 @@ func assemble(name, version, like string) *Distro {
 	distroType, ok := IDMapping[name]
 
 	// Both distro and version must be present
-	if len(name) == 0 {
+	if len(name) == 0 && len(version) == 0 {
 		return nil
 	}
 

--- a/syft/distro/identify_test.go
+++ b/syft/distro/identify_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/internal"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/anchore/syft/syft/source"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIdentifyDistro(t *testing.T) {
@@ -84,6 +83,20 @@ func TestIdentifyDistro(t *testing.T) {
 		{
 			fixture: "test-fixtures/os/arch",
 			Type:    ArchLinux,
+		},
+		{
+			fixture: "test-fixtures/partial-fields/missing-id",
+			Type:    Debian,
+			Version: "8.0.0",
+		},
+		{
+			fixture: "test-fixtures/partial-fields/unknown-id",
+			Type:    Debian,
+			Version: "8.0.0",
+		},
+		{
+			fixture: "test-fixtures/partial-fields/missing-version",
+			Type:    UnknownDistroType,
 		},
 	}
 

--- a/syft/distro/test-fixtures/partial-fields/missing-id/usr/lib/os-release
+++ b/syft/distro/test-fixtures/partial-fields/missing-id/usr/lib/os-release
@@ -1,0 +1,3 @@
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+ID_LIKE=debian

--- a/syft/distro/test-fixtures/partial-fields/missing-version/usr/lib/os-release
+++ b/syft/distro/test-fixtures/partial-fields/missing-version/usr/lib/os-release
@@ -1,0 +1,2 @@
+NAME="Debian GNU/Linux"
+ID_LIKE=debian

--- a/syft/distro/test-fixtures/partial-fields/unknown-id/usr/lib/os-release
+++ b/syft/distro/test-fixtures/partial-fields/unknown-id/usr/lib/os-release
@@ -1,0 +1,4 @@
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+ID=my-awesome-distro
+ID_LIKE=debian


### PR DESCRIPTION
While scanning a Debian derivative that is not mapped by `syft` I discovered that the entire `name:version:like` tuple is `nil`. The functional impact is limited as the _catalogers_ still find the DPKG files, but there's an empty `distro` object in the final JSON and the `purl` URLs aren't computed either.

This PR tries lazily to achieve that by avoiding returning `nil` early and attempting mapping again with the `ID_LIKE` value, if it was detected.

This of course means the `purl` URLs might be inaccurate and it might warrant some form of debug warning to the user, or a strict mode.

One final element to consider is that the distro _name_ (as declared in, say, `/etc/os-release`) seems to get effectively overridden by the way `syft` calls distros (the mapping result) but this is minor (it can be fixed in the resulting output very easily) and I didn't suggest any changes for that.

I can build locally, but I was unable to run unit or integration tests locally as I use `podman` and didn't want to mess the `Makefile` too much by trying to hack the calls.

Thank you for the opportunity to learn a little bit from the codebase and for all the very cool work happening with `syft` lately. While this is a minor patch, I still look forward to learning from your observations, input and continued work.