### PR TITLE
Add chronicle as the changelog generator tool

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,10 +96,6 @@ jobs:
     steps:
       - uses: docker-practice/actions-setup-docker@v1
 
-      # note, it is important to always be auth'd into docker.io to prevent rate limiting issues
-      - name: Login to Docker Hub
-        run: echo ${{ secrets.TOOLBOX_DOCKER_PASS }} | docker login docker.io -u ${{ secrets.TOOLBOX_DOCKER_USER }} --password-stdin
-
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}


### PR DESCRIPTION
Swaps out the existing changelog generator tool for [chronicle](https://github.com/anchore/chronicle) to save on time in the release process and problems with API rate limiting.