### PR TITLE
Fix unhelpful error message for oci-archive scheme

### DIFF
--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -264,7 +264,7 @@ func packagesExecWorker(userInput string) <-chan error {
 
 		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), appConfig.Exclusions...)
 		if err != nil {
-			errs <- fmt.Errorf("analysis failed: %w", err)
+			errs <- fmt.Errorf("failed to construct source from user input %q: %w", userInput, err)
 			return
 		}
 		if cleanup != nil {

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -264,7 +264,7 @@ func packagesExecWorker(userInput string) <-chan error {
 
 		src, cleanup, err := source.New(userInput, appConfig.Registry.ToOptions(), appConfig.Exclusions...)
 		if err != nil {
-			errs <- fmt.Errorf("failed to determine image source: %w", err)
+			errs <- fmt.Errorf("analysis failed: %w", err)
 			return
 		}
 		if cleanup != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
 	github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29
-	github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd
+	github.com/anchore/stereoscope v0.0.0-20211222141827-6e663afeef5d
 	// we are hinting brotli to latest due to warning when installing archiver v3:
 	// go: warning: github.com/andybalholm/brotli@v1.0.1: retracted by module author: occasional panics and data corruption
 	github.com/andybalholm/brotli v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
 	github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29
-	github.com/anchore/stereoscope v0.0.0-20211203160213-5a5e323a5c89
+	github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd
 	// we are hinting brotli to latest due to warning when installing archiver v3:
 	// go: warning: github.com/andybalholm/brotli@v1.0.1: retracted by module author: occasional panics and data corruption
 	github.com/andybalholm/brotli v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
-github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd h1:y5yBc2lolfs+tDzqrjVsPBcmsr5HkliIz825SUzFrJc=
-github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd/go.mod h1:FNm1rtauEjkC3elA3jr3bJkU+/4QiovApwJdPnHQ9x0=
+github.com/anchore/stereoscope v0.0.0-20211222141827-6e663afeef5d h1:ggdC5SRb8rAXmBkwxah8gfSxwpoAVcpp12tQ+XbDi20=
+github.com/anchore/stereoscope v0.0.0-20211222141827-6e663afeef5d/go.mod h1:FNm1rtauEjkC3elA3jr3bJkU+/4QiovApwJdPnHQ9x0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
-github.com/anchore/stereoscope v0.0.0-20211203160213-5a5e323a5c89 h1:pcMFN7wjIQIxdZm8NA0R3JiRRFn5Eyx9mhagHOVS4Bw=
-github.com/anchore/stereoscope v0.0.0-20211203160213-5a5e323a5c89/go.mod h1:FNm1rtauEjkC3elA3jr3bJkU+/4QiovApwJdPnHQ9x0=
+github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd h1:y5yBc2lolfs+tDzqrjVsPBcmsr5HkliIz825SUzFrJc=
+github.com/anchore/stereoscope v0.0.0-20211219220256-a73ea91b74bd/go.mod h1:FNm1rtauEjkC3elA3jr3bJkU+/4QiovApwJdPnHQ9x0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -51,7 +51,7 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 	case DirectoryScheme:
 		source, cleanupFn, err = generateDirectorySource(fs, location)
 	case ImageScheme:
-		source, cleanupFn, err = generateImageSource(location, userInput, imageSource, registryOptions)
+		source, cleanupFn, err = generateImageSource(location, imageSource, registryOptions)
 	default:
 		err = fmt.Errorf("unable to process input for scanning: '%s'", userInput)
 	}
@@ -63,13 +63,11 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 	return source, cleanupFn, err
 }
 
