### PR TITLE
Catalog java bundle-version if nothing else found

### DIFF
--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -127,6 +127,7 @@ func selectVersion(manifest *pkg.JavaManifest, filenameObj archiveFilename) stri
 		"Implementation-Version",
 		"Specification-Version",
 		"Plugin-Version",
+		"Bundle-Version",
 	}
 
 	for _, fieldName := range fieldNames {

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -212,6 +212,22 @@ func TestSelectVersion(t *testing.T) {
 			},
 			expected: "1.8.2",
 		},
+		{
+			name: "Implementation-Version takes precedence over Specification-Version in subsequent section",
+			manifest: pkg.JavaManifest{
+				Main: map[string]string{
+					"Manifest-Version": "1.0",
+					"Ant-Version":      "Apache Ant 1.8.2",
+					"Created-By":       "1.5.0_22-b03 (Sun Microsystems Inc.)",
+				},
+				NamedSections: map[string]map[string]string{
+					"some-other-section": {
+						"Bundle-Version": "1.11.28",
+					},
+				},
+			},
+			expected: "1.11.28",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The issue is the MANIFEST for the `tomcat-jdbc.jar` only included a `Bundle-Version`, so we can fall back to this as a last resort.

```
Manifest-Version: 1.0
Ant-Version: Apache Ant 1.9.16
Created-By: 11.0.13+8 (Eclipse Adoptium)
Export-Package: org.apache.tomcat.jdbc.naming;uses:="javax.naming,org.
 apache.juli.logging,javax.naming.spi";version="10.0.14",org.apache.to
 mcat.jdbc.pool;uses:="org.apache.juli.logging,javax.sql,org.apache.to
 mcat.jdbc.pool.jmx,javax.management,javax.naming,javax.naming.spi,org
 .apache.tomcat.jdbc.pool.interceptor";version="10.0.14",org.apache.to
 mcat.jdbc.pool.interceptor;uses:="org.apache.tomcat.jdbc.pool,org.apa
 che.juli.logging,javax.management.openmbean,javax.management";version
 ="10.0.14",org.apache.tomcat.jdbc.pool.jmx;uses:="org.apache.tomcat.j
 dbc.pool,org.apache.juli.logging,javax.management";version="10.0.14"
Bundle-Vendor: Apache Software Foundation
Bundle-Version: 10.0.14
Bundle-Name: Apache Tomcat JDBC Connection Pool
Bundle-ManifestVersion: 2
Bundle-SymbolicName: org.apache.tomcat.jdbc
Import-Package:  javax.management;version="0", javax.management.openmb
 ean;version="0", javax.naming;version="0", javax.naming.spi;version="
 0", javax.sql;version="0", org.apache.juli.logging;version="0"
```