### PR TITLE
Fix directory resolver indexer to report one progressable object

### DIFF
--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/stretchr/testify/assert"
+	"github.com/wagoodman/go-progress"
 )
 
 func TestDirectoryResolver_FilesByPath(t *testing.T) {
@@ -350,7 +351,7 @@ type indexerMock struct {
 	additionalRoots map[string][]string
 }
 
-func (m *indexerMock) indexer(s string) ([]string, error) {
+func (m *indexerMock) indexer(s string, _ *progress.Stage) ([]string, error) {
 	m.observedRoots = append(m.observedRoots, s)
 	return m.additionalRoots[s], nil
 }


### PR DESCRIPTION
If the directory resolver indexes multiple roots (due to sym links found) then each discovered root shows up as a progress bar on the ETUI. This should not be the case --instead only the requested root should be reported.