### PR TITLE
Allow file digests instances to be optional for alpine metadata

### DIFF
--- a/syft/file/classification_cataloger.go
+++ b/syft/file/classification_cataloger.go
@@ -31,7 +31,7 @@ func (i *ClassificationCataloger) Catalog(resolver source.FileResolver) (map[sou
 			}
 		}
 	}
-	log.Debugf("classification cataloger discovered %d results", numResults)
+	log.Debugf("file classifier discovered %d results", numResults)
 
 	return results, nil
 }

--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -37,11 +37,11 @@ type ApkMetadata struct {
 
 // ApkFileRecord represents a single file listing and metadata from a APK DB entry (which may have many of these file records).
 type ApkFileRecord struct {
-	Path        string      `json:"path"`
-	OwnerUID    string      `json:"ownerUid,omitempty"`
-	OwnerGID    string      `json:"ownerGid,omitempty"`
-	Permissions string      `json:"permissions,omitempty"`
-	Digest      file.Digest `json:"digest,omitempty"`
+	Path        string       `json:"path"`
+	OwnerUID    string       `json:"ownerUid,omitempty"`
+	OwnerGID    string       `json:"ownerGid,omitempty"`
+	Permissions string       `json:"permissions,omitempty"`
+	Digest      *file.Digest `json:"digest,omitempty"`
 }
 
 // PackageURL returns the PURL for the specific Alpine package (see https://github.com/package-url/purl-spec)

--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -128,7 +128,7 @@ func parseApkDBEntry(reader io.Reader) (*pkg.ApkMetadata, error) {
 				log.Warnf("checksum field with no parent record: %q", value)
 				continue
 			}
-			fileRecord.Digest = file.Digest{
+			fileRecord.Digest = &file.Digest{
 				Algorithm: "sha1",
 				Value:     value,
 			}

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -41,7 +41,7 @@ func TestExtraFileAttributes(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1M0C9qfC/+kdRiOodeihG2GMRtkE=",
 						},
@@ -110,7 +110,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
 						},
@@ -126,7 +126,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
 						},
@@ -136,7 +136,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
 						},
@@ -146,7 +146,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
 						},
@@ -156,7 +156,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
 						},
@@ -195,49 +195,49 @@ func TestSinglePackageDetails(t *testing.T) {
 					},
 					{
 						Path: "/etc/fstab",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q11Q7hNe8QpDS531guqCdrXBzoA/o=",
 						},
 					},
 					{
 						Path: "/etc/group",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1oJ16xWudgKOrXIEquEDzlF2Lsm4=",
 						},
 					},
 					{
 						Path: "/etc/hostname",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q16nVwYVXP/tChvUPdukVD2ifXOmc=",
 						},
 					},
 					{
 						Path: "/etc/hosts",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1BD6zJKZTRWyqGnPi4tSfd3krsMU=",
 						},
 					},
 					{
 						Path: "/etc/inittab",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1TsthbhW7QzWRe1E/NKwTOuD4pHc=",
 						},
 					},
 					{
 						Path: "/etc/modules",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1toogjUipHGcMgECgPJX64SwUT1M=",
 						},
 					},
 					{
 						Path: "/etc/motd",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1XmduVVNURHQ27TvYp1Lr5TMtFcA=",
 						},
@@ -247,35 +247,35 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "777",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1kiljhXXH1LlQroHsEJIkPZg2eiw=",
 						},
 					},
 					{
 						Path: "/etc/passwd",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1TchuuLUfur0izvfZQZxgN/LJhB8=",
 						},
 					},
 					{
 						Path: "/etc/profile",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1KpFb8kl5LvwXWlY3e58FNsjrI34=",
 						},
 					},
 					{
 						Path: "/etc/protocols",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q13FqXUnvuOpMDrH/6rehxuYAEE34=",
 						},
 					},
 					{
 						Path: "/etc/services",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1C6HJNgQvLWqt5VY+n7MZJ1rsDuY=",
 						},
