### PR TITLE
Add vendor + product known good CPE field values

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -4,38 +4,7 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-var productCandidatesByPkgType = candidatesByPackageType{
-	pkg.JavaPkg: {
-		"springframework": []string{"spring_framework", "springsource_spring_framework"},
-		"spring-core":     []string{"spring_framework", "springsource_spring_framework"},
-	},
-	pkg.NpmPkg: {
-		"hapi":             []string{"hapi_server_framework"},
-		"handlebars.js":    []string{"handlebars"},
-		"is-my-json-valid": []string{"is_my_json_valid"},
-		"mustache":         []string{"mustache.js"},
-	},
-	pkg.GemPkg: {
-		"Arabic-Prawn":        []string{"arabic_prawn"},
-		"bio-basespace-sdk":   []string{"basespace_ruby_sdk"},
-		"cremefraiche":        []string{"creme_fraiche"},
-		"html-sanitizer":      []string{"html_sanitizer"},
-		"sentry-raven":        []string{"raven-ruby"},
-		"RedCloth":            []string{"redcloth_library"},
-		"VladTheEnterprising": []string{"vladtheenterprising"},
-		"yajl-ruby":           []string{"yajl-ruby_gem"},
-	},
-	pkg.PythonPkg: {
-		"python-rrdtool": []string{"rrdtool"},
-	},
-}
-
-// this is a static mapping of known package names (keys) to official cpe names for each package
-type candidatesByPackageType map[pkg.Type]map[string][]string
-
-/////////////////////////////
-
-var candidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+var defaultCandidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition{
 	pkg.JavaPkg: {
 		candidateAdditionKey{
 			PkgName: "springframework",
@@ -49,25 +18,21 @@ var candidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition
 		},
 	},
 	pkg.NpmPkg: {
-		//"hapi":             []string{"hapi_server_framework"},
 		candidateAdditionKey{
 			PkgName: "hapi",
 		}: {
 			AdditionalProducts: []string{"hapi_server_framework"},
 		},
-		//"handlebars.js":    []string{"handlebars"},
 		candidateAdditionKey{
 			PkgName: "handlebars.js",
 		}: {
 			AdditionalProducts: []string{"handlebars"},
 		},
-		//"is-my-json-valid": []string{"is_my_json_valid"},
 		candidateAdditionKey{
 			PkgName: "is-my-json-valid",
 		}: {
 			AdditionalProducts: []string{"is_my_json_valid"},
 		},
-		//"mustache":         []string{"mustache.js"},
 		candidateAdditionKey{
 			PkgName: "mustache",
 		}: {
@@ -75,49 +40,41 @@ var candidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition
 		},
 	},
 	pkg.GemPkg: {
-		//"Arabic-Prawn":        []string{"arabic_prawn"},
 		candidateAdditionKey{
 			PkgName: "Arabic-Prawn",
 		}: {
 			AdditionalProducts: []string{"arabic_prawn"},
 		},
-		//"bio-basespace-sdk":   []string{"basespace_ruby_sdk"},
 		candidateAdditionKey{
 			PkgName: "bio-basespace-sdk",
 		}: {
 			AdditionalProducts: []string{"basespace_ruby_sdk"},
 		},
-		//"cremefraiche":        []string{"creme_fraiche"},
 		candidateAdditionKey{
 			PkgName: "cremefraiche",
 		}: {
 			AdditionalProducts: []string{"creme_fraiche"},
 		},
-		//"html-sanitizer":      []string{"html_sanitizer"},
 		candidateAdditionKey{
 			PkgName: "html-sanitizer",
 		}: {
 			AdditionalProducts: []string{"html_sanitizer"},
 		},
-		//"sentry-raven":        []string{"raven-ruby"},
 		candidateAdditionKey{
 			PkgName: "sentry-raven",
 		}: {
 			AdditionalProducts: []string{"raven-ruby"},
 		},
-		//"RedCloth":            []string{"redcloth_library"},
 		candidateAdditionKey{
 			PkgName: "RedCloth",
 		}: {
 			AdditionalProducts: []string{"redcloth_library"},
 		},
-		//"VladTheEnterprising": []string{"vladtheenterprising"},
 		candidateAdditionKey{
 			PkgName: "VladTheEnterprising",
 		}: {
 			AdditionalProducts: []string{"vladtheenterprising"},
 		},
-		//"yajl-ruby":           []string{"yajl-ruby_gem"},
 		candidateAdditionKey{
 			PkgName: "yajl-ruby",
 		}: {
@@ -125,7 +82,6 @@ var candidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition
 		},
 	},
 	pkg.PythonPkg: {
-		//"python-rrdtool": []string{"rrdtool"},
 		candidateAdditionKey{
 			PkgName: "python-rrdtool",
 		}: {
@@ -146,12 +102,8 @@ type candidateAddition struct {
 	AdditionalVendors  []string
 }
 
-// type + package name -> product name addition(s)
-// type + vendor name -> vendor name addition(s)
-// type + package name + vendor name -> vendor name addition(s)
-
 // AdditionalVendors(type, product, vendor)
-func additionalVendors(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName, vendor string) (vendors []string) {
+func findAdditionalVendors(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName, vendor string) (vendors []string) {
 	// TODO: rename
 	typedAddition, ok := allAdditions[ty]
 	if !ok {
@@ -180,8 +132,8 @@ func additionalVendors(allAdditions map[pkg.Type]map[candidateAdditionKey]candid
 	return vendors
 }
 
-// additionalProducts(type, product)
-func additionalProducts(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName string) (products []string) {
+// findAdditionalProducts(type, product)
+func findAdditionalProducts(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName string) (products []string) {
 	// TODO: rename
 	typedAddition, ok := allAdditions[ty]
 	if !ok {
@@ -195,16 +147,4 @@ func additionalProducts(allAdditions map[pkg.Type]map[candidateAdditionKey]candi
 	}
 
 	return products
-}
-
-func (s candidatesByPackageType) getCandidates(t pkg.Type, key string) []string {
-	if _, ok := s[t]; !ok {
-		return nil
-	}
-	value, ok := s[t][key]
-	if !ok {
-		return nil
-	}
-
-	return value
 }

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -1,9 +1,201 @@
 package cpe
 
-import "github.com/anchore/syft/syft/pkg"
+import (
+	"github.com/anchore/syft/syft/pkg"
+)
+
+var productCandidatesByPkgType = candidatesByPackageType{
+	pkg.JavaPkg: {
+		"springframework": []string{"spring_framework", "springsource_spring_framework"},
+		"spring-core":     []string{"spring_framework", "springsource_spring_framework"},
+	},
+	pkg.NpmPkg: {
+		"hapi":             []string{"hapi_server_framework"},
+		"handlebars.js":    []string{"handlebars"},
+		"is-my-json-valid": []string{"is_my_json_valid"},
+		"mustache":         []string{"mustache.js"},
+	},
+	pkg.GemPkg: {
+		"Arabic-Prawn":        []string{"arabic_prawn"},
+		"bio-basespace-sdk":   []string{"basespace_ruby_sdk"},
+		"cremefraiche":        []string{"creme_fraiche"},
+		"html-sanitizer":      []string{"html_sanitizer"},
+		"sentry-raven":        []string{"raven-ruby"},
+		"RedCloth":            []string{"redcloth_library"},
+		"VladTheEnterprising": []string{"vladtheenterprising"},
+		"yajl-ruby":           []string{"yajl-ruby_gem"},
+	},
+	pkg.PythonPkg: {
+		"python-rrdtool": []string{"rrdtool"},
+	},
+}
 
 // this is a static mapping of known package names (keys) to official cpe names for each package
 type candidatesByPackageType map[pkg.Type]map[string][]string
+
+/////////////////////////////
+
+var candidateAdditions = map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+	pkg.JavaPkg: {
+		candidateAdditionKey{
+			PkgName: "springframework",
+		}: {
+			AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
+		},
+		candidateAdditionKey{
+			PkgName: "spring-core",
+		}: {
+			AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
+		},
+	},
+	pkg.NpmPkg: {
+		//"hapi":             []string{"hapi_server_framework"},
+		candidateAdditionKey{
+			PkgName: "hapi",
+		}: {
+			AdditionalProducts: []string{"hapi_server_framework"},
+		},
+		//"handlebars.js":    []string{"handlebars"},
+		candidateAdditionKey{
+			PkgName: "handlebars.js",
+		}: {
+			AdditionalProducts: []string{"handlebars"},
+		},
+		//"is-my-json-valid": []string{"is_my_json_valid"},
+		candidateAdditionKey{
+			PkgName: "is-my-json-valid",
+		}: {
+			AdditionalProducts: []string{"is_my_json_valid"},
+		},
+		//"mustache":         []string{"mustache.js"},
+		candidateAdditionKey{
+			PkgName: "mustache",
+		}: {
+			AdditionalProducts: []string{"mustache.js"},
+		},
+	},
+	pkg.GemPkg: {
+		//"Arabic-Prawn":        []string{"arabic_prawn"},
+		candidateAdditionKey{
+			PkgName: "Arabic-Prawn",
+		}: {
+			AdditionalProducts: []string{"arabic_prawn"},
+		},
+		//"bio-basespace-sdk":   []string{"basespace_ruby_sdk"},
+		candidateAdditionKey{
+			PkgName: "bio-basespace-sdk",
+		}: {
+			AdditionalProducts: []string{"basespace_ruby_sdk"},
+		},
+		//"cremefraiche":        []string{"creme_fraiche"},
+		candidateAdditionKey{
+			PkgName: "cremefraiche",
+		}: {
+			AdditionalProducts: []string{"creme_fraiche"},
+		},
+		//"html-sanitizer":      []string{"html_sanitizer"},
+		candidateAdditionKey{
+			PkgName: "html-sanitizer",
+		}: {
+			AdditionalProducts: []string{"html_sanitizer"},
+		},
+		//"sentry-raven":        []string{"raven-ruby"},
+		candidateAdditionKey{
+			PkgName: "sentry-raven",
+		}: {
+			AdditionalProducts: []string{"raven-ruby"},
+		},
+		//"RedCloth":            []string{"redcloth_library"},
+		candidateAdditionKey{
+			PkgName: "RedCloth",
+		}: {
+			AdditionalProducts: []string{"redcloth_library"},
+		},
+		//"VladTheEnterprising": []string{"vladtheenterprising"},
+		candidateAdditionKey{
+			PkgName: "VladTheEnterprising",
+		}: {
+			AdditionalProducts: []string{"vladtheenterprising"},
+		},
+		//"yajl-ruby":           []string{"yajl-ruby_gem"},
+		candidateAdditionKey{
+			PkgName: "yajl-ruby",
+		}: {
+			AdditionalProducts: []string{"yajl-ruby_gem"},
+		},
+	},
+	pkg.PythonPkg: {
+		//"python-rrdtool": []string{"rrdtool"},
+		candidateAdditionKey{
+			PkgName: "python-rrdtool",
+		}: {
+			AdditionalProducts: []string{"rrdtool"},
+		},
+	},
+}
+
+type candidateAdditionKey struct {
+	// The following fields are considered jointly
+	Vendor  string // empty value means no constraint
+	PkgName string // empty value means no constraint
+}
+
+type candidateAddition struct {
+	// Add additional values to consider as field candidates
+	AdditionalProducts []string
+	AdditionalVendors  []string
+}
+
+// type + package name -> product name addition(s)
+// type + vendor name -> vendor name addition(s)
+// type + package name + vendor name -> vendor name addition(s)
+
+// AdditionalVendors(type, product, vendor)
+func additionalVendors(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName, vendor string) (vendors []string) {
+	// TODO: rename
+	typedAddition, ok := allAdditions[ty]
+	if !ok {
+		return nil
+	}
+
+	if additions, ok := typedAddition[candidateAdditionKey{
+		Vendor:  vendor,
+		PkgName: pkgName,
+	}]; ok {
+		vendors = append(vendors, additions.AdditionalVendors...)
+	}
+
+	if additions, ok := typedAddition[candidateAdditionKey{
+		PkgName: pkgName,
+	}]; ok {
+		vendors = append(vendors, additions.AdditionalVendors...)
+	}
+
+	if additions, ok := typedAddition[candidateAdditionKey{
+		Vendor: vendor,
+	}]; ok {
+		vendors = append(vendors, additions.AdditionalVendors...)
+	}
+
+	return vendors
+}
+
+// additionalProducts(type, product)
+func additionalProducts(allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition, ty pkg.Type, pkgName string) (products []string) {
+	// TODO: rename
+	typedAddition, ok := allAdditions[ty]
+	if !ok {
+		return nil
+	}
+
+	if additions, ok := typedAddition[candidateAdditionKey{
+		PkgName: pkgName,
+	}]; ok {
+		products = append(products, additions.AdditionalProducts...)
+	}
+
+	return products
+}
 
 func (s candidatesByPackageType) getCandidates(t pkg.Type, key string) []string {
 	if _, ok := s[t]; !ok {

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -4,170 +4,184 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-type candidateAdditions map[pkg.Type]map[candidateKey]candidateAddition
-
+// candidateComposite is a convenience when creating the defaultCandidateAdditions set
 type candidateComposite struct {
 	pkg.Type
 	candidateKey
 	candidateAddition
 }
 
-var candidateComposites = []candidateComposite{
-	{
-		pkg.JavaPkg,
-		candidateKey{PkgName: "springframework"},
-		candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
-	},
-	{
-		pkg.JavaPkg,
-		candidateKey{PkgName: "spring-core"},
-		candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
-	},
-}
+// defaultCandidateAdditions is all of the known cases for product and vendor field values that should be used when
+// select package information is discovered
+var defaultCandidateAdditions = buildCandidateLookup(
+	[]candidateComposite{
+		// Java packages
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "springframework"},
+			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "spring-core"},
+			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
+		},
+		{
+			// example image: docker.io/nuxeo:latest
+			pkg.JavaPkg,
+			candidateKey{PkgName: "elasticsearch"}, //, Vendor: "elasticsearch"},
+			candidateAddition{AdditionalVendors: []string{"elastic"}},
+		},
+		{
+			// example image: docker.io/kaazing-gateway:latest
+			pkg.JavaPkg,
+			candidateKey{PkgName: "log4j"}, //, Vendor: "apache-software-foundation"},
+			candidateAddition{AdditionalVendors: []string{"apache"}},
+		},
 
-func init() {
-	defaultCandidateAdditions = buildCandidateLookup(candidateComposites)
-}
+		{
+			// example image: cassandra:latest
+			pkg.JavaPkg,
+			candidateKey{PkgName: "apache-cassandra"}, //, Vendor: "apache"},
+			candidateAddition{AdditionalProducts: []string{"cassandra"}},
+		},
 
-func buildCandidateLookup(cc []candidateComposite) (ca candidateAdditions) {
+		// NPM packages
+		{
+			pkg.NpmPkg,
+			candidateKey{PkgName: "hapi"},
+			candidateAddition{AdditionalProducts: []string{"hapi_server_framework"}},
+		},
+		{
+			pkg.NpmPkg,
+			candidateKey{PkgName: "handlebars.js"},
+			candidateAddition{AdditionalProducts: []string{"handlebars"}},
+		},
+		{
+			pkg.NpmPkg,
+			candidateKey{PkgName: "is-my-json-valid"},
+			candidateAddition{AdditionalProducts: []string{"is_my_json_valid"}},
+		},
+		{
+			pkg.NpmPkg,
+			candidateKey{PkgName: "mustache"},
+			candidateAddition{AdditionalProducts: []string{"mustache.js"}},
+		},
+
+		// Gem packages
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "Arabic-Prawn"},
+			candidateAddition{AdditionalProducts: []string{"arabic_prawn"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "bio-basespace-sdk"},
+			candidateAddition{AdditionalProducts: []string{"basespace_ruby_sdk"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "cremefraiche"},
+			candidateAddition{AdditionalProducts: []string{"creme_fraiche"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "html-sanitizer"},
+			candidateAddition{AdditionalProducts: []string{"html_sanitizer"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "sentry-raven"},
+			candidateAddition{AdditionalProducts: []string{"raven-ruby"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "RedCloth"},
+			candidateAddition{AdditionalProducts: []string{"redcloth_library"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "VladTheEnterprising"},
+			candidateAddition{AdditionalProducts: []string{"vladtheenterprising"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "yajl-ruby"},
+			candidateAddition{AdditionalProducts: []string{"yajl-ruby_gem"}},
+		},
+		// Python packages
+		{
+			pkg.PythonPkg,
+			candidateKey{PkgName: "python-rrdtool"},
+			candidateAddition{AdditionalProducts: []string{"rrdtool"}},
+		},
+	})
+
+// buildCandidateLookup is a convenience function for creating the defaultCandidateAdditions set
+func buildCandidateLookup(cc []candidateComposite) (ca map[pkg.Type]map[candidateKey]candidateAddition) {
 	ca = make(map[pkg.Type]map[candidateKey]candidateAddition)
 	for _, c := range cc {
-		ca[c.Type] = map[candidateKey]candidateAddition{
-			c.candidateKey: c.candidateAddition,
+		if _, ok := ca[c.Type]; !ok {
+			ca[c.Type] = make(map[candidateKey]candidateAddition)
 		}
+		ca[c.Type][c.candidateKey] = c.candidateAddition
 	}
 
 	return ca
 }
 
-var defaultCandidateAdditions = map[pkg.Type]map[candidateKey]candidateAddition{
-	pkg.NpmPkg: {
-		candidateKey{
-			PkgName: "hapi",
-		}: {
-			AdditionalProducts: []string{"hapi_server_framework"},
-		},
-		candidateKey{
-			PkgName: "handlebars.js",
-		}: {
-			AdditionalProducts: []string{"handlebars"},
-		},
-		candidateKey{
-			PkgName: "is-my-json-valid",
-		}: {
-			AdditionalProducts: []string{"is_my_json_valid"},
-		},
-		candidateKey{
-			PkgName: "mustache",
-		}: {
-			AdditionalProducts: []string{"mustache.js"},
-		},
-	},
-	pkg.GemPkg: {
-		candidateKey{
-			PkgName: "Arabic-Prawn",
-		}: {
-			AdditionalProducts: []string{"arabic_prawn"},
-		},
-		candidateKey{
-			PkgName: "bio-basespace-sdk",
-		}: {
-			AdditionalProducts: []string{"basespace_ruby_sdk"},
-		},
-		candidateKey{
-			PkgName: "cremefraiche",
-		}: {
-			AdditionalProducts: []string{"creme_fraiche"},
-		},
-		candidateKey{
-			PkgName: "html-sanitizer",
-		}: {
-			AdditionalProducts: []string{"html_sanitizer"},
-		},
-		candidateKey{
-			PkgName: "sentry-raven",
-		}: {
-			AdditionalProducts: []string{"raven-ruby"},
-		},
-		candidateKey{
-			PkgName: "RedCloth",
-		}: {
-			AdditionalProducts: []string{"redcloth_library"},
-		},
-		candidateKey{
-			PkgName: "VladTheEnterprising",
-		}: {
-			AdditionalProducts: []string{"vladtheenterprising"},
-		},
-		candidateKey{
-			PkgName: "yajl-ruby",
-		}: {
-			AdditionalProducts: []string{"yajl-ruby_gem"},
-		},
-	},
-	pkg.PythonPkg: {
-		candidateKey{
-			PkgName: "python-rrdtool",
-		}: {
-			AdditionalProducts: []string{"rrdtool"},
-		},
-	},
-}
-
+// candidateKey represents the set of inputs that should be matched on in order to signal more candidate additions to be used.
 type candidateKey struct {
-	// The following fields are considered jointly
-	Vendor  string // empty value means no constraint
-	PkgName string // empty value means no constraint
+	Vendor  string
+	PkgName string
 }
 
+// candidateAddition are the specific additions that should be considered during CPE generation (given a specific candidateKey)
 type candidateAddition struct {
-	// Add additional values to consider as field candidates
 	AdditionalProducts []string
 	AdditionalVendors  []string
 }
 
-// AdditionalVendors(type, product, vendor)
+// findAdditionalVendors searches all possible vendor additions that could be added during the CPE generation process (given package info + a vendor candidate)
 func findAdditionalVendors(allAdditions map[pkg.Type]map[candidateKey]candidateAddition, ty pkg.Type, pkgName, vendor string) (vendors []string) {
-	// TODO: rename
-	typedAddition, ok := allAdditions[ty]
+	additions, ok := allAdditions[ty]
 	if !ok {
 		return nil
 	}
 
-	if additions, ok := typedAddition[candidateKey{
+	if addition, ok := additions[candidateKey{
 		Vendor:  vendor,
 		PkgName: pkgName,
 	}]; ok {
-		vendors = append(vendors, additions.AdditionalVendors...)
+		vendors = append(vendors, addition.AdditionalVendors...)
 	}
 
-	if additions, ok := typedAddition[candidateKey{
+	if addition, ok := additions[candidateKey{
 		PkgName: pkgName,
 	}]; ok {
-		vendors = append(vendors, additions.AdditionalVendors...)
+		vendors = append(vendors, addition.AdditionalVendors...)
 	}
 
-	if additions, ok := typedAddition[candidateKey{
+	if addition, ok := additions[candidateKey{
 		Vendor: vendor,
 	}]; ok {
-		vendors = append(vendors, additions.AdditionalVendors...)
+		vendors = append(vendors, addition.AdditionalVendors...)
 	}
 
 	return vendors
 }
 
-// findAdditionalProducts(type, product)
+// findAdditionalProducts searches all possible product additions that could be added during the CPE generation process (given package info)
 func findAdditionalProducts(allAdditions map[pkg.Type]map[candidateKey]candidateAddition, ty pkg.Type, pkgName string) (products []string) {
-	// TODO: rename
-	typedAddition, ok := allAdditions[ty]
+	additions, ok := allAdditions[ty]
 	if !ok {
 		return nil
 	}
 
-	if additions, ok := typedAddition[candidateKey{
+	if addition, ok := additions[candidateKey{
 		PkgName: pkgName,
 	}]; ok {
-		products = append(products, additions.AdditionalProducts...)
+		products = append(products, addition.AdditionalProducts...)
 	}
 
 	return products

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
@@ -10,16 +10,16 @@ import (
 func Test_additionalProducts(t *testing.T) {
 	tests := []struct {
 		name         string
-		allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition
+		allAdditions map[pkg.Type]map[candidateKey]candidateAddition
 		ty           pkg.Type
 		pkgName      string
 		expected     []string
 	}{
 		{
 			name: "product name addition",
-			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+			allAdditions: map[pkg.Type]map[candidateKey]candidateAddition{
 				pkg.JavaPkg: {
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "spring-core",
 					}: {
 						AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
@@ -32,9 +32,9 @@ func Test_additionalProducts(t *testing.T) {
 		},
 		{
 			name: "no addition found",
-			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+			allAdditions: map[pkg.Type]map[candidateKey]candidateAddition{
 				pkg.JavaPkg: {
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "spring-core",
 					}: {
 						AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
@@ -56,7 +56,7 @@ func Test_additionalProducts(t *testing.T) {
 func Test_additionalVendors(t *testing.T) {
 	tests := []struct {
 		name         string
-		allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition
+		allAdditions map[pkg.Type]map[candidateKey]candidateAddition
 		ty           pkg.Type
 		pkgName      string
 		vendor       string
@@ -64,21 +64,21 @@ func Test_additionalVendors(t *testing.T) {
 	}{
 		{
 			name: "vendor addition by input vendor",
-			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+			allAdditions: map[pkg.Type]map[candidateKey]candidateAddition{
 				pkg.JavaPkg: {
-					candidateAdditionKey{
+					candidateKey{
 						Vendor: "my-vendor",
 					}: {
 						AdditionalVendors: []string{"awesome-vendor-addition"},
 					},
 					// note: the below keys should not be matched
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 						Vendor:  "my-vendor",
 					}: {
 						AdditionalVendors: []string{"bad-addition"},
 					},
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 					}: {
 						AdditionalVendors: []string{"bad-addition"},
@@ -92,21 +92,21 @@ func Test_additionalVendors(t *testing.T) {
 		},
 		{
 			name: "vendor addition by input package name",
-			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+			allAdditions: map[pkg.Type]map[candidateKey]candidateAddition{
 				pkg.JavaPkg: {
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 					}: {
 						AdditionalVendors: []string{"awesome-vendor-addition"},
 					},
 					// note: the below keys should not be matched
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 						Vendor:  "my-vendor",
 					}: {
 						AdditionalVendors: []string{"bad-addition"},
 					},
-					candidateAdditionKey{
+					candidateKey{
 						Vendor: "my-vendor",
 					}: {
 						AdditionalVendors: []string{"bad-addition"},
@@ -120,21 +120,21 @@ func Test_additionalVendors(t *testing.T) {
 		},
 		{
 			name: "vendor addition by input package name + vendor",
-			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+			allAdditions: map[pkg.Type]map[candidateKey]candidateAddition{
 				pkg.JavaPkg: {
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 						Vendor:  "my-vendor",
 					}: {
 						AdditionalVendors: []string{"awesome-vendor-addition"},
 					},
 					// note: the below keys should not be matched
-					candidateAdditionKey{
+					candidateKey{
 						PkgName: "my-package-name",
 					}: {
 						AdditionalVendors: []string{"one-good-addition"},
 					},
-					candidateAdditionKey{
+					candidateKey{
 						Vendor: "my-vendor",
 					}: {
 						AdditionalVendors: []string{"another-good-addition"},

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
@@ -1,0 +1,132 @@
+package cpe
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_additionalProducts(t *testing.T) {
+	tests := []struct {
+		name         string
+		allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition
+		ty           pkg.Type
+		pkgName      string
+		expected     []string
+	}{
+		{
+			name: "product name addition",
+			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+				pkg.JavaPkg: {
+					candidateAdditionKey{
+						PkgName: "spring-core",
+					}: {
+						AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
+					},
+				},
+			},
+			ty:       pkg.JavaPkg,
+			pkgName:  "spring-core",
+			expected: []string{"spring_framework", "springsource_spring_framework"},
+		},
+		{
+			name: "no addition found",
+			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+				pkg.JavaPkg: {
+					candidateAdditionKey{
+						PkgName: "spring-core",
+					}: {
+						AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"},
+					},
+				},
+			},
+			ty:       pkg.JavaPkg,
+			pkgName:  "nothing",
+			expected: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, additionalProducts(test.allAdditions, test.ty, test.pkgName))
+		})
+	}
+}
+
+func Test_additionalVendors(t *testing.T) {
+	tests := []struct {
+		name         string
+		allAdditions map[pkg.Type]map[candidateAdditionKey]candidateAddition
+		ty           pkg.Type
+		pkgName      string
+		vendor       string
+		expected     []string
+	}{
+		{
+			name: "vendor addition by input vendor",
+			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+				pkg.JavaPkg: {
+					candidateAdditionKey{
+						Vendor: "my-vendor",
+					}: {
+						AdditionalVendors: []string{"awesome-vendor-addition"},
+					},
+				},
+			},
+			ty:       pkg.JavaPkg,
+			pkgName:  "spring-core",
+			vendor:   "my-vendor",
+			expected: []string{"awesome-vendor-addition"},
+		},
+		{
+			name: "vendor addition by input package name",
+			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+				pkg.JavaPkg: {
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+					}: {
+						AdditionalVendors: []string{"awesome-vendor-addition"},
+					},
+				},
+			},
+			ty:       pkg.JavaPkg,
+			pkgName:  "my-package-name",
+			vendor:   "my-vendor",
+			expected: []string{"awesome-vendor-addition"},
+		},
+		{
+			name: "vendor addition by input package name + vendor",
+			allAdditions: map[pkg.Type]map[candidateAdditionKey]candidateAddition{
+				pkg.JavaPkg: {
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+						Vendor:  "my-vendor",
+					}: {
+						AdditionalVendors: []string{"awesome-vendor-addition"},
+					},
+					// note: the below keys should not be matched
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
+					// note: the below keys should not be matched
+					candidateAdditionKey{
+						Vendor: "my-vendor",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
+				},
+			},
+			ty:       pkg.JavaPkg,
+			pkgName:  "my-package-name",
+			vendor:   "my-vendor",
+			expected: []string{"awesome-vendor-addition"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, additionalVendors(test.allAdditions, test.ty, test.pkgName, test.vendor))
+		})
+	}
+}

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
@@ -48,7 +48,7 @@ func Test_additionalProducts(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, additionalProducts(test.allAdditions, test.ty, test.pkgName))
+			assert.Equal(t, test.expected, findAdditionalProducts(test.allAdditions, test.ty, test.pkgName))
 		})
 	}
 }
@@ -71,10 +71,22 @@ func Test_additionalVendors(t *testing.T) {
 					}: {
 						AdditionalVendors: []string{"awesome-vendor-addition"},
 					},
+					// note: the below keys should not be matched
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+						Vendor:  "my-vendor",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
 				},
 			},
 			ty:       pkg.JavaPkg,
-			pkgName:  "spring-core",
+			pkgName:  "NOT-MY-PACKAGE",
 			vendor:   "my-vendor",
 			expected: []string{"awesome-vendor-addition"},
 		},
@@ -87,11 +99,23 @@ func Test_additionalVendors(t *testing.T) {
 					}: {
 						AdditionalVendors: []string{"awesome-vendor-addition"},
 					},
+					// note: the below keys should not be matched
+					candidateAdditionKey{
+						PkgName: "my-package-name",
+						Vendor:  "my-vendor",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
+					candidateAdditionKey{
+						Vendor: "my-vendor",
+					}: {
+						AdditionalVendors: []string{"bad-addition"},
+					},
 				},
 			},
 			ty:       pkg.JavaPkg,
 			pkgName:  "my-package-name",
-			vendor:   "my-vendor",
+			vendor:   "NOT-MY-VENDOR",
 			expected: []string{"awesome-vendor-addition"},
 		},
 		{
@@ -108,25 +132,24 @@ func Test_additionalVendors(t *testing.T) {
 					candidateAdditionKey{
 						PkgName: "my-package-name",
 					}: {
-						AdditionalVendors: []string{"bad-addition"},
+						AdditionalVendors: []string{"one-good-addition"},
 					},
-					// note: the below keys should not be matched
 					candidateAdditionKey{
 						Vendor: "my-vendor",
 					}: {
-						AdditionalVendors: []string{"bad-addition"},
+						AdditionalVendors: []string{"another-good-addition"},
 					},
 				},
 			},
 			ty:       pkg.JavaPkg,
 			pkgName:  "my-package-name",
 			vendor:   "my-vendor",
-			expected: []string{"awesome-vendor-addition"},
+			expected: []string{"awesome-vendor-addition", "one-good-addition", "another-good-addition"},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, additionalVendors(test.allAdditions, test.ty, test.pkgName, test.vendor))
+			assert.Equal(t, test.expected, findAdditionalVendors(test.allAdditions, test.ty, test.pkgName, test.vendor))
 		})
 	}
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate.go
@@ -1,6 +1,8 @@
 package cpe
 
 import (
+	"strconv"
+
 	"github.com/scylladb/go-set/strset"
 )
 
@@ -34,7 +36,7 @@ func (s fieldCandidateSet) addValue(values ...string) {
 	for _, value := range values {
 		// default candidate as an allow-all
 		candidate := fieldCandidate{
-			value: value,
+			value: cleanCandidateField(value),
 		}
 		s[candidate] = struct{}{}
 	}
@@ -42,6 +44,7 @@ func (s fieldCandidateSet) addValue(values ...string) {
 
 func (s fieldCandidateSet) add(candidates ...fieldCandidate) {
 	for _, candidate := range candidates {
+		candidate.value = cleanCandidateField(candidate.value)
 		s[candidate] = struct{}{}
 	}
 }
@@ -98,4 +101,12 @@ func (s fieldCandidateSet) copy() fieldCandidateSet {
 	newSet.add(s.list()...)
 
 	return newSet
+}
+
+func cleanCandidateField(field string) string {
+	cleanedValue, err := strconv.Unquote(field)
+	if err != nil {
+		return field
+	}
+	return cleanedValue
 }

--- a/syft/pkg/cataloger/common/cpe/field_candidate_test.go
+++ b/syft/pkg/cataloger/common/cpe/field_candidate_test.go
@@ -141,6 +141,22 @@ func Test_cpeCandidateValues_filter(t *testing.T) {
 	}
 }
 
+func Test_cpeFieldCandidateSet_addValue(t *testing.T) {
+	s := newFieldCandidateSet()
+	// we should clean all values (unquote strings)
+	s.addValue(`"string!"`)
+	assert.ElementsMatch(t, []string{"string!"}, s.values())
+}
+
+func Test_cpeFieldCandidateSet_add(t *testing.T) {
+	s := newFieldCandidateSet()
+	// we should clean all values (unquote strings)
+	s.add(fieldCandidate{
+		value: `"string!"`,
+	})
+	assert.ElementsMatch(t, []string{"string!"}, s.values())
+}
+
 func Test_cpeFieldCandidateSet_clear(t *testing.T) {
 	s := newFieldCandidateSet("1", "2")
 	assert.NotEmpty(t, s.values())

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -12,32 +12,6 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-var productCandidatesByPkgType = candidatesByPackageType{
-	pkg.JavaPkg: {
-		"springframework": []string{"spring_framework", "springsource_spring_framework"},
-		"spring-core":     []string{"spring_framework", "springsource_spring_framework"},
-	},
-	pkg.NpmPkg: {
-		"hapi":             []string{"hapi_server_framework"},
-		"handlebars.js":    []string{"handlebars"},
-		"is-my-json-valid": []string{"is_my_json_valid"},
-		"mustache":         []string{"mustache.js"},
-	},
-	pkg.GemPkg: {
-		"Arabic-Prawn":        []string{"arabic_prawn"},
-		"bio-basespace-sdk":   []string{"basespace_ruby_sdk"},
-		"cremefraiche":        []string{"creme_fraiche"},
-		"html-sanitizer":      []string{"html_sanitizer"},
-		"sentry-raven":        []string{"raven-ruby"},
-		"RedCloth":            []string{"redcloth_library"},
-		"VladTheEnterprising": []string{"vladtheenterprising"},
-		"yajl-ruby":           []string{"yajl-ruby_gem"},
-	},
-	pkg.PythonPkg: {
-		"python-rrdtool": []string{"rrdtool"},
-	},
-}
-
 func newCPE(product, vendor, version, targetSW string) wfn.Attributes {
 	cpe := *(wfn.NewAttributesWithAny())
 	cpe.Part = "a"

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -103,7 +103,14 @@ func candidateVendors(p pkg.Package) []string {
 	// generate sub-selections of each candidate based on separators (e.g. jenkins-ci -> [jenkins, jenkins-ci])
 	addAllSubSelections(vendors)
 
-	return vendors.uniqueValues()
+	// add more candidates for the package info for each vendor candidate
+	vendorCandidates := vendors.uniqueValues()
+	var additionalCandidates []string
+	for _, vendor := range vendorCandidates {
+		additionalCandidates = append(additionalCandidates, findAdditionalVendors(defaultCandidateAdditions, p.Type, p.Name, vendor)...)
+	}
+
+	return append(additionalCandidates, vendorCandidates...)
 }
 
 func candidateProducts(p pkg.Package) []string {
@@ -133,7 +140,7 @@ func candidateProducts(p pkg.Package) []string {
 	addDelimiterVariations(products)
 
 	// prepend any known product names for the given package type and name (note: this is not a replacement)
-	return append(productCandidatesByPkgType.getCandidates(p.Type, p.Name), products.uniqueValues()...)
+	return append(findAdditionalProducts(defaultCandidateAdditions, p.Type, p.Name), products.uniqueValues()...)
 }
 
 func addAllSubSelections(fields fieldCandidateSet) {

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -103,14 +103,12 @@ func candidateVendors(p pkg.Package) []string {
 	// generate sub-selections of each candidate based on separators (e.g. jenkins-ci -> [jenkins, jenkins-ci])
 	addAllSubSelections(vendors)
 
-	// add more candidates for the package info for each vendor candidate
-	vendorCandidates := vendors.uniqueValues()
-	var additionalCandidates []string
-	for _, vendor := range vendorCandidates {
-		additionalCandidates = append(additionalCandidates, findAdditionalVendors(defaultCandidateAdditions, p.Type, p.Name, vendor)...)
+	// add more candidates based on the package info for each vendor candidate
+	for _, vendor := range vendors.uniqueValues() {
+		vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, p.Type, p.Name, vendor)...)
 	}
 
-	return append(additionalCandidates, vendorCandidates...)
+	return vendors.uniqueValues()
 }
 
 func candidateProducts(p pkg.Package) []string {
@@ -139,8 +137,10 @@ func candidateProducts(p pkg.Package) []string {
 	// try swapping hyphens for underscores, vice versa, and removing separators altogether
 	addDelimiterVariations(products)
 
-	// prepend any known product names for the given package type and name (note: this is not a replacement)
-	return append(findAdditionalProducts(defaultCandidateAdditions, p.Type, p.Name), products.uniqueValues()...)
+	// add known candidate additions
+	products.addValue(findAdditionalProducts(defaultCandidateAdditions, p.Type, p.Name)...)
+
+	return products.uniqueValues()
 }
 
 func addAllSubSelections(fields fieldCandidateSet) {

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -553,6 +553,14 @@ func TestCandidateProducts(t *testing.T) {
 		expected []string
 	}{
 		{
+			name: "apache-cassandra",
+			p: pkg.Package{
+				Name: "apache-cassandra",
+				Type: pkg.JavaPkg,
+			},
+			expected: []string{"cassandra" /* <-- known good names | default guess --> */, "apache-cassandra", "apache_cassandra"},
+		},
+		{
 			name: "springframework",
 			p: pkg.Package{
 				Name: "springframework",
@@ -631,6 +639,37 @@ func TestCandidateProducts(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v %+v", test.p, test.expected), func(t *testing.T) {
 			assert.ElementsMatch(t, test.expected, candidateProducts(test.p))
+		})
+	}
+}
+
+func TestCandidateVendor(t *testing.T) {
+	tests := []struct {
+		name     string
+		p        pkg.Package
+		expected []string
+	}{
+		{
+			name: "elasticsearch",
+			p: pkg.Package{
+				Name: "elasticsearch",
+				Type: pkg.JavaPkg,
+			},
+			expected: []string{"elastic" /* <-- known good names | default guess --> */, "elasticsearch"},
+		},
+		{
+			name: "log4j",
+			p: pkg.Package{
+				Name: "log4j",
+				Type: pkg.JavaPkg,
+			},
+			expected: []string{"apache" /* <-- known good names | default guess --> */, "log4j"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v %+v", test.p, test.expected), func(t *testing.T) {
+			assert.ElementsMatch(t, test.expected, candidateVendors(test.p))
 		})
 	}
 }

--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -192,13 +192,13 @@ func groupIDsFromPomProperties(properties *pkg.PomProperties) (groupIDs []string
 	}
 
 	if startsWithTopLevelDomain(properties.GroupID) {
-		groupIDs = append(groupIDs, strings.TrimSpace(properties.GroupID))
+		groupIDs = append(groupIDs, cleanGroupID(properties.GroupID))
 	}
 
 	// sometimes the publisher puts the group ID in the artifact ID field unintentionally
 	if startsWithTopLevelDomain(properties.ArtifactID) && len(strings.Split(properties.ArtifactID, ".")) > 1 {
 		// there is a strong indication that the artifact ID is really a group ID
-		groupIDs = append(groupIDs, strings.TrimSpace(properties.ArtifactID))
+		groupIDs = append(groupIDs, cleanGroupID(properties.ArtifactID))
 	}
 
 	return groupIDs
@@ -224,13 +224,13 @@ func groupIDsFromPomProject(project *pkg.PomProject) (groupIDs []string) {
 
 func addGroupIDsFromGroupIDsAndArtifactID(groupID, artifactID string) (groupIDs []string) {
 	if startsWithTopLevelDomain(groupID) {
-		groupIDs = append(groupIDs, strings.TrimSpace(groupID))
+		groupIDs = append(groupIDs, cleanGroupID(groupID))
 	}
 
 	// sometimes the publisher puts the group ID in the artifact ID field unintentionally
 	if startsWithTopLevelDomain(artifactID) && len(strings.Split(artifactID, ".")) > 1 {
 		// there is a strong indication that the artifact ID is really a group ID
-		groupIDs = append(groupIDs, strings.TrimSpace(artifactID))
+		groupIDs = append(groupIDs, cleanGroupID(artifactID))
 	}
 	return groupIDs
 }
@@ -263,19 +263,30 @@ func getManifestFieldGroupIDs(manifest *pkg.JavaManifest, fields []string) (grou
 	for _, name := range fields {
 		if value, exists := manifest.Main[name]; exists {
 			if startsWithTopLevelDomain(value) {
-				groupIDs = append(groupIDs, value)
+				groupIDs = append(groupIDs, cleanGroupID(value))
 			}
 		}
 		for _, section := range manifest.NamedSections {
 			if value, exists := section[name]; exists {
 				if startsWithTopLevelDomain(value) {
-					groupIDs = append(groupIDs, value)
+					groupIDs = append(groupIDs, cleanGroupID(value))
 				}
 			}
 		}
 	}
 
 	return groupIDs
+}
+
+func cleanGroupID(groupID string) string {
+	return strings.TrimSpace(removeOSCIDirectives(groupID))
+}
+
+func removeOSCIDirectives(groupID string) string {
+	// for example:
+	// 		org.bar;uses:=“org.foo”		-> 	org.bar
+	// more about OSGI directives see https://spring.io/blog/2008/10/20/understanding-the-osgi-uses-directive/
+	return strings.Split(groupID, ";")[0]
 }
 
 func startsWithTopLevelDomain(value string) bool {

--- a/syft/pkg/cataloger/common/cpe/java_test.go
+++ b/syft/pkg/cataloger/common/cpe/java_test.go
@@ -153,7 +153,7 @@ func Test_groupIDsFromJavaPackage(t *testing.T) {
 			pkg: pkg.Package{
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
-						GroupID: "io.jenkins-ci.plugin.thing",
+						GroupID: "io.jenkins-ci.plugin.thing;version='[2,3)'",
 					},
 				},
 			},
@@ -164,7 +164,7 @@ func Test_groupIDsFromJavaPackage(t *testing.T) {
 			pkg: pkg.Package{
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
-						ArtifactID: "io.jenkins-ci.plugin.thing",
+						ArtifactID: "io.jenkins-ci.plugin.thing; version='[2,3)' ; org.something.else",
 					},
 				},
 			},


### PR DESCRIPTION
This PR at a minimum adds vendor + product CPE field generation cases found in `docker.io/kaazing-gateway:latest`, `docker.io/cassandra:latest`, and `docker.io/nuxeo:latest`.

Additionally this PR:
- refactors the mechanism used to specify and find CPE field additions for vendor and product
- removes OSGI directives from Java group ID fields
- removes double quotes from any CPE field generated