### PR TITLE
Recover from panics from the stdlib when cataloging malformed binaries

### DIFF
--- a/syft/pkg/cataloger/golang/binary_cataloger.go
+++ b/syft/pkg/cataloger/golang/binary_cataloger.go
@@ -40,12 +40,12 @@ func (c *Cataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, []arti
 	for _, location := range fileMatches {
 		r, err := resolver.FileContentsByLocation(location)
 		if err != nil {
-			return pkgs, nil, fmt.Errorf("failed to resolve file contents by location: %w", err)
+			return pkgs, nil, fmt.Errorf("failed to resolve file contents by location=%q: %w", location.RealPath, err)
 		}
 
-		goPkgs, err := parseGoBin(location, r)
+		goPkgs, err := parseGoBin(location, r, openExe)
 		if err != nil {
-			log.Warnf("could not parse possible go binary: %+v", err)
+			log.Warnf("could not parse possible go binary at %q: %+v", location.RealPath, err)
 		}
 
 		internal.CloseAndLogError(r, location.RealPath)

--- a/syft/pkg/cataloger/golang/parse_go_bin.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin.go
@@ -23,7 +23,7 @@ func parseGoBin(location source.Location, reader io.ReadCloser, opener exeOpener
 	// bubbling up and halting execution. For this reason we try to recover from any panic and return an error.
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("recovered panic while parse go binary at %q: %+v", location.RealPath, r)
+			err = fmt.Errorf("recovered from panic while parse go binary at %q: %+v", location.RealPath, r)
 		}
 	}()
 

--- a/syft/pkg/cataloger/golang/parse_go_bin.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"strings"
 
@@ -14,19 +15,29 @@ const (
 	replaceIdentifier = "=>"
 )
 
-func parseGoBin(location source.Location, reader io.ReadCloser) ([]pkg.Package, error) {
+type exeOpener func(file io.ReadCloser) ([]exe, error)
+
+func parseGoBin(location source.Location, reader io.ReadCloser, opener exeOpener) (pkgs []pkg.Package, err error) {
+	var exes []exe
+	// it has been found that there are stdlib paths within openExe that can panic. We want to prevent this behavior
+	// bubbling up and halting execution. For this reason we try to recover from any panic and return an error.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered panic while parse go binary at %q: %+v", location.RealPath, r)
+		}
+	}()
+
 	// Identify if bin was compiled by go
-	exes, err := openExe(reader)
+	exes, err = opener(reader)
 	if err != nil {
-		return nil, err
+		return pkgs, err
 	}
 
-	var pkgs []pkg.Package
 	for _, x := range exes {
 		goVersion, mod := findVers(x)
 		pkgs = append(pkgs, buildGoPkgInfo(location, mod, goVersion, x.ArchName())...)
 	}
-	return pkgs, nil
+	return pkgs, err
 }
 
 func buildGoPkgInfo(location source.Location, mod, goVersion, arch string) []pkg.Package {

--- a/test/cli/test-fixtures/image-bad-binaries/Dockerfile
+++ b/test/cli/test-fixtures/image-bad-binaries/Dockerfile
@@ -1,0 +1,5 @@
+FROM debian:sid
+ADD sources.list /etc/apt/sources.list.d/sources.list
+RUN apt update -y && apt install -y dpkg-dev
+# this as a "macho-invalid" directory which is useful for testing
+RUN apt-get source -y clang-13

--- a/test/cli/test-fixtures/image-bad-binaries/sources.list
+++ b/test/cli/test-fixtures/image-bad-binaries/sources.list
@@ -1,0 +1,1 @@
+deb-src http://deb.debian.org/debian sid main

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func getFixtureImage(t testing.TB, fixtureImageName string) string {
+	t.Logf("obtaining fixture image for %s", fixtureImageName)
 	imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
 	return imagetest.GetFixtureImageTarPath(t, fixtureImageName)
 }


### PR DESCRIPTION
Addresses anchore/grype#526

When processing malformed binaries the stdlib does not take into consideration several edge cases, resulting in a panic instead of returning an error. When this happens grype (or syft) will exit with an error. 

This PR attempts to recover from any panics from this specific execution path until these cases can be dealt with within the stdlib. This allows for syft/grype to continue cataloging paths that didn't have problems and still produce a report instead of exiting early.