@@ -285,21 +285,21 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "42",
 						Permissions: "640",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1ltrPIAW2zHeDiajsex2Bdmq3uqA=",
 						},
 					},
 					{
 						Path: "/etc/shells",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1ojm2YdpCJ6B/apGDaZ/Sdb2xJkA=",
 						},
 					},
 					{
 						Path: "/etc/sysctl.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q14upz3tfnNxZkIEsUhWn7Xoiw96g=",
 						},
@@ -318,7 +318,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "600",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1vfk1apUWI4yLJGhhNRd0kJixfvY=",
 						},
@@ -331,28 +331,28 @@ func TestSinglePackageDetails(t *testing.T) {
 					},
 					{
 						Path: "/etc/modprobe.d/aliases.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1WUbh6TBYNVK7e4Y+uUvLs/7viqk=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/blacklist.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1xxYGU6S6TLQvb7ervPrWWwAWqMg=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/i386.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1pnay/njn6ol9cCssL7KiZZ8etlc=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/kms.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1ynbLn3GYDpvajba/ldp1niayeog=",
 						},
@@ -401,14 +401,14 @@ func TestSinglePackageDetails(t *testing.T) {
 					},
 					{
 						Path: "/etc/profile.d/color_prompt",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q10wL23GuSCVfumMRgakabUI6EsSk=",
 						},
 					},
 					{
 						Path: "/etc/profile.d/locale",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1R4bIEpnKxxOSrlnZy9AoawqZ5DU=",
 						},
@@ -436,7 +436,7 @@ func TestSinglePackageDetails(t *testing.T) {
 					},
 					{
 						Path: "/lib/sysctl.d/00-alpine.conf",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1HpElzW1xEgmKfERtTy7oommnq6c=",
 						},
@@ -479,7 +479,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "755",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1YeuSmC7iDbEWrusPzA/zUQF6YSg=",
 						},
@@ -537,7 +537,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "777",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q11/SNZz/8cK2dSKK+cJpVrZIuF4Q=",
 						},
@@ -586,7 +586,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "777",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1dzbdazYZA2nTzSIG3YyNw7d4Juc=",
 						},
@@ -599,7 +599,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerUID:    "0",
 						OwnerGID:    "0",
 						Permissions: "777",
-						Digest: file.Digest{
+						Digest: &file.Digest{
 							Algorithm: "sha1",
 							Value:     "Q1OFZt+ZMp7j0Gny0rqSKuWJyqYmA=",
 						},
@@ -704,7 +704,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerUID:    "0",
 								OwnerGID:    "0",
 								Permissions: "755",
-								Digest: file.Digest{
+								Digest: &file.Digest{
 									Algorithm: "sha1",
 									Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
 								},
@@ -720,7 +720,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerUID:    "0",
 								OwnerGID:    "0",
 								Permissions: "755",
-								Digest: file.Digest{
+								Digest: &file.Digest{
 									Algorithm: "sha1",
 									Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
 								},
@@ -730,7 +730,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerUID:    "0",
 								OwnerGID:    "0",
 								Permissions: "755",
-								Digest: file.Digest{
+								Digest: &file.Digest{
 									Algorithm: "sha1",
 									Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
 								},
@@ -740,7 +740,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerUID:    "0",
 								OwnerGID:    "0",
 								Permissions: "755",
-								Digest: file.Digest{
+								Digest: &file.Digest{
 									Algorithm: "sha1",
 									Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
 								},
@@ -750,7 +750,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerUID:    "0",
 								OwnerGID:    "0",
 								Permissions: "755",
-								Digest: file.Digest{
+								Digest: &file.Digest{
 									Algorithm: "sha1",
 									Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
 								},


### PR DESCRIPTION
File digest information on alpine metadata is optional (since dir entries are valid), leading to entries that look like this:
```json
    {
    "originPackage": "busybox",
    ...
    "files": [
     {
      "path": "/usr",
      "digest": {
       "algorithm": "",
       "value": ""
      }
     },
   ...
```

This makes the digest field optional in the alpine datastructure, in which case it won't be included in the JSON output when there are no values.