### PR TITLE
Force exiting the ETUI upon worker error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ cli: $(SNAPSHOTDIR) ## Run CLI tests
 	SYFT_BINARY_LOCATION='$(SNAPSHOT_CMD)' \
 		go test -count=1 -v ./test/cli
 
-.PHONY: changlog-release
+.PHONY: changelog-release
 changelog-release:
 	$(TEMPDIR)/chronicle --since-tag $(SECOND_TO_LAST_TAG) --until-tag $(LAST_TAG) -vv > CHANGELOG.md
 


### PR DESCRIPTION
The ETUI has internal state (such as spinners running before a stop event) which needs to be ignored when shutting down the  UI if there has been a worker error (in which case this ETUI state no longer matters).

I've also removed the warning for errors when unsubscribing from the bus since this is not helpful for the user.

Related to behavior seen in https://github.com/anchore/grype/issues/460