### PR TITLE
Adjust CPE generation for log4j

### DIFF
--- a/syft/pkg/cataloger/common/cpe/filter.go
+++ b/syft/pkg/cataloger/common/cpe/filter.go
@@ -17,6 +17,7 @@ var cpeFilters = []filterFn{
 	disallowJenkinsServerCPEForPluginPackage,
 	disallowJenkinsCPEsNotAssociatedWithJenkins,
 	disallowNonParseableCPEs,
+	disallowLog4JCVE202144228FalsePositives,
 }
 
 func filter(cpes []pkg.CPE, p pkg.Package, filters ...filterFn) (result []pkg.CPE) {
@@ -66,6 +67,16 @@ func disallowJiraClientServerMismatch(cpe pkg.CPE, p pkg.Package) bool {
 	// jira / atlassian should not apply to clients
 	if cpe.Product == "jira" && strings.Contains(strings.ToLower(p.Name), "client") {
 		if cpe.Vendor == wfn.Any || cpe.Vendor == "jira" || cpe.Vendor == "atlassian" {
+			return true
+		}
+	}
+	return false
+}
+
+// known false positives for CVE-2021-44228 (https://github.com/anchore/grype/issues/552)
+func disallowLog4JCVE202144228FalsePositives(cpe pkg.CPE, p pkg.Package) bool {
+	if cpe.Vendor == "apache" && cpe.Product == "log4j" && p.Type == pkg.JavaPkg {
+		if p.Name == "log4j-api" || p.Name == "log4j-slf4j-impl" {
 			return true
 		}
 	}

--- a/syft/pkg/cataloger/common/cpe/filter.go
+++ b/syft/pkg/cataloger/common/cpe/filter.go
@@ -76,7 +76,7 @@ func disallowJiraClientServerMismatch(cpe pkg.CPE, p pkg.Package) bool {
 // known false positives for CVE-2021-44228 (https://github.com/anchore/grype/issues/552)
 func disallowLog4JCVE202144228FalsePositives(cpe pkg.CPE, p pkg.Package) bool {
 	if cpe.Vendor == "apache" && cpe.Product == "log4j" && p.Type == pkg.JavaPkg {
-		if p.Name == "log4j-api" || p.Name == "log4j-slf4j-impl" {
+		if p.Name == "log4j-api" || p.Name == "log4j-to-slf4j" || p.Name == "log4j-slf4j-impl" {
 			return true
 		}
 	}

--- a/syft/pkg/cataloger/common/cpe/filter_test.go
+++ b/syft/pkg/cataloger/common/cpe/filter_test.go
@@ -165,3 +165,101 @@ func Test_disallowJiraClientServerMismatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_disallowLog4JCVE202144228FalsePositives(t *testing.T) {
+	tests := []struct {
+		name     string
+		cpe      pkg.CPE
+		pkg      pkg.Package
+		expected bool
+	}{
+		// filter out
+		{
+			name: "filter out log4j-api java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-api",
+				Type: pkg.JavaPkg,
+			},
+			expected: true,
+		},
+		{
+			name: "filter out log4j-slf4j-impl java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-slf4j-impl",
+				Type: pkg.JavaPkg,
+			},
+			expected: true,
+		},
+		/// keep
+		{
+			name: "keep log4j-slf4j-impl for non-java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-slf4j-impl",
+				Type: pkg.JenkinsPluginPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j-api non-java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-api",
+				Type: pkg.JenkinsPluginPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j-slf4j-impl java packages with wrong vendor",
+			cpe:  mustCPE("cpe:2.3:a:NOT-apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-slf4j-impl",
+				Type: pkg.JavaPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j-api java packages with wrong vendor",
+			cpe:  mustCPE("cpe:2.3:a:NOT-apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-api",
+				Type: pkg.JavaPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j-slf4j-impl java packages with wrong product",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j-diff:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-slf4j-impl",
+				Type: pkg.JavaPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j-api java packages with wrong product",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j-diff:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-api",
+				Type: pkg.JavaPkg,
+			},
+			expected: false,
+		},
+		{
+			name: "keep log4j java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j",
+				Type: pkg.JavaPkg,
+			},
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, disallowLog4JCVE202144228FalsePositives(test.cpe, test.pkg))
+		})
+	}
+}

--- a/syft/pkg/cataloger/common/cpe/filter_test.go
+++ b/syft/pkg/cataloger/common/cpe/filter_test.go
@@ -192,6 +192,15 @@ func Test_disallowLog4JCVE202144228FalsePositives(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "filter out log4j-to-slf4j java packages",
+			cpe:  mustCPE("cpe:2.3:a:apache:log4j:3.2:*:*:*:*:*:*:*"),
+			pkg: pkg.Package{
+				Name: "log4j-to-slf4j",
+				Type: pkg.JavaPkg,
+			},
+			expected: true,
+		},
 		/// keep
 		{
 			name: "keep log4j-slf4j-impl for non-java packages",


### PR DESCRIPTION
Some false positives for the log4j vulnerability are showing up as noted in https://github.com/anchore/grype/issues/552 This will add filtering for them.

NOTE: there is some request to leave the current behavior as-is: https://github.com/anchore/grype/issues/552#issuecomment-996502034