### PR TITLE
update goreleaser with correct tag information

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -144,15 +144,15 @@ dockers:
 docker_manifests:
   - name_template: anchore/syft:{{ .Version }}
     image_templates:
-      - anchore/syft:{{ .Version }}-amd64
+      - anchore/syft:{{ .Tag }}-amd64
       - anchore/syft:v{{ .Major }}-amd64
       - anchore/syft:v{{ .Major }}.{{ .Minor }}-amd64
-      - anchore/syft:{{ .Version }}-arm64v8
+      - anchore/syft:{{ .Tag }}-arm64v8
       - anchore/syft:v{{ .Major }}-arm64v8
       - anchore/syft:v{{ .Major }}.{{ .Minor }}-arm64v8
   - name_template: anchore/syft:latest
     image_templates:
-      - anchore/syft:{{ .Version }}-amd64
+      - anchore/syft:{{ .Tag }}-amd64
       - anchore/syft:v{{ .Major }}-amd64
       - anchore/syft:v{{ .Major }}.{{ .Minor }}-amd64
       - anchore/syft:{{ .Version }}-arm64v8


### PR DESCRIPTION
Update to use `Tag` over `Version` since `Tag` contains the `v` that will match the generated container.

See this error:
https://github.com/anchore/syft/runs/4037352553?check_suite_focus=true

Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>