### PR TITLE
Add mariner to distro types

### DIFF
--- a/syft/distro/identify_test.go
+++ b/syft/distro/identify_test.go
@@ -118,6 +118,11 @@ func TestIdentifyDistro(t *testing.T) {
 			Type:    CentOS,
 			Version: "5.7.0",
 		},
+		{
+			fixture: "test-fixtures/os/mariner",
+			Type:    Mariner,
+			Version: "1.0.0",
+		},
 	}
 
 	observedDistros := internal.NewStringSet()

--- a/syft/distro/test-fixtures/os/mariner/etc/os-release
+++ b/syft/distro/test-fixtures/os/mariner/etc/os-release
@@ -1,0 +1,9 @@
+NAME="Common Base Linux Mariner"
+VERSION="1.0.20210901"
+ID=mariner
+VERSION_ID=1.0
+PRETTY_NAME="CBL-Mariner/Linux"
+ANSI_COLOR="1;34"
+HOME_URL="https://aka.ms/cbl-mariner"
+BUG_REPORT_URL="https://aka.ms/cbl-mariner"
+SUPPORT_URL="https://aka.ms/cbl-mariner"

--- a/syft/distro/type.go
+++ b/syft/distro/type.go
@@ -20,6 +20,7 @@ const (
 	SLES              Type = "sles"
 	Photon            Type = "photon"
 	Windows           Type = "windows"
+	Mariner           Type = "mariner"
 )
 
 // All contains all Linux distribution options
@@ -38,6 +39,7 @@ var All = []Type{
 	SLES,
 	Photon,
 	Windows,
+	Mariner,
 }
 
 // IDMapping connects a distro ID like "ubuntu" to a Distro type
@@ -56,6 +58,7 @@ var IDMapping = map[string]Type{
 	"sles":          SLES,
 	"photon":        Photon,
 	"windows":       Windows,
+	"mariner":       Mariner,
 }
 
 // String returns the string representation of the given Linux distribution.


### PR DESCRIPTION
This PR adds [Mariner](https://github.com/microsoft/CBL-Mariner) to the list of distro types that syft recognizes.