### PR TITLE
Update concurrency primitives for relationships

### DIFF
--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -123,9 +123,7 @@ func powerUserExecWorker(userInput string) <-chan error {
 			go runTask(task, &s.Artifacts, src, c, errs)
 		}
 
-		relationships := mergeResults(results...)
-
-		s.Relationships = append(s.Relationships, relationships...)
+		s.Relationships = append(s.Relationships, mergeResults(results...)...)
 
 		bus.Publish(partybus.Event{
 			Type:  event.PresenterReady,


### PR DESCRIPTION
Discussion on a separate PR was made around how we populate relationships.

This pr removes a level of concurrency and returns a slice. If we're good with this we can apply it to the `packages` command.

Previous discussion: https://github.com/anchore/syft/pull/636#discussion_r752440947
Signed-off-by: Christopher Angelo Phillips <christopher.phillips@anchore.com>