### PR TITLE
Add help message when no arguments are provided

### DIFF
--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -47,7 +47,7 @@ const (
 
 var (
 	packagesPresenterOpt packages.PresenterOption
-	packagesArgs         = cobra.MinimumNArgs(1)
+	packagesArgs         = cobra.MaximumNArgs(1)
 	packagesCmd          = &cobra.Command{
 		Use:   "packages [SOURCE]",
 		Short: "Generate a package SBOM",
@@ -65,8 +65,7 @@ var (
 				if err != nil {
 					return err
 				}
-				// silently exit
-				return fmt.Errorf("")
+				return fmt.Errorf("an image/directory argument is required")
 			}
 
 			// set the presenter

--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -34,11 +34,19 @@ var powerUserCmd = &cobra.Command{
 		"appName": internal.ApplicationName,
 		"command": "power-user",
 	}),
-	Args:          cobra.ExactArgs(1),
+	Args:          cobra.MaximumNArgs(1),
 	Hidden:        true,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			err := cmd.Help()
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("an image/directory argument is required")
+		}
+
 		if appConfig.Dev.ProfileCPU && appConfig.Dev.ProfileMem {
 			return fmt.Errorf("cannot profile CPU and memory simultaneously")
 		}

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -17,6 +17,15 @@ func TestPackagesCmdFlags(t *testing.T) {
 		assertions []traitAssertion
 	}{
 		{
+			name: "no-args-shows-help",
+			args: []string{"packages"},
+			assertions: []traitAssertion{
+				assertInOutput("an image/directory argument is required"),              // specific error that should be shown
+				assertInOutput("Generate a packaged-based Software Bill Of Materials"), // excerpt from help description
+				assertFailingReturnCode,
+			},
+		},
+		{
 			name: "json-output-flag",
 			args: []string{"packages", "-o", "json", request},
 			assertions: []traitAssertion{

--- a/test/cli/power_user_cmd_test.go
+++ b/test/cli/power_user_cmd_test.go
@@ -13,6 +13,15 @@ func TestPowerUserCmdFlags(t *testing.T) {
 		assertions []traitAssertion
 	}{
 		{
+			name: "no-args-shows-help",
+			args: []string{"power-user"},
+			assertions: []traitAssertion{
+				assertInOutput("an image/directory argument is required"), // specific error that should be shown
+				assertInOutput("Run bulk operations on container images"), // excerpt from help description
+				assertFailingReturnCode,
+			},
+		},
+		{
 			name: "json-output-flag-fails",
 			args: []string{"power-user", "-o", "json", "docker-archive:" + getFixtureImage(t, "image-pkg-coverage")},
 			assertions: []traitAssertion{


### PR DESCRIPTION
Now when no arguments are provided, the default help text is displayed:
```
$ syft packages
Generate a packaged-based Software Bill Of Materials (SBOM) from container images and filesystems

Usage:
   packages [SOURCE] [flags]

...

an image/directory argument is required
exit status 1

```