### PR TITLE
Force UI teardown when event is sourced from a signal interrupt

### DIFF
--- a/cmd/event_loop_test.go
+++ b/cmd/event_loop_test.go
@@ -37,7 +37,7 @@ func (u *uiMock) Handle(event partybus.Event) error {
 	return u.Called(event).Error(0)
 }
 
-func (u *uiMock) Teardown() error {
+func (u *uiMock) Teardown(_ bool) error {
 	u.t.Logf("UI Teardown called")
 	return u.Called().Error(0)
 }

--- a/internal/ui/logger_ui.go
+++ b/internal/ui/logger_ui.go
@@ -33,6 +33,6 @@ func (l loggerUI) Handle(event partybus.Event) error {
 	return l.unsubscribe()
 }
 
-func (l loggerUI) Teardown() error {
+func (l loggerUI) Teardown(_ bool) error {
 	return nil
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -7,5 +7,5 @@ import (
 type UI interface {
 	Setup(unsubscribe func() error) error
 	partybus.Handler
-	Teardown() error
+	Teardown(force bool) error
 }


### PR DESCRIPTION
This PR fixes the behavior in v0.18.0 where ctrl C does not appear to interrupt the application execution. When a signal interrupt is handled it is important that the UI is forcefully torn down, not waiting for any unfinished elements (e.g. spinners). This PR adds this forcing mechanism.