### PR TITLE
Remove unnecessary CodeQL checkout steps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,15 +31,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Removes the `git checkout HEAD^2` from the codeQL step due to warnings.

<img width="929" alt="Screen Shot 2021-10-18 at 11 02 59 AM" src="https://user-images.githubusercontent.com/590471/137758433-e095306a-4375-4cdf-b6b8-690e0e5a3c02.png">

Addresses https://github.com/anchore/syft/issues/519#issuecomment-930236090