### PR TITLE
(#495) Update `documentNamespace` uniqueness for spdx-json output

### DIFF
--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/anchore/syft/internal"
@@ -16,7 +15,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const anchoreNamespace = "https://anchore.com/syft/image"
+const anchoreNamespace = "https://anchore.com/syft"
 
 // SPDXJsonPresenter is a SPDX presentation object for the syft results (see https://github.com/spdx/spdx-spec)
 type SPDXJsonPresenter struct {
@@ -51,10 +50,10 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		name = srcMetadata.ImageMetadata.UserInput
-		identifier = strings.Trim(fmt.Sprintf("%s-%s", name, uniqueID.String()), "-")
+		identifier = fmt.Sprintf("image/%s", uniqueID.String())
 	case source.DirectoryScheme:
 		name = srcMetadata.Path
-		identifier = uniqueID.String()
+		identifier = fmt.Sprintf("dir/%s", uniqueID.String())
 	}
 
 	namespace := fmt.Sprintf("%s/%s", anchoreNamespace, identifier)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -58,7 +58,7 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 		if name != "." {
 			identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
 		} else {
-			identifier = path.Join("dir", fmt.Sprintf("%s", uniqueID.String()))
+			identifier = path.Join("dir", uniqueID.String())
 		}
 	}
 

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -52,10 +52,16 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		name = cleanSPDXName(srcMetadata.ImageMetadata.UserInput)
-		identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		if name != "" {
+			identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		}
+		identifier = path.Join("image", fmt.Sprintf("%s", uniqueID.String()))
 	case source.DirectoryScheme:
 		name = cleanSPDXName(srcMetadata.Path)
-		identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		if name != "" {
+			identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		}
+		identifier = path.Join("dir", fmt.Sprintf("%s", uniqueID.String()))
 	}
 
 	namespace := path.Join(anchoreNamespace, identifier)
@@ -130,6 +136,10 @@ func cleanSPDXName(name string) string {
 
 	// remove : for url construction
 	name = strings.Replace(name, ":", "-", -1)
+
+	// trim bad characters
+	name = strings.Trim(name, "/")
+	name = strings.Trim(name, ".")
 
 	// clean relative pathing
 	return path.Clean(name)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -52,16 +52,10 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		name = cleanSPDXName(srcMetadata.ImageMetadata.UserInput)
-		if name != "" {
-			identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
-		}
-		identifier = path.Join("image", fmt.Sprintf("%s", uniqueID.String()))
+		identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
 	case source.DirectoryScheme:
 		name = cleanSPDXName(srcMetadata.Path)
-		if name != "" {
-			identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
-		}
-		identifier = path.Join("dir", fmt.Sprintf("%s", uniqueID.String()))
+		identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
 	}
 
 	namespace := path.Join(anchoreNamespace, identifier)
@@ -136,10 +130,6 @@ func cleanSPDXName(name string) string {
 
 	// remove : for url construction
 	name = strings.Replace(name, ":", "-", -1)
-
-	// trim bad characters
-	name = strings.Trim(name, "/")
-	name = strings.Trim(name, ".")
 
 	// clean relative pathing
 	return path.Clean(name)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -50,10 +50,10 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		name = srcMetadata.ImageMetadata.UserInput
-		identifier = fmt.Sprintf("image/%s", uniqueID.String())
+		identifier = fmt.Sprintf("image/%s-%s", name, uniqueID.String())
 	case source.DirectoryScheme:
 		name = srcMetadata.Path
-		identifier = fmt.Sprintf("dir/%s", uniqueID.String())
+		identifier = fmt.Sprintf("dir/%s-%s", name, uniqueID.String())
 	}
 
 	namespace := fmt.Sprintf("%s/%s", anchoreNamespace, identifier)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/syft/internal/version"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
+	"github.com/google/uuid"
 )
 
 // SPDXJsonPresenter is a SPDX presentation object for the syft results (see https://github.com/spdx/spdx-spec)
@@ -50,6 +51,7 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 	}
 
 	packages, files, relationships := newSPDXJsonElements(catalog)
