### PR TITLE
287 - Add retry for image fetch using user's input

### DIFF
--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/syft/internal/log"
 	"github.com/spf13/afero"
 )
 
@@ -68,6 +69,12 @@ func New(userInput string, registryOptions *image.RegistryOptions) (*Source, fun
 
 	case ImageScheme:
 		img, err := stereoscope.GetImageFromSource(location, imageSource, registryOptions)
+		if err != nil {
+			log.Debugf("error parsing location: %s after detecting scheme; pulling image: %s", location, userInput)
+			// we may have been to aggresive reading the source hint
+			// try the input as supplied by the user if our inital parse failed
+			img, err = stereoscope.GetImageFromSource(userInput, imageSource, registryOptions)
+		}
 		cleanup := stereoscope.Cleanup
 
 		if err != nil || img == nil {


### PR DESCRIPTION
Add a second call to `GetImageFromSource` if a prefix was aggressively parsed causing an image name to be shortened into an invalid image.

Docker image cases now covered:
- docker:20.10.0-rc2-git
- docker:docker:20.10.0-rc2-git

#287 (Can't link the issue for some reason)

Had to break things into smaller components because of the linter.