### PR TITLE
679 pip vcs url

### DIFF
--- a/syft/pkg/cataloger/python/package_cataloger.go
+++ b/syft/pkg/cataloger/python/package_cataloger.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -148,6 +149,10 @@ func (c *PackageCataloger) fetchTopLevelPackages(resolver source.FileResolver, m
 	return pkgs, sources, nil
 }
 
+func (c *PackageCataloger) fetchDirectURLData(resolver source.FileResolver, metadataLocation source.Location) (*pkg.DirectURLOrigin, []source.Location, error) {
+	return nil, nil, errors.New("unimplemented")
+}
+
 // assembleEggOrWheelMetadata discovers and accumulates python package metadata from multiple file sources and returns a single metadata object as well as a list of files where the metadata was derived from.
 func (c *PackageCataloger) assembleEggOrWheelMetadata(resolver source.FileResolver, metadataLocation source.Location) (*pkg.PythonPackageMetadata, []source.Location, error) {
 	var sources = []source.Location{metadataLocation}
@@ -178,6 +183,14 @@ func (c *PackageCataloger) assembleEggOrWheelMetadata(resolver source.FileResolv
 	}
 	sources = append(sources, s...)
 	metadata.TopLevelPackages = p
+
+	// attach any direct-url package data found for the given wheel/egg installation
+	d, s, err := c.fetchDirectURLData(resolver, metadataLocation)
+	if err != nil {
+		// TODO log error
+	}
+	sources = append(sources, s...)
+	metadata.DirectURLOrigin = d
 
 	return &metadata, sources, nil
 }

--- a/syft/pkg/python_package_metadata.go
+++ b/syft/pkg/python_package_metadata.go
@@ -32,6 +32,17 @@ type PythonPackageMetadata struct {
 	Files                []PythonFileRecord `json:"files,omitempty"`
 	SitePackagesRootPath string             `json:"sitePackagesRootPath"`
 	TopLevelPackages     []string           `json:"topLevelPackages,omitempty"`
+	DirectURL            DirectURL          `json:"directUrl,omitempty"`
+}
+
+type DirectURL struct {
+	URL     string `json:"url"`
+	VCSInfo `json:"vcsInfo"`
+}
+
+type VCSInfo struct {
+	CommitID string `json:"commitId"`
+	VCS      string `json:"vcs"`
 }
 
 func (m PythonPackageMetadata) OwnedFiles() (result []string) {

--- a/syft/pkg/python_package_metadata.go
+++ b/syft/pkg/python_package_metadata.go
@@ -32,10 +32,10 @@ type PythonPackageMetadata struct {
 	Files                []PythonFileRecord `json:"files,omitempty"`
 	SitePackagesRootPath string             `json:"sitePackagesRootPath"`
 	TopLevelPackages     []string           `json:"topLevelPackages,omitempty"`
-	DirectURL            DirectURL          `json:"directUrl,omitempty"`
+	DirectURLOrigin      *DirectURLOrigin   `json:"directUrlOrigin,omitempty"`
 }
 
-type DirectURL struct {
+type DirectURLOrigin struct {
 	URL     string `json:"url"`
 	VCSInfo `json:"vcsInfo"`
 }

--- a/syft/pkg/python_package_metadata.go
+++ b/syft/pkg/python_package_metadata.go
@@ -21,28 +21,45 @@ type PythonFileRecord struct {
 	Size   string            `json:"size,omitempty"`
 }
 
+type PythonDirectURLOriginInfo struct {
+	URL      string `json:"url"`
+	CommitID string `json:"commitId,omitempty"`
+	VCS      string `json:"vcs,omitempty"`
+}
+
 // PythonPackageMetadata represents all captured data for a python egg or wheel package.
 type PythonPackageMetadata struct {
-	Name                 string             `json:"name" mapstruct:"Name"`
-	Version              string             `json:"version" mapstruct:"Version"`
-	License              string             `json:"license" mapstruct:"License"`
-	Author               string             `json:"author" mapstruct:"Author"`
-	AuthorEmail          string             `json:"authorEmail" mapstruct:"Authoremail"`
-	Platform             string             `json:"platform" mapstruct:"Platform"`
-	Files                []PythonFileRecord `json:"files,omitempty"`
-	SitePackagesRootPath string             `json:"sitePackagesRootPath"`
-	TopLevelPackages     []string           `json:"topLevelPackages,omitempty"`
-	DirectURLOrigin      *DirectURLOrigin   `json:"directUrlOrigin,omitempty"`
+	Name                 string                     `json:"name" mapstruct:"Name"`
+	Version              string                     `json:"version" mapstruct:"Version"`
+	License              string                     `json:"license" mapstruct:"License"`
+	Author               string                     `json:"author" mapstruct:"Author"`
+	AuthorEmail          string                     `json:"authorEmail" mapstruct:"Authoremail"`
+	Platform             string                     `json:"platform" mapstruct:"Platform"`
+	Files                []PythonFileRecord         `json:"files,omitempty"`
+	SitePackagesRootPath string                     `json:"sitePackagesRootPath"`
+	TopLevelPackages     []string                   `json:"topLevelPackages,omitempty"`
+	DirectURLOrigin      *PythonDirectURLOriginInfo `json:"directUrlOrigin,omitempty"`
 }
 
 type DirectURLOrigin struct {
-	URL     string `json:"url"`
-	VCSInfo `json:"vcsInfo"`
+	URL         string      `json:"url"`
+	VCSInfo     VCSInfo     `json:"vcs_info"`
+	ArchiveInfo ArchiveInfo `json:"archive_info"`
+	DirInfo     DirInfo     `json:"dir_info"`
+}
+
+type DirInfo struct {
+	Editable bool `json:"editable"`
+}
+
+type ArchiveInfo struct {
+	Hash string `json:"hash"`
 }
 
 type VCSInfo struct {
-	CommitID string `json:"commitId"`
-	VCS      string `json:"vcs"`
+	CommitID          string `json:"commit_id"`
+	VCS               string `json:"vcs"`
+	RequestedRevision string `json:"requested_revision"`
 }
 
 func (m PythonPackageMetadata) OwnedFiles() (result []string) {


### PR DESCRIPTION
## Add initial support for pip VCS URL specification

Issue linked, see [here](https://packaging.python.org/en/latest/specifications/direct-url/#example-direct-url-json) for more information.

Screenshot from a repository with direct VCS installation of httpie run in virtual env.

TODO:
- Discuss struct flattening and camel vs underscore for decoding/encoding
- Fix/Add unit tests


![Screen Shot 2021-12-14 at 1 16 16 AM](https://user-images.githubusercontent.com/32073428/145943911-db40602a-685c-41a5-8354-5b884a849744.png)