### PR TITLE
Add layer information for go-module-binary-cataloger

### DIFF
--- a/syft/pkg/cataloger/golang/bin_cataloger.go
+++ b/syft/pkg/cataloger/golang/bin_cataloger.go
@@ -48,7 +48,7 @@ func (c *Cataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, error)
 			return pkgs, fmt.Errorf("failed to resolve file contents by location: %w", err)
 		}
 
-		goPkgs, err := parseGoBin(location.RealPath, r)
+		goPkgs, err := parseGoBin(location, r)
 		if err != nil {
 			log.Warnf("could not parse possible go binary: %+v", err)
 		}

--- a/syft/pkg/cataloger/golang/parse_go_bin.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin.go
@@ -14,7 +14,7 @@ const (
 	replaceIdentifier = "=>"
 )
 
-func parseGoBin(path string, reader io.ReadCloser) ([]pkg.Package, error) {
+func parseGoBin(location source.Location, reader io.ReadCloser) ([]pkg.Package, error) {
 	// Identify if bin was compiled by go
 	x, err := openExe(reader)
 	if err != nil {
@@ -23,12 +23,12 @@ func parseGoBin(path string, reader io.ReadCloser) ([]pkg.Package, error) {
 
 	goVersion, mod := findVers(x)
 
-	pkgs := buildGoPkgInfo(path, mod, goVersion)
+	pkgs := buildGoPkgInfo(location, mod, goVersion)
 
 	return pkgs, nil
 }
 
-func buildGoPkgInfo(path, mod, goVersion string) []pkg.Package {
+func buildGoPkgInfo(location source.Location, mod, goVersion string) []pkg.Package {
 	pkgsSlice := make([]pkg.Package, 0)
 	scanner := bufio.NewScanner(strings.NewReader(mod))
 
@@ -48,9 +48,7 @@ func buildGoPkgInfo(path, mod, goVersion string) []pkg.Package {
 				Language: pkg.Go,
 				Type:     pkg.GoModulePkg,
 				Locations: []source.Location{
-					{
-						RealPath: path,
-					},
+					location,
 				},
 				MetadataType: pkg.GolangBinMetadataType,
 				Metadata: pkg.GolangBinMetadata{

--- a/syft/pkg/cataloger/golang/parse_go_bin_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin_test.go
@@ -115,7 +115,8 @@ func TestBuildGoPkgInfo(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			pkgs := buildGoPkgInfo("", tt.mod, goCompiledVersion)
+			location := source.Location{RealPath: "", FileSystemID: ""}
+			pkgs := buildGoPkgInfo(location, tt.mod, goCompiledVersion)
 			assert.Equal(t, tt.expected, pkgs)
 		})
 	}

--- a/syft/pkg/cataloger/golang/parse_go_bin_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin_test.go
@@ -33,7 +33,10 @@ func TestBuildGoPkgInfo(t *testing.T) {
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: []source.Location{
-						{},
+						{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
 					},
 					MetadataType: pkg.GolangBinMetadataType,
 					Metadata: pkg.GolangBinMetadata{
@@ -47,7 +50,10 @@ func TestBuildGoPkgInfo(t *testing.T) {
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: []source.Location{
-						{},
+						{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
 					},
 					MetadataType: pkg.GolangBinMetadataType,
 					Metadata: pkg.GolangBinMetadata{
@@ -72,7 +78,10 @@ func TestBuildGoPkgInfo(t *testing.T) {
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: []source.Location{
-						{},
+						{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
 					},
 					MetadataType: pkg.GolangBinMetadataType,
 					Metadata: pkg.GolangBinMetadata{
@@ -86,7 +95,10 @@ func TestBuildGoPkgInfo(t *testing.T) {
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: []source.Location{
-						{},
+						{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
 					},
 					MetadataType: pkg.GolangBinMetadataType,
 					Metadata: pkg.GolangBinMetadata{
@@ -100,7 +112,10 @@ func TestBuildGoPkgInfo(t *testing.T) {
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: []source.Location{
-						{},
+						{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
 					},
 					MetadataType: pkg.GolangBinMetadataType,
 					Metadata: pkg.GolangBinMetadata{
@@ -115,7 +130,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			location := source.Location{RealPath: "", FileSystemID: ""}
+			location := source.Location{RealPath: "/a-path", FileSystemID: "layer-id"}
 			pkgs := buildGoPkgInfo(location, tt.mod, goCompiledVersion)
 			assert.Equal(t, tt.expected, pkgs)
 		})

--- a/syft/source/all_layers_resolver.go
+++ b/syft/source/all_layers_resolver.go
@@ -198,7 +198,7 @@ func (r *allLayersResolver) FilesByMIMEType(types ...string) ([]Location, error)
 		}
 
 		for _, ref := range refs {
-			locations = append(locations, NewLocationFromReference(ref))
+			locations = append(locations, NewLocationFromImage(string(ref.RealPath), ref, r.img))
 		}
 	}
 

--- a/syft/source/all_layers_resolver_test.go
+++ b/syft/source/all_layers_resolver_test.go
@@ -272,3 +272,32 @@ func Test_imageAllLayersResolver_FilesByMIMEType(t *testing.T) {
 		})
 	}
 }
+
+func Test_imageAllLayersResolver_hasFilesystemIDInLocation(t *testing.T) {
+	img := imagetest.GetFixtureImage(t, "docker-archive", "image-duplicate-path")
+
+	resolver, err := newAllLayersResolver(img)
+	assert.NoError(t, err)
+
+	locations, err := resolver.FilesByMIMEType("text/plain")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+	locations, err = resolver.FilesByGlob("*.txt")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+	locations, err = resolver.FilesByPath("/somefile-1.txt")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+}

--- a/syft/source/image_squash_resolver.go
+++ b/syft/source/image_squash_resolver.go
@@ -159,7 +159,7 @@ func (r *imageSquashResolver) FilesByMIMEType(types ...string) ([]Location, erro
 
 	var locations []Location
 	for _, ref := range refs {
-		locations = append(locations, NewLocationFromReference(ref))
+		locations = append(locations, NewLocationFromImage(string(ref.RealPath), ref, r.img))
 	}
 
 	return locations, nil

--- a/syft/source/image_squash_resolver_test.go
+++ b/syft/source/image_squash_resolver_test.go
@@ -259,3 +259,32 @@ func Test_imageSquashResolver_FilesByMIMEType(t *testing.T) {
 		})
 	}
 }
+
+func Test_imageSquashResolver_hasFilesystemIDInLocation(t *testing.T) {
+	img := imagetest.GetFixtureImage(t, "docker-archive", "image-duplicate-path")
+
+	resolver, err := newImageSquashResolver(img)
+	assert.NoError(t, err)
+
+	locations, err := resolver.FilesByMIMEType("text/plain")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+	locations, err = resolver.FilesByGlob("*.txt")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+	locations, err = resolver.FilesByPath("/somefile-1.txt")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, locations)
+	for _, location := range locations {
+		assert.NotEmpty(t, location.FileSystemID)
+	}
+
+}

--- a/syft/source/location.go
+++ b/syft/source/location.go
@@ -53,14 +53,6 @@ func NewLocationFromDirectory(responsePath string, ref file.Reference) Location 
 	}
 }
 
-func NewLocationFromReference(ref file.Reference) Location {
-	return Location{
-		VirtualPath: string(ref.RealPath),
-		RealPath:    string(ref.RealPath),
-		ref:         ref,
-	}
-}
-
 func (l Location) String() string {
 	str := ""
 	if l.ref.ID() != 0 {


### PR DESCRIPTION
Add more context to the parse function. Rather than only pass `realPath` we pass Location so `layerID` information could be populated.

This additionally fixes the image-based `source.FileResolver`s to always include layer information in `Location` references returned.

Closes #619 