### PR TITLE
497 stable sorted CPE array (JSON and SPDX)

### DIFF
--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -35,7 +35,7 @@ const (
 
   Supports the following image sources:
     {{.appName}} {{.command}} yourrepo/yourimage:tag     defaults to using images from a Docker daemon. If Docker is not present, the image is pulled directly from the registry.
-    {{.appName}} {{.command}} path/to/a/file/or/dir      a Docker tar, OCI tar, OCI directory, or generic filesystem directory 
+    {{.appName}} {{.command}} path/to/a/file/or/dir      a Docker tar, OCI tar, OCI directory, or generic filesystem directory
 
   You can also explicitly specify the scheme to use:
     {{.appName}} {{.command}} docker:yourrepo/yourimage:tag          explicitly use the Docker daemon

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -18,16 +18,18 @@ func (c BySpecificity) Less(i, j int) bool {
 	iScore := weightedCountForSpecifiedFields(c[i])
 	jScore := weightedCountForSpecifiedFields(c[j])
 
-	if iScore == jScore {
-		if countFieldLength(c[i]) == countFieldLength(c[j]) {
-			// we want this to be < than since we want
-			// - to come before _ in vendor:product
-			return c[i].BindToFmtString() < c[j].BindToFmtString()
-		}
+	// check weighted sort first
+	if iScore != jScore {
+		return iScore > jScore
+	}
 
+	// sort longer fields to top
+	if countFieldLength(c[i]) != countFieldLength(c[j]) {
 		return countFieldLength(c[i]) > countFieldLength(c[j])
 	}
-	return iScore > jScore
+
+	// if score and length are equal then text sort
+	return c[i].BindToFmtString() < c[j].BindToFmtString()
 }
 
 func countFieldLength(cpe wfn.Attributes) int {

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -30,6 +30,11 @@ func (c BySpecificity) Less(i, j int) bool {
 	return iScore > jScore
 }
 
+// if countFieldLength is equal for adjacent members
+// Less has the option of randomly ordering the items
+// dashIndex is used to stabilize the sort so that Vendor
+// and Product combinations are given a stable hierarchy
+// if their countFieldLength sums are equal.
 func dashIndex(cpe wfn.Attributes) int {
 	count := 0
 	dash := "-"

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -2,6 +2,7 @@ package cpe
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/facebookincubator/nvdtools/wfn"
 )
@@ -19,9 +20,28 @@ func (c BySpecificity) Less(i, j int) bool {
 	jScore := weightedCountForSpecifiedFields(c[j])
 
 	if iScore == jScore {
+		if countFieldLength(c[i]) == countFieldLength(c[j]) {
+			// lower index count prefered
+			return dashIndex(c[i]) > dashIndex(c[j])
+		}
+
 		return countFieldLength(c[i]) > countFieldLength(c[j])
 	}
 	return iScore > jScore
+}
+
+func dashIndex(cpe wfn.Attributes) int {
+	count := 0
+	dash := "-"
+	if strings.Contains(cpe.Vendor, dash) {
+		count += 2
+	}
+
+	if strings.Contains(cpe.Product, dash) {
+		count += 1
+	}
+
+	return count
 }
 
 func countFieldLength(cpe wfn.Attributes) int {

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -34,11 +34,11 @@ func dashIndex(cpe wfn.Attributes) int {
 	count := 0
 	dash := "-"
 	if strings.Contains(cpe.Vendor, dash) {
-		count = count + 2
+		count += 2
 	}
 
 	if strings.Contains(cpe.Product, dash) {
-		count = count + 1
+		count++
 	}
 
 	return count

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -21,7 +21,7 @@ func (c BySpecificity) Less(i, j int) bool {
 
 	if iScore == jScore {
 		if countFieldLength(c[i]) == countFieldLength(c[j]) {
-			// lower index count prefered
+			// lower index count preferred
 			return dashIndex(c[i]) > dashIndex(c[j])
 		}
 
@@ -34,11 +34,11 @@ func dashIndex(cpe wfn.Attributes) int {
 	count := 0
 	dash := "-"
 	if strings.Contains(cpe.Vendor, dash) {
-		count += 2
+		count = count + 2
 	}
 
 	if strings.Contains(cpe.Product, dash) {
-		count += 1
+		count = count + 1
 	}
 
 	return count

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -2,7 +2,6 @@ package cpe
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/facebookincubator/nvdtools/wfn"
 )
@@ -21,32 +20,14 @@ func (c BySpecificity) Less(i, j int) bool {
 
 	if iScore == jScore {
 		if countFieldLength(c[i]) == countFieldLength(c[j]) {
-			// lower index count preferred
-			return dashIndex(c[i]) > dashIndex(c[j])
+			// we want this to be < than since we want
+			// - to come before _ in vendor:product
+			return c[i].BindToFmtString() < c[j].BindToFmtString()
 		}
 
 		return countFieldLength(c[i]) > countFieldLength(c[j])
 	}
 	return iScore > jScore
-}
-
-// if countFieldLength is equal for adjacent members
-// Less has the option of randomly ordering the items
-// dashIndex is used to stabilize the sort so that Vendor
-// and Product combinations are given a stable hierarchy
-// if their countFieldLength sums are equal.
-func dashIndex(cpe wfn.Attributes) int {
-	count := 0
-	dash := "-"
-	if strings.Contains(cpe.Vendor, dash) {
-		count += 2
-	}
-
-	if strings.Contains(cpe.Product, dash) {
-		count++
-	}
-
-	return count
 }
 
 func countFieldLength(cpe wfn.Attributes) int {

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
@@ -83,12 +83,12 @@ func TestCPESpecificity(t *testing.T) {
 		{
 			name: "sort by mix of field length, specificity, dash",
 			input: []pkg.CPE{
-				mustCPE("cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
-				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
-				mustCPE("cpe:2.3:a:alpine_keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
-				mustCPE("cpe:2.3:a:alpine_keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
 				mustCPE("cpe:2.3:a:alpine:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
 				mustCPE("cpe:2.3:a:alpine:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
 			},
 			expected: []pkg.CPE{
 				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
@@ -81,7 +81,7 @@ func TestCPESpecificity(t *testing.T) {
 			},
 		},
 		{
-			name: "sort by mix of field length, specificity, alpha",
+			name: "sort by mix of field length, specificity, dash",
 			input: []pkg.CPE{
 				mustCPE("cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
 				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity_test.go
@@ -80,6 +80,25 @@ func TestCPESpecificity(t *testing.T) {
 				mustCPE("cpe:2.3:a:1:*:333:*:*:*:*:*:*:*"),
 			},
 		},
+		{
+			name: "sort by mix of field length, specificity, alpha",
+			input: []pkg.CPE{
+				mustCPE("cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+			},
+			expected: []pkg.CPE{
+				mustCPE("cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine_keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine:alpine-keys:2.3-r1:*:*:*:*:*:*:*"),
+				mustCPE("cpe:2.3:a:alpine:alpine_keys:2.3-r1:*:*:*:*:*:*:*"),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Attempts to Solve #497 

To see the current issue you can:
```
syft -o json alpine:latest > /tmp/alpine.json:latest
syft -o json alpine:latest > /tmp/alpine.json:latest:2 
diff -u /tmp/alpine.json:2 /tmp/alpine.json:latest
```

This will produce a diff where the `cpes` field for some packages is sorted differently from run to run.

In the case where `countFieldLength` is equal for two sequential CPE in a given list of CPE, then our sort function would return a non deterministic order for cases as seen below:
```
cpe:2.3:a:alpine-keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*
cpe:2.3:a:alpine-keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*
cpe:2.3:a:alpine_keys:alpine_keys:2.3-r1:*:*:*:*:*:*:*
cpe:2.3:a:alpine_keys:alpine-keys:2.3-r1:*:*:*:*:*:*:*
cpe:2.3:a:alpine:alpine_keys:2.3-r1:*:*:*:*:*:*:*
cpe:2.3:a:alpine:alpine-keys:2.3-r1:*:*:*:*:*:*:*
```

```
// If both Less(i, j) and Less(j, i) are false,
// then the elements at index i and j are considered equal.
// Sort may place equal elements in any order in the final result,
// while Stable preserves the original input order of equal elements.
```

If the below change is too specific or fragile I can explore using the `Stable` interface to see if that at least keeps us consistent across runs.

The array order coming into the sort is always consistent, but where we get the `diff` between runs is when ` Less(i, j) and Less(j, i) are false,`.

This PR assigns a priority based on the character `-` for the `Vendor` and `Product` fields.
Given the above example the ideal sorted output would be:
```
xxx-xxx-xxx
xxx-xxx_xxx
xxx_xxx-xxx
xxx_xxx_xxx
xx-xx
xx_xx
```

Currently I'm trying to find images which break the assumptions found in this code. 