### PR TITLE
Add --exclude flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,17 @@ registry:yourrepo/yourimage:tag        pull image directly from a registry (no c
 Syft can exclude files and paths from being scanned within a source by using glob expressions
 with one or more `--exclude` parameters:
 ```
-syft <source> --exclude ./out/**/*.json --exclude /etc
+syft <source> --exclude './out/**/*.json' --exclude /etc
 ```
 **Note:** in the case of _image scanning_, since the entire filesystem is scanned it is
-possible to use absolute paths, e.g. `/etc` or `/usr/**/*.txt` whereas _directory scans_
+possible to use absolute paths like `/etc` or `/usr/**/*.txt` whereas _directory scans_
 exclude files _relative to the specified directory_. For example: scanning `/usr/foo` with
-`--exclude ./package.json` would exclude `/usr/foo/package.json` and `--exclude **/package.json`
+`--exclude ./package.json` would exclude `/usr/foo/package.json` and `--exclude '**/package.json'`
 would exclude all `package.json` files under `/usr/foo`. For _directory scans_,
 it is required to begin path expressions with `./`, `*/`, or `**/`, all of which
-will be resolved _relative to the specified scan directory_.
+will be resolved _relative to the specified scan directory_. Keep in mind, your shell
+may attempt to expand wildcards, so put those parameters in single quotes, like:
+`'**/*.json'`.
 
 ### Output formats
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+<p style="text-align: center">
     <img src="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png" width="271" alt="Cute pink owl syft logo">
 </p>
 
@@ -91,6 +91,12 @@ oci-dir:path/to/yourimage              read directly from a path on disk for OCI
 dir:path/to/yourproject                read directly from a path on disk (any directory)
 file:path/to/yourproject/file          read directly from a path on disk (any single file)
 registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
+```
+
+Syft can exclude files and paths from being scanned within a source by using
+one or more `--exclude` parameters:
+```
+syft packages path/to/dir --exclude **/*.png --exclude **/generated/**
 ```
 
 ### Output formats
@@ -218,6 +224,12 @@ file: ""
 # enable/disable checking for application updates on startup
 # same as SYFT_CHECK_FOR_APP_UPDATE env var
 check-for-app-update: true
+
+# a list of globs to exclude. same as --exclude ; for example:
+# exclude:
+#   - '/etc/**'
+#   - '/tmp/**/*.png'
+exclude:
 
 # cataloging packages is exposed through the packages and power-user subcommands
 package:

--- a/README.md
+++ b/README.md
@@ -93,13 +93,20 @@ file:path/to/yourproject/file          read directly from a path on disk (any si
 registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
 ```
 
-#### Excluding file paths
+### Excluding file paths
 
 Syft can exclude files and paths from being scanned within a source by using glob expressions
 with one or more `--exclude` parameters:
 ```
-syft packages path/to/dir --exclude **/*.png --exclude **/generated/**
+syft <source> --exclude ./out/**/*.json --exclude /etc
 ```
+**Note:** in the case of _image scanning_, since the entire filesystem is scanned it is
+possible to use absolute paths, e.g. `/etc` or `/usr/**/*.txt` whereas _directory scans_
+exclude files _relative to the specified directory_. For example: scanning `/usr/foo` with
+`--exclude ./package.json` would exclude `/usr/foo/package.json` and `--exclude **/package.json`
+would exclude all `package.json` files under `/usr/foo`. For _directory scans_,
+it is required to begin path expressions with `./`, `*/`, or `**/`, all of which
+will be resolved _relative to the specified scan directory_.
 
 ### Output formats
 
@@ -230,7 +237,7 @@ check-for-app-update: true
 # a list of globs to exclude from scanning. same as --exclude ; for example:
 # exclude:
 #   - '/etc/**'
-#   - '/tmp/**/*.png'
+#   - './out/**/*.json'
 exclude:
 
 # cataloging packages is exposed through the packages and power-user subcommands

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p style="text-align: center">
+<p align="center">
     <img src="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png" width="271" alt="Cute pink owl syft logo">
 </p>
 
@@ -93,8 +93,10 @@ file:path/to/yourproject/file          read directly from a path on disk (any si
 registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)
 ```
 
-Syft can exclude files and paths from being scanned within a source by using
-one or more `--exclude` parameters:
+#### Excluding file paths
+
+Syft can exclude files and paths from being scanned within a source by using glob expressions
+with one or more `--exclude` parameters:
 ```
 syft packages path/to/dir --exclude **/*.png --exclude **/generated/**
 ```
@@ -225,7 +227,7 @@ file: ""
 # same as SYFT_CHECK_FOR_APP_UPDATE env var
 check-for-app-update: true
 
-# a list of globs to exclude. same as --exclude ; for example:
+# a list of globs to exclude from scanning. same as --exclude ; for example:
 # exclude:
 #   - '/etc/**'
 #   - '/tmp/**/*.png'

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -19,7 +19,6 @@ import (
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
-	"github.com/bmatcuk/doublestar/v2"
 	"github.com/pkg/profile"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -263,7 +262,7 @@ func packagesExecWorker(userInput string) <-chan error {
 
 		checkForApplicationUpdate()
 
-		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), getExclusionFunction(appConfig.Exclusions))
+		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), appConfig.Exclusions...)
 		if err != nil {
 			errs <- fmt.Errorf("failed to determine image source: %w", err)
 			return
@@ -361,22 +360,4 @@ func runPackageSbomUpload(src *source.Source, s sbom.SBOM) error {
 	}
 
 	return nil
-}
-
-func getExclusionFunction(exclusions []string) func(string) bool {
-	if exclusions == nil || len(exclusions) == 0 {
-		return nil
-	}
-	return func(path string) bool {
-		for _, exclusion := range exclusions {
-			matches, err := doublestar.Match(exclusion, path)
-			if err != nil {
-				return false
-			}
-			if matches {
-				return true
-			}
-		}
-		return false
-	}
 }

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -134,7 +134,7 @@ func setPackageFlags(flags *pflag.FlagSet) {
 
 	flags.StringArrayP(
 		"exclude", "", nil,
-		"exclude paths using a glob expression",
+		"exclude paths from being scanned using a glob expression",
 	)
 
 	flags.Bool(

--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -113,7 +113,7 @@ func powerUserExecWorker(userInput string) <-chan error {
 
 		checkForApplicationUpdate()
 
-		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), getExclusionFunction(appConfig.Exclusions))
+		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), appConfig.Exclusions...)
 		if err != nil {
 			errs <- err
 			return

--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -113,7 +113,7 @@ func powerUserExecWorker(userInput string) <-chan error {
 
 		checkForApplicationUpdate()
 
-		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions())
+		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), getExclusionFunction(appConfig.Exclusions))
 		if err != nil {
 			errs <- err
 			return

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -44,6 +44,7 @@ type Application struct {
 	FileContents       fileContents       `yaml:"file-contents" json:"file-contents" mapstructure:"file-contents"`
 	Secrets            secrets            `yaml:"secrets" json:"secrets" mapstructure:"secrets"`
 	Registry           registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
+	Exclusions         []string           `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
 }
 
 // PowerUserCatalogerEnabledDefault switches all catalogers to be enabled when running power-user command

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -54,10 +54,6 @@ func CatalogPackages(src *source.Source, scope source.Scope) (*pkg.Catalog, []ar
 	case source.ImageScheme:
 		log.Info("cataloging image")
 		catalogers = cataloger.ImageCatalogers()
-		// image tree contains all paths, so we filter out the excluded entries afterwards
-		if src.Exclude != nil {
-			resolver = source.NewExcludingResolver(resolver, src.Exclude)
-		}
 	case source.FileScheme:
 		log.Info("cataloging file")
 		catalogers = cataloger.AllCatalogers()

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -54,6 +54,10 @@ func CatalogPackages(src *source.Source, scope source.Scope) (*pkg.Catalog, []ar
 	case source.ImageScheme:
 		log.Info("cataloging image")
 		catalogers = cataloger.ImageCatalogers()
+		// image tree contains all paths, so we filter out the excluded entries afterwards
+		if src.Exclude != nil {
+			resolver = source.NewExcludingResolver(resolver, src.Exclude)
+		}
 	case source.FileScheme:
 		log.Info("cataloging file")
 		catalogers = cataloger.AllCatalogers()

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -59,17 +59,13 @@ func newDirectoryResolver(root string, pathFilters ...pathFilterFn) (*directoryR
 		currentWdRelRoot = filepath.Clean(root)
 	}
 
-	if pathFilters == nil {
-		pathFilters = []pathFilterFn{isUnallowableFileType, isUnixSystemRuntimePath}
-	}
-
 	resolver := directoryResolver{
 		path:                    root,
 		currentWd:               currentWd,
 		currentWdRelativeToRoot: currentWdRelRoot,
 		fileTree:                filetree.NewFileTree(),
 		metadata:                make(map[file.ID]FileMetadata),
-		pathFilterFns:           pathFilters,
+		pathFilterFns:           append([]pathFilterFn{isUnallowableFileType, isUnixSystemRuntimePath}, pathFilters...),
 		refsByMIMEType:          make(map[string][]file.Reference),
 		errPaths:                make(map[string]error),
 	}
@@ -118,7 +114,7 @@ func (r *directoryResolver) indexTree(root string, stager *progress.Stage) ([]st
 func (r *directoryResolver) indexPath(path string, info os.FileInfo, err error) string {
 	// ignore any path which a filter function returns true
 	for _, filterFn := range r.pathFilterFns {
-		if filterFn(path, info) {
+		if filterFn != nil && filterFn(path, info) {
 			return ""
 		}
 	}

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -123,9 +123,8 @@ func (r *directoryResolver) indexPath(path string, info os.FileInfo, err error) 
 		if filterFn != nil && filterFn(path, info) {
 			if info.IsDir() {
 				return "", fs.SkipDir
-			} else {
-				return "", nil
 			}
+			return "", nil
 		}
 	}
 

--- a/syft/source/excluding_file_resolver.go
+++ b/syft/source/excluding_file_resolver.go
@@ -1,0 +1,71 @@
+package source
+
+import (
+	"io"
+	"os"
+)
+
+type excludeFn func(string, os.FileInfo) bool
+
+type excludingResolver struct {
+	delegate  FileResolver
+	excludeFn excludeFn
+}
+
+func NewExcludingResolver(delegate FileResolver, excludeFn excludeFn) FileResolver {
+	return &excludingResolver{
+		delegate,
+		excludeFn,
+	}
+}
+
+func (r *excludingResolver) FileContentsByLocation(location Location) (io.ReadCloser, error) {
+	return r.delegate.FileContentsByLocation(location)
+}
+
+func (r *excludingResolver) FileMetadataByLocation(location Location) (FileMetadata, error) {
+	return r.delegate.FileMetadataByLocation(location)
+}
+
+func (r *excludingResolver) HasPath(path string) bool {
+	return r.delegate.HasPath(path)
+}
+
+func (r *excludingResolver) FilesByPath(paths ...string) ([]Location, error) {
+	locations, err := r.delegate.FilesByPath(paths...)
+	return filterLocations(locations, err, r.excludeFn)
+}
+
+func (r *excludingResolver) FilesByGlob(patterns ...string) ([]Location, error) {
+	locations, err := r.delegate.FilesByGlob(patterns...)
+	return filterLocations(locations, err, r.excludeFn)
+}
+
+func (r *excludingResolver) FilesByMIMEType(types ...string) ([]Location, error) {
+	locations, err := r.delegate.FilesByMIMEType(types...)
+	return filterLocations(locations, err, r.excludeFn)
+}
+
+func (r *excludingResolver) RelativeFileByPath(location Location, path string) *Location {
+	return r.delegate.RelativeFileByPath(location, path)
+}
+
+func (r *excludingResolver) AllLocations() <-chan Location {
+	return r.delegate.AllLocations()
+}
+
+func filterLocations(locations []Location, err error, exclusionFn excludeFn) ([]Location, error) {
+	if err != nil {
+		return nil, err
+	}
+	if exclusionFn != nil {
+		for i := 0; i < len(locations); i++ {
+			location := locations[i]
+			if exclusionFn(location.RealPath, nil) || exclusionFn(location.VirtualPath, nil) {
+				locations = append(locations[:i], locations[i+1:]...)
+				i--
+			}
+		}
+	}
+	return locations, nil
+}

--- a/syft/source/excluding_file_resolver.go
+++ b/syft/source/excluding_file_resolver.go
@@ -1,17 +1,22 @@
 package source
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
 
 type excludeFn func(string, os.FileInfo) bool
 
+// excludingResolver decorates a resolver with an exclusion function that is used to
+// filter out entries in the delegate resolver
 type excludingResolver struct {
 	delegate  FileResolver
 	excludeFn excludeFn
 }
 
+// NewExcludingResolver create a new resolver which wraps the provided delegate and excludes
+// entries based on a provided path exclusion function
 func NewExcludingResolver(delegate FileResolver, excludeFn excludeFn) FileResolver {
 	return &excludingResolver{
 		delegate,
@@ -20,14 +25,23 @@ func NewExcludingResolver(delegate FileResolver, excludeFn excludeFn) FileResolv
 }
 
 func (r *excludingResolver) FileContentsByLocation(location Location) (io.ReadCloser, error) {
+	if locationMatches(&location, r.excludeFn) {
+		return nil, fmt.Errorf("no such location: %+v", location.RealPath)
+	}
 	return r.delegate.FileContentsByLocation(location)
 }
 
 func (r *excludingResolver) FileMetadataByLocation(location Location) (FileMetadata, error) {
+	if locationMatches(&location, r.excludeFn) {
+		return FileMetadata{}, fmt.Errorf("no such location: %+v", location.RealPath)
+	}
 	return r.delegate.FileMetadataByLocation(location)
 }
 
 func (r *excludingResolver) HasPath(path string) bool {
+	if r.excludeFn(path, nil) {
+		return false
+	}
 	return r.delegate.HasPath(path)
 }
 
@@ -47,11 +61,28 @@ func (r *excludingResolver) FilesByMIMEType(types ...string) ([]Location, error)
 }
 
 func (r *excludingResolver) RelativeFileByPath(location Location, path string) *Location {
-	return r.delegate.RelativeFileByPath(location, path)
+	l := r.delegate.RelativeFileByPath(location, path)
+	if l != nil && locationMatches(l, r.excludeFn) {
+		return nil
+	}
+	return l
 }
 
 func (r *excludingResolver) AllLocations() <-chan Location {
-	return r.delegate.AllLocations()
+	c := make(chan Location)
+	go func() {
+		defer close(c)
+		for location := range r.delegate.AllLocations() {
+			if !locationMatches(&location, r.excludeFn) {
+				c <- location
+			}
+		}
+	}()
+	return c
+}
+
+func locationMatches(location *Location, exclusionFn excludeFn) bool {
+	return exclusionFn(location.RealPath, nil) || exclusionFn(location.VirtualPath, nil)
 }
 
 func filterLocations(locations []Location, err error, exclusionFn excludeFn) ([]Location, error) {
@@ -60,8 +91,8 @@ func filterLocations(locations []Location, err error, exclusionFn excludeFn) ([]
 	}
 	if exclusionFn != nil {
 		for i := 0; i < len(locations); i++ {
-			location := locations[i]
-			if exclusionFn(location.RealPath, nil) || exclusionFn(location.VirtualPath, nil) {
+			location := &locations[i]
+			if locationMatches(location, exclusionFn) {
 				locations = append(locations[:i], locations[i+1:]...)
 				i--
 			}

--- a/syft/source/excluding_file_resolver.go
+++ b/syft/source/excluding_file_resolver.go
@@ -3,10 +3,9 @@ package source
 import (
 	"fmt"
 	"io"
-	"os"
 )
 
-type excludeFn func(string, os.FileInfo) bool
+type excludeFn func(string) bool
 
 // excludingResolver decorates a resolver with an exclusion function that is used to
 // filter out entries in the delegate resolver
@@ -39,7 +38,7 @@ func (r *excludingResolver) FileMetadataByLocation(location Location) (FileMetad
 }
 
 func (r *excludingResolver) HasPath(path string) bool {
-	if r.excludeFn(path, nil) {
+	if r.excludeFn(path) {
 		return false
 	}
 	return r.delegate.HasPath(path)
@@ -82,7 +81,7 @@ func (r *excludingResolver) AllLocations() <-chan Location {
 }
 
 func locationMatches(location *Location, exclusionFn excludeFn) bool {
-	return exclusionFn(location.RealPath, nil) || exclusionFn(location.VirtualPath, nil)
+	return exclusionFn(location.RealPath) || exclusionFn(location.VirtualPath)
 }
 
 func filterLocations(locations []Location, err error, exclusionFn excludeFn) ([]Location, error) {

--- a/syft/source/excluding_file_resolver_test.go
+++ b/syft/source/excluding_file_resolver_test.go
@@ -59,13 +59,13 @@ func TestExcludingResolver(t *testing.T) {
 			excludingResolver := NewExcludingResolver(resolver, test.excludeFn)
 
 			fc, _ := excludingResolver.FilesByPath()
-			assert.Equal(t, test.expectedLength, len(fc))
+			assert.Len(t, fc, test.expectedLength)
 
 			fc, _ = excludingResolver.FilesByGlob()
-			assert.Equal(t, test.expectedLength, len(fc))
+			assert.Len(t, fc, test.expectedLength)
 
 			fc, _ = excludingResolver.FilesByMIMEType()
-			assert.Equal(t, test.expectedLength, len(fc))
+			assert.Len(t, fc, test.expectedLength)
 		})
 	}
 }

--- a/syft/source/excluding_file_resolver_test.go
+++ b/syft/source/excluding_file_resolver_test.go
@@ -2,7 +2,6 @@ package source
 
 import (
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -16,13 +15,13 @@ func TestExcludingResolver(t *testing.T) {
 	tests := []struct {
 		name      string
 		locations []string
-		excludeFn func(string, os.FileInfo) bool
+		excludeFn excludeFn
 		expected  []string
 	}{
 		{
 			name:      "keeps locations",
 			locations: []string{"a", "b", "c"},
-			excludeFn: func(s string, info os.FileInfo) bool {
+			excludeFn: func(s string) bool {
 				return false
 			},
 			expected: []string{"a", "b", "c"},
@@ -30,7 +29,7 @@ func TestExcludingResolver(t *testing.T) {
 		{
 			name:      "removes locations",
 			locations: []string{"d", "e", "f"},
-			excludeFn: func(s string, info os.FileInfo) bool {
+			excludeFn: func(s string) bool {
 				return true
 			},
 			expected: []string{},
@@ -38,7 +37,7 @@ func TestExcludingResolver(t *testing.T) {
 		{
 			name:      "removes first match",
 			locations: []string{"g", "h", "i"},
-			excludeFn: func(s string, info os.FileInfo) bool {
+			excludeFn: func(s string) bool {
 				return s == "g"
 			},
 			expected: []string{"h", "i"},
@@ -46,7 +45,7 @@ func TestExcludingResolver(t *testing.T) {
 		{
 			name:      "removes last match",
 			locations: []string{"j", "k", "l"},
-			excludeFn: func(s string, info os.FileInfo) bool {
+			excludeFn: func(s string) bool {
 				return s == "l"
 			},
 			expected: []string{"j", "k"},

--- a/syft/source/excluding_file_resolver_test.go
+++ b/syft/source/excluding_file_resolver_test.go
@@ -1,0 +1,121 @@
+package source
+
+import (
+	"github.com/anchore/stereoscope/pkg/file"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExcludingResolver(t *testing.T) {
+
+	tests := []struct {
+		name           string
+		locations      []string
+		excludeFn      func(string, os.FileInfo) bool
+		expectedLength int
+	}{
+		{
+			name:      "keeps locations",
+			locations: []string{"a", "b", "c"},
+			excludeFn: func(s string, info os.FileInfo) bool {
+				return false
+			},
+			expectedLength: 3,
+		},
+		{
+			name:      "removes locations",
+			locations: []string{"d", "e", "f"},
+			excludeFn: func(s string, info os.FileInfo) bool {
+				return true
+			},
+			expectedLength: 0,
+		},
+		{
+			name:      "removes first match",
+			locations: []string{"g", "h", "i"},
+			excludeFn: func(s string, info os.FileInfo) bool {
+				return s == "g"
+			},
+			expectedLength: 2,
+		},
+		{
+			name:      "removes last match",
+			locations: []string{"j", "k", "l"},
+			excludeFn: func(s string, info os.FileInfo) bool {
+				return s == "l"
+			},
+			expectedLength: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &mockResolver{
+				locations: test.locations,
+			}
+			excludingResolver := NewExcludingResolver(resolver, test.excludeFn)
+
+			fc, _ := excludingResolver.FilesByPath()
+			assert.Equal(t, test.expectedLength, len(fc))
+
+			fc, _ = excludingResolver.FilesByGlob()
+			assert.Equal(t, test.expectedLength, len(fc))
+
+			fc, _ = excludingResolver.FilesByMIMEType()
+			assert.Equal(t, test.expectedLength, len(fc))
+		})
+	}
+}
+
+type mockResolver struct {
+	locations []string
+}
+
+func (r *mockResolver) getLocations() ([]Location, error) {
+	out := []Location{}
+	for _, l := range r.locations {
+		out = append(out, Location{
+			Coordinates: Coordinates{
+				RealPath:     l,
+				FileSystemID: "",
+			},
+			VirtualPath: l,
+			ref:         file.Reference{},
+		})
+	}
+	return out, nil
+}
+
+func (r *mockResolver) FileContentsByLocation(_ Location) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (r *mockResolver) FileMetadataByLocation(_ Location) (FileMetadata, error) {
+	return FileMetadata{}, nil
+}
+
+func (r *mockResolver) HasPath(_ string) bool {
+	return false
+}
+
+func (r *mockResolver) FilesByPath(_ ...string) ([]Location, error) {
+	return r.getLocations()
+}
+
+func (r *mockResolver) FilesByGlob(_ ...string) ([]Location, error) {
+	return r.getLocations()
+}
+
+func (r *mockResolver) FilesByMIMEType(_ ...string) ([]Location, error) {
+	return r.getLocations()
+}
+
+func (r *mockResolver) RelativeFileByPath(_ Location, _ string) *Location {
+	return &Location{}
+}
+
+func (r *mockResolver) AllLocations() <-chan Location {
+	return nil
+}

--- a/syft/source/excluding_file_resolver_test.go
+++ b/syft/source/excluding_file_resolver_test.go
@@ -1,10 +1,11 @@
 package source
 
 import (
-	"github.com/anchore/stereoscope/pkg/file"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/anchore/stereoscope/pkg/file"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -227,7 +227,7 @@ func unarchiveToTmp(path string, unarchiver archiver.Unarchiver) (string, func()
 }
 
 func getExclusionFunction(exclusions []string) pathFilterFn {
-	if exclusions == nil || len(exclusions) == 0 {
+	if len(exclusions) == 0 {
 		return nil
 	}
 	return func(path string, _ os.FileInfo) bool {

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -43,15 +43,15 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 	}
 
 	source := &Source{}
-	fn := func() {}
+	cleanupFn := func() {}
 
 	switch parsedScheme {
 	case FileScheme:
-		source, fn, err = generateFileSource(fs, location)
+		source, cleanupFn, err = generateFileSource(fs, location)
 	case DirectoryScheme:
-		source, fn, err = generateDirectorySource(fs, location)
+		source, cleanupFn, err = generateDirectorySource(fs, location)
 	case ImageScheme:
-		source, fn, err = generateImageSource(location, userInput, imageSource, registryOptions)
+		source, cleanupFn, err = generateImageSource(location, userInput, imageSource, registryOptions)
 	default:
 		err = fmt.Errorf("unable to process input for scanning: '%s'", userInput)
 	}
@@ -60,7 +60,7 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 		source.Exclusions = exclusions
 	}
 
-	return source, fn, err
+	return source, cleanupFn, err
 }
 
 func generateImageSource(location, userInput string, imageSource image.Source, registryOptions *image.RegistryOptions) (*Source, func(), error) {

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -276,16 +276,14 @@ func getDirectoryExclusionFunctions(root string, exclusions []string) ([]pathFil
 	}
 
 	if !strings.HasSuffix(root, "/") {
-		root = root + "/"
+		root += "/"
 	}
 
 	var errors []string
 	for idx, exclusion := range exclusions {
 		// check exclusions for supported paths, these are all relative to the "scan root"
 		if strings.HasPrefix(exclusion, "./") || strings.HasPrefix(exclusion, "*/") || strings.HasPrefix(exclusion, "**/") {
-			if strings.HasPrefix(exclusion, "./") {
-				exclusion = exclusion[2:]
-			}
+			exclusion = strings.TrimPrefix(exclusion, "./")
 			exclusions[idx] = root + exclusion
 		} else {
 			errors = append(errors, exclusion)

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -321,60 +322,114 @@ func TestFilesByGlob(t *testing.T) {
 
 func TestDirectoryExclusions(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		input    string
-		glob     string
-		expected int
-		excludes []string
+		desc       string
+		input      string
+		glob       string
+		expected   int
+		exclusions []string
+		err        bool
 	}{
 		{
-			input:    "test-fixtures/system_paths",
-			desc:     "exclude everything",
-			glob:     "**",
-			expected: 0,
-			excludes: []string{"/**"},
+			input:      "test-fixtures/system_paths",
+			desc:       "exclude everything",
+			glob:       "**",
+			expected:   0,
+			exclusions: []string{"**/*"},
 		},
 		{
-			input:    "test-fixtures/image-simple",
-			desc:     "a single path excluded",
-			glob:     "**",
-			expected: 3,
-			excludes: []string{"**/target/**"},
+			input:      "test-fixtures/image-simple",
+			desc:       "a single path excluded",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"**/target/**"},
 		},
 		{
-			input:    "test-fixtures/image-simple",
-			desc:     "exclude files deeper",
-			glob:     "**",
-			expected: 3,
-			excludes: []string{"**/really/**"},
+			input:      "test-fixtures/image-simple",
+			desc:       "exclude explicit directory relative to the root",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"./target"},
 		},
 		{
-			input:    "test-fixtures/image-simple",
-			desc:     "files excluded with extension",
-			glob:     "**",
-			expected: 1,
-			excludes: []string{"**/*.txt"},
+			input:      "test-fixtures/image-simple",
+			desc:       "exclude explicit file relative to the root",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"./file-1.txt"},
 		},
 		{
-			input:    "test-fixtures/image-simple",
-			desc:     "keep files with different extensions",
-			glob:     "**",
-			expected: 4,
-			excludes: []string{"**/target/**/*.jar"},
+			input:      "test-fixtures/image-simple",
+			desc:       "exclude wildcard relative to the root",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"./*.txt"},
 		},
 		{
-			input:    "test-fixtures/path-detected",
-			desc:     "file directly excluded",
-			glob:     "**",
-			expected: 1,
-			excludes: []string{"**/empty"},
+			input:      "test-fixtures/image-simple",
+			desc:       "exclude files deeper",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"**/really/**"},
+		},
+		{
+			input:      "test-fixtures/image-simple",
+			desc:       "files excluded with extension",
+			glob:       "**",
+			expected:   1,
+			exclusions: []string{"**/*.txt"},
+		},
+		{
+			input:      "test-fixtures/image-simple",
+			desc:       "keep files with different extensions",
+			glob:       "**",
+			expected:   4,
+			exclusions: []string{"**/target/**/*.jar"},
+		},
+		{
+			input:      "test-fixtures/path-detected",
+			desc:       "file directly excluded",
+			glob:       "**",
+			expected:   1,
+			exclusions: []string{"**/empty"},
+		},
+		{
+			input:      "test-fixtures/path-detected",
+			desc:       "pattern error containing **/",
+			glob:       "**",
+			expected:   1,
+			exclusions: []string{"/**/empty"},
+			err:        true,
+		},
+		{
+			input:      "test-fixtures/path-detected",
+			desc:       "pattern error incorrect start",
+			glob:       "**",
+			expected:   1,
+			exclusions: []string{"empty"},
+			err:        true,
+		},
+		{
+			input:      "test-fixtures/path-detected",
+			desc:       "pattern error starting with /",
+			glob:       "**",
+			expected:   1,
+			exclusions: []string{"/empty"},
+			err:        true,
 		},
 	}
 	registryOpts := &image.RegistryOptions{}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
-			src, fn, err := New("dir:"+test.input, registryOpts, test.excludes...)
+			src, fn, err := New("dir:"+test.input, registryOpts, test.exclusions...)
 			defer fn()
+
+			if test.err {
+				_, err = src.FileResolver(SquashedScope)
+				if err == nil {
+					t.Errorf("expected an error for patterns: %s", strings.Join(test.exclusions, " or "))
+				}
+				return
+			}
 
 			if err != nil {
 				t.Errorf("could not create NewDirScope: %+v", err)
@@ -396,53 +451,68 @@ func TestDirectoryExclusions(t *testing.T) {
 
 func TestImageExclusions(t *testing.T) {
 	testCases := []struct {
-		desc     string
-		input    string
-		glob     string
-		expected int
-		excludes []string
+		desc       string
+		input      string
+		glob       string
+		expected   int
+		exclusions []string
 	}{
+		// NOTE: in the Dockerfile, /target is moved to /, which makes /really a top-level dir
 		{
-			input:    "image-simple",
-			desc:     "a single path excluded",
-			glob:     "**",
-			expected: 2,
-			excludes: []string{"/really/**"}, // /target moved to / in Dockerfile
+			input:      "image-simple",
+			desc:       "a single path excluded",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"/really/**"},
 		},
 		{
-			input:    "image-simple",
-			desc:     "exclude files deeper",
-			glob:     "**",
-			expected: 2,
-			excludes: []string{"**/nested/**"},
+			input:      "image-simple",
+			desc:       "a directly referenced directory is excluded",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"/really"},
 		},
 		{
-			input:    "image-simple",
-			desc:     "files excluded with extension",
-			glob:     "**",
-			expected: 2,
-			excludes: []string{"**/*1.txt"},
+			input:      "image-simple",
+			desc:       "a partial directory is not excluded",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"/reall"},
 		},
 		{
-			input:    "image-simple",
-			desc:     "keep files with different extensions",
-			glob:     "**",
-			expected: 3,
-			excludes: []string{"**/target/**/*.jar"},
+			input:      "image-simple",
+			desc:       "exclude files deeper",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"**/nested/**"},
 		},
 		{
-			input:    "image-simple",
-			desc:     "file directly excluded",
-			glob:     "**",
-			expected: 2,
-			excludes: []string{"**/somefile-1.txt"}, // file-1 renamed to somefile-1 in Dockerfile
+			input:      "image-simple",
+			desc:       "files excluded with extension",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"**/*1.txt"},
+		},
+		{
+			input:      "image-simple",
+			desc:       "keep files with different extensions",
+			glob:       "**",
+			expected:   3,
+			exclusions: []string{"**/target/**/*.jar"},
+		},
+		{
+			input:      "image-simple",
+			desc:       "file directly excluded",
+			glob:       "**",
+			expected:   2,
+			exclusions: []string{"**/somefile-1.txt"}, // file-1 renamed to somefile-1 in Dockerfile
 		},
 	}
 	registryOpts := &image.RegistryOptions{}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			archiveLocation := imagetest.PrepareFixtureImage(t, "docker-archive", test.input)
-			src, fn, err := New(archiveLocation, registryOpts, test.excludes...)
+			src, fn, err := New(archiveLocation, registryOpts, test.exclusions...)
 			defer fn()
 
 			if err != nil {

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -341,14 +341,14 @@ func TestDirectoryExclusions(t *testing.T) {
 		},
 		{
 			input:    "test-fixtures/image-simple",
-			desc:     "skip files deeper",
+			desc:     "exclude files deeper",
 			glob:     "**",
 			expected: 3,
 			excludes: []string{"**/really/**"},
 		},
 		{
 			input:    "test-fixtures/image-simple",
-			desc:     "file excluded with extension",
+			desc:     "files excluded with extension",
 			glob:     "**",
 			expected: 1,
 			excludes: []string{"**/*.txt"},
@@ -362,7 +362,7 @@ func TestDirectoryExclusions(t *testing.T) {
 		},
 		{
 			input:    "test-fixtures/path-detected",
-			desc:     "multiple matches",
+			desc:     "file directly excluded",
 			glob:     "**",
 			expected: 1,
 			excludes: []string{"**/empty"},


### PR DESCRIPTION
This adds the `--exclude` flag to exclude paths from directory, archive, and image scans. This addresses #221

TODO:
- [x] add tests
- [x] add documentation
- [x] add more tests
- [x] add even more tests
