### PR TITLE
Prevent invalid CPE field values

### DIFF
--- a/syft/pkg/cataloger/common/cpe/field_candidate.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate.go
@@ -73,26 +73,29 @@ func (s fieldCandidateSet) union(others ...fieldCandidateSet) {
 	}
 }
 
-func (s fieldCandidateSet) list(filters ...fieldCandidateCondition) (results []fieldCandidate) {
-candidateLoop:
+func (s fieldCandidateSet) list() (results []fieldCandidate) {
 	for c := range s {
-		for _, fn := range filters {
-			if fn(c) {
-				continue candidateLoop
-			}
-		}
 		results = append(results, c)
 	}
+
 	return results
 }
 
-func (s fieldCandidateSet) values(filters ...fieldCandidateCondition) (results []string) {
-	for _, c := range s.list(filters...) {
+func (s fieldCandidateSet) values() (results []string) {
+	for _, c := range s.list() {
 		results = append(results, c.value)
 	}
+
 	return results
 }
 
-func (s fieldCandidateSet) uniqueValues(filters ...fieldCandidateCondition) []string {
-	return strset.New(s.values(filters...)...).List()
+func (s fieldCandidateSet) uniqueValues() []string {
+	return strset.New(s.values()...).List()
+}
+
+func (s fieldCandidateSet) copy() fieldCandidateSet {
+	newSet := newFieldCandidateSet()
+	newSet.add(s.list()...)
+
+	return newSet
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate.go
@@ -16,7 +16,7 @@ type fieldCandidate struct {
 
 type fieldCandidateSet map[fieldCandidate]struct{}
 
-func newFieldCandidateFromSets(sets ...fieldCandidateSet) fieldCandidateSet {
+func newFieldCandidateSetFromSets(sets ...fieldCandidateSet) fieldCandidateSet {
 	s := newFieldCandidateSet()
 	for _, set := range sets {
 		s.add(set.list()...)
@@ -48,16 +48,12 @@ func (s fieldCandidateSet) add(candidates ...fieldCandidate) {
 
 func (s fieldCandidateSet) removeByValue(values ...string) {
 	for _, value := range values {
-		for candidate := range s {
-			if candidate.value == value {
-				delete(s, candidate)
-			}
-		}
+		s.removeWhere(valueEquals(value))
 	}
 }
 
-// removeByCondition removes all entries from the fieldCandidateSet for which the condition function returns true.
-func (s fieldCandidateSet) removeByCondition(condition func(candidate fieldCandidate) bool) {
+// removeWhere removes all entries from the fieldCandidateSet for which the condition function returns true.
+func (s fieldCandidateSet) removeWhere(condition fieldCandidateCondition) {
 	for candidate := range s {
 		if condition(candidate) {
 			delete(s, candidate)
@@ -77,7 +73,7 @@ func (s fieldCandidateSet) union(others ...fieldCandidateSet) {
 	}
 }
 
-func (s fieldCandidateSet) list(filters ...filterFieldCandidateFn) (results []fieldCandidate) {
+func (s fieldCandidateSet) list(filters ...fieldCandidateCondition) (results []fieldCandidate) {
 candidateLoop:
 	for c := range s {
 		for _, fn := range filters {
@@ -90,13 +86,13 @@ candidateLoop:
 	return results
 }
 
-func (s fieldCandidateSet) values(filters ...filterFieldCandidateFn) (results []string) {
+func (s fieldCandidateSet) values(filters ...fieldCandidateCondition) (results []string) {
 	for _, c := range s.list(filters...) {
 		results = append(results, c.value)
 	}
 	return results
 }
 
-func (s fieldCandidateSet) uniqueValues(filters ...filterFieldCandidateFn) []string {
+func (s fieldCandidateSet) uniqueValues(filters ...fieldCandidateCondition) []string {
 	return strset.New(s.values(filters...)...).List()
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate.go
@@ -56,6 +56,15 @@ func (s fieldCandidateSet) removeByValue(values ...string) {
 	}
 }
 
+// removeByCondition removes all entries from the fieldCandidateSet for which the condition function returns true.
+func (s fieldCandidateSet) removeByCondition(condition func(candidate fieldCandidate) bool) {
+	for candidate := range s {
+		if condition(candidate) {
+			delete(s, candidate)
+		}
+	}
+}
+
 func (s fieldCandidateSet) clear() {
 	for k := range s {
 		delete(s, k)

--- a/syft/pkg/cataloger/common/cpe/field_candidate_filter.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_filter.go
@@ -1,12 +1,24 @@
 package cpe
 
-// filterFieldCandidateFn instances should return true if the given fieldCandidate should be removed from a collection
-type filterFieldCandidateFn func(fieldCandidate) bool
+import "strings"
 
-func filterOutBySubselection(c fieldCandidate) bool {
+// A fieldCandidateCondition returns true if the condition is true for a given fieldCandidate.
+type fieldCandidateCondition func(fieldCandidate) bool
+
+func subSelectionsDisallowed(c fieldCandidate) bool {
 	return c.disallowSubSelections
 }
 
-func filterOutByDelimiterVariations(c fieldCandidate) bool {
+func delimiterVariationsDisallowed(c fieldCandidate) bool {
 	return c.disallowDelimiterVariations
+}
+
+func invalidFieldValue(candidate fieldCandidate) bool {
+	return strings.Contains(candidate.value, ":")
+}
+
+func valueEquals(v string) fieldCandidateCondition {
+	return func(candidate fieldCandidate) bool {
+		return candidate.value == v
+	}
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate_filter.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_filter.go
@@ -1,7 +1,5 @@
 package cpe
 
-import "strings"
-
 // A fieldCandidateCondition returns true if the condition is true for a given fieldCandidate.
 type fieldCandidateCondition func(fieldCandidate) bool
 
@@ -11,10 +9,6 @@ func subSelectionsDisallowed(c fieldCandidate) bool {
 
 func delimiterVariationsDisallowed(c fieldCandidate) bool {
 	return c.disallowDelimiterVariations
-}
-
-func invalidFieldValue(candidate fieldCandidate) bool {
-	return strings.Contains(candidate.value, ":")
 }
 
 func valueEquals(v string) fieldCandidateCondition {

--- a/syft/pkg/cataloger/common/cpe/field_candidate_test.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_test.go
@@ -11,7 +11,7 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   []fieldCandidate
-		filters []filterFieldCandidateFn
+		filters []fieldCandidateCondition
 		expect  []string
 	}{
 		{
@@ -61,8 +61,8 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []filterFieldCandidateFn{
-				filterOutBySubselection,
+			filters: []fieldCandidateCondition{
+				subSelectionsDisallowed,
 			},
 			expect: []string{
 				"allow anything",
@@ -89,8 +89,8 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []filterFieldCandidateFn{
-				filterOutByDelimiterVariations,
+			filters: []fieldCandidateCondition{
+				delimiterVariationsDisallowed,
 			},
 			expect: []string{
 				"allow anything",
@@ -117,9 +117,9 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []filterFieldCandidateFn{
-				filterOutByDelimiterVariations,
-				filterOutBySubselection,
+			filters: []fieldCandidateCondition{
+				delimiterVariationsDisallowed,
+				subSelectionsDisallowed,
 			},
 			expect: []string{
 				"allow anything",
@@ -315,13 +315,13 @@ func Test_cpeFieldCandidateSet_removeByCondition(t *testing.T) {
 
 	assert.Len(t, s.values(), 3)
 
-	s.removeByCondition(func(candidate fieldCandidate) bool {
+	s.removeWhere(func(candidate fieldCandidate) bool {
 		return candidate.disallowSubSelections == true
 	})
 
 	assert.Len(t, s.values(), 2)
 
-	s.removeByCondition(func(candidate fieldCandidate) bool {
+	s.removeWhere(func(candidate fieldCandidate) bool {
 		return strings.Contains(candidate.value, "-")
 	})
 

--- a/syft/pkg/cataloger/common/cpe/field_candidate_test.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_test.go
@@ -1,6 +1,7 @@
 package cpe
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -264,6 +265,7 @@ func Test_cpeFieldCandidateSet_uniqueValues(t *testing.T) {
 
 func Test_cpeFieldCandidateSet_removeByValue(t *testing.T) {
 	s := newFieldCandidateSet()
+
 	// should be removed
 	s.add(fieldCandidate{
 		value:                       "1",
@@ -281,13 +283,47 @@ func Test_cpeFieldCandidateSet_removeByValue(t *testing.T) {
 	s.add(fieldCandidate{
 		value: "1",
 	})
+
 	// should not be removed
 	s.add(fieldCandidate{
 		value: "2",
 	})
+
 	assert.Len(t, s.values(), 5)
 
 	s.removeByValue("1")
+
+	assert.Len(t, s.values(), 1)
+}
+
+func Test_cpeFieldCandidateSet_removeByCondition(t *testing.T) {
+	s := newFieldCandidateSet()
+
+	// should be removed
+	s.add(fieldCandidate{
+		value:                 "1",
+		disallowSubSelections: true,
+	})
+	s.add(fieldCandidate{
+		value: "hello-world",
+	})
+
+	// should not be removed
+	s.add(fieldCandidate{
+		value: "2",
+	})
+
+	assert.Len(t, s.values(), 3)
+
+	s.removeByCondition(func(candidate fieldCandidate) bool {
+		return candidate.disallowSubSelections == true
+	})
+
+	assert.Len(t, s.values(), 2)
+
+	s.removeByCondition(func(candidate fieldCandidate) bool {
+		return strings.Contains(candidate.value, "-")
+	})
 
 	assert.Len(t, s.values(), 1)
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate_test.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_test.go
@@ -9,10 +9,10 @@ import (
 
 func Test_cpeCandidateValues_filter(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   []fieldCandidate
-		filters []fieldCandidateCondition
-		expect  []string
+		name                string
+		input               []fieldCandidate
+		exclusionConditions []fieldCandidateCondition
+		expect              []string
 	}{
 		{
 			name: "gocase",
@@ -61,7 +61,7 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []fieldCandidateCondition{
+			exclusionConditions: []fieldCandidateCondition{
 				subSelectionsDisallowed,
 			},
 			expect: []string{
@@ -89,7 +89,7 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []fieldCandidateCondition{
+			exclusionConditions: []fieldCandidateCondition{
 				delimiterVariationsDisallowed,
 			},
 			expect: []string{
@@ -98,7 +98,7 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 			},
 		},
 		{
-			name: "all filters",
+			name: "all exclusionConditions",
 			input: []fieldCandidate{
 				{
 					value: "allow anything",
@@ -117,7 +117,7 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 					disallowDelimiterVariations: true,
 				},
 			},
-			filters: []fieldCandidateCondition{
+			exclusionConditions: []fieldCandidateCondition{
 				delimiterVariationsDisallowed,
 				subSelectionsDisallowed,
 			},
@@ -131,7 +131,12 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			set := newFieldCandidateSet()
 			set.add(test.input...)
-			assert.ElementsMatch(t, test.expect, set.values(test.filters...))
+
+			for _, condition := range test.exclusionConditions {
+				set.removeWhere(condition)
+			}
+
+			assert.ElementsMatch(t, test.expect, set.values())
 		})
 	}
 }

--- a/syft/pkg/cataloger/common/cpe/filter.go
+++ b/syft/pkg/cataloger/common/cpe/filter.go
@@ -16,6 +16,7 @@ var cpeFilters = []filterFn{
 	disallowJiraClientServerMismatch,
 	disallowJenkinsServerCPEForPluginPackage,
 	disallowJenkinsCPEsNotAssociatedWithJenkins,
+	disallowNonParseableCPEs,
 }
 
 func filter(cpes []pkg.CPE, p pkg.Package, filters ...filterFn) (result []pkg.CPE) {
@@ -30,6 +31,15 @@ cpeLoop:
 		result = append(result, cpe)
 	}
 	return result
+}
+
+func disallowNonParseableCPEs(cpe pkg.CPE, _ pkg.Package) bool {
+	v := cpe.BindToFmtString()
+	_, err := pkg.NewCPE(v)
+
+	cannotParse := err != nil
+
+	return cannotParse
 }
 
 // jenkins plugins should not match against jenkins

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -84,6 +84,10 @@ func Generate(p pkg.Package) []pkg.CPE {
 	return cpes
 }
 
+func invalidCPEValue(candidate fieldCandidate) bool {
+	return strings.Contains(candidate.value, ":")
+}
+
 func candidateVendors(p pkg.Package) []string {
 	// in ecosystems where the packaging metadata does not have a clear field to indicate a vendor (or a field that
 	// could be interpreted indirectly as such) the project name tends to be a common stand in. Examples of this
@@ -129,6 +133,8 @@ func candidateVendors(p pkg.Package) []string {
 	// generate sub-selections of each candidate based on separators (e.g. jenkins-ci -> [jenkins, jenkins-ci])
 	addAllSubSelections(vendors)
 
+	vendors.removeByCondition(invalidCPEValue)
+
 	return vendors.uniqueValues()
 }
 
@@ -157,6 +163,8 @@ func candidateProducts(p pkg.Package) []string {
 
 	// try swapping hyphens for underscores, vice versa, and removing separators altogether
 	addDelimiterVariations(products)
+
+	products.removeByCondition(invalidCPEValue)
 
 	// prepend any known product names for the given package type and name (note: this is not a replacement)
 	return append(productCandidatesByPkgType.getCandidates(p.Type, p.Name), products.uniqueValues()...)

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -166,9 +166,12 @@ func candidateProducts(p pkg.Package) []string {
 	return append(productCandidatesByPkgType.getCandidates(p.Type, p.Name), products.uniqueValues()...)
 }
 
-func addAllSubSelections(set fieldCandidateSet) {
-	for _, candidate := range set.values(subSelectionsDisallowed) {
-		set.addValue(generateSubSelections(candidate)...)
+func addAllSubSelections(fields fieldCandidateSet) {
+	candidatesForVariations := fields.copy()
+	candidatesForVariations.removeWhere(subSelectionsDisallowed)
+
+	for _, candidate := range candidatesForVariations.values() {
+		fields.addValue(generateSubSelections(candidate)...)
 	}
 }
 
@@ -230,7 +233,10 @@ func scanByHyphenOrUnderscore(data []byte, atEOF bool) (advance int, token []byt
 }
 
 func addDelimiterVariations(fields fieldCandidateSet) {
-	for _, candidate := range fields.list(delimiterVariationsDisallowed) {
+	candidatesForVariations := fields.copy()
+	candidatesForVariations.removeWhere(delimiterVariationsDisallowed)
+
+	for _, candidate := range candidatesForVariations.list() {
 		field := candidate.value
 		hasHyphen := strings.Contains(field, "-")
 		hasUnderscore := strings.Contains(field, "_")

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -129,8 +129,6 @@ func candidateVendors(p pkg.Package) []string {
 	// generate sub-selections of each candidate based on separators (e.g. jenkins-ci -> [jenkins, jenkins-ci])
 	addAllSubSelections(vendors)
 
-	vendors.removeWhere(invalidFieldValue)
-
 	return vendors.uniqueValues()
 }
 
@@ -159,8 +157,6 @@ func candidateProducts(p pkg.Package) []string {
 
 	// try swapping hyphens for underscores, vice versa, and removing separators altogether
 	addDelimiterVariations(products)
-
-	products.removeWhere(invalidFieldValue)
 
 	// prepend any known product names for the given package type and name (note: this is not a replacement)
 	return append(productCandidatesByPkgType.getCandidates(p.Type, p.Name), products.uniqueValues()...)

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -180,6 +180,43 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 		},
 		{
+			name: "java with URL in metadata", // regression: https://github.com/anchore/grype/issues/417
+			p: pkg.Package{
+				Name:         "wstx-asl",
+				Version:      "3.2.7",
+				Type:         pkg.JavaPkg,
+				MetadataType: pkg.JavaMetadataType,
+				Metadata: pkg.JavaMetadata{
+					Manifest: &pkg.JavaManifest{
+						Main: map[string]string{
+							"Ant-Version":            "Apache Ant 1.6.5",
+							"Built-By":               "tatu",
+							"Created-By":             "1.4.2_03-b02 (Sun Microsystems Inc.)",
+							"Implementation-Title":   "WoodSToX XML-processor",
+							"Implementation-Vendor":  "woodstox.codehaus.org",
+							"Implementation-Version": "3.2.7",
+							"Manifest-Version":       "1.0",
+							"Specification-Title":    "StAX 1.0 API",
+							"Specification-Vendor":   "http://jcp.org/en/jsr/detail?id=173",
+							"Specification-Version":  "1.0",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:woodstox_codehaus_org:wstx-asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:woodstox_codehaus_org:wstx_asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:woodstox-codehaus-org:wstx_asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:woodstox-codehaus-org:wstx-asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx_asl:wstx-asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx-asl:wstx-asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx-asl:wstx_asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx_asl:wstx_asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx:wstx_asl:3.2.7:*:*:*:*:*:*:*",
+				"cpe:2.3:a:wstx:wstx-asl:3.2.7:*:*:*:*:*:*:*",
+			},
+		},
+		{
 			name: "jenkins package identified via pkg type",
 			p: pkg.Package{
 				Name:     "name",

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -488,7 +488,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				actualCpeSet.Add(a.BindToFmtString())
 			}
 
-			extra := strset.Difference(expectedCpeSet, actualCpeSet).List()
+			extra := strset.Difference(actualCpeSet, expectedCpeSet).List()
 			sort.Strings(extra)
 			if len(extra) > 0 {
 				t.Errorf("found extra CPEs:")
@@ -497,7 +497,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				fmt.Printf("   %q,\n", d)
 			}
 
-			missing := strset.Difference(actualCpeSet, expectedCpeSet).List()
+			missing := strset.Difference(expectedCpeSet, actualCpeSet).List()
 			sort.Strings(missing)
 			if len(missing) > 0 {
 				t.Errorf("missing CPEs:")

--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -46,7 +46,7 @@ func candidateProductsForJava(p pkg.Package) []string {
 func candidateVendorsForJava(p pkg.Package) fieldCandidateSet {
 	gidVendors := vendorsFromGroupIDs(groupIDsFromJavaPackage(p))
 	nameVendors := vendorsFromJavaManifestNames(p)
-	return newFieldCandidateFromSets(gidVendors, nameVendors)
+	return newFieldCandidateSetFromSets(gidVendors, nameVendors)
 }
 
 func vendorsFromJavaManifestNames(p pkg.Package) fieldCandidateSet {


### PR DESCRIPTION
This is the second half of the solution to https://github.com/anchore/grype/issues/417 (the first half being https://github.com/anchore/grype/pull/425).

This PR prevents CPEs from being generated where the product or vendor field contains URL-like strings (e.g. `http://jcp_org/en/jsr/detail?id=173`), or more generically, invalid string values.

This PR takes the approach of considering any field value that contains a colon (`:`) to be invalid, since colons are the delimiter of CPE fields, and this covers the case of URLs that contain substrings like `http://`.