### PR TITLE
Disable docker releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,11 +94,15 @@ jobs:
     needs: [quality-gate]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
-      - uses: docker-practice/actions-setup-docker@v1
 
-      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
-      - name: Login to Docker Hub
-        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
+# we are having an infinite loop of installing docker https://github.com/anchore/syft/actions/runs/1199137004
+# we are still looking for a fix
+
+#      - uses: docker-practice/actions-setup-docker@v1
+#
+#      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
+#      - name: Login to Docker Hub
+#        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
 
       - uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,16 +91,19 @@ brews:
     homepage: *website
     description: *description
 
-dockers:
-  - dockerfile: Dockerfile
-    image_templates:
-      - "anchore/syft:latest"
-      - "anchore/syft:{{ .Tag }}"
-      - "anchore/syft:v{{ .Major }}"
-      - "anchore/syft:v{{ .Major }}.{{ .Minor }}"
-    build_flag_templates:
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-    use_buildx: true
+# we are having an infinite loop of installing docker https://github.com/anchore/syft/actions/runs/1199137004
+# we are still looking for a fix
+
+#dockers:
+#  - dockerfile: Dockerfile
+#    image_templates:
+#      - "anchore/syft:latest"
+#      - "anchore/syft:{{ .Tag }}"
+#      - "anchore/syft:v{{ .Major }}"
+#      - "anchore/syft:v{{ .Major }}.{{ .Minor }}"
+#    build_flag_templates:
+#      - "--build-arg=BUILD_DATE={{.Date}}"
+#      - "--build-arg=BUILD_VERSION={{.Version}}"
+#      - "--build-arg=VCS_REF={{.FullCommit}}"
+#      - "--build-arg=VCS_URL={{.GitURL}}"
+#    use_buildx: true


### PR DESCRIPTION
Currently cannot install docker onto the mac runners in GHA, which we need for signing. The workaround is to disable docker releases for the short-term until we have a fix in place (but we cannot block binary releases on this)

Example infinite loop:
https://github.com/anchore/syft/actions/runs/1199137004