### PR TITLE
Prefer warning over erroring out when parsing java manifests

### DIFF
--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -70,6 +70,15 @@ func TestParseJavaManifest(t *testing.T) {
 					"thing-1": {
 						"Built-By": "?",
 					},
+					"thing-2": {
+						"Built-By": "someone!",
+					},
+					"2": {
+						"Other": "things",
+					},
+					"3": {
+						"Last": "item",
+					},
 				},
 			},
 		},

--- a/syft/pkg/cataloger/java/test-fixtures/manifest/extra-empty-lines
+++ b/syft/pkg/cataloger/java/test-fixtures/manifest/extra-empty-lines
@@ -5,3 +5,18 @@ Created-By: Apache Maven 3.6.3
 
 Name: thing-1
 Built-By: ?
+
+.
+
+Name: thing-2
+Built-By: someone!
+
+
+ :
+
+Other: things
+junk
+
+:
+
+Last: item


### PR DESCRIPTION
When originally developing the java manifest parsing it was heavy in returning errors over returning partial results. This PR adjusts the behavior of the parser to be "best-effort" and return results when possible (even if partial).