### PR TITLE
Swap go binary parsing warning logging entry

### DIFF
--- a/syft/pkg/cataloger/golang/bin_cataloger.go
+++ b/syft/pkg/cataloger/golang/bin_cataloger.go
@@ -50,7 +50,7 @@ func (c *Cataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, error)
 
 		goPkgs, err := parseGoBin(location.RealPath, r)
 		if err != nil {
-			log.Infof("could not parse go bin for: %w", err)
+			log.Warnf("could not parse possible go binary: %+v", err)
 		}
 
 		r.Close()


### PR DESCRIPTION
Fixes the logging for go binary parsing problems --was seeing these entries in the log:
```
[0000]  INFO could not parse go bin for: %!w(*errors.errorString=&{unrecognized executable format})
[0000]  INFO could not parse go bin for: %!w(*errors.errorString=&{Unrecognised COFF file header machine value of 0xaa64.})  
```