### PR TITLE
Fix content access for directory resolver

### DIFF
--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -326,7 +326,10 @@ func (r *directoryResolver) RelativeFileByPath(_ Location, path string) *Locatio
 // FileContentsByLocation fetches file contents for a single file reference relative to a directory.
 // If the path does not exist an error is returned.
 func (r directoryResolver) FileContentsByLocation(location Location) (io.ReadCloser, error) {
-	return file.NewLazyReadCloser(location.RealPath), nil
+	if location.ref.RealPath == "" {
+		return nil, errors.New("empty path given")
+	}
+	return file.NewLazyReadCloser(string(location.ref.RealPath)), nil
 }
 
 func (r *directoryResolver) AllLocations() <-chan Location {


### PR DESCRIPTION
The directory resolver `FileContentsByLocation` method currently does not rely on `file.Reference` to fetch content, which may lead to empty responses when infact there is content available.