### PR TITLE
Revert "Disable docker releases"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,15 +94,11 @@ jobs:
     needs: [quality-gate]
     runs-on: macos-latest # Due to our code signing process, it's vital that we run our release steps on macOS.
     steps:
+      - uses: docker-practice/actions-setup-docker@v1
 
-# we are having an infinite loop of installing docker https://github.com/anchore/syft/actions/runs/1199137004
-# we are still looking for a fix
-
-#      - uses: docker-practice/actions-setup-docker@v1
-#
-#      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
-#      - name: Login to Docker Hub
-#        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
+      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
+      - name: Login to Docker Hub
+        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
 
       - uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,19 +91,16 @@ brews:
     homepage: *website
     description: *description
 
-# we are having an infinite loop of installing docker https://github.com/anchore/syft/actions/runs/1199137004
-# we are still looking for a fix
-
-#dockers:
-#  - dockerfile: Dockerfile
-#    image_templates:
-#      - "anchore/syft:latest"
-#      - "anchore/syft:{{ .Tag }}"
-#      - "anchore/syft:v{{ .Major }}"
-#      - "anchore/syft:v{{ .Major }}.{{ .Minor }}"
-#    build_flag_templates:
-#      - "--build-arg=BUILD_DATE={{.Date}}"
-#      - "--build-arg=BUILD_VERSION={{.Version}}"
-#      - "--build-arg=VCS_REF={{.FullCommit}}"
-#      - "--build-arg=VCS_URL={{.GitURL}}"
-#    use_buildx: true
+dockers:
+  - dockerfile: Dockerfile
+    image_templates:
+      - "anchore/syft:latest"
+      - "anchore/syft:{{ .Tag }}"
+      - "anchore/syft:v{{ .Major }}"
+      - "anchore/syft:v{{ .Major }}.{{ .Minor }}"
+    build_flag_templates:
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+    use_buildx: true


### PR DESCRIPTION
Reverts anchore/syft#493

Testing the docker install process on a fork shows that this issue has been resolved. There is the larger issue of this occurring again in the future --it would be ideal to solve this by removing the dependency on `docker-practice/actions-setup-docker@v1` and docker desktop for mac in general. (Migrating to builds via podman + qemu?)