### PR TITLE
Use Anchore fork of packageurl lib without replace directive

### DIFF
--- a/.bouncer.yaml
+++ b/.bouncer.yaml
@@ -6,7 +6,7 @@ permit:
   - ISC
 ignore-packages:
   # packageurl-go is released under the MIT license located in the root of the repo at /mit.LICENSE
-  - github.com/package-url/packageurl-go
+  - github.com/anchore/packageurl-go
 
   # from: https://github.com/spdx/tools-golang/blob/main/LICENSE.code
   # The tools-golang source code is provided and may be used, at your option,

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
+	github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29
 	github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a
 	github.com/antihax/optional v1.0.0
 	github.com/bmatcuk/doublestar/v2 v2.0.4
@@ -24,7 +25,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.1
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/package-url/packageurl-go v0.1.0
 	github.com/pelletier/go-toml v1.8.0
 	github.com/pkg/profile v1.5.0
 	github.com/scylladb/go-set v1.0.2
@@ -47,5 +47,3 @@ require (
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d
 	gopkg.in/yaml.v2 v2.3.0
 )
-
-replace github.com/package-url/packageurl-go v0.1.0 => github.com/anchore/packageurl-go v0.1.0-fixed

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/packageurl-go v0.1.0-fixed h1:2QJUTALDF7m2WHPOS1NyHguSX4ciG0xD3idaBQwHJS8=
-github.com/anchore/packageurl-go v0.1.0-fixed/go.mod h1:C/ApiuWpmbpni4DIOECf6WCjFUZV7O1Fx7VAzrZHgBw=
+github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
+github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
 github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a h1:RQb+Gft1MKxjDfJCnHP/f1mwfy0Jz50Kp9QGgSWKQiY=
 github.com/anchore/stereoscope v0.0.0-20210817160504-0f4abc2a5a5a/go.mod h1:165DfE5jApgEkHTWwu7Bijeml9fofudrgcpuWaD9+tk=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/internal/spdxlicense/generate_license_list.go
+++ b/internal/spdxlicense/generate_license_list.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/anchore/syft/syft/file"
 
-	"github.com/package-url/packageurl-go"
+	"github.com/anchore/packageurl-go"
 	"github.com/scylladb/go-set/strset"
 )
 

--- a/syft/pkg/apk_metadata_test.go
+++ b/syft/pkg/apk_metadata_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/go-test/deep"
-	"github.com/package-url/packageurl-go"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 

--- a/syft/pkg/cataloger/package_url.go
+++ b/syft/pkg/cataloger/package_url.go
@@ -4,9 +4,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/distro"
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/package-url/packageurl-go"
 )
 
 // generatePackageURL returns a package-URL representation of the given package (see https://github.com/package-url/purl-spec)

--- a/syft/pkg/dpkg_metadata.go
+++ b/syft/pkg/dpkg_metadata.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/anchore/syft/syft/file"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/distro"
-	"github.com/package-url/packageurl-go"
 	"github.com/scylladb/go-set/strset"
 )
 
@@ -41,6 +41,7 @@ func (m DpkgMetadata) PackageURL(d *distro.Distro) string {
 	}
 	pURL := packageurl.NewPackageURL(
 		// TODO: replace with `packageurl.TypeDebian` upon merge of https://github.com/package-url/packageurl-go/pull/21
+		// TODO: or, since we're now using an Anchore fork of this module, we could do this sooner.
 		"deb",
 		d.Type.String(),
 		m.Package,

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -3,8 +3,8 @@ package pkg
 import (
 	"strings"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/internal"
-	"github.com/package-url/packageurl-go"
 )
 
 var JenkinsPluginPomPropertiesGroupIDs = []string{

--- a/syft/pkg/rpmdb_metadata.go
+++ b/syft/pkg/rpmdb_metadata.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/distro"
-	"github.com/package-url/packageurl-go"
 )
 
 const RpmDbGlob = "**/var/lib/rpm/Packages"

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -1,6 +1,6 @@
 package pkg
 
-import "github.com/package-url/packageurl-go"
+import "github.com/anchore/packageurl-go"
 
 // Type represents a Package Type for or within a language ecosystem (there may be multiple package types within a language ecosystem)
 type Type string


### PR DESCRIPTION
As [discussed in the community Slack](https://anchorecommunity.slack.com/archives/C0190NF9TSM/p1632315222000900), using a `replace` directive in a module's `go.mod` means that projects like Syft will build differently themselves than when imported by consumers and then built. This could mean that consumers of Syft experience unexpected behavior, or even potentially broken builds, since they're using a state different than we're testing in Syft.

This PR follows up https://github.com/anchore/packageurl-go/pull/2 by removing the `replace` directive from Syft's `go.mod`, thereby pivoting Syft to rely more directly on Anchore's fork.