### PR TITLE
stop hidding `complete` command from help doc

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,9 +14,8 @@ import (
 
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
-	Hidden: true,
-	Use:    "completion [bash|zsh|fish]",
-	Short:  "Generate a shell completion for Syft (listing local docker images)",
+	Use:   "completion [bash|zsh|fish]",
+	Short: "Generate a shell completion for Syft (listing local docker images)",
 	Long: `To load completions (docker image list):
 
 Bash:


### PR DESCRIPTION
Following https://github.com/anchore/grype `complete` command, make it visible in syft's help docs.

New list of commands:
```
Available Commands:
  completion  Generate a shell completion for Syft (listing local docker images)
  help        Help about any command
  packages    Generate a package SBOM
  version     show the version
```

closes #594 