### PR TITLE
Allow for cataloging a single file

### DIFF
--- a/syft/lib.go
+++ b/syft/lib.go
@@ -52,6 +52,9 @@ func CatalogPackages(src *source.Source, scope source.Scope) (*pkg.Catalog, *dis
 	case source.ImageScheme:
 		log.Info("cataloging image")
 		catalogers = cataloger.ImageCatalogers()
+	case source.FileScheme:
+		log.Info("cataloging file")
+		catalogers = cataloger.DirectoryCatalogers()
 	case source.DirectoryScheme:
 		log.Info("cataloging directory")
 		catalogers = cataloger.DirectoryCatalogers()

--- a/syft/source/scheme.go
+++ b/syft/source/scheme.go
@@ -19,41 +19,49 @@ const (
 	DirectoryScheme Scheme = "DirectoryScheme"
 	// ImageScheme indicates the source being cataloged is a container image
 	ImageScheme Scheme = "ImageScheme"
+	// FileScheme indicates the source being cataloged is a single file
+	FileScheme Scheme = "FileScheme"
 )
 
 func detectScheme(fs afero.Fs, imageDetector sourceDetector, userInput string) (Scheme, image.Source, string, error) {
-	if strings.HasPrefix(userInput, "dir:") {
-		// blindly trust the user's scheme
+	switch {
+	case strings.HasPrefix(userInput, "dir:"):
 		dirLocation, err := homedir.Expand(strings.TrimPrefix(userInput, "dir:"))
 		if err != nil {
 			return UnknownScheme, image.UnknownSource, "", fmt.Errorf("unable to expand directory path: %w", err)
 		}
 		return DirectoryScheme, image.UnknownSource, dirLocation, nil
+
+	case strings.HasPrefix(userInput, "file:"):
+		fileLocation, err := homedir.Expand(strings.TrimPrefix(userInput, "file:"))
+		if err != nil {
+			return UnknownScheme, image.UnknownSource, "", fmt.Errorf("unable to expand directory path: %w", err)
+		}
+		return FileScheme, image.UnknownSource, fileLocation, nil
 	}
 
-	// we should attempt to let stereoscope determine what the source is first --but, just because the source is a valid directory
-	// doesn't mean we yet know if it is an OCI layout directory (to be treated as an image) or if it is a generic filesystem directory.
+	// try the most specific sources first and move out towards more generic sources.
+
+	// first: let's try the image detector, which has more scheme parsing internal to stereoscope
 	source, imageSpec, err := imageDetector(userInput)
-	if err != nil {
-		return UnknownScheme, image.UnknownSource, "", fmt.Errorf("unable to detect the scheme from %q: %w", userInput, err)
+	if err == nil && source != image.UnknownSource {
+		return ImageScheme, source, imageSpec, nil
 	}
 
-	if source == image.UnknownSource {
-		dirLocation, err := homedir.Expand(userInput)
-		if err != nil {
-			return UnknownScheme, image.UnknownSource, "", fmt.Errorf("unable to expand potential directory path: %w", err)
-		}
+	// next: let's try more generic sources (dir, file, etc.)
 
-		fileMeta, err := fs.Stat(dirLocation)
-		if err != nil {
-			return UnknownScheme, source, "", nil
-		}
+	location, err := homedir.Expand(userInput)
+	if err != nil {
+		return UnknownScheme, image.UnknownSource, "", fmt.Errorf("unable to expand potential directory path: %w", err)
+	}
 
-		if fileMeta.IsDir() {
-			return DirectoryScheme, source, dirLocation, nil
-		}
+	fileMeta, err := fs.Stat(location)
+	if err != nil {
 		return UnknownScheme, source, "", nil
 	}
 
-	return ImageScheme, source, imageSpec, nil
+	if fileMeta.IsDir() {
+		return DirectoryScheme, source, location, nil
+	}
+	return FileScheme, source, location, nil
 }

--- a/syft/source/scheme_test.go
+++ b/syft/source/scheme_test.go
@@ -21,6 +21,7 @@ func TestDetectScheme(t *testing.T) {
 		name             string
 		userInput        string
 		dirs             []string
+		files            []string
 		detection        detectorResult
 		expectedScheme   Scheme
 		expectedLocation string
@@ -153,6 +154,28 @@ func TestDetectScheme(t *testing.T) {
 			expectedLocation: "some/path-to-dir",
 		},
 		{
+			name:      "explicit-file",
+			userInput: "file:some/path-to-file",
+			detection: detectorResult{
+				src: image.UnknownSource,
+				ref: "",
+			},
+			files:            []string{"some/path-to-file"},
+			expectedScheme:   FileScheme,
+			expectedLocation: "some/path-to-file",
+		},
+		{
+			name:      "implicit-file",
+			userInput: "some/path-to-file",
+			detection: detectorResult{
+				src: image.UnknownSource,
+				ref: "",
+			},
+			files:            []string{"some/path-to-file"},
+			expectedScheme:   FileScheme,
+			expectedLocation: "some/path-to-file",
+		},
+		{
 			name:      "explicit-current-dir",
 			userInput: "dir:.",
 			detection: detectorResult{
@@ -225,7 +248,18 @@ func TestDetectScheme(t *testing.T) {
 				}
 				err = fs.Mkdir(expandedExpectedLocation, os.ModePerm)
 				if err != nil {
-					t.Fatalf("failed to create dummy tar: %+v", err)
+					t.Fatalf("failed to create dummy dir: %+v", err)
+				}
+			}
+
+			for _, p := range test.files {
+				expandedExpectedLocation, err := homedir.Expand(p)
+				if err != nil {
+					t.Fatalf("unable to expand path=%q: %+v", p, err)
+				}
+				_, err = fs.Create(expandedExpectedLocation)
+				if err != nil {
+					t.Fatalf("failed to create dummy file: %+v", err)
 				}
 			}
 

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -130,6 +130,16 @@ func TestPackagesCmdFlags(t *testing.T) {
 				assertFailingReturnCode, // upload can't go anywhere, so if this passes that would be surprising
 			},
 		},
+		{
+			// we want to make certain that syft can catalog a single go binary and get a SBOM report that is not empty
+			name: "catalog-single-go-binary",
+			args: []string{"packages", "-o", "json", getSyftBinaryLocation(t)},
+			assertions: []traitAssertion{
+				assertJsonReport,
+				assertStdoutLengthGreaterThan(1000),
+				assertSuccessfulReturnCode,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -75,6 +75,16 @@ func assertInOutput(data string) traitAssertion {
 	}
 }
 
+func assertStdoutLengthGreaterThan(length uint) traitAssertion {
+	return func(tb testing.TB, stdout, _ string, _ int) {
+		tb.Helper()
+		if uint(len(stdout)) < length {
+			tb.Errorf("not enough output (expected at least %d, got %d)", length, len(stdout))
+
+		}
+	}
+}
+
 func assertFailingReturnCode(tb testing.TB, _, _ string, rc int) {
 	tb.Helper()
 	if rc == 0 {


### PR DESCRIPTION
This PR allows for cataloging a single file by adding a `file` scheme (in addition to the existing `dir` and image-oriented schemes):

```bash
❯ cat requirements.txt
flask==4.0.0

❯ syft requirements.txt
 ✔ Indexed requirements.txt 
 ✔ Cataloged packages      [1 packages]

NAME   VERSION  TYPE   
flask  4.0.0    python 
```

Example usage:
```bash
# explicit file scheme
$ syft file:./path/to/file

# implicit file scheme
$ syft ./path/to/file
```

Closes #541 