### PR TITLE
Add some additional property fileds to cycloneDX output.

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/format.go
+++ b/internal/formats/common/cyclonedxhelpers/format.go
@@ -1,186 +1,186 @@
 package cyclonedxhelpers
 
 import (
-    "time"
+	"time"
 
-    "github.com/CycloneDX/cyclonedx-go"
-    "github.com/anchore/syft/internal"
-    "github.com/anchore/syft/internal/version"
-    "github.com/anchore/syft/syft/distro"
-    "github.com/anchore/syft/syft/pkg"
-    "github.com/anchore/syft/syft/sbom"
-    "github.com/anchore/syft/syft/source"
-    "github.com/google/uuid"
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/anchore/syft/internal"
+	"github.com/anchore/syft/internal/version"
+	"github.com/anchore/syft/syft/distro"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+	"github.com/google/uuid"
 )
 
 func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
-    cdxBOM := cyclonedx.NewBOM()
-    versionInfo := version.FromBuild()
+	cdxBOM := cyclonedx.NewBOM()
+	versionInfo := version.FromBuild()
 
-    // NOTE(jonasagx): cycloneDX requires URN uuids (URN returns the RFC 2141 URN form of uuid):
-    // https://github.com/CycloneDX/specification/blob/master/schema/bom-1.3-strict.schema.json#L36
-    // "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-    cdxBOM.SerialNumber = uuid.New().URN()
-    cdxBOM.Metadata = toBomDescriptor(internal.ApplicationName, versionInfo.Version, s.Source, s.Artifacts.Distro)
+	// NOTE(jonasagx): cycloneDX requires URN uuids (URN returns the RFC 2141 URN form of uuid):
+	// https://github.com/CycloneDX/specification/blob/master/schema/bom-1.3-strict.schema.json#L36
+	// "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+	cdxBOM.SerialNumber = uuid.New().URN()
+	cdxBOM.Metadata = toBomDescriptor(internal.ApplicationName, versionInfo.Version, s.Source, s.Artifacts.Distro)
 
-    packages := s.Artifacts.PackageCatalog.Sorted()
-    components := make([]cyclonedx.Component, len(packages))
-    for i, p := range packages {
-        components[i] = toComponent(p)
-    }
-    cdxBOM.Components = &components
+	packages := s.Artifacts.PackageCatalog.Sorted()
+	components := make([]cyclonedx.Component, len(packages))
+	for i, p := range packages {
+		components[i] = toComponent(p)
+	}
+	cdxBOM.Components = &components
 
