### PR TITLE
Use named pipe bit when checking for piped input

### DIFF
--- a/internal/input.go
+++ b/internal/input.go
@@ -13,7 +13,7 @@ func IsPipedInput() (bool, error) {
 	}
 
 	// note: we should NOT use the absence of a character device here as the hint that there may be input expected
-	// on stdin, as running grype as a subprocess you would expect no character device to be present but input can
+	// on stdin, as running syft as a subprocess you would expect no character device to be present but input can
 	// be from either stdin or indicated by the CLI. Checking if stdin is a pipe is the most direct way to determine
 	// if there *may* be bytes that will show up on stdin that should be used for the analysis source.
 	return fi.Mode()&os.ModeNamedPipe != 0, nil

--- a/internal/input.go
+++ b/internal/input.go
@@ -12,5 +12,9 @@ func IsPipedInput() (bool, error) {
 		return false, fmt.Errorf("unable to determine if there is piped input: %w", err)
 	}
 
-	return fi.Mode()&os.ModeCharDevice == 0, nil
+	// note: we should NOT use the absence of a character device here as the hint that there may be input expected
+	// on stdin, as running grype as a subprocess you would expect no character device to be present but input can
+	// be from either stdin or indicated by the CLI. Checking if stdin is a pipe is the most direct way to determine
+	// if there *may* be bytes that will show up on stdin that should be used for the analysis source.
+	return fi.Mode()&os.ModeNamedPipe != 0, nil
 }


### PR DESCRIPTION
This is the sister PR to github.com/anchore/grype/pull/484, however, since syft currently does not accept input directly there are no further changes needed. See the code comment for more details on the nature of the change.