### PR TITLE
Power user dir

### DIFF
--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -237,7 +237,7 @@ func packagesExecWorker(userInput string) <-chan error {
 	return errs
 }
 
-func runPackageSbomUpload(src source.Source, s source.Metadata, catalog *pkg.Catalog, d *distro.Distro, scope source.Scope) error {
+func runPackageSbomUpload(src *source.Source, s source.Metadata, catalog *pkg.Catalog, d *distro.Distro, scope source.Scope) error {
 	log.Infof("uploading results to %s", appConfig.Anchore.Host)
 
 	if src.Metadata.Scheme != source.ImageScheme {

--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -102,11 +102,6 @@ func powerUserExecWorker(userInput string) <-chan error {
 		}
 		defer cleanup()
 
-		if src.Metadata.Scheme != source.ImageScheme {
-			errs <- fmt.Errorf("the power-user subcommand only allows for 'image' schemes, given %q", src.Metadata.Scheme)
-			return
-		}
-
 		analysisResults := poweruser.JSONDocumentConfig{
 			SourceMetadata:    src.Metadata,
 			ApplicationConfig: *appConfig,

--- a/cmd/power_user_tasks.go
+++ b/cmd/power_user_tasks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-type powerUserTask func(*poweruser.JSONDocumentConfig, source.Source) error
+type powerUserTask func(*poweruser.JSONDocumentConfig, *source.Source) error
 
 func powerUserTasks() ([]powerUserTask, error) {
 	var tasks []powerUserTask
@@ -42,7 +42,7 @@ func catalogPackagesTask() (powerUserTask, error) {
 		return nil, nil
 	}
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		packageCatalog, theDistro, err := syft.CatalogPackages(src, appConfig.Package.Cataloger.ScopeOpt)
 		if err != nil {
 			return err
@@ -64,7 +64,7 @@ func catalogFileMetadataTask() (powerUserTask, error) {
 
 	metadataCataloger := file.NewMetadataCataloger()
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		resolver, err := src.FileResolver(appConfig.FileMetadata.Cataloger.ScopeOpt)
 		if err != nil {
 			return err
@@ -110,7 +110,7 @@ func catalogFileDigestsTask() (powerUserTask, error) {
 		return nil, err
 	}
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		resolver, err := src.FileResolver(appConfig.FileMetadata.Cataloger.ScopeOpt)
 		if err != nil {
 			return err
@@ -142,7 +142,7 @@ func catalogSecretsTask() (powerUserTask, error) {
 		return nil, err
 	}
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		resolver, err := src.FileResolver(appConfig.Secrets.Cataloger.ScopeOpt)
 		if err != nil {
 			return err
@@ -170,7 +170,7 @@ func catalogFileClassificationsTask() (powerUserTask, error) {
 		return nil, err
 	}
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		resolver, err := src.FileResolver(appConfig.FileClassification.Cataloger.ScopeOpt)
 		if err != nil {
 			return err
@@ -197,7 +197,7 @@ func catalogContentsTask() (powerUserTask, error) {
 		return nil, err
 	}
 
-	task := func(results *poweruser.JSONDocumentConfig, src source.Source) error {
+	task := func(results *poweruser.JSONDocumentConfig, src *source.Source) error {
 		resolver, err := src.FileResolver(appConfig.FileContents.Cataloger.ScopeOpt)
 		if err != nil {
 			return err

--- a/internal/err_helper.go
+++ b/internal/err_helper.go
@@ -30,9 +30,9 @@ func IsErrPath(err error) bool {
 }
 
 func IsErrPathPermission(err error) bool {
-	path_err, ok := err.(ErrPath)
+	pathErr, ok := err.(ErrPath)
 	if ok {
-		return os.IsPermission(path_err.Err)
+		return os.IsPermission(pathErr.Err)
 	}
 	return ok
 }

--- a/internal/err_helper.go
+++ b/internal/err_helper.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"fmt"
 	"io"
+	"os"
 
 	"github.com/anchore/syft/internal/log"
 )
@@ -11,4 +13,26 @@ func CloseAndLogError(closer io.Closer, location string) {
 	if err := closer.Close(); err != nil {
 		log.Warnf("unable to close file for location=%q: %+v", location, err)
 	}
+}
+
+type ErrObserve struct {
+	Path string
+	Err  error
+}
+
+func (e ErrObserve) Error() string {
+	return fmt.Sprintf("unable to observe contents of %+v: %v", e.Path, e.Err)
+}
+
+func IsErrObserve(err error) bool {
+	_, ok := err.(ErrObserve)
+	return ok
+}
+
+func IsErrObservePermission(err error) bool {
+	observe_err, ok := err.(ErrObserve)
+	if ok {
+		return os.IsPermission(observe_err.Err)
+	}
+	return ok
 }

--- a/internal/err_helper.go
+++ b/internal/err_helper.go
@@ -15,24 +15,24 @@ func CloseAndLogError(closer io.Closer, location string) {
 	}
 }
 
-type ErrObserve struct {
+type ErrPath struct {
 	Path string
 	Err  error
 }
 
-func (e ErrObserve) Error() string {
+func (e ErrPath) Error() string {
 	return fmt.Sprintf("unable to observe contents of %+v: %v", e.Path, e.Err)
 }
 
-func IsErrObserve(err error) bool {
-	_, ok := err.(ErrObserve)
+func IsErrPath(err error) bool {
+	_, ok := err.(ErrPath)
 	return ok
 }
 
-func IsErrObservePermission(err error) bool {
-	observe_err, ok := err.(ErrObserve)
+func IsErrPathPermission(err error) bool {
+	path_err, ok := err.(ErrPath)
 	if ok {
-		return os.IsPermission(observe_err.Err)
+		return os.IsPermission(path_err.Err)
 	}
 	return ok
 }

--- a/syft/file/classification_cataloger_test.go
+++ b/syft/file/classification_cataloger_test.go
@@ -118,11 +118,18 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 
 			loc := source.NewLocation(test.location)
 
-			if _, ok := actualResults[loc]; !ok {
+			ok := false
+			for actual_loc, actual_classification := range actualResults {
+				if loc.RealPath == actual_loc.RealPath {
+					ok = true
+					assert.Equal(t, test.expected, actual_classification)
+				}
+			}
+
+			if !ok {
 				t.Fatalf("could not find test location=%q", test.location)
 			}
 
-			assert.Equal(t, test.expected, actualResults[loc])
 		})
 	}
 }

--- a/syft/file/contents_cataloger.go
+++ b/syft/file/contents_cataloger.go
@@ -42,7 +42,7 @@ func (i *ContentsCataloger) Catalog(resolver source.FileResolver) (map[source.Lo
 		}
 
 		result, err := i.catalogLocation(resolver, location)
-		if internal.IsErrObservePermission(err) {
+		if internal.IsErrPathPermission(err) {
 			log.Debugf("file contents cataloger skipping - %+v", err)
 			continue
 		}
@@ -65,7 +65,7 @@ func (i *ContentsCataloger) catalogLocation(resolver source.FileResolver, locati
 
 	buf := &bytes.Buffer{}
 	if _, err = io.Copy(base64.NewEncoder(base64.StdEncoding, buf), contentReader); err != nil {
-		return "", internal.ErrObserve{Path: location.RealPath, Err: err}
+		return "", internal.ErrPath{Path: location.RealPath, Err: err}
 	}
 
 	return buf.String(), nil

--- a/syft/file/digest_cataloger.go
+++ b/syft/file/digest_cataloger.go
@@ -39,7 +39,7 @@ func (i *DigestsCataloger) Catalog(resolver source.FileResolver) (map[source.Loc
 	for _, location := range locations {
 		stage.Current = location.RealPath
 		result, err := i.catalogLocation(resolver, location)
-		if internal.IsErrObservePermission(err) {
+		if internal.IsErrPathPermission(err) {
 			log.Debugf("file digests cataloger skipping - %+v", err)
 			continue
 		}
@@ -72,7 +72,7 @@ func (i *DigestsCataloger) catalogLocation(resolver source.FileResolver, locatio
 
 	size, err := io.Copy(io.MultiWriter(writers...), contentReader)
 	if err != nil {
-		return nil, internal.ErrObserve{Path: location.RealPath, Err: err}
+		return nil, internal.ErrPath{Path: location.RealPath, Err: err}
 	}
 
 	if size == 0 {

--- a/syft/file/digest_cataloger.go
+++ b/syft/file/digest_cataloger.go
@@ -39,6 +39,11 @@ func (i *DigestsCataloger) Catalog(resolver source.FileResolver) (map[source.Loc
 	for _, location := range locations {
 		stage.Current = location.RealPath
 		result, err := i.catalogLocation(resolver, location)
+		if internal.IsErrObservePermission(err) {
+			log.Debugf("file digests cataloger skipping - %+v", err)
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -67,7 +72,7 @@ func (i *DigestsCataloger) catalogLocation(resolver source.FileResolver, locatio
 
 	size, err := io.Copy(io.MultiWriter(writers...), contentReader)
 	if err != nil {
-		return nil, fmt.Errorf("unable to observe contents of %+v: %+v", location.RealPath, err)
+		return nil, internal.ErrObserve{Path: location.RealPath, Err: err}
 	}
 
 	if size == 0 {

--- a/syft/file/secrets_cataloger.go
+++ b/syft/file/secrets_cataloger.go
@@ -50,6 +50,11 @@ func (i *SecretsCataloger) Catalog(resolver source.FileResolver) (map[source.Loc
 	for _, location := range locations {
 		stage.Current = location.RealPath
 		result, err := i.catalogLocation(resolver, location)
+		if internal.IsErrObservePermission(err) {
+			log.Debugf("secrets cataloger skipping - %+v", err)
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +82,7 @@ func (i *SecretsCataloger) catalogLocation(resolver source.FileResolver, locatio
 	// TODO: in the future we can swap out search strategies here
 	secrets, err := catalogLocationByLine(resolver, location, i.patterns)
 	if err != nil {
-		return nil, err
+		return nil, internal.ErrObserve{Path: location.RealPath, Err: err}
 	}
 
 	if i.revealValues {

--- a/syft/file/secrets_cataloger.go
+++ b/syft/file/secrets_cataloger.go
@@ -50,7 +50,7 @@ func (i *SecretsCataloger) Catalog(resolver source.FileResolver) (map[source.Loc
 	for _, location := range locations {
 		stage.Current = location.RealPath
 		result, err := i.catalogLocation(resolver, location)
-		if internal.IsErrObservePermission(err) {
+		if internal.IsErrPathPermission(err) {
 			log.Debugf("secrets cataloger skipping - %+v", err)
 			continue
 		}
@@ -82,7 +82,7 @@ func (i *SecretsCataloger) catalogLocation(resolver source.FileResolver, locatio
 	// TODO: in the future we can swap out search strategies here
 	secrets, err := catalogLocationByLine(resolver, location, i.patterns)
 	if err != nil {
-		return nil, internal.ErrObserve{Path: location.RealPath, Err: err}
+		return nil, internal.ErrPath{Path: location.RealPath, Err: err}
 	}
 
 	if i.revealValues {

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -32,7 +32,7 @@ import (
 // CatalogPackages takes an inventory of packages from the given image from a particular perspective
 // (e.g. squashed source, all-layers source). Returns the discovered  set of packages, the identified Linux
 // distribution, and the source object used to wrap the data source.
-func CatalogPackages(src source.Source, scope source.Scope) (*pkg.Catalog, *distro.Distro, error) {
+func CatalogPackages(src *source.Source, scope source.Scope) (*pkg.Catalog, *distro.Distro, error) {
 	resolver, err := src.FileResolver(scope)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to determine resolver while cataloging packages: %w", err)

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -234,7 +234,7 @@ func (r directoryResolver) FilesByGlob(patterns ...string) ([]Location, error) {
 			return nil, err
 		}
 		for _, globResult := range globResults {
-			result = append(result, NewLocation(r.responsePath(string(globResult.MatchPath))))
+			result = append(result, NewLocationFromDirectory(r.responsePath(string(globResult.MatchPath)), globResult.Reference))
 		}
 	}
 
@@ -267,7 +267,7 @@ func (r *directoryResolver) AllLocations() <-chan Location {
 	go func() {
 		defer close(results)
 		for _, ref := range r.fileTree.AllFiles() {
-			results <- NewLocation(r.responsePath(string(ref.RealPath)))
+			results <- NewLocationFromDirectory(r.responsePath(string(ref.RealPath)), ref)
 		}
 	}()
 	return results
@@ -276,7 +276,7 @@ func (r *directoryResolver) AllLocations() <-chan Location {
 func (r *directoryResolver) FileMetadataByLocation(location Location) (FileMetadata, error) {
 	info, exists := r.infos[location.ref.ID()]
 	if !exists {
-		return FileMetadata{}, fmt.Errorf("location: %+v : %w", location, os.ErrExist)
+		return FileMetadata{}, fmt.Errorf("location: %+v : %w", location, os.ErrNotExist)
 	}
 
 	return FileMetadata{

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -171,6 +171,7 @@ func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 
 	// all paths should be found (non filtering matches a path)
 	refs, err := resolver.FilesByGlob("**/place")
+
 	assert.NoError(t, err)
 	// 4: within target/
 	// 1: target/link --> relative path to "place"
@@ -178,9 +179,17 @@ func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 	assert.Len(t, refs, 6)
 
 	// ensure that symlink indexing outside of root worked
-	assert.Contains(t, refs, Location{
-		RealPath: "test-fixtures/system_paths/outside_root/link_target/place",
-	})
+	ok := false
+	test_location := "test-fixtures/system_paths/outside_root/link_target/place"
+	for _, actual_loc := range refs {
+		if test_location == actual_loc.RealPath {
+			ok = true
+		}
+	}
+
+	if !ok {
+		t.Fatalf("could not find test location=%q", test_location)
+	}
 }
 
 func TestDirectoryResolverUsesPathFilterFunction(t *testing.T) {

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -171,7 +171,6 @@ func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 
 	// all paths should be found (non filtering matches a path)
 	refs, err := resolver.FilesByGlob("**/place")
-
 	assert.NoError(t, err)
 	// 4: within target/
 	// 1: target/link --> relative path to "place"

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/stretchr/testify/assert"
 	"github.com/wagoodman/go-progress"
 )
@@ -65,7 +66,7 @@ func TestDirectoryResolver_FilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver(c.root)
+			resolver, err := newDirectoryResolver(nil, c.root)
 			assert.NoError(t, err)
 
 			hasPath := resolver.HasPath(c.input)
@@ -121,7 +122,7 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver("./test-fixtures")
+			resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 			assert.NoError(t, err)
 			refs, err := resolver.FilesByPath(c.input...)
 			assert.NoError(t, err)
@@ -133,8 +134,59 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 	}
 }
 
+func TestDirectoryResolver_SharedTreeMultipleFilesByPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    []string
+		refCount int
+	}{
+		{
+			name:     "finds multiple files first resolver",
+			input:    []string{"test-fixtures/image-symlinks/file-1.txt", "test-fixtures/image-symlinks/file-2.txt"},
+			refCount: 2,
+		},
+		{
+			name:     "skips non-existing files",
+			input:    []string{"test-fixtures/image-symlinks/bogus.txt", "test-fixtures/image-symlinks/file-1.txt"},
+			refCount: 1,
+		},
+		{
+			name:     "does not return anything for non-existing directories",
+			input:    []string{"test-fixtures/non-existing/bogus.txt", "test-fixtures/non-existing/file-1.txt"},
+			refCount: 0,
+		},
+		{
+			name:     "find file second resolver",
+			input:    []string{"test-fixtures/path-detected/.vimrc"},
+			refCount: 1,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fileTree := filetree.NewFileTree()
+			first_resolver, err := newDirectoryResolver(fileTree, "./test-fixtures/image-symlinks")
+			assert.NoError(t, err)
+			second_resolver, err := newDirectoryResolver(fileTree, "./test-fixtures/path-detected")
+			assert.NoError(t, err)
+
+			first_refs, err := first_resolver.FilesByPath(c.input...)
+			assert.NoError(t, err)
+			second_refs, err := second_resolver.FilesByPath(c.input...)
+			assert.NoError(t, err)
+
+			if len(first_refs) != len(second_refs) {
+				t.Errorf("unsynced number of refs: %d != %d", len(first_refs), len(second_refs))
+			}
+
+			if len(first_refs) != c.refCount {
+				t.Errorf("unexpected number of refs: %d != %d", len(first_refs), c.refCount)
+			}
+		})
+	}
+}
+
 func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/file*")
 	assert.NoError(t, err)
@@ -143,7 +195,7 @@ func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/image-symlinks")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures/image-symlinks")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/*.txt")
 	assert.NoError(t, err)
@@ -151,7 +203,7 @@ func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobSingle(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver(nil, "./test-fixtures")
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/*1.txt")
 	assert.NoError(t, err)
@@ -162,7 +214,7 @@ func TestDirectoryResolver_FilesByGlobSingle(t *testing.T) {
 
 func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 	// let's make certain that "dev/place" is not ignored, since it is not "/dev/place"
-	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	resolver, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target")
 	assert.NoError(t, err)
 	// ensure the correct filter function is wired up by default
 	expectedFn := reflect.ValueOf(isUnixSystemRuntimePath)
@@ -198,7 +250,7 @@ func TestDirectoryResolverUsesPathFilterFunction(t *testing.T) {
 		return strings.Contains(s, "dev/place") || strings.Contains(s, "proc/place") || strings.Contains(s, "sys/place")
 	}
 
-	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target", filter)
+	resolver, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target", filter)
 	assert.NoError(t, err)
 
 	// ensure the correct filter function is wired up by default
@@ -260,7 +312,7 @@ func Test_isUnixSystemRuntimePath(t *testing.T) {
 
 func Test_directoryResolver_index(t *testing.T) {
 	// note: this test is testing the effects from newDirectoryResolver, indexTree, and addPathToIndex
-	r, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	r, err := newDirectoryResolver(nil, "test-fixtures/system_paths/target")
 	if err != nil {
 		t.Fatalf("unable to get indexed dir resolver: %+v", err)
 	}

--- a/syft/source/location.go
+++ b/syft/source/location.go
@@ -45,6 +45,14 @@ func NewLocationFromImage(virtualPath string, ref file.Reference, img *image.Ima
 	}
 }
 
+// NewLocationFromDirectory creates a new Location representing the given path (extracted from the ref) relative to the given directory.
+func NewLocationFromDirectory(responsePath string, ref file.Reference) Location {
+	return Location{
+		RealPath: responsePath,
+		ref:      ref,
+	}
+}
+
 func NewLocationFromReference(ref file.Reference) Location {
 	return Location{
 		VirtualPath: string(ref.RealPath),

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/anchore/stereoscope"
-	"github.com/anchore/stereoscope/pkg/filetree"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/spf13/afero"
 )
@@ -18,61 +17,60 @@ import (
 // Source is an object that captures the data source to be cataloged, configuration, and a specific resolver used
 // in cataloging (based on the data source and configuration)
 type Source struct {
-	Image    *image.Image // the image object to be cataloged (image only)
-	Tree     *filetree.FileTree
-	Metadata Metadata
-	Mutex    *sync.Mutex
+	Image             *image.Image // the image object to be cataloged (image only)
+	DirectoryResolver *directoryResolver
+	Metadata          Metadata
+	Mutex             *sync.Mutex
 }
 
 type sourceDetector func(string) (image.Source, string, error)
 
 // New produces a Source based on userInput like dir: or image:tag
-func New(userInput string, registryOptions *image.RegistryOptions) (Source, func(), error) {
+func New(userInput string, registryOptions *image.RegistryOptions) (*Source, func(), error) {
 	fs := afero.NewOsFs()
 	parsedScheme, imageSource, location, err := detectScheme(fs, image.DetectSource, userInput)
 	if err != nil {
-		return Source{}, func() {}, fmt.Errorf("unable to parse input=%q: %w", userInput, err)
+		return &Source{}, func() {}, fmt.Errorf("unable to parse input=%q: %w", userInput, err)
 	}
 
 	switch parsedScheme {
 	case DirectoryScheme:
 		fileMeta, err := fs.Stat(location)
 		if err != nil {
-			return Source{}, func() {}, fmt.Errorf("unable to stat dir=%q: %w", location, err)
+			return &Source{}, func() {}, fmt.Errorf("unable to stat dir=%q: %w", location, err)
 		}
 
 		if !fileMeta.IsDir() {
-			return Source{}, func() {}, fmt.Errorf("given path is not a directory (path=%q): %w", location, err)
+			return &Source{}, func() {}, fmt.Errorf("given path is not a directory (path=%q): %w", location, err)
 		}
 
 		s, err := NewFromDirectory(location)
 		if err != nil {
-			return Source{}, func() {}, fmt.Errorf("could not populate source from path=%q: %w", location, err)
+			return &Source{}, func() {}, fmt.Errorf("could not populate source from path=%q: %w", location, err)
 		}
-		return s, func() {}, nil
+		return &s, func() {}, nil
 
 	case ImageScheme:
 		img, err := stereoscope.GetImageFromSource(location, imageSource, registryOptions)
 		cleanup := stereoscope.Cleanup
 
 		if err != nil || img == nil {
-			return Source{}, cleanup, fmt.Errorf("could not fetch image '%s': %w", location, err)
+			return &Source{}, cleanup, fmt.Errorf("could not fetch image '%s': %w", location, err)
 		}
 
 		s, err := NewFromImage(img, location)
 		if err != nil {
-			return Source{}, cleanup, fmt.Errorf("could not populate source with image: %w", err)
+			return &Source{}, cleanup, fmt.Errorf("could not populate source with image: %w", err)
 		}
-		return s, cleanup, nil
+		return &s, cleanup, nil
 	}
 
-	return Source{}, func() {}, fmt.Errorf("unable to process input for scanning: '%s'", userInput)
+	return &Source{}, func() {}, fmt.Errorf("unable to process input for scanning: '%s'", userInput)
 }
 
 // NewFromDirectory creates a new source object tailored to catalog a given filesystem directory recursively.
 func NewFromDirectory(path string) (Source, error) {
 	return Source{
-		Tree:  filetree.NewFileTree(),
 		Mutex: &sync.Mutex{},
 		Metadata: Metadata{
 			Scheme: DirectoryScheme,
@@ -97,12 +95,19 @@ func NewFromImage(img *image.Image, userImageStr string) (Source, error) {
 	}, nil
 }
 
-func (s Source) FileResolver(scope Scope) (FileResolver, error) {
+func (s *Source) FileResolver(scope Scope) (FileResolver, error) {
 	switch s.Metadata.Scheme {
 	case DirectoryScheme:
 		s.Mutex.Lock()
 		defer s.Mutex.Unlock()
-		return newDirectoryResolver(s.Tree, s.Metadata.Path)
+		if s.DirectoryResolver == nil {
+			directoryResolver, err := newDirectoryResolver(s.Metadata.Path)
+			if err != nil {
+				return nil, err
+			}
+			s.DirectoryResolver = directoryResolver
+		}
+		return s.DirectoryResolver, nil
 	case ImageScheme:
 		switch scope {
 		case SquashedScope:

--- a/test/cli/power_user_cmd_test.go
+++ b/test/cli/power_user_cmd_test.go
@@ -71,6 +71,29 @@ func TestPowerUserCmdFlags(t *testing.T) {
 				assertSuccessfulReturnCode,
 			},
 		},
+		{
+			name: "default-dir-results-w-pkg-coverage",
+			args: []string{"power-user", "dir:test-fixtures/image-pkg-coverage"},
+			assertions: []traitAssertion{
+				assertNotInOutput(" command is deprecated"),     // only the root command should be deprecated
+				assertInOutput(`"type": "RegularFile"`),         // proof of file-metadata data
+				assertInOutput(`"algorithm": "sha256"`),         // proof of file-metadata default digest algorithm of sha256
+				assertInOutput(`"metadataType": "ApkMetadata"`), // proof of package artifacts data
+				assertSuccessfulReturnCode,
+			},
+		},
+		{
+			name: "defaut-secrets-dir-results-w-reveal-values",
+			env: map[string]string{
+				"SYFT_SECRETS_REVEAL_VALUES": "true",
+			},
+			args: []string{"power-user", "dir:test-fixtures/image-secrets"},
+			assertions: []traitAssertion{
+				assertInOutput(`"classification": "generic-api-key"`),                            // proof of the secrets cataloger finding something
+				assertInOutput(`"12345A7a901b345678901234567890123456789012345678901234567890"`), // proof of the secrets cataloger finding the api key
+				assertSuccessfulReturnCode,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func catalogFixtureImage(t *testing.T, fixtureImageName string) (*pkg.Catalog, *distro.Distro, source.Source) {
+func catalogFixtureImage(t *testing.T, fixtureImageName string) (*pkg.Catalog, *distro.Distro, *source.Source) {
 	imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
 	tarPath := imagetest.GetFixtureImageTarPath(t, fixtureImageName)
 
@@ -28,7 +28,7 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string) (*pkg.Catalog, *
 	return pkgCatalog, actualDistro, theSource
 }
 
-func catalogDirectory(t *testing.T, dir string) (*pkg.Catalog, *distro.Distro, source.Source) {
+func catalogDirectory(t *testing.T, dir string) (*pkg.Catalog, *distro.Distro, *source.Source) {
 	theSource, cleanupSource, err := source.New("dir:"+dir, nil)
 	t.Cleanup(cleanupSource)
 	if err != nil {


### PR DESCRIPTION
Hi guys.
My first contribution here, sorry if i am missing something.

Add support of using directory type sources on the **power-user** command.

**Following support have been addressed**
- Digest, contents and secret catalogers require `read` permissions, encountering  a permission error fails the catalogers.
    **Fix**: Log the error (debug) instead of failing, skip ahead.
- Digest and metadata cataloger will fail saying all files sent do not exists in resolver  - cataloger fails.
    **Reason**: `directoryResolver.AllLocations`, `directoryResolver.FilesByGlob` returns locations that is not connected to the directory resolver file references.
    **PR**: Return locations that are connected to directory resolver file references.
    
**Test**
- Added cli test `test/cli/power_user_cmd_test.go`, `default-dir-results-w-pkg-coverage` using the `dir:test-fixtures/image-pkg-coverage` source.
 - Added cli test `test/cli/power_user_cmd_test.go`, `defaut-secrets-dir-results-w-reveal-values` using the `dir:test-fixtures/image-secrets` source.
- Unit test - location assertion changed from structural compare to string compare on the location real path field.
 (`TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths`, `TestClassifierCataloger_DefaultClassifiers_PositiveCases`)

**Open issue**
- Should directory resolver locations include the relative path in the virtual path fields and use the reference path for the real path field?

Hope minor patch helps.
Ps love your work.