-func generateImageSource(location, userInput string, imageSource image.Source, registryOptions *image.RegistryOptions) (*Source, func(), error) {
+func generateImageSource(location string, imageSource image.Source, registryOptions *image.RegistryOptions) (*Source,
+	func(), error) {
 	img, err := stereoscope.GetImageFromSource(location, imageSource, registryOptions)
 	if err != nil {
-		log.Debugf("error parsing location: %s after detecting scheme; pulling image: %s", location, userInput)
-		// we may have been to aggressive reading the source hint
-		// try the input as supplied by the user if our initial parse failed
-		img, err = stereoscope.GetImageFromSource(userInput, imageSource, registryOptions)
+		return nil, nil, err
 	}
 
 	cleanup := stereoscope.Cleanup

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -114,6 +114,8 @@ func getImageWithRetryStrategy(userInput, location string, imageSource image.Sou
 		err,
 	)
 
+	// We need to determine the image source again, such that this determination
+	// doesn't take scheme parsing into account.
 	imageSource = image.DetermineImagePullSource(userInput)
 	img, err = stereoscope.GetImageFromSource(userInput, imageSource, registryOptions)
 	if err != nil {

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -51,7 +51,7 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 	case DirectoryScheme:
 		source, cleanupFn, err = generateDirectorySource(fs, location)
 	case ImageScheme:
-		source, cleanupFn, err = generateImageSource(location, imageSource, registryOptions)
+		source, cleanupFn, err = generateImageSource(userInput, location, imageSource, registryOptions)
 	default:
 		err = fmt.Errorf("unable to process input for scanning: '%s'", userInput)
 	}
@@ -63,15 +63,8 @@ func New(userInput string, registryOptions *image.RegistryOptions, exclusions ..
 	return source, cleanupFn, err
 }
 
-func generateImageSource(location string, imageSource image.Source, registryOptions *image.RegistryOptions) (*Source,
-	func(), error) {
-	img, err := stereoscope.GetImageFromSource(location, imageSource, registryOptions)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cleanup := stereoscope.Cleanup
-
+func generateImageSource(userInput, location string, imageSource image.Source, registryOptions *image.RegistryOptions) (*Source, func(), error) {
+	img, cleanup, err := getImageWithRetryStrategy(userInput, location, imageSource, registryOptions)
 	if err != nil || img == nil {
 		return &Source{}, cleanup, fmt.Errorf("could not fetch image '%s': %w", location, err)
 	}
@@ -82,6 +75,51 @@ func generateImageSource(location string, imageSource image.Source, registryOpti
 	}
 
 	return &s, cleanup, nil
+}
+
+func parseScheme(userInput string) string {
+	parts := strings.SplitN(userInput, ":", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+
+	return parts[0]
+}
+
+func getImageWithRetryStrategy(userInput, location string, imageSource image.Source, registryOptions *image.RegistryOptions) (*image.Image, func(), error) {
+	img, err := stereoscope.GetImageFromSource(location, imageSource, registryOptions)
+	if err == nil {
+		// Success on the first try!
+		return img, stereoscope.Cleanup, nil
+	}
+
+	scheme := parseScheme(userInput)
+	if !(scheme == "docker" || scheme == "registry") {
+		// Image retrieval failed, and we shouldn't retry it. It's most likely that the
+		// user _did_ intend the parsed scheme, but there was a legitimate failure with
+		// using the scheme to load the image. Alert the user to this failure, so they
+		// can fix the problem.
+		return nil, nil, err
+	}
+
+	// Maybe the user wanted "docker" or "registry" to refer to an _image name_
+	// (e.g. "docker:latest"), not a scheme. We'll retry image retrieval with this
+	// alternative interpretation, in an attempt to avoid unnecessary user friction.
+
+	log.Warnf(
+		"scheme %q specified, but it coincides with a common image name; re-examining user input %q"+
+			" without scheme parsing because image retrieval using scheme parsing was unsuccessful: %v",
+		scheme,
+		userInput,
+		err,
+	)
+
+	img, err = stereoscope.GetImageFromSource(userInput, imageSource, registryOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return img, stereoscope.Cleanup, nil
 }
 
 func generateDirectorySource(fs afero.Fs, location string) (*Source, func(), error) {

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -114,6 +114,7 @@ func getImageWithRetryStrategy(userInput, location string, imageSource image.Sou
 		err,
 	)
 
+	imageSource = image.DetermineImagePullSource(userInput)
 	img, err = stereoscope.GetImageFromSource(userInput, imageSource, registryOptions)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This fixes #701, ~although this is likely to revert the fix applied for #287 in the PR #626~ (**EDIT**: This is no longer true, we can preserve the retry functionality used in #626 with some minor tweaks 🎉 ).

Due to the complexity of the call graph for determining and processing an image source, it's probably best if user input is processed only one way if a scheme is specified, to avoid even more potential execution paths. What was happening that led to the misleading error message in #701 was that a second attempt of interpreting user input caused the error message from the first attempt to be swallowed (an error message which would've helped the user figure out the issue more quickly).

~This PR is intended to be dependent on https://github.com/anchore/stereoscope/pull/92, so I'll start by opening this in **draft**, with a `replace` directive left in `go.mod`.~ **EDIT**: With the stereoscope PR merged, this PR has been updated to use the latest commit of stereoscope.