### PR TITLE
Use SBOM data structure in ImportConfig

### DIFF
--- a/internal/anchore/import.go
+++ b/internal/anchore/import.go
@@ -6,24 +6,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/antihax/optional"
-
 	"github.com/anchore/client-go/pkg/external"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/internal/bus"
-	"github.com/anchore/syft/syft/distro"
 	"github.com/anchore/syft/syft/event"
-	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/source"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/antihax/optional"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 )
 
 type ImportConfig struct {
 	ImageMetadata           image.Metadata
-	SourceMetadata          source.Metadata
-	Catalog                 *pkg.Catalog
-	Distro                  *distro.Distro
+	SBOM                    sbom.SBOM
 	Dockerfile              []byte
 	OverwriteExistingUpload bool
 	Timeout                 uint
@@ -73,19 +68,19 @@ func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 	prog.N++
 	sessionID := startOperation.Uuid
 
-	packageDigest, err := importPackageSBOM(authedCtx, c.client.ImportsApi, sessionID, cfg.SourceMetadata, cfg.Catalog, cfg.Distro, stage)
+	packageDigest, err := importPackageSBOM(authedCtx, c.client.ImportsApi, sessionID, cfg.SBOM, stage)
 	if err != nil {
 		return fmt.Errorf("failed to import Package SBOM: %w", err)
 	}
 	prog.N++
 
-	manifestDigest, err := importManifest(authedCtx, c.client.ImportsApi, sessionID, cfg.ImageMetadata.RawManifest, stage)
+	manifestDigest, err := importManifest(authedCtx, c.client.ImportsApi, sessionID, cfg.SBOM.Source.ImageMetadata.RawManifest, stage)
 	if err != nil {
 		return fmt.Errorf("failed to import Manifest: %w", err)
 	}
 	prog.N++
 
-	configDigest, err := importConfig(authedCtx, c.client.ImportsApi, sessionID, cfg.ImageMetadata.RawConfig, stage)
+	configDigest, err := importConfig(authedCtx, c.client.ImportsApi, sessionID, cfg.SBOM.Source.ImageMetadata.RawConfig, stage)
 	if err != nil {
 		return fmt.Errorf("failed to import Config: %w", err)
 	}

--- a/internal/anchore/import_package_sbom_test.go
+++ b/internal/anchore/import_package_sbom_test.go
@@ -74,7 +74,15 @@ func TestPackageSbomToModel(t *testing.T) {
 
 	c := pkg.NewCatalog(p)
 
-	model, err := packageSbomModel(m, c, &d)
+	sbomResult := sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			PackageCatalog: c,
+			Distro:         &d,
+		},
+		Source: m,
+	}
+
+	model, err := packageSbomModel(sbomResult)
 	if err != nil {
 		t.Fatalf("unable to generate model from source material: %+v", err)
 	}
@@ -197,7 +205,15 @@ func TestPackageSbomImport(t *testing.T) {
 
 	d, _ := distro.NewDistro(distro.CentOS, "8.0", "")
 
-	theModel, err := packageSbomModel(m, catalog, &d)
+	sbomResult := sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			PackageCatalog: catalog,
+			Distro:         &d,
+		},
+		Source: m,
+	}
+
+	theModel, err := packageSbomModel(sbomResult)
 	if err != nil {
 		t.Fatalf("could not get sbom model: %+v", err)
 	}
@@ -236,7 +252,7 @@ func TestPackageSbomImport(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			digest, err := importPackageSBOM(context.TODO(), test.api, sessionID, m, catalog, &d, &progress.Stage{})
+			digest, err := importPackageSBOM(context.TODO(), test.api, sessionID, sbomResult, &progress.Stage{})
 
 			// validate error handling
 			if err != nil && !test.expectsError {


### PR DESCRIPTION
Migrates the `import` code to use the new `sbom.SBOM` data structure.

This is a follow up from a PR comment here: https://github.com/anchore/syft/pull/606#discussion_r743688889