+	uuid := uuid.Must(uuid.NewRandom())
 
 	return spdx22.Document{
 		Element: spdx22.Element{
@@ -67,7 +69,7 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 			LicenseListVersion: spdxlicense.Version,
 		},
 		DataLicense:       "CC0-1.0",
-		DocumentNamespace: fmt.Sprintf("https://anchore.com/syft/image/%s", srcMetadata.ImageMetadata.UserInput),
+		DocumentNamespace: fmt.Sprintf("https://anchore.com/syft/image/%s-%s", srcMetadata.ImageMetadata.UserInput, uuid.String()),
 		Packages:          packages,
 		Files:             files,
 		Relationships:     relationships,

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -48,18 +48,20 @@ func (pres *SPDXJsonPresenter) Present(output io.Writer) error {
 func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx22.Document {
 	uniqueID := uuid.Must(uuid.NewRandom())
 
-	var name, identifier string
+	var name, input, identifier string
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		name = cleanSPDXName(srcMetadata.ImageMetadata.UserInput)
-		identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		input = "image"
 	case source.DirectoryScheme:
 		name = cleanSPDXName(srcMetadata.Path)
-		if name != "." {
-			identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
-		} else {
-			identifier = path.Join("dir", uniqueID.String())
-		}
+		input = "dir"
+	}
+
+	if name != "." {
+		identifier = path.Join(input, fmt.Sprintf("%s-%s", name, uniqueID.String()))
+	} else {
+		identifier = path.Join(input, uniqueID.String())
 	}
 
 	namespace := path.Join(anchoreNamespace, identifier)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -55,7 +55,11 @@ func newSPDXJsonDocument(catalog *pkg.Catalog, srcMetadata source.Metadata) spdx
 		identifier = path.Join("image", fmt.Sprintf("%s-%s", name, uniqueID.String()))
 	case source.DirectoryScheme:
 		name = cleanSPDXName(srcMetadata.Path)
-		identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		if name != "." {
+			identifier = path.Join("dir", fmt.Sprintf("%s-%s", name, uniqueID.String()))
+		} else {
+			identifier = path.Join("dir", fmt.Sprintf("%s", uniqueID.String()))
+		}
 	}
 
 	namespace := path.Join(anchoreNamespace, identifier)

--- a/internal/presenter/packages/spdx_json_presenter.go
+++ b/internal/presenter/packages/spdx_json_presenter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var anchoreNamespace = "https://anchore.com/syft/image"
+const anchoreNamespace = "https://anchore.com/syft/image"
 
 // SPDXJsonPresenter is a SPDX presentation object for the syft results (see https://github.com/spdx/spdx-spec)
 type SPDXJsonPresenter struct {

--- a/internal/presenter/packages/spdx_json_presenter_test.go
+++ b/internal/presenter/packages/spdx_json_presenter_test.go
@@ -31,6 +31,10 @@ func TestSPDXJSONImagePresenter(t *testing.T) {
 func spdxJsonRedactor(s []byte) []byte {
 	// each SBOM reports the time it was generated, which is not useful during snapshot testing
 	s = regexp.MustCompile(`"created": .*`).ReplaceAll(s, []byte("redacted"))
+
+	// each SBOM reports a unique documentNamespace when generated, this is not useful for snapshot testing
+	s = regexp.MustCompile(`"documentNamespace": .*`).ReplaceAll(s, []byte("redacted"))
+
 	// the license list will be updated periodically, the value here should not be directly tested in snapshot tests
 	return regexp.MustCompile(`"licenseListVersion": .*`).ReplaceAll(s, []byte("redacted"))
 }

--- a/internal/presenter/packages/test-fixtures/snapshot/TestSPDXJSONDirectoryPresenter.golden
+++ b/internal/presenter/packages/test-fixtures/snapshot/TestSPDXJSONDirectoryPresenter.golden
@@ -1,6 +1,6 @@
 {
  "SPDXID": "SPDXRef-DOCUMENT",
- "name": "/some/path",
+ "name": "some/path",
  "spdxVersion": "SPDX-2.2",
  "creationInfo": {
   "created": "2021-09-16T20:44:35.198887Z",

--- a/internal/presenter/packages/test-fixtures/snapshot/TestSPDXJSONDirectoryPresenter.golden
+++ b/internal/presenter/packages/test-fixtures/snapshot/TestSPDXJSONDirectoryPresenter.golden
@@ -1,6 +1,6 @@
 {
  "SPDXID": "SPDXRef-DOCUMENT",
- "name": "some/path",
+ "name": "/some/path",
  "spdxVersion": "SPDX-2.2",
  "creationInfo": {
   "created": "2021-09-16T20:44:35.198887Z",


### PR DESCRIPTION
Fixes: #495 

In the case where an input directory is `.` or `./` the name is stripped and a `uuidv4` becomes the namespace identifier.

When a URL is an input here is an example of the format output:
```
"documentNamespace": "https:/anchore.com/syft/image/gcr.io/distroless/nodejs-debian10-6d671418-314c-480b-a620-c86d985d5441",
```

Since `.` is unreserved I believe we can get away with keeping the baseURL for image inputs in the path:
https://datatracker.ietf.org/doc/html/rfc3986#section-2.3

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>