### PR TITLE
Add --file option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ output: "table"
 # same as -q ; SYFT_QUIET env var
 quiet: false
 
+# same as --file; write output report to a file (default is to write to stdout)
+file: ""
+
 # enable/disable checking for application updates on startup
 # same as SYFT_CHECK_FOR_APP_UPDATE env var
 check-for-app-update: true


### PR DESCRIPTION
As a follow up to https://github.com/anchore/syft/pull/530, adds the config docs to the README.