-    return cdxBOM
+	return cdxBOM
 }
 
 // NewBomDescriptor returns a new BomDescriptor tailored for the current time and "syft" tool details.
 func toBomDescriptor(name, version string, srcMetadata source.Metadata, distro *distro.Distro) *cyclonedx.Metadata {
-    metaData := cyclonedx.Metadata{
-        Timestamp: time.Now().Format(time.RFC3339),
-        Tools: &[]cyclonedx.Tool{
-            {
-                Vendor:  "anchore",
-                Name:    name,
-                Version: version,
-            },
-        },
-        Component: toBomDescriptorComponent(srcMetadata),
-    }
-    if distro != nil {
-        metaData.Properties = toBomDescriptorProperties(distro)
-    }
+	metaData := cyclonedx.Metadata{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Tools: &[]cyclonedx.Tool{
+			{
+				Vendor:  "anchore",
+				Name:    name,
+				Version: version,
+			},
+		},
+		Component: toBomDescriptorComponent(srcMetadata),
+	}
+	if distro != nil {
+		metaData.Properties = toBomDescriptorProperties(distro)
+	}
 
-    return &metaData
+	return &metaData
 }
 
 func toComponent(p pkg.Package) cyclonedx.Component {
-    return cyclonedx.Component{
-        Type:       cyclonedx.ComponentTypeLibrary,
-        Name:       p.Name,
-        Version:    p.Version,
-        PackageURL: p.PURL,
-        Licenses:   toLicenses(p.Licenses),
-        Properties: toPackageProperties(p),
-    }
+	return cyclonedx.Component{
+		Type:       cyclonedx.ComponentTypeLibrary,
+		Name:       p.Name,
+		Version:    p.Version,
+		PackageURL: p.PURL,
+		Licenses:   toLicenses(p.Licenses),
+		Properties: toPackageProperties(p),
+	}
 }
 
 func toBomDescriptorComponent(srcMetadata source.Metadata) *cyclonedx.Component {
-    switch srcMetadata.Scheme {
-    case source.ImageScheme:
-        return &cyclonedx.Component{
-            Type:    cyclonedx.ComponentTypeContainer,
-            Name:    srcMetadata.ImageMetadata.UserInput,
-            Version: srcMetadata.ImageMetadata.ManifestDigest,
-        }
-    case source.DirectoryScheme, source.FileScheme:
-        return &cyclonedx.Component{
-            Type: cyclonedx.ComponentTypeFile,
-            Name: srcMetadata.Path,
-        }
-    }
+	switch srcMetadata.Scheme {
+	case source.ImageScheme:
+		return &cyclonedx.Component{
+			Type:    cyclonedx.ComponentTypeContainer,
+			Name:    srcMetadata.ImageMetadata.UserInput,
+			Version: srcMetadata.ImageMetadata.ManifestDigest,
+		}
+	case source.DirectoryScheme, source.FileScheme:
+		return &cyclonedx.Component{
+			Type: cyclonedx.ComponentTypeFile,
+			Name: srcMetadata.Path,
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func toLicenses(ls []string) *cyclonedx.Licenses {
-    if len(ls) == 0 {
-        return nil
-    }
+	if len(ls) == 0 {
+		return nil
+	}
 
-    lc := make(cyclonedx.Licenses, len(ls))
-    for i, licenseName := range ls {
-        lc[i] = cyclonedx.LicenseChoice{
-            License: &cyclonedx.License{
-                Name: licenseName,
-            },
-        }
-    }
+	lc := make(cyclonedx.Licenses, len(ls))
+	for i, licenseName := range ls {
+		lc[i] = cyclonedx.LicenseChoice{
+			License: &cyclonedx.License{
+				Name: licenseName,
+			},
+		}
+	}
 
-    return &lc
+	return &lc
 }
 
 func toPackageProperties(p pkg.Package) *[]cyclonedx.Property {
-    properties := prepareOrigin(p)
-    properties = append(properties, prepareLocations(p.Locations)...)
+	properties := prepareOrigin(p)
+	properties = append(properties, prepareLocations(p.Locations)...)
 
-    return &properties
+	return &properties
 }
 
 func prepareOrigin(p pkg.Package) []cyclonedx.Property {
-    properties := []cyclonedx.Property{}
-    switch p.MetadataType {
-    case pkg.DpkgMetadataType:
-        metaData, _ := p.Metadata.(pkg.DpkgMetadata)
-        properties = []cyclonedx.Property{
-            {
-                Name:  "source",
-                Value: metaData.Source,
-            },
-        }
-    case pkg.ApkMetadataType:
-        metaData, _ := p.Metadata.(pkg.ApkMetadata)
-        properties = []cyclonedx.Property{
-            {
-                Name:  "originPackage",
-                Value: metaData.OriginPackage,
-            },
-        }
-    case pkg.RpmdbMetadataType:
-        metaData, _ := p.Metadata.(pkg.RpmdbMetadata)
-        properties = []cyclonedx.Property{
-            {
-                Name:  "sourceRpm",
-                Value: metaData.SourceRpm,
-            },
-        }
-    case pkg.JavaMetadataType:
-        metaData, _ := p.Metadata.(pkg.JavaMetadata)
-        if metaData.PomProperties != nil {
-            properties = []cyclonedx.Property{
-                {
-                    Name:  "artifactId",
-                    Value: metaData.PomProperties.ArtifactID,
-                },
-                {
-                    Name:  "groupId",
-                    Value: metaData.PomProperties.GroupID,
-                },
-            }
-        }
-    }
+	properties := []cyclonedx.Property{}
+	switch p.MetadataType {
+	case pkg.DpkgMetadataType:
+		metaData, _ := p.Metadata.(pkg.DpkgMetadata)
+		properties = []cyclonedx.Property{
+			{
+				Name:  "source",
+				Value: metaData.Source,
+			},
+		}
+	case pkg.ApkMetadataType:
+		metaData, _ := p.Metadata.(pkg.ApkMetadata)
+		properties = []cyclonedx.Property{
+			{
+				Name:  "originPackage",
+				Value: metaData.OriginPackage,
+			},
+		}
+	case pkg.RpmdbMetadataType:
+		metaData, _ := p.Metadata.(pkg.RpmdbMetadata)
+		properties = []cyclonedx.Property{
+			{
+				Name:  "sourceRpm",
+				Value: metaData.SourceRpm,
+			},
+		}
+	case pkg.JavaMetadataType:
+		metaData, _ := p.Metadata.(pkg.JavaMetadata)
+		if metaData.PomProperties != nil {
+			properties = []cyclonedx.Property{
+				{
+					Name:  "artifactId",
+					Value: metaData.PomProperties.ArtifactID,
+				},
+				{
+					Name:  "groupId",
+					Value: metaData.PomProperties.GroupID,
+				},
+			}
+		}
+	}
 
-    return properties
+	return properties
 }
 
 func prepareLocations(l []source.Location) []cyclonedx.Property {
-    properties := []cyclonedx.Property{}
-    for _, location := range l {
-        properties = []cyclonedx.Property{
-            {
-                Name:  "path",
-                Value: location.RealPath,
-            },
-            {
-                Name:  "layerID",
-                Value: location.FileSystemID,
-            },
-        }
-    }
+	properties := []cyclonedx.Property{}
+	for _, location := range l {
+		properties = []cyclonedx.Property{
+			{
+				Name:  "path",
+				Value: location.RealPath,
+			},
+			{
+				Name:  "layerID",
+				Value: location.FileSystemID,
+			},
+		}
+	}
 
-    return properties
+	return properties
 }
 
 func toBomDescriptorProperties(distro *distro.Distro) *[]cyclonedx.Property {
-    properties := []cyclonedx.Property{
-        {
-            Name:  "distroName",
-            Value: distro.Name(),
-        },
-        {
-            Name:  "distroVersion",
-            Value: distro.FullVersion(),
-        },
-    }
+	properties := []cyclonedx.Property{
+		{
+			Name:  "distroName",
+			Value: distro.Name(),
+		},
+		{
+			Name:  "distroVersion",
+			Value: distro.FullVersion(),
+		},
+	}
 
-    return &properties
+	return &properties
 }

--- a/internal/formats/common/cyclonedxhelpers/format.go
+++ b/internal/formats/common/cyclonedxhelpers/format.go
@@ -1,93 +1,186 @@
 package cyclonedxhelpers
 
 import (
-	"time"
+    "time"
 
-	"github.com/CycloneDX/cyclonedx-go"
-	"github.com/anchore/syft/internal"
-	"github.com/anchore/syft/internal/version"
-	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/sbom"
-	"github.com/anchore/syft/syft/source"
-	"github.com/google/uuid"
+    "github.com/CycloneDX/cyclonedx-go"
+    "github.com/anchore/syft/internal"
+    "github.com/anchore/syft/internal/version"
+    "github.com/anchore/syft/syft/distro"
+    "github.com/anchore/syft/syft/pkg"
+    "github.com/anchore/syft/syft/sbom"
+    "github.com/anchore/syft/syft/source"
+    "github.com/google/uuid"
 )
 
 func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
-	cdxBOM := cyclonedx.NewBOM()
-	versionInfo := version.FromBuild()
+    cdxBOM := cyclonedx.NewBOM()
+    versionInfo := version.FromBuild()
 
-	// NOTE(jonasagx): cycloneDX requires URN uuids (URN returns the RFC 2141 URN form of uuid):
-	// https://github.com/CycloneDX/specification/blob/master/schema/bom-1.3-strict.schema.json#L36
-	// "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-	cdxBOM.SerialNumber = uuid.New().URN()
-	cdxBOM.Metadata = toBomDescriptor(internal.ApplicationName, versionInfo.Version, s.Source)
+    // NOTE(jonasagx): cycloneDX requires URN uuids (URN returns the RFC 2141 URN form of uuid):
+    // https://github.com/CycloneDX/specification/blob/master/schema/bom-1.3-strict.schema.json#L36
+    // "pattern": "^urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    cdxBOM.SerialNumber = uuid.New().URN()
+    cdxBOM.Metadata = toBomDescriptor(internal.ApplicationName, versionInfo.Version, s.Source, s.Artifacts.Distro)
 
-	packages := s.Artifacts.PackageCatalog.Sorted()
-	components := make([]cyclonedx.Component, len(packages))
-	for i, p := range packages {
-		components[i] = toComponent(p)
-	}
-	cdxBOM.Components = &components
+    packages := s.Artifacts.PackageCatalog.Sorted()
+    components := make([]cyclonedx.Component, len(packages))
+    for i, p := range packages {
+        components[i] = toComponent(p)
+    }
+    cdxBOM.Components = &components
 
-	return cdxBOM
+    return cdxBOM
 }
 
 // NewBomDescriptor returns a new BomDescriptor tailored for the current time and "syft" tool details.
-func toBomDescriptor(name, version string, srcMetadata source.Metadata) *cyclonedx.Metadata {
-	return &cyclonedx.Metadata{
-		Timestamp: time.Now().Format(time.RFC3339),
-		Tools: &[]cyclonedx.Tool{
-			{
-				Vendor:  "anchore",
-				Name:    name,
-				Version: version,
-			},
-		},
-		Component: toBomDescriptorComponent(srcMetadata),
-	}
+func toBomDescriptor(name, version string, srcMetadata source.Metadata, distro *distro.Distro) *cyclonedx.Metadata {
+    metaData := cyclonedx.Metadata{
+        Timestamp: time.Now().Format(time.RFC3339),
+        Tools: &[]cyclonedx.Tool{
+            {
+                Vendor:  "anchore",
+                Name:    name,
+                Version: version,
+            },
+        },
+        Component: toBomDescriptorComponent(srcMetadata),
+    }
+    if distro != nil {
+        metaData.Properties = toBomDescriptorProperties(distro)
+    }
+
+    return &metaData
 }
 
 func toComponent(p pkg.Package) cyclonedx.Component {
-	return cyclonedx.Component{
-		Type:       cyclonedx.ComponentTypeLibrary,
-		Name:       p.Name,
-		Version:    p.Version,
-		PackageURL: p.PURL,
-		Licenses:   toLicenses(p.Licenses),
-	}
+    return cyclonedx.Component{
+        Type:       cyclonedx.ComponentTypeLibrary,
+        Name:       p.Name,
+        Version:    p.Version,
+        PackageURL: p.PURL,
+        Licenses:   toLicenses(p.Licenses),
+        Properties: toPackageProperties(p),
+    }
 }
 
 func toBomDescriptorComponent(srcMetadata source.Metadata) *cyclonedx.Component {
-	switch srcMetadata.Scheme {
-	case source.ImageScheme:
-		return &cyclonedx.Component{
-			Type:    cyclonedx.ComponentTypeContainer,
-			Name:    srcMetadata.ImageMetadata.UserInput,
-			Version: srcMetadata.ImageMetadata.ManifestDigest,
-		}
-	case source.DirectoryScheme, source.FileScheme:
-		return &cyclonedx.Component{
-			Type: cyclonedx.ComponentTypeFile,
-			Name: srcMetadata.Path,
-		}
-	}
+    switch srcMetadata.Scheme {
+    case source.ImageScheme:
+        return &cyclonedx.Component{
+            Type:    cyclonedx.ComponentTypeContainer,
+            Name:    srcMetadata.ImageMetadata.UserInput,
+            Version: srcMetadata.ImageMetadata.ManifestDigest,
+        }
+    case source.DirectoryScheme, source.FileScheme:
+        return &cyclonedx.Component{
+            Type: cyclonedx.ComponentTypeFile,
+            Name: srcMetadata.Path,
+        }
+    }
 
-	return nil
+    return nil
 }
 
 func toLicenses(ls []string) *cyclonedx.Licenses {
-	if len(ls) == 0 {
-		return nil
-	}
+    if len(ls) == 0 {
+        return nil
+    }
 
-	lc := make(cyclonedx.Licenses, len(ls))
-	for i, licenseName := range ls {
-		lc[i] = cyclonedx.LicenseChoice{
-			License: &cyclonedx.License{
-				Name: licenseName,
-			},
-		}
-	}
+    lc := make(cyclonedx.Licenses, len(ls))
+    for i, licenseName := range ls {
+        lc[i] = cyclonedx.LicenseChoice{
+            License: &cyclonedx.License{
+                Name: licenseName,
+            },
+        }
+    }
 
-	return &lc
+    return &lc
+}
+
+func toPackageProperties(p pkg.Package) *[]cyclonedx.Property {
+    properties := prepareOrigin(p)
+    properties = append(properties, prepareLocations(p.Locations)...)
+
+    return &properties
+}
+
+func prepareOrigin(p pkg.Package) []cyclonedx.Property {
+    properties := []cyclonedx.Property{}
+    switch p.MetadataType {
+    case pkg.DpkgMetadataType:
+        metaData, _ := p.Metadata.(pkg.DpkgMetadata)
+        properties = []cyclonedx.Property{
+            {
+                Name:  "source",
+                Value: metaData.Source,
+            },
+        }
+    case pkg.ApkMetadataType:
+        metaData, _ := p.Metadata.(pkg.ApkMetadata)
+        properties = []cyclonedx.Property{
+            {
+                Name:  "originPackage",
+                Value: metaData.OriginPackage,
+            },
+        }
+    case pkg.RpmdbMetadataType:
+        metaData, _ := p.Metadata.(pkg.RpmdbMetadata)
+        properties = []cyclonedx.Property{
+            {
+                Name:  "sourceRpm",
+                Value: metaData.SourceRpm,
+            },
+        }
+    case pkg.JavaMetadataType:
+        metaData, _ := p.Metadata.(pkg.JavaMetadata)
+        if metaData.PomProperties != nil {
+            properties = []cyclonedx.Property{
+                {
+                    Name:  "artifactId",
+                    Value: metaData.PomProperties.ArtifactID,
+                },
+                {
+                    Name:  "groupId",
+                    Value: metaData.PomProperties.GroupID,
+                },
+            }
+        }
+    }
+
+    return properties
+}
+
+func prepareLocations(l []source.Location) []cyclonedx.Property {
+    properties := []cyclonedx.Property{}
+    for _, location := range l {
+        properties = []cyclonedx.Property{
+            {
+                Name:  "path",
+                Value: location.RealPath,
+            },
+            {
+                Name:  "layerID",
+                Value: location.FileSystemID,
+            },
+        }
+    }
+
+    return properties
+}
+
+func toBomDescriptorProperties(distro *distro.Distro) *[]cyclonedx.Property {
+    properties := []cyclonedx.Property{
+        {
+            Name:  "distroName",
+            Value: distro.Name(),
+        },
+        {
+            Name:  "distroVersion",
+            Value: distro.FullVersion(),
+        },
+    }
+
+    return &properties
 }

--- a/internal/formats/cyclonedx13json/encoder_test.go
+++ b/internal/formats/cyclonedx13json/encoder_test.go
@@ -31,8 +31,9 @@ func TestCycloneDxImagePresenter(t *testing.T) {
 func cycloneDxRedactor(s []byte) []byte {
 	serialPattern := regexp.MustCompile(`urn:uuid:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 	rfc3339Pattern := regexp.MustCompile(`([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))`)
+	sha256Pattern := regexp.MustCompile(`sha256:[A-Fa-f0-9]{64}`)
 
-	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern} {
+	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern, sha256Pattern} {
 		s = pattern.ReplaceAll(s, []byte("redacted"))
 	}
 	return s

--- a/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxDirectoryPresenter.golden
+++ b/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxDirectoryPresenter.golden
@@ -16,7 +16,17 @@
       "type": "file",
       "name": "/some/path",
       "version": ""
-    }
+    },
+    "properties": [
+      {
+        "name": "distroName",
+        "value": "debian"
+      },
+      {
+        "name": "distroVersion",
+        "value": "1.2.3"
+      }
+    ]
   },
   "components": [
     {
@@ -30,13 +40,37 @@
           }
         }
       ],
-      "purl": "a-purl-2"
+      "purl": "a-purl-2",
+      "properties": [
+        {
+          "name": "path",
+          "value": "/some/path/pkg1"
+        },
+        {
+          "name": "layerID",
+          "value": ""
+        }
+      ]
     },
     {
       "type": "library",
       "name": "package-2",
       "version": "2.0.1",
-      "purl": "a-purl-2"
+      "purl": "a-purl-2",
+      "properties": [
+        {
+          "name": "source",
+          "value": ""
+        },
+        {
+          "name": "path",
+          "value": "/some/path/pkg1"
+        },
+        {
+          "name": "layerID",
+          "value": ""
+        }
+      ]
     }
   ]
 }

--- a/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxImagePresenter.golden
+++ b/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxImagePresenter.golden
@@ -16,7 +16,17 @@
       "type": "container",
       "name": "user-image-input",
       "version": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368"
-    }
+    },
+    "properties": [
+      {
+        "name": "distroName",
+        "value": "debian"
+      },
+      {
+        "name": "distroVersion",
+        "value": "1.2.3"
+      }
+    ]
   },
   "components": [
     {
@@ -30,13 +40,37 @@
           }
         }
       ],
-      "purl": "a-purl-1"
+      "purl": "a-purl-1",
+      "properties": [
+        {
+          "name": "path",
+          "value": "/somefile-1.txt"
+        },
+        {
+          "name": "layerID",
+          "value": "sha256:d8fa3ce64b8228215c105c9a307ef852b27bf6075cec407ad54509f0a6121c1a"
+        }
+      ]
     },
     {
       "type": "library",
       "name": "package-2",
       "version": "2.0.1",
-      "purl": "a-purl-2"
+      "purl": "a-purl-2",
+      "properties": [
+        {
+          "name": "source",
+          "value": ""
+        },
+        {
+          "name": "path",
+          "value": "/somefile-2.txt"
+        },
+        {
+          "name": "layerID",
+          "value": "sha256:a2f67dceefd26123b36e015c60bb458d624a72f752801e9999d5b604764afecd"
+        }
+      ]
     }
   ]
 }

--- a/internal/formats/cyclonedx13xml/encoder_test.go
+++ b/internal/formats/cyclonedx13xml/encoder_test.go
@@ -31,8 +31,9 @@ func TestCycloneDxImagePresenter(t *testing.T) {
 func cycloneDxRedactor(s []byte) []byte {
 	serialPattern := regexp.MustCompile(`serialNumber="[a-zA-Z0-9\-:]+"`)
 	rfc3339Pattern := regexp.MustCompile(`([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))`)
+	sha256Pattern := regexp.MustCompile(`sha256:[A-Fa-f0-9]{64}`)
 
-	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern} {
+	for _, pattern := range []*regexp.Regexp{serialPattern, rfc3339Pattern, sha256Pattern} {
 		s = pattern.ReplaceAll(s, []byte("redacted"))
 	}
 	return s

--- a/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxDirectoryPresenter.golden
+++ b/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxDirectoryPresenter.golden
@@ -13,6 +13,10 @@
       <name>/some/path</name>
       <version></version>
     </component>
+    <properties>
+      <property name="distroName">debian</property>
+      <property name="distroVersion">1.2.3</property>
+    </properties>
   </metadata>
   <components>
     <component type="library">
@@ -24,11 +28,20 @@
         </license>
       </licenses>
       <purl>a-purl-2</purl>
+      <properties>
+        <property name="path">/some/path/pkg1</property>
+        <property name="layerID"></property>
+      </properties>
     </component>
     <component type="library">
       <name>package-2</name>
       <version>2.0.1</version>
       <purl>a-purl-2</purl>
+      <properties>
+        <property name="source"></property>
+        <property name="path">/some/path/pkg1</property>
+        <property name="layerID"></property>
+      </properties>
     </component>
   </components>
 </bom>

--- a/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxImagePresenter.golden
+++ b/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxImagePresenter.golden
@@ -13,6 +13,10 @@
       <name>user-image-input</name>
       <version>sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368</version>
     </component>
+    <properties>
+      <property name="distroName">debian</property>
+      <property name="distroVersion">1.2.3</property>
+    </properties>
   </metadata>
   <components>
     <component type="library">
@@ -24,11 +28,20 @@
         </license>
       </licenses>
       <purl>a-purl-1</purl>
+      <properties>
+        <property name="path">/somefile-1.txt</property>
+        <property name="layerID">sha256:d8fa3ce64b8228215c105c9a307ef852b27bf6075cec407ad54509f0a6121c1a</property>
+      </properties>
     </component>
     <component type="library">
       <name>package-2</name>
       <version>2.0.1</version>
       <purl>a-purl-2</purl>
+      <properties>
+        <property name="source"></property>
+        <property name="path">/somefile-2.txt</property>
+        <property name="layerID">sha256:a2f67dceefd26123b36e015c60bb458d624a72f752801e9999d5b604764afecd</property>
+      </properties>
     </component>
   </components>
 </bom>


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

Related https://github.com/anchore/grype/issues/481

This PR adds some additional properties to the CycloneDX output. After converting the generated CyclonDX format to Syft JSON format with these properties, the Grype using the converted json can find the vulnerabilities.