### PR TITLE
Fix CPE encode/decode when it contains special chars

### DIFF
--- a/internal/formats/common/spdxhelpers/external_refs.go
+++ b/internal/formats/common/spdxhelpers/external_refs.go
@@ -12,7 +12,7 @@ func ExternalRefs(p pkg.Package) (externalRefs []model.ExternalRef) {
 	for _, c := range p.CPEs {
 		externalRefs = append(externalRefs, model.ExternalRef{
 			ReferenceCategory: model.SecurityReferenceCategory,
-			ReferenceLocator:  c.BindToFmtString(),
+			ReferenceLocator:  pkg.CPEString(c),
 			ReferenceType:     model.Cpe23ExternalRefType,
 		})
 	}

--- a/internal/formats/common/spdxhelpers/external_refs_test.go
+++ b/internal/formats/common/spdxhelpers/external_refs_test.go
@@ -26,7 +26,7 @@ func Test_ExternalRefs(t *testing.T) {
 			expected: []model.ExternalRef{
 				{
 					ReferenceCategory: model.SecurityReferenceCategory,
-					ReferenceLocator:  testCPE.BindToFmtString(),
+					ReferenceLocator:  pkg.CPEString(testCPE),
 					ReferenceType:     model.Cpe23ExternalRefType,
 				},
 				{

--- a/internal/formats/syftjson/to_format_model.go
+++ b/internal/formats/syftjson/to_format_model.go
@@ -142,7 +142,7 @@ func toPackageModels(catalog *pkg.Catalog) []model.Package {
 func toPackageModel(p pkg.Package) model.Package {
 	var cpes = make([]string, len(p.CPEs))
 	for i, c := range p.CPEs {
-		cpes[i] = c.BindToFmtString()
+		cpes[i] = pkg.CPEString(c)
 	}
 
 	var licenses = make([]string, 0)

--- a/syft/pkg/cataloger/common/cpe/filter.go
+++ b/syft/pkg/cataloger/common/cpe/filter.go
@@ -34,7 +34,7 @@ cpeLoop:
 }
 
 func disallowNonParseableCPEs(cpe pkg.CPE, _ pkg.Package) bool {
-	v := cpe.BindToFmtString()
+	v := pkg.CPEString(cpe)
 	_, err := pkg.NewCPE(v)
 
 	cannotParse := err != nil

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -28,7 +28,6 @@ func newCPE(product, vendor, version, targetSW string) wfn.Attributes {
 func Generate(p pkg.Package) []pkg.CPE {
 	vendors := candidateVendors(p)
 	products := candidateProducts(p)
-	version := sanitizeVersion(p)
 	if len(products) == 0 {
 		return nil
 	}
@@ -38,13 +37,13 @@ func Generate(p pkg.Package) []pkg.CPE {
 	for _, product := range products {
 		for _, vendor := range vendors {
 			// prevent duplicate entries...
-			key := fmt.Sprintf("%s|%s|%s", product, vendor, version)
+			key := fmt.Sprintf("%s|%s|%s", product, vendor, p.Version)
 			if keys.Contains(key) {
 				continue
 			}
 			keys.Add(key)
 			// add a new entry...
-			cpes = append(cpes, newCPE(product, vendor, version, wfn.Any))
+			cpes = append(cpes, newCPE(product, vendor, p.Version, wfn.Any))
 		}
 	}
 
@@ -54,21 +53,6 @@ func Generate(p pkg.Package) []pkg.CPE {
 	sort.Sort(BySpecificity(cpes))
 
 	return cpes
-}
-
-func sanitizeVersion(p pkg.Package) string {
-	v := p.Version
-	switch p.MetadataType {
-	case pkg.DpkgMetadataType, pkg.RpmdbMetadataType:
-		o := strings.SplitN(p.Version, ":", 2)
-		// If the version contains ":", it means the version
-		// contains an epoch and is of the form "{epoch}:{actualVersion}"
-		// in this case we extract out the actual version for further usage
-		if len(o) > 1 {
-			v = o[1]
-		}
-	}
-	return v
 }
 
 func candidateVendors(p pkg.Package) []string {

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -12,35 +12,14 @@ import (
 	"github.com/facebookincubator/nvdtools/wfn"
 )
 
-func newCPE(product, vendor, version, targetSW string) (wfn.Attributes, error) {
-	var err error
+func newCPE(product, vendor, version, targetSW string) wfn.Attributes {
 	cpe := *(wfn.NewAttributesWithAny())
 	cpe.Part = "a"
-	if cpe.Product, err = sanitize(product); err != nil {
-		return *(wfn.NewAttributesWithAny()), err
-	}
-	if cpe.Vendor, err = sanitize(vendor); err != nil {
-		return *(wfn.NewAttributesWithAny()), err
-	}
-	if cpe.Version, err = sanitize(version); err != nil {
-		return *(wfn.NewAttributesWithAny()), err
-	}
-	if cpe.TargetSW, err = sanitize(targetSW); err != nil {
-		return *(wfn.NewAttributesWithAny()), err
-	}
-	return cpe, nil
-}
-
-func sanitize(input string) (string, error) {
-	// WFNize from thw nvdtools package has a bug where if it encounters
-	// ':' in the input strings, it will truncate all output in the string after ':'
-	// instead of correctly quoting it. For now, let's just throw and error and prevent generation
-	// of invalid CPEs with incorrect/truncated data.
-	// This is similar to how we filter CPEs in the filter handler
-	if strings.Contains(input, ":") {
-		return "", fmt.Errorf("unable to sanitize strings that contain ':' correctly")
-	}
-	return wfn.WFNize(input)
+	cpe.Product = product
+	cpe.Vendor = vendor
+	cpe.Version = version
+	cpe.TargetSW = targetSW
+	return cpe
 }
 
 // Generate Create a list of CPEs for a given package, trying to guess the vendor, product tuple. We should be trying to
@@ -64,11 +43,8 @@ func Generate(p pkg.Package) []pkg.CPE {
 				continue
 			}
 			keys.Add(key)
-
 			// add a new entry...
-			if cpe, err := newCPE(product, vendor, version, wfn.Any); err == nil {
-				cpes = append(cpes, cpe)
-			}
+			cpes = append(cpes, newCPE(product, vendor, version, wfn.Any))
 		}
 	}
 

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -328,6 +328,38 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 		},
 		{
+			name: "rpm with epoch",
+			p: pkg.Package{
+				Name:         "name",
+				Version:      "1:3.2",
+				FoundBy:      "some-analyzer",
+				Type:         pkg.RpmPkg,
+				MetadataType: pkg.RpmdbMetadataType,
+				Metadata: pkg.RpmdbMetadata{
+					Vendor: "some-vendor",
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:some-vendor:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:some_vendor:name:3.2:*:*:*:*:*:*:*",
+			},
+		},
+		{
+			name: "deb with epoch",
+			p: pkg.Package{
+				Name:         "name",
+				Version:      "1:3.2",
+				FoundBy:      "some-analyzer",
+				Type:         pkg.DebPkg,
+				MetadataType: pkg.DpkgMetadataType,
+				Metadata:     pkg.DpkgMetadata{},
+			},
+			expected: []string{
+				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+			},
+		},
+		{
 			name: "cloudbees jenkins package identified via groupId",
 			p: pkg.Package{
 				Name:     "name",

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -340,9 +340,9 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
-				"cpe:2.3:a:some-vendor:name:3.2:*:*:*:*:*:*:*",
-				"cpe:2.3:a:some_vendor:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:name:name:1\\:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:some-vendor:name:1\\:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:some_vendor:name:1\\:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -356,7 +356,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				Metadata:     pkg.DpkgMetadata{},
 			},
 			expected: []string{
-				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:name:name:1\\:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -554,7 +554,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			expectedCpeSet := set.NewStringSet(test.expected...)
 			actualCpeSet := set.NewStringSet()
 			for _, a := range actual {
-				actualCpeSet.Add(a.BindToFmtString())
+				actualCpeSet.Add(pkg.CPEString(a))
 			}
 
 			extra := strset.Difference(actualCpeSet, expectedCpeSet).List()

--- a/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
+++ b/syft/pkg/cataloger/common/cpe/sort_by_specificity.go
@@ -29,6 +29,9 @@ func (c BySpecificity) Less(i, j int) bool {
 	}
 
 	// if score and length are equal then text sort
+	// note that we are not using CPEString from the syft pkg
+	// as we are not encoding/decoding this CPE string so we don't
+	// need the proper quoted version of the CPE.
 	return c[i].BindToFmtString() < c[j].BindToFmtString()
 }
 

--- a/syft/pkg/cpe.go
+++ b/syft/pkg/cpe.go
@@ -64,7 +64,24 @@ func normalizeCpeField(field string) string {
 	if field == "*" {
 		return wfn.Any
 	}
-	return strings.ReplaceAll(wfn.StripSlashes(field), `\/`, "/")
+	return stripSlashes(field)
+}
+
+// stripSlashes is a reverse of the sanitize function below.
+// It correctly removes slashes that are followed by allowed puncts.
+// This is to allow for a correct round trip parsing of cpes with quoted characters.
+func stripSlashes(s string) string {
+	const allowedPunct = "-!\"#$%&'()+,./:;<=>@[]^`{|}!~"
+	buf := make([]byte, 0, len(s))
+	for i, c := range s {
+		c := byte(c)
+		if c == '\\' && i+1 < len(s) && strings.IndexByte(allowedPunct, s[i+1]) != -1 {
+			continue
+		} else {
+			buf = append(buf, c)
+		}
+	}
+	return string(buf)
 }
 
 func CPEString(c CPE) string {

--- a/syft/pkg/cpe.go
+++ b/syft/pkg/cpe.go
@@ -13,17 +13,17 @@ type CPE = wfn.Attributes
 // This regex string is taken from
 // https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd which has the official cpe spec
 // This first part matches CPE urls and the second part matches binding strings
-const cpeRegexString = ((`([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})`) +
+const cpeRegexString = ((`^([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})`) +
 	// Or match the CPE binding string
 	// Note that we had to replace '`' with '\x60' to escape the backticks
-	`|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){4})`)
+	`|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){4})$`)
 
 var cpeRegex = regexp.MustCompile(cpeRegexString)
 
 func NewCPE(cpeStr string) (CPE, error) {
 	// We should filter out all CPEs that do not match the official CPE regex
 	// The facebook nvdtools parser can sometimes incorrectly parse invalid CPE strings
-	if !cpeRegex.Match([]byte(cpeStr)) {
+	if !cpeRegex.MatchString(cpeStr) {
 		return CPE{}, fmt.Errorf("failed to parse CPE=%q as it doesn't match the regex=%s", cpeStr, cpeRegexString)
 	}
 	value, err := wfn.Parse(cpeStr)

--- a/syft/pkg/cpe.go
+++ b/syft/pkg/cpe.go
@@ -72,16 +72,15 @@ func normalizeCpeField(field string) string {
 // This is to allow for a correct round trip parsing of cpes with quoted characters.
 func stripSlashes(s string) string {
 	const allowedPunct = "-!\"#$%&'()+,./:;<=>@[]^`{|}!~"
-	buf := make([]byte, 0, len(s))
+	sb := strings.Builder{}
 	for i, c := range s {
-		c := byte(c)
-		if c == '\\' && i+1 < len(s) && strings.IndexByte(allowedPunct, s[i+1]) != -1 {
+		if c == '\\' && i+1 < len(s) && strings.ContainsRune(allowedPunct, rune(s[i+1])) {
 			continue
 		} else {
-			buf = append(buf, c)
+			sb.WriteRune(c)
 		}
 	}
-	return string(buf)
+	return sb.String()
 }
 
 func CPEString(c CPE) string {
@@ -114,16 +113,12 @@ func sanitize(s string) string {
 	const allowedPunct = "-!\"#$%&'()+,./:;<=>@[]^`{|}!~"
 	// replace spaces with underscores
 	in := strings.ReplaceAll(s, " ", "_")
-	// we allocate 2x the input to the buffer assuming
-	// we have to quote every character in the input
-	buf := make([]byte, 0, 2*len(in))
+	sb := strings.Builder{}
 	for _, c := range in {
-		c := byte(c)
-		if strings.IndexByte(allowedPunct, c) != -1 {
-			buf = append(buf, '\\', c)
-		} else {
-			buf = append(buf, c)
+		if strings.ContainsRune(allowedPunct, c) {
+			sb.WriteRune('\\')
 		}
+		sb.WriteRune(c)
 	}
-	return string(buf)
+	return sb.String()
 }

--- a/syft/pkg/cpe.go
+++ b/syft/pkg/cpe.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/facebookincubator/nvdtools/wfn"
@@ -9,7 +10,22 @@ import (
 
 type CPE = wfn.Attributes
 
+// This regex string is taken from
+// https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd which has the official cpe spec
+// This first part matches CPE urls and the second part matches binding strings
+const cpeRegexString = ((`([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})`) +
+	// Or match the CPE binding string
+	// Note that we had to replace '`' with '\x60' to escape the backticks
+	`|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^\x60\{\|}~]))+(\?*|\*?))|[\*\-])){4})`)
+
+var cpeRegex = regexp.MustCompile(cpeRegexString)
+
 func NewCPE(cpeStr string) (CPE, error) {
+	// We should filter out all CPEs that do not match the official CPE regex
+	// The facebook nvdtools parser can sometimes incorrectly parse invalid CPE strings
+	if !cpeRegex.Match([]byte(cpeStr)) {
+		return CPE{}, fmt.Errorf("failed to parse CPE=%q as it doesn't match the regex=%s", cpeStr, cpeRegexString)
+	}
 	value, err := wfn.Parse(cpeStr)
 	if err != nil {
 		return CPE{}, fmt.Errorf("failed to parse CPE=%q: %w", cpeStr, err)

--- a/syft/pkg/cpe_test.go
+++ b/syft/pkg/cpe_test.go
@@ -32,7 +32,7 @@ func TestNewCPE(t *testing.T) {
 		{
 			name:     "URL escape characters",
 			input:    `cpe:/a:%240.99_kindle_books_project:%240.99_kindle_books:6::~~~android~~`,
-			expected: must(NewCPE(`cpe:2.3:a:$0.99_kindle_books_project:$0.99_kindle_books:6:*:*:*:*:android:*:*`)),
+			expected: must(NewCPE(`cpe:2.3:a:\$0.99_kindle_books_project:\$0.99_kindle_books:6:*:*:*:*:android:*:*`)),
 		},
 	}
 

--- a/syft/pkg/cpe_test.go
+++ b/syft/pkg/cpe_test.go
@@ -43,8 +43,8 @@ func TestNewCPE(t *testing.T) {
 				t.Fatalf("got an error while creating CPE: %+v", err)
 			}
 
-			if actual.BindToFmtString() != test.expected.BindToFmtString() {
-				t.Errorf("mismatched entries:\n\texpected:%+v\n\t  actual:%+v\n", test.expected.BindToFmtString(), actual.BindToFmtString())
+			if CPEString(actual) != CPEString(test.expected) {
+				t.Errorf("mismatched entries:\n\texpected:%+v\n\t  actual:%+v\n", CPEString(test.expected), CPEString(actual))
 			}
 
 		})

--- a/syft/pkg/cpe_test.go
+++ b/syft/pkg/cpe_test.go
@@ -80,3 +80,55 @@ func Test_normalizeCpeField(t *testing.T) {
 		})
 	}
 }
+
+func Test_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		cpe       string
+		parsedCPE CPE
+	}{
+		{
+			name: "normal",
+			cpe:  "cpe:2.3:a:some-vendor:name:3.2:*:*:*:*:*:*:*",
+			parsedCPE: CPE{
+				Part:    "a",
+				Vendor:  "some-vendor",
+				Product: "name",
+				Version: "3.2",
+			},
+		},
+		{
+			name: "escaped colon",
+			cpe:  "cpe:2.3:a:some-vendor:name:1\\:3.2:*:*:*:*:*:*:*",
+			parsedCPE: CPE{
+				Part:    "a",
+				Vendor:  "some-vendor",
+				Product: "name",
+				Version: "1:3.2",
+			},
+		},
+		{
+			name: "escaped forward slash",
+			cpe:  "cpe:2.3:a:test\\/some-vendor:name:3.2:*:*:*:*:*:*:*",
+			parsedCPE: CPE{
+				Part:    "a",
+				Vendor:  "test/some-vendor",
+				Product: "name",
+				Version: "3.2",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// CPE string must be preserved through a round trip
+			assert.Equal(t, test.cpe, CPEString(MustCPE(test.cpe)))
+			// The parsed CPE must be the same after a round trip
+			assert.Equal(t, MustCPE(test.cpe), MustCPE(CPEString(MustCPE(test.cpe))))
+			// The test case parsed CPE must be the same after parsing the input string
+			assert.Equal(t, test.parsedCPE, MustCPE(test.cpe))
+			// The test case parsed CPE must produce the same string as the input cpe
+			assert.Equal(t, CPEString(test.parsedCPE), test.cpe)
+		})
+	}
+}

--- a/syft/pkg/test-fixtures/cpe-data.json
+++ b/syft/pkg/test-fixtures/cpe-data.json
@@ -1,0 +1,16934 @@
+[
+  {
+    "cpe-string": "cpe:2.3:h:supermicro:x9drff-7\\/i\\(t\\)g\\+:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:supermicro:x9drff-7%2fi%28t%29g%2b:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "supermicro",
+      "Product": "x9drff-7/i(t)g+",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:thimpress:learnpress:3.0.0:closebeta.2:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:thimpress:learnpress:3.0.0:closebeta.2:~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "thimpress",
+      "Product": "learnpress",
+      "Version": "3.0.0",
+      "Update": "closebeta.2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fortinet:fortisiem:3.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fortinet:fortisiem:3.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fortinet",
+      "Product": "fortisiem",
+      "Version": "3.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:uglifyjs_project:uglifyjs:2.8.12:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:uglifyjs_project:uglifyjs:2.8.12::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "uglifyjs_project",
+      "Product": "uglifyjs",
+      "Version": "2.8.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:drogon:drogon:1.0.0:beta10:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:drogon:drogon:1.0.0:beta10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "drogon",
+      "Product": "drogon",
+      "Version": "1.0.0",
+      "Update": "beta10",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gtranslate:gtranslate:1.0.4:*:*:*:enterprise:wordpress:*:*",
+    "cpe-url": "cpe:/a:gtranslate:gtranslate:1.0.4::~~enterprise~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gtranslate",
+      "Product": "gtranslate",
+      "Version": "1.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:abb:800xa_system:5.1:feature_pack_4_revision_d:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:abb:800xa_system:5.1:feature_pack_4_revision_d",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "abb",
+      "Product": "800xa_system",
+      "Version": "5.1",
+      "Update": "feature_pack_4_revision_d",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:totvs:fluig_mobile:1.17.13:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:totvs:fluig_mobile:1.17.13::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "totvs",
+      "Product": "fluig_mobile",
+      "Version": "1.17.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:diesel:diesel:1.4.2:*:*:*:*:rust:*:*",
+    "cpe-url": "cpe:/a:diesel:diesel:1.4.2::~~~rust~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "diesel",
+      "Product": "diesel",
+      "Version": "1.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "rust",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:mitsubishielectric:r16mtcpu_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:mitsubishielectric:r16mtcpu_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "mitsubishielectric",
+      "Product": "r16mtcpu_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:communigate:communigate_pro:5.4.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:communigate:communigate_pro:5.4.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "communigate",
+      "Product": "communigate_pro",
+      "Version": "5.4.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:smartertools:smartermail:7.0.3845:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:smartertools:smartermail:7.0.3845",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "smartertools",
+      "Product": "smartermail",
+      "Version": "7.0.3845",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bluetrace:opentrace:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bluetrace:opentrace:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bluetrace",
+      "Product": "opentrace",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:crocoblock:jetwidgets_for_elementor:1.0.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:crocoblock:jetwidgets_for_elementor:1.0.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "crocoblock",
+      "Product": "jetwidgets_for_elementor",
+      "Version": "1.0.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:on_demand_services_sdk:0.14.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:on_demand_services_sdk:0.14.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "on_demand_services_sdk",
+      "Version": "0.14.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:horde:wicked:2.0.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:horde:wicked:2.0.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "horde",
+      "Product": "wicked",
+      "Version": "2.0.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kopano:groupware_core:8.7.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kopano:groupware_core:8.7.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kopano",
+      "Product": "groupware_core",
+      "Version": "8.7.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nasm:netwide_assembler:2.14.0:rc14:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nasm:netwide_assembler:2.14.0:rc14",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nasm",
+      "Product": "netwide_assembler",
+      "Version": "2.14.0",
+      "Update": "rc14",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:components_for_wp_bakery_page_builder_project:components_for_wp_bakery_page_builder:4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:components_for_wp_bakery_page_builder_project:components_for_wp_bakery_page_builder:4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "components_for_wp_bakery_page_builder_project",
+      "Product": "components_for_wp_bakery_page_builder",
+      "Version": "4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dollar_bank:dollar_bank_mobile:2.4.2:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:dollar_bank:dollar_bank_mobile:2.4.2::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dollar_bank",
+      "Product": "dollar_bank_mobile",
+      "Version": "2.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adm-zip_project:adm-zip:0.1.4:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:adm-zip_project:adm-zip:0.1.4::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adm-zip_project",
+      "Product": "adm-zip",
+      "Version": "0.1.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vega_project:vega:5.0.0:rc3:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:vega_project:vega:5.0.0:rc3:~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vega_project",
+      "Product": "vega",
+      "Version": "5.0.0",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:citrix:gateway:12.1-62.25:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:citrix:gateway:12.1-62.25",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "citrix",
+      "Product": "gateway",
+      "Version": "12.1-62.25",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nystudio107:seomatic:3.1.38:*:*:*:*:craft_cms:*:*",
+    "cpe-url": "cpe:/a:nystudio107:seomatic:3.1.38::~~~craft_cms~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nystudio107",
+      "Product": "seomatic",
+      "Version": "3.1.38",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "craft_cms",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:lucene:2.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:lucene:2.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "lucene",
+      "Version": "2.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spinnaker:orca:1.307.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:spinnaker:orca:1.307.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spinnaker",
+      "Product": "orca",
+      "Version": "1.307.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:apple:iphone:1.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:apple:iphone:1.0.1",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "apple",
+      "Product": "iphone",
+      "Version": "1.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:scapy:scapy:0.9.17.33:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:scapy:scapy:0.9.17.33",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "scapy",
+      "Product": "scapy",
+      "Version": "0.9.17.33",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:metabox:meta_box:3.1.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:metabox:meta_box:3.1.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "metabox",
+      "Product": "meta_box",
+      "Version": "3.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:segue_project:segue:2.2.8.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:segue_project:segue:2.2.8.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "segue_project",
+      "Product": "segue",
+      "Version": "2.2.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:idreamsoft:icms:7.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:idreamsoft:icms:7.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "idreamsoft",
+      "Product": "icms",
+      "Version": "7.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spreecommerce:spree:0.30.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:spreecommerce:spree:0.30.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spreecommerce",
+      "Product": "spree",
+      "Version": "0.30.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ruby-lang:ruby:1.8.7:p357:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ruby-lang:ruby:1.8.7:p357",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ruby-lang",
+      "Product": "ruby",
+      "Version": "1.8.7",
+      "Update": "p357",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:lucene:3.6.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:lucene:3.6.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "lucene",
+      "Version": "3.6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:socket.io-file_project:socket.io-file:1.0.41:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:socket.io-file_project:socket.io-file:1.0.41::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "socket.io-file_project",
+      "Product": "socket.io-file",
+      "Version": "1.0.41",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mintty_project:mintty:2.2.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mintty_project:mintty:2.2.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mintty_project",
+      "Product": "mintty",
+      "Version": "2.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:netgear:gs110tp:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:netgear:gs110tp:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "netgear",
+      "Product": "gs110tp",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rsvpmaker_project:rsvpmaker:4.5.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:rsvpmaker_project:rsvpmaker:4.5.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rsvpmaker_project",
+      "Product": "rsvpmaker",
+      "Version": "4.5.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:security_qradar_analyst_workflow:1.18.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:security_qradar_analyst_workflow:1.18.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "security_qradar_analyst_workflow",
+      "Version": "1.18.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:docker:docker:2.1.0.2:*:*:*:community:*:*:*",
+    "cpe-url": "cpe:/a:docker:docker:2.1.0.2::~~community~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "docker",
+      "Product": "docker",
+      "Version": "2.1.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "community",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudfoundry:cf-deployment:4.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudfoundry:cf-deployment:4.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudfoundry",
+      "Product": "cf-deployment",
+      "Version": "4.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:procurve_switch:jg247a:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:procurve_switch:jg247a",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "procurve_switch",
+      "Version": "jg247a",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:microsoft:ms-dos:4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:microsoft:ms-dos:4.0",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "microsoft",
+      "Product": "ms-dos",
+      "Version": "4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:horde:horde_translation:1.0.0:alpha1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:horde:horde_translation:1.0.0:alpha1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "horde",
+      "Product": "horde_translation",
+      "Version": "1.0.0",
+      "Update": "alpha1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:saltos:saltos:3.7:8870:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:saltos:saltos:3.7:8870",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "saltos",
+      "Product": "saltos",
+      "Version": "3.7",
+      "Update": "8870",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:mikrotik:routeros:6.43.7:*:*:*:-:*:*:*",
+    "cpe-url": "cpe:/o:mikrotik:routeros:6.43.7::~~-~~~",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "mikrotik",
+      "Product": "routeros",
+      "Version": "6.43.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.3.364:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.3.364",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.3.364",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:telegram:telegram_desktop:0.8.46:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:telegram:telegram_desktop:0.8.46",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "telegram",
+      "Product": "telegram_desktop",
+      "Version": "0.8.46",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hiawatha-webserver:hiawatha:5.8.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hiawatha-webserver:hiawatha:5.8.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hiawatha-webserver",
+      "Product": "hiawatha",
+      "Version": "5.8.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cpe17:autorun_killer:1.8.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cpe17:autorun_killer:1.8.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cpe17",
+      "Product": "autorun_killer",
+      "Version": "1.8.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:tri-band_wireless-ac_17265:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:tri-band_wireless-ac_17265:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "tri-band_wireless-ac_17265",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:goodiware:goodreader:2.5:-:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:goodiware:goodreader:2.5:-:~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "goodiware",
+      "Product": "goodreader",
+      "Version": "2.5",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:brainstormforce:astra:1.7.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:brainstormforce:astra:1.7.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "brainstormforce",
+      "Product": "astra",
+      "Version": "1.7.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pyrocms:pyrocms:3.4.14:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pyrocms:pyrocms:3.4.14",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pyrocms",
+      "Product": "pyrocms",
+      "Version": "3.4.14",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:iij:seil_b1_firmware:4.61:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:iij:seil_b1_firmware:4.61",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "iij",
+      "Product": "seil_b1_firmware",
+      "Version": "4.61",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:imagemagick:imagemagick:6.7.3-5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:imagemagick:imagemagick:6.7.3-5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "imagemagick",
+      "Product": "imagemagick",
+      "Version": "6.7.3-5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:doctrine-project:object_relational_mapper:2.5.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:doctrine-project:object_relational_mapper:2.5.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "doctrine-project",
+      "Product": "object_relational_mapper",
+      "Version": "2.5.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:typo3:typo3:6.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:typo3:typo3:6.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "typo3",
+      "Product": "typo3",
+      "Version": "6.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:libgee:0.8.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:libgee:0.8.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "libgee",
+      "Version": "0.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:horde:internet_mail_program:6.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:horde:internet_mail_program:6.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "horde",
+      "Product": "internet_mail_program",
+      "Version": "6.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:arubanetworks:aruba_instant:6.4.4.8-4.2.4.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:arubanetworks:aruba_instant:6.4.4.8-4.2.4.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "arubanetworks",
+      "Product": "aruba_instant",
+      "Version": "6.4.4.8-4.2.4.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:racket-lang:racket:6.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:racket-lang:racket:6.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "racket-lang",
+      "Product": "racket",
+      "Version": "6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nlnetlabs:name_server_daemon:4.1.16:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nlnetlabs:name_server_daemon:4.1.16:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nlnetlabs",
+      "Product": "name_server_daemon",
+      "Version": "4.1.16",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:scilab:scilab:5.1.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:scilab:scilab:5.1.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "scilab",
+      "Product": "scilab",
+      "Version": "5.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:ibm:mcs-7815i-2.0:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:ibm:mcs-7815i-2.0:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "ibm",
+      "Product": "mcs-7815i-2.0",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:plainware:locatoraid:3.2.4:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:plainware:locatoraid:3.2.4::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "plainware",
+      "Product": "locatoraid",
+      "Version": "3.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:httplib2_project:httplib2:0.10.1:*:*:*:*:python:*:*",
+    "cpe-url": "cpe:/a:httplib2_project:httplib2:0.10.1::~~~python~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "httplib2_project",
+      "Product": "httplib2",
+      "Version": "0.10.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "python",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:virtuemart:virtuemart:3.0.0:*:*:*:*:joomla\\!:*:*",
+    "cpe-url": "cpe:/a:virtuemart:virtuemart:3.0.0::~~~joomla%21~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "virtuemart",
+      "Product": "virtuemart",
+      "Version": "3.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "joomla!",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:microsoft:.net_core:5.0:preview2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:microsoft:.net_core:5.0:preview2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "microsoft",
+      "Product": ".net_core",
+      "Version": "5.0",
+      "Update": "preview2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:jira:6.0.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlassian:jira:6.0.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "jira",
+      "Version": "6.0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxcontainers:lxc:1.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxcontainers:lxc:1.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxcontainers",
+      "Product": "lxc",
+      "Version": "1.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pear:html_ajax:0.3.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pear:html_ajax:0.3.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pear",
+      "Product": "html_ajax",
+      "Version": "0.3.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:evo:evolution_cms:1.4.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:evo:evolution_cms:1.4.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "evo",
+      "Product": "evolution_cms",
+      "Version": "1.4.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:abb:cp676-web_firmware:1.76:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:abb:cp676-web_firmware:1.76",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "abb",
+      "Product": "cp676-web_firmware",
+      "Version": "1.76",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:fortinet:fortios:4.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:fortinet:fortios:4.0.4",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "fortinet",
+      "Product": "fortios",
+      "Version": "4.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openwhyd:openwhyd:1.26.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openwhyd:openwhyd:1.26.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openwhyd",
+      "Product": "openwhyd",
+      "Version": "1.26.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:axis:mpeg-2_video_server:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:axis:mpeg-2_video_server:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "axis",
+      "Product": "mpeg-2_video_server",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:d845bg_motherboard:p02-0015:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:d845bg_motherboard:p02-0015",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "d845bg_motherboard",
+      "Version": "p02-0015",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redis:redis:2.8.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redis:redis:2.8.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redis",
+      "Product": "redis",
+      "Version": "2.8.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:db2:9.7.0.3:*:*:*:express:*:*:*",
+    "cpe-url": "cpe:/a:ibm:db2:9.7.0.3::~~express~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "db2",
+      "Version": "9.7.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "express",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ninjaforms:ninja_forms:3.0.21:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ninjaforms:ninja_forms:3.0.21::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ninjaforms",
+      "Product": "ninja_forms",
+      "Version": "3.0.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim_project:vim:0.15.4:*:*:*:*:visual_studio_code:*:*",
+    "cpe-url": "cpe:/a:vim_project:vim:0.15.4::~~~visual_studio_code~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim_project",
+      "Product": "vim",
+      "Version": "0.15.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "visual_studio_code",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jekyllrb:jekyll:1.4.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jekyllrb:jekyll:1.4.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jekyllrb",
+      "Product": "jekyll",
+      "Version": "1.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:eclipse:keti:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:eclipse:keti:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "eclipse",
+      "Product": "keti",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:softvelum:nimble_streamer:3.4.0-4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:softvelum:nimble_streamer:3.4.0-4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "softvelum",
+      "Product": "nimble_streamer",
+      "Version": "3.4.0-4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:netgear:r7850:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:netgear:r7850:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "netgear",
+      "Product": "r7850",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:proftpd:proftpd:1.2.2:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:proftpd:proftpd:1.2.2:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "proftpd",
+      "Product": "proftpd",
+      "Version": "1.2.2",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rocomotion:pplog:2.32:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rocomotion:pplog:2.32",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rocomotion",
+      "Product": "pplog",
+      "Version": "2.32",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sysstat_project:sysstat:9.1.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sysstat_project:sysstat:9.1.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sysstat_project",
+      "Product": "sysstat",
+      "Version": "9.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:beaker:0.8.0-11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:beaker:0.8.0-11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "beaker",
+      "Version": "0.8.0-11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:percona:percona_server:5.6.44-85.0-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:percona:percona_server:5.6.44-85.0-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "percona",
+      "Product": "percona_server",
+      "Version": "5.6.44-85.0-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:omniauth:omniauth:1.1.3:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:omniauth:omniauth:1.1.3::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "omniauth",
+      "Product": "omniauth",
+      "Version": "1.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:videojs:video.js:6.1.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:videojs:video.js:6.1.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "videojs",
+      "Product": "video.js",
+      "Version": "6.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:httpie:httpie:0.1.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:httpie:httpie:0.1.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "httpie",
+      "Product": "httpie",
+      "Version": "0.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fortinet:fortimanager:5.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fortinet:fortimanager:5.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fortinet",
+      "Product": "fortimanager",
+      "Version": "5.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:check_mk_project:check_mk:1.4.0:p25:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:check_mk_project:check_mk:1.4.0:p25",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "check_mk_project",
+      "Product": "check_mk",
+      "Version": "1.4.0",
+      "Update": "p25",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wp-livechat:live_chat_support:2.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wp-livechat:live_chat_support:2.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wp-livechat",
+      "Product": "live_chat_support",
+      "Version": "2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:signal:signal:2.25.0.10:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:signal:signal:2.25.0.10::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "signal",
+      "Product": "signal",
+      "Version": "2.25.0.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:telerik:ui_for_asp.net_core:2018.2.620:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:telerik:ui_for_asp.net_core:2018.2.620",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "telerik",
+      "Product": "ui_for_asp.net_core",
+      "Version": "2018.2.620",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kde:paste_applet:4.6.90:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kde:paste_applet:4.6.90",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kde",
+      "Product": "paste_applet",
+      "Version": "4.6.90",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:5.0.382.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:5.0.382.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "5.0.382.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:fronius:primo_5.0-1_firmware:3.14.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:fronius:primo_5.0-1_firmware:3.14.1",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "fronius",
+      "Product": "primo_5.0-1_firmware",
+      "Version": "3.14.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:videolan:vlc_media_player:2.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:videolan:vlc_media_player:2.0.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "videolan",
+      "Product": "vlc_media_player",
+      "Version": "2.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:woocommerce:woocommerce:3.5.7:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:woocommerce:woocommerce:3.5.7::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "woocommerce",
+      "Product": "woocommerce",
+      "Version": "3.5.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:yajl-ruby_project:yajl-ruby:1.2.3:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:yajl-ruby_project:yajl-ruby:1.2.3::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "yajl-ruby_project",
+      "Product": "yajl-ruby",
+      "Version": "1.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gitlab:gitlab:8.2.4:*:*:*:community:*:*:*",
+    "cpe-url": "cpe:/a:gitlab:gitlab:8.2.4::~~community~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gitlab",
+      "Product": "gitlab",
+      "Version": "8.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "community",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:b3log:symphony:3.4.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:b3log:symphony:3.4.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "b3log",
+      "Product": "symphony",
+      "Version": "3.4.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gajim:gajim:1.3.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gajim:gajim:1.3.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gajim",
+      "Product": "gajim",
+      "Version": "1.3.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rope_project:rope:0.15.0:*:*:*:*:python:*:*",
+    "cpe-url": "cpe:/a:rope_project:rope:0.15.0::~~~python~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rope_project",
+      "Product": "rope",
+      "Version": "0.15.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "python",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:microsoft:sql_srv:7.0:sp3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:microsoft:sql_srv:7.0:sp3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "microsoft",
+      "Product": "sql_srv",
+      "Version": "7.0",
+      "Update": "sp3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openconext:openconext_engineblock:1.17.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openconext:openconext_engineblock:1.17.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openconext",
+      "Product": "openconext_engineblock",
+      "Version": "1.17.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nmap:nmap:7.30:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nmap:nmap:7.30",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nmap",
+      "Product": "nmap",
+      "Version": "7.30",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:openmeetings:3.3.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:openmeetings:3.3.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "openmeetings",
+      "Version": "3.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:owasp_dependency-track:3.1.0:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:owasp_dependency-track:3.1.0::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "owasp_dependency-track",
+      "Version": "3.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpsymposiumpro:wp_symposium:13.08.01:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpsymposiumpro:wp_symposium:13.08.01::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpsymposiumpro",
+      "Product": "wp_symposium",
+      "Version": "13.08.01",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:4.0.249.51:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:4.0.249.51",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "4.0.249.51",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:feehi:feehi_cms:2.1.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:feehi:feehi_cms:2.1.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "feehi",
+      "Product": "feehi_cms",
+      "Version": "2.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:altiris:network_discovery_language_pack:6.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:altiris:network_discovery_language_pack:6.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "altiris",
+      "Product": "network_discovery_language_pack",
+      "Version": "6.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:python:3.9.0:alpha6:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:python:3.9.0:alpha6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "python",
+      "Version": "3.9.0",
+      "Update": "alpha6",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:app_engine_python_sdk:1.9.71:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:app_engine_python_sdk:1.9.71",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "app_engine_python_sdk",
+      "Version": "1.9.71",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:web_security_appliance:7.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:web_security_appliance:7.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "web_security_appliance",
+      "Version": "7.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:html-pdf_project:html-pdf:-:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:html-pdf_project:html-pdf:-::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "html-pdf_project",
+      "Product": "html-pdf",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:htmlsanitizer_project:htmlsanitizer:3.3.125:beta:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:htmlsanitizer_project:htmlsanitizer:3.3.125:beta",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "htmlsanitizer_project",
+      "Product": "htmlsanitizer",
+      "Version": "3.3.125",
+      "Update": "beta",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:neliosoftware:nelio_ab_testing:4.4.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:neliosoftware:nelio_ab_testing:4.4.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "neliosoftware",
+      "Product": "nelio_ab_testing",
+      "Version": "4.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:jbpm:7.12.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:jbpm:7.12.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "jbpm",
+      "Version": "7.12.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:businessobjects_business_intelligence:4.1:support_package1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:businessobjects_business_intelligence:4.1:support_package1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "businessobjects_business_intelligence",
+      "Version": "4.1",
+      "Update": "support_package1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:cordova:5.2.2:*:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:apache:cordova:5.2.2::~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "cordova",
+      "Version": "5.2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:nx-os:12.0\\(1q\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:nx-os:12.0%281q%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "nx-os",
+      "Version": "12.0(1q)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:solarwinds:serv-u:15.2.2:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:solarwinds:serv-u:15.2.2:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "solarwinds",
+      "Product": "serv-u",
+      "Version": "15.2.2",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpdeveloper:essential_addons_for_elementor:2.8.7:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpdeveloper:essential_addons_for_elementor:2.8.7::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpdeveloper",
+      "Product": "essential_addons_for_elementor",
+      "Version": "2.8.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:sourcetree:1.0.7:*:*:*:*:macos:*:*",
+    "cpe-url": "cpe:/a:atlassian:sourcetree:1.0.7::~~~macos~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "sourcetree",
+      "Version": "1.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "macos",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:infinispan:infinispan-server-runtime:11.0.0:alpha1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:infinispan:infinispan-server-runtime:11.0.0:alpha1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "infinispan",
+      "Product": "infinispan-server-runtime",
+      "Version": "11.0.0",
+      "Update": "alpha1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.3.485:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.3.485",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.3.485",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bytecodealliance:cranelift-codegen:0.17.0:alpha:*:*:*:rust:*:*",
+    "cpe-url": "cpe:/a:bytecodealliance:cranelift-codegen:0.17.0:alpha:~~~rust~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bytecodealliance",
+      "Product": "cranelift-codegen",
+      "Version": "0.17.0",
+      "Update": "alpha",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "rust",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zeit:next.js:9.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zeit:next.js:9.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zeit",
+      "Product": "next.js",
+      "Version": "9.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ansible-vault_project:ansible-vault:1.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ansible-vault_project:ansible-vault:1.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ansible-vault_project",
+      "Product": "ansible-vault",
+      "Version": "1.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:sg300-28p_firmware:1.4.8.06:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:sg300-28p_firmware:1.4.8.06",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "sg300-28p_firmware",
+      "Version": "1.4.8.06",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:digium:asterisk:1.4.40:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:digium:asterisk:1.4.40:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "digium",
+      "Product": "asterisk",
+      "Version": "1.4.40",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:idrive:remotepc:7.6.26:*:*:*:*:macos:*:*",
+    "cpe-url": "cpe:/a:idrive:remotepc:7.6.26::~~~macos~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "idrive",
+      "Product": "remotepc",
+      "Version": "7.6.26",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "macos",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oracle:ireceivables:12.2.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oracle:ireceivables:12.2.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oracle",
+      "Product": "ireceivables",
+      "Version": "12.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloud_foundry:bits_service:2.25.0:dev7:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloud_foundry:bits_service:2.25.0:dev7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloud_foundry",
+      "Product": "bits_service",
+      "Version": "2.25.0",
+      "Update": "dev7",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zeromq:zeromq:0.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zeromq:zeromq:0.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zeromq",
+      "Product": "zeromq",
+      "Version": "0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mobyproject:moby:0.1.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mobyproject:moby:0.1.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mobyproject",
+      "Product": "moby",
+      "Version": "0.1.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:jira:3.7:*:enterprise:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlassian:jira:3.7::enterprise",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "jira",
+      "Version": "3.7",
+      "Update": "",
+      "Edition": "enterprise",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:ac_9462_firmware:22.40:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:ac_9462_firmware:22.40",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "ac_9462_firmware",
+      "Version": "22.40",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:lenovo:thinkpad_usb_3.0_ethernet_adapter:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:lenovo:thinkpad_usb_3.0_ethernet_adapter:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "lenovo",
+      "Product": "thinkpad_usb_3.0_ethernet_adapter",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:ui:unifi_dream_machine_pro_firmware:1.8.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:ui:unifi_dream_machine_pro_firmware:1.8.4",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "ui",
+      "Product": "unifi_dream_machine_pro_firmware",
+      "Version": "1.8.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:php:php:3.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:php:php:3.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "php",
+      "Product": "php",
+      "Version": "3.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:handsontable:handsontable:0.32.0:beta2:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:handsontable:handsontable:0.32.0:beta2:~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "handsontable",
+      "Product": "handsontable",
+      "Version": "0.32.0",
+      "Update": "beta2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:charlesproxy:charles:3.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:charlesproxy:charles:3.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "charlesproxy",
+      "Product": "charles",
+      "Version": "3.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:f5:big-ip_analytics:13.1.1.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:f5:big-ip_analytics:13.1.1.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "f5",
+      "Product": "big-ip_analytics",
+      "Version": "13.1.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:jenkins:1.437:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jenkins:jenkins:1.437",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "jenkins",
+      "Version": "1.437",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:shout_project:shout:0.32.5:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:shout_project:shout:0.32.5::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "shout_project",
+      "Product": "shout",
+      "Version": "0.32.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openenergymonitor:emoncms:10.1.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openenergymonitor:emoncms:10.1.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openenergymonitor",
+      "Product": "emoncms",
+      "Version": "10.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:advancedcustomfields:advanced_custom_fields:5.5.7:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:advancedcustomfields:advanced_custom_fields:5.5.7::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "advancedcustomfields",
+      "Product": "advanced_custom_fields",
+      "Version": "5.5.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cpanel:cpanel:11.38.0.19:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cpanel:cpanel:11.38.0.19",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cpanel",
+      "Product": "cpanel",
+      "Version": "11.38.0.19",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ovirt:ovirt:4.2.4.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ovirt:ovirt:4.2.4.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ovirt",
+      "Product": "ovirt",
+      "Version": "4.2.4.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ruamel.yaml_project:ruamel.yaml:0.15.13:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ruamel.yaml_project:ruamel.yaml:0.15.13",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ruamel.yaml_project",
+      "Product": "ruamel.yaml",
+      "Version": "0.15.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:cisco:firepower_1020:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:cisco:firepower_1020:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "cisco",
+      "Product": "firepower_1020",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:libsoup:2.34.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:libsoup:2.34.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "libsoup",
+      "Version": "2.34.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:setuptools:36.2.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:setuptools:36.2.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "setuptools",
+      "Version": "36.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sonarsource:sonarqube_docker_image:6.7.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sonarsource:sonarqube_docker_image:6.7.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sonarsource",
+      "Product": "sonarqube_docker_image",
+      "Version": "6.7.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gatsbyjs:gatsby-source-wordpress:3.1.70:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:gatsbyjs:gatsby-source-wordpress:3.1.70::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gatsbyjs",
+      "Product": "gatsby-source-wordpress",
+      "Version": "3.1.70",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:jboss-ejb-client:4.0.0:cr6:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:jboss-ejb-client:4.0.0:cr6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "jboss-ejb-client",
+      "Version": "4.0.0",
+      "Update": "cr6",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:octopus:tentacle:6.1.1016:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:octopus:tentacle:6.1.1016",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "octopus",
+      "Product": "tentacle",
+      "Version": "6.1.1016",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dpl:product_feed_on_woocommerce_for_google\\,_awin\\,_shareasale\\,_bing\\,_and_more:3.0.0.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:dpl:product_feed_on_woocommerce_for_google%2c_awin%2c_shareasale%2c_bing%2c_and_more:3.0.0.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dpl",
+      "Product": "product_feed_on_woocommerce_for_google,_awin,_shareasale,_bing,_and_more",
+      "Version": "3.0.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:xeon_e5-1428l_v3_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:xeon_e5-1428l_v3_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "xeon_e5-1428l_v3_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:netgear:r7000p_firmware:v1.0.11.100_10.2.100:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:netgear:r7000p_firmware:v1.0.11.100_10.2.100",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "netgear",
+      "Product": "r7000p_firmware",
+      "Version": "v1.0.11.100_10.2.100",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:lynxtechnology:twonky_server:7.3.1-3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:lynxtechnology:twonky_server:7.3.1-3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "lynxtechnology",
+      "Product": "twonky_server",
+      "Version": "7.3.1-3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:shareaholic:shareaholic:7.0.4.7:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:shareaholic:shareaholic:7.0.4.7::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "shareaholic",
+      "Product": "shareaholic",
+      "Version": "7.0.4.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:12.2\\(31\\)sga9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:12.2%2831%29sga9",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "12.2(31)sga9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:veronalabs:wp_statistics:8.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:veronalabs:wp_statistics:8.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "veronalabs",
+      "Product": "wp_statistics",
+      "Version": "8.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zom:zom:1.0.17:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:zom:zom:1.0.17::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zom",
+      "Product": "zom",
+      "Version": "1.0.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:codepeople:appointment_booking_calendar:1.2.44:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:codepeople:appointment_booking_calendar:1.2.44::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "codepeople",
+      "Product": "appointment_booking_calendar",
+      "Version": "1.2.44",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxcontainers:lxd:2.0.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxcontainers:lxd:2.0.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxcontainers",
+      "Product": "lxd",
+      "Version": "2.0.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bochs_project:bochs:2.0:pre1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bochs_project:bochs:2.0:pre1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bochs_project",
+      "Product": "bochs",
+      "Version": "2.0",
+      "Update": "pre1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:qualcomm:smb1394_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:qualcomm:smb1394_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "qualcomm",
+      "Product": "smb1394_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.4a.015:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.4a.015",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.4a.015",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:superantispyware:superantispyware:4.26.1002:*:*:*:professional:*:*:*",
+    "cpe-url": "cpe:/a:superantispyware:superantispyware:4.26.1002::~~professional~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "superantispyware",
+      "Product": "superantispyware",
+      "Version": "4.26.1002",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "professional",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:silverstripe:silverstripe:2.4.4:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:silverstripe:silverstripe:2.4.4:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "silverstripe",
+      "Product": "silverstripe",
+      "Version": "2.4.4",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:advantech:webaccess:7.0-2010.05.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:advantech:webaccess:7.0-2010.05.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "advantech",
+      "Product": "webaccess",
+      "Version": "7.0-2010.05.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tinyxml2_project:tinyxml2:5.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tinyxml2_project:tinyxml2:5.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tinyxml2_project",
+      "Product": "tinyxml2",
+      "Version": "5.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:eclipse:jetty:4.2.23:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:eclipse:jetty:4.2.23:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "eclipse",
+      "Product": "jetty",
+      "Version": "4.2.23",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:property-expr_project:property-expr:1.0.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:property-expr_project:property-expr:1.0.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "property-expr_project",
+      "Product": "property-expr",
+      "Version": "1.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:netgear:srs60_firmware:2.5.2.104:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:netgear:srs60_firmware:2.5.2.104",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "netgear",
+      "Product": "srs60_firmware",
+      "Version": "2.5.2.104",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spinnaker:orca:6.77.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:spinnaker:orca:6.77.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spinnaker",
+      "Product": "orca",
+      "Version": "6.77.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:protobufjs_project:protobufjs:1.0.0:beta5:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:protobufjs_project:protobufjs:1.0.0:beta5:~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "protobufjs_project",
+      "Product": "protobufjs",
+      "Version": "1.0.0",
+      "Update": "beta5",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:imagemagick:imagemagick:6.4.5-9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:imagemagick:imagemagick:6.4.5-9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "imagemagick",
+      "Product": "imagemagick",
+      "Version": "6.4.5-9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:evolution-ews:3.8.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:evolution-ews:3.8.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "evolution-ews",
+      "Version": "3.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openstack:horizon:18.3.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openstack:horizon:18.3.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openstack",
+      "Product": "horizon",
+      "Version": "18.3.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:advanced_access_manager_project:advanced_access_manager:6.3.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:advanced_access_manager_project:advanced_access_manager:6.3.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "advanced_access_manager_project",
+      "Product": "advanced_access_manager",
+      "Version": "6.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rails_admin_project:rails_admin:0.6.8:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:rails_admin_project:rails_admin:0.6.8::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rails_admin_project",
+      "Product": "rails_admin",
+      "Version": "0.6.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:moxa:nport_ia5150a_firmware:1.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:moxa:nport_ia5150a_firmware:1.4",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "moxa",
+      "Product": "nport_ia5150a_firmware",
+      "Version": "1.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jkeenan:file-path_module:2.09:*:*:*:*:perl:*:*",
+    "cpe-url": "cpe:/a:jkeenan:file-path_module:2.09::~~~perl~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jkeenan",
+      "Product": "file-path_module",
+      "Version": "2.09",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "perl",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:corusent:global_tv:4.3.1:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:corusent:global_tv:4.3.1::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "corusent",
+      "Product": "global_tv",
+      "Version": "4.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ldapauth_project:ldapauth:2.3.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:ldapauth_project:ldapauth:2.3.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ldapauth_project",
+      "Product": "ldapauth",
+      "Version": "2.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openvswitch:openvswitch:2.9.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openvswitch:openvswitch:2.9.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openvswitch",
+      "Product": "openvswitch",
+      "Version": "2.9.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:packagekit_project:packagekit:0.8.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:packagekit_project:packagekit:0.8.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "packagekit_project",
+      "Product": "packagekit",
+      "Version": "0.8.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:piwik:piwik:1.11.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:piwik:piwik:1.11.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "piwik",
+      "Product": "piwik",
+      "Version": "1.11.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.1609:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.1609",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.1609",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:npmjs:npm:1.2.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:npmjs:npm:1.2.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "npmjs",
+      "Product": "npm",
+      "Version": "1.2.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:maximo_for_aviation:7.6.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:maximo_for_aviation:7.6.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "maximo_for_aviation",
+      "Version": "7.6.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:infinispan:infinispan:12.0.0:dev07:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:infinispan:infinispan:12.0.0:dev07",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "infinispan",
+      "Product": "infinispan",
+      "Version": "12.0.0",
+      "Update": "dev07",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:exponentcms:exponent_cms:2.3.5:patch2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:exponentcms:exponent_cms:2.3.5:patch2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "exponentcms",
+      "Product": "exponent_cms",
+      "Version": "2.3.5",
+      "Update": "patch2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:puppet:facter:3.1.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:puppet:facter:3.1.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "puppet",
+      "Product": "facter",
+      "Version": "3.1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:boot2docker:boot2docker:17.11.0:rc2:*:*:community:*:*:*",
+    "cpe-url": "cpe:/o:boot2docker:boot2docker:17.11.0:rc2:~~community~~~",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "boot2docker",
+      "Product": "boot2docker",
+      "Version": "17.11.0",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "community",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:flask-appbuilder_project:flask-appbuilder:1.9.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:flask-appbuilder_project:flask-appbuilder:1.9.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "flask-appbuilder_project",
+      "Product": "flask-appbuilder",
+      "Version": "1.9.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:samsung:tizenrt:3.0:gbb:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:samsung:tizenrt:3.0:gbb",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "samsung",
+      "Product": "tizenrt",
+      "Version": "3.0",
+      "Update": "gbb",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bit_project:bit:0.6.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bit_project:bit:0.6.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bit_project",
+      "Product": "bit",
+      "Version": "0.6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.3.300:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.3.300",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.3.300",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:isc:dhcp:4.1-esv:r8_rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:isc:dhcp:4.1-esv:r8_rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "isc",
+      "Product": "dhcp",
+      "Version": "4.1-esv",
+      "Update": "r8_rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:bosh_cli:0.0.95:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:bosh_cli:0.0.95",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "bosh_cli",
+      "Version": "0.0.95",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fortinet:fortimail:5.1.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fortinet:fortimail:5.1.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fortinet",
+      "Product": "fortimail",
+      "Version": "5.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:bitbucket:4.14.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlassian:bitbucket:4.14.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "bitbucket",
+      "Version": "4.14.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libnl_project:libnl:3.2.21:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libnl_project:libnl:3.2.21",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libnl_project",
+      "Product": "libnl",
+      "Version": "3.2.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:livezilla:livezilla:7.0.2.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:livezilla:livezilla:7.0.2.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "livezilla",
+      "Product": "livezilla",
+      "Version": "7.0.2.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gwolle_guestbook_project:gwolle_guestbook:2.5.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:gwolle_guestbook_project:gwolle_guestbook:2.5.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gwolle_guestbook_project",
+      "Product": "gwolle_guestbook",
+      "Version": "2.5.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:microsoft:visual_studio_2019:8.1:*:*:*:*:macos:*:*",
+    "cpe-url": "cpe:/a:microsoft:visual_studio_2019:8.1::~~~macos~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "microsoft",
+      "Product": "visual_studio_2019",
+      "Version": "8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "macos",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:linux:acrn:2018w30.2-140000p:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:linux:acrn:2018w30.2-140000p",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "linux",
+      "Product": "acrn",
+      "Version": "2018w30.2-140000p",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:herry:sfpagent:0.4.9:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:herry:sfpagent:0.4.9::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "herry",
+      "Product": "sfpagent",
+      "Version": "0.4.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wedevs:happy_addons_for_elementor:2.21.0:*:*:*:-:wordpress:*:*",
+    "cpe-url": "cpe:/a:wedevs:happy_addons_for_elementor:2.21.0::~~-~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wedevs",
+      "Product": "happy_addons_for_elementor",
+      "Version": "2.21.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:iij:seil_b1_firmware:3.26:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:iij:seil_b1_firmware:3.26",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "iij",
+      "Product": "seil_b1_firmware",
+      "Version": "3.26",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mechanize_project:mechanize:0.8.3:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:mechanize_project:mechanize:0.8.3::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mechanize_project",
+      "Product": "mechanize",
+      "Version": "0.8.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:digium:certified_asterisk:1.2.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:digium:certified_asterisk:1.2.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "digium",
+      "Product": "certified_asterisk",
+      "Version": "1.2.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:dell:vostro_5401:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:dell:vostro_5401:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "dell",
+      "Product": "vostro_5401",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:canonical:microk8s:1.15.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:canonical:microk8s:1.15.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "canonical",
+      "Product": "microk8s",
+      "Version": "1.15.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:w3m_project:w3m:0.5.3-34.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:w3m_project:w3m:0.5.3-34.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "w3m_project",
+      "Product": "w3m",
+      "Version": "0.5.3-34.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wekan_project:wekan:2.59:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wekan_project:wekan:2.59",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wekan_project",
+      "Product": "wekan",
+      "Version": "2.59",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pippinsplugins:featured_comments:1.2.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:pippinsplugins:featured_comments:1.2.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pippinsplugins",
+      "Product": "featured_comments",
+      "Version": "1.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:signal:messenger:3.7.0:*:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:signal:messenger:3.7.0::~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "signal",
+      "Product": "messenger",
+      "Version": "3.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:youtube_embed_project:youtube_embed:5.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:youtube_embed_project:youtube_embed:5.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "youtube_embed_project",
+      "Product": "youtube_embed",
+      "Version": "5.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:camunda:modeler:4.6.0:rc0:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:camunda:modeler:4.6.0:rc0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "camunda",
+      "Product": "modeler",
+      "Version": "4.6.0",
+      "Update": "rc0",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:beanshell:beanshell:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:beanshell:beanshell:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "beanshell",
+      "Product": "beanshell",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:infolific:ultimate_category_excluder:0.2:beta:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:infolific:ultimate_category_excluder:0.2:beta:~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "infolific",
+      "Product": "ultimate_category_excluder",
+      "Version": "0.2",
+      "Update": "beta",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:isc:bind:9.7.1:rc1:*:*:-:*:*:*",
+    "cpe-url": "cpe:/a:isc:bind:9.7.1:rc1:~~-~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "isc",
+      "Product": "bind",
+      "Version": "9.7.1",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:shapeshift:keepkey_firmware:5.2.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:shapeshift:keepkey_firmware:5.2.2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "shapeshift",
+      "Product": "keepkey_firmware",
+      "Version": "5.2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:puppet:puppet:3.7.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:puppet:puppet:3.7.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "puppet",
+      "Product": "puppet",
+      "Version": "3.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sangoma:freepbx:13.0.119.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sangoma:freepbx:13.0.119.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sangoma",
+      "Product": "freepbx",
+      "Version": "13.0.119.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phpunit_project:phpunit:3.2.20:*:*:*:*:-:*:*",
+    "cpe-url": "cpe:/a:phpunit_project:phpunit:3.2.20::~~~-~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phpunit_project",
+      "Product": "phpunit",
+      "Version": "3.2.20",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "-",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:http.rb_project:http.rb:0.8.9:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:http.rb_project:http.rb:0.8.9::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "http.rb_project",
+      "Product": "http.rb",
+      "Version": "0.8.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:verbb:image_resizer:0.0.2:*:*:*:*:craft_cms:*:*",
+    "cpe-url": "cpe:/a:verbb:image_resizer:0.0.2::~~~craft_cms~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "verbb",
+      "Product": "image_resizer",
+      "Version": "0.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "craft_cms",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:minecraft:minecraft:1.17:*:*:*:java:*:*:*",
+    "cpe-url": "cpe:/a:minecraft:minecraft:1.17::~~java~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "minecraft",
+      "Product": "minecraft",
+      "Version": "1.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "java",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ip_conference_phone_7832_firmware:12.5\\(1\\)sr2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ip_conference_phone_7832_firmware:12.5%281%29sr2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ip_conference_phone_7832_firmware",
+      "Version": "12.5(1)sr2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpmobilepack:wordpress_mobile_pack:2.1.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpmobilepack:wordpress_mobile_pack:2.1.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpmobilepack",
+      "Product": "wordpress_mobile_pack",
+      "Version": "2.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:abus:secvest_wireless_remote_control_fube50015_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:abus:secvest_wireless_remote_control_fube50015_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "abus",
+      "Product": "secvest_wireless_remote_control_fube50015_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnu:mailman:2.1.14-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnu:mailman:2.1.14-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnu",
+      "Product": "mailman",
+      "Version": "2.1.14-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inedo:otter:1.5.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:inedo:otter:1.5.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inedo",
+      "Product": "otter",
+      "Version": "1.5.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:10web:photo_gallery:1.2.82:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:10web:photo_gallery:1.2.82::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "10web",
+      "Product": "photo_gallery",
+      "Version": "1.2.82",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nodejs:node.js:9.5.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nodejs:node.js:9.5.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nodejs",
+      "Product": "node.js",
+      "Version": "9.5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:the-guild:graphql-tools:0.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:the-guild:graphql-tools:0.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "the-guild",
+      "Product": "graphql-tools",
+      "Version": "0.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jetbrains:kotlin:1.4.0:dev250:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jetbrains:kotlin:1.4.0:dev250",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jetbrains",
+      "Product": "kotlin",
+      "Version": "1.4.0",
+      "Update": "dev250",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:restafary_project:restafary:1.6.4:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:restafary_project:restafary:1.6.4::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "restafary_project",
+      "Product": "restafary",
+      "Version": "1.6.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpshopstyling:wp-ecommerce-shop-styling:1.4:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpshopstyling:wp-ecommerce-shop-styling:1.4::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpshopstyling",
+      "Product": "wp-ecommerce-shop-styling",
+      "Version": "1.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:buttle_project:buttle:0.0.4:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:buttle_project:buttle:0.0.4::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "buttle_project",
+      "Product": "buttle",
+      "Version": "0.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ueberhamm-design:youtube_video_inserter:1.2.0.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ueberhamm-design:youtube_video_inserter:1.2.0.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ueberhamm-design",
+      "Product": "youtube_video_inserter",
+      "Version": "1.2.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:asr_5000_software:18.1_base:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:asr_5000_software:18.1_base",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "asr_5000_software",
+      "Version": "18.1_base",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:quagga:quagga:0.99.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:quagga:quagga:0.99.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "quagga",
+      "Product": "quagga",
+      "Version": "0.99.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cognitoys:stemosaur_firmware:0.0.794:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cognitoys:stemosaur_firmware:0.0.794",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cognitoys",
+      "Product": "stemosaur_firmware",
+      "Version": "0.0.794",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pagerduty:rundeck:3.4.3:rc2:*:*:community:*:*:*",
+    "cpe-url": "cpe:/a:pagerduty:rundeck:3.4.3:rc2:~~community~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pagerduty",
+      "Product": "rundeck",
+      "Version": "3.4.3",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "community",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudfoundry:cf-deployment:7.10.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudfoundry:cf-deployment:7.10.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudfoundry",
+      "Product": "cf-deployment",
+      "Version": "7.10.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:litespeedtech:litespeed_cache:2.9.7.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:litespeedtech:litespeed_cache:2.9.7.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "litespeedtech",
+      "Product": "litespeed_cache",
+      "Version": "2.9.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netflix:priam:3.11.33:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netflix:priam:3.11.33",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netflix",
+      "Product": "priam",
+      "Version": "3.11.33",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.0086:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.0086",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.0086",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bolt:bolt_cms:3.3.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bolt:bolt_cms:3.3.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bolt",
+      "Product": "bolt_cms",
+      "Version": "3.3.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:synacor:zimbra_collaboration_suite:8.8.8:patch10:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:synacor:zimbra_collaboration_suite:8.8.8:patch10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "synacor",
+      "Product": "zimbra_collaboration_suite",
+      "Version": "8.8.8",
+      "Update": "patch10",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:credhub-release:2.5.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:credhub-release:2.5.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "credhub-release",
+      "Version": "2.5.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gluster:glusterfs:3.5.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gluster:glusterfs:3.5.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gluster",
+      "Product": "glusterfs",
+      "Version": "3.5.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:glib:2.27.92:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:glib:2.27.92",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "glib",
+      "Version": "2.27.92",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rom_walton:boinc:7.0.67:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rom_walton:boinc:7.0.67",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rom_walton",
+      "Product": "boinc",
+      "Version": "7.0.67",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:geode:1.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:geode:1.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "geode",
+      "Version": "1.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:online_bus_booking_system_project:online_bus_booking_system:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:online_bus_booking_system_project:online_bus_booking_system:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "online_bus_booking_system_project",
+      "Product": "online_bus_booking_system",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:jspwiki:2.9.0:incubating_rc4:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:jspwiki:2.9.0:incubating_rc4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "jspwiki",
+      "Version": "2.9.0",
+      "Update": "incubating_rc4",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:z.cash:zcash:1.0.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:z.cash:zcash:1.0.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "z.cash",
+      "Product": "zcash",
+      "Version": "1.0.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:cloud_foundry:221:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:cloud_foundry:221",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "cloud_foundry",
+      "Version": "221",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ays-pro:quiz_maker:6.2.1.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ays-pro:quiz_maker:6.2.1.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ays-pro",
+      "Product": "quiz_maker",
+      "Version": "6.2.1.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:torproject:tor_browser:7.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:torproject:tor_browser:7.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "torproject",
+      "Product": "tor_browser",
+      "Version": "7.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:revive-adserver:revive_adserver:3.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:revive-adserver:revive_adserver:3.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "revive-adserver",
+      "Product": "revive_adserver",
+      "Version": "3.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:opennms:meridian:2019.1.14-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:opennms:meridian:2019.1.14-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "opennms",
+      "Product": "meridian",
+      "Version": "2019.1.14-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bitcoincore:bitcoin_core:0.7.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bitcoincore:bitcoin_core:0.7.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bitcoincore",
+      "Product": "bitcoin_core",
+      "Version": "0.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:aws_elastic_beanstalk_publisher:1.4.1:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:aws_elastic_beanstalk_publisher:1.4.1::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "aws_elastic_beanstalk_publisher",
+      "Version": "1.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpml:wpml:2.6.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpml:wpml:2.6.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpml",
+      "Product": "wpml",
+      "Version": "2.6.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:saasproject:booking_package:1.2.72:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:saasproject:booking_package:1.2.72::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "saasproject",
+      "Product": "booking_package",
+      "Version": "1.2.72",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rsvpmaker_project:rsvpmaker:0.7.4:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:rsvpmaker_project:rsvpmaker:0.7.4::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rsvpmaker_project",
+      "Product": "rsvpmaker",
+      "Version": "0.7.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudfoundry:credhub:1.3.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudfoundry:credhub:1.3.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudfoundry",
+      "Product": "credhub",
+      "Version": "1.3.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:horde:horde_prefs:2.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:horde:horde_prefs:2.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "horde",
+      "Product": "horde_prefs",
+      "Version": "2.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:linux:linux_kernel:2.6.5:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:linux:linux_kernel:2.6.5:rc3",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "linux",
+      "Product": "linux_kernel",
+      "Version": "2.6.5",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:restsharp:restsharp:106.6.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:restsharp:restsharp:106.6.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "restsharp",
+      "Product": "restsharp",
+      "Version": "106.6.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:lenovo:thinkagile_7y12:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:lenovo:thinkagile_7y12:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "lenovo",
+      "Product": "thinkagile_7y12",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hashicorp:vault:0.8.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hashicorp:vault:0.8.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hashicorp",
+      "Product": "vault",
+      "Version": "0.8.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wppopupmaker:popup_maker:1.5.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wppopupmaker:popup_maker:1.5.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wppopupmaker",
+      "Product": "popup_maker",
+      "Version": "1.5.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:netgear:r6020_firmware:1.0.0.48:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:netgear:r6020_firmware:1.0.0.48",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "netgear",
+      "Product": "r6020_firmware",
+      "Version": "1.0.0.48",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:verdaccio:verdaccio:0.1.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:verdaccio:verdaccio:0.1.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "verdaccio",
+      "Product": "verdaccio",
+      "Version": "0.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:nvidia:quadro_m3000m:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:nvidia:quadro_m3000m:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "nvidia",
+      "Product": "quadro_m3000m",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:s2600cwt_firmware:01.01.0029:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:s2600cwt_firmware:01.01.0029",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "s2600cwt_firmware",
+      "Version": "01.01.0029",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxfoundation:jaeger:1.7.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxfoundation:jaeger:1.7.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxfoundation",
+      "Product": "jaeger",
+      "Version": "1.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:brainstormforce:starter_templates:1.2.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:brainstormforce:starter_templates:1.2.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "brainstormforce",
+      "Product": "starter_templates",
+      "Version": "1.2.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oisf:suricata:2.0.1:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oisf:suricata:2.0.1:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oisf",
+      "Product": "suricata",
+      "Version": "2.0.1",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inedo:buildmaster:5.0.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:inedo:buildmaster:5.0.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inedo",
+      "Product": "buildmaster",
+      "Version": "5.0.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:typelevel:http4s:0.16.0:milestone2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:typelevel:http4s:0.16.0:milestone2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "typelevel",
+      "Product": "http4s",
+      "Version": "0.16.0",
+      "Update": "milestone2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vovsoft:vov_sticky_notes:6.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vovsoft:vov_sticky_notes:6.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vovsoft",
+      "Product": "vov_sticky_notes",
+      "Version": "6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bitnami:containers:7.6.0-debian-10-r38:*:*:*:*:laravel:*:*",
+    "cpe-url": "cpe:/a:bitnami:containers:7.6.0-debian-10-r38::~~~laravel~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bitnami",
+      "Product": "containers",
+      "Version": "7.6.0-debian-10-r38",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "laravel",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:glib:2.6.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:glib:2.6.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "glib",
+      "Version": "2.6.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:schedmd:slurm:18.08.0.0:pre1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:schedmd:slurm:18.08.0.0:pre1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "schedmd",
+      "Product": "slurm",
+      "Version": "18.08.0.0",
+      "Update": "pre1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:29.0.1547.31:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:29.0.1547.31",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "29.0.1547.31",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.1502:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.1502",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.1502",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:weekly_schedule_project:weekly_schedule:2.2.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:weekly_schedule_project:weekly_schedule:2.2.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "weekly_schedule_project",
+      "Product": "weekly_schedule",
+      "Version": "2.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:websphere_commerce:8.0.4.10:*:*:*:professional:*:*:*",
+    "cpe-url": "cpe:/a:ibm:websphere_commerce:8.0.4.10::~~professional~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "websphere_commerce",
+      "Version": "8.0.4.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "professional",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:chef:chef:15.4.61:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:chef:chef:15.4.61",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "chef",
+      "Product": "chef",
+      "Version": "15.4.61",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:bodhi:2.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:bodhi:2.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "bodhi",
+      "Version": "2.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cartpauj:mingle-forum:1.0.18:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cartpauj:mingle-forum:1.0.18",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cartpauj",
+      "Product": "mingle-forum",
+      "Version": "1.0.18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wclovers:frontend_manager_for_woocommerce_along_with_bookings_subscription_listings_compatible:2.0.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wclovers:frontend_manager_for_woocommerce_along_with_bookings_subscription_listings_compatible:2.0.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wclovers",
+      "Product": "frontend_manager_for_woocommerce_along_with_bookings_subscription_listings_compatible",
+      "Version": "2.0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tryton:trytond:3.6.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tryton:trytond:3.6.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tryton",
+      "Product": "trytond",
+      "Version": "3.6.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cmsmadesimple:form_builder:0.6b1:*:*:*:*:cms_made_simple:*:*",
+    "cpe-url": "cpe:/a:cmsmadesimple:form_builder:0.6b1::~~~cms_made_simple~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cmsmadesimple",
+      "Product": "form_builder",
+      "Version": "0.6b1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "cms_made_simple",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:15.2\\(4\\)jb6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:15.2%284%29jb6",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "15.2(4)jb6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ldap_\\/_sso_authentication_project:ldap_\\/_sso_authentication:3.2.1:*:*:*:*:typo3:*:*",
+    "cpe-url": "cpe:/a:ldap_%2f_sso_authentication_project:ldap_%2f_sso_authentication:3.2.1::~~~typo3~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ldap_/_sso_authentication_project",
+      "Product": "ldap_/_sso_authentication",
+      "Version": "3.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "typo3",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adaltas:printf:0.2.3:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:adaltas:printf:0.2.3::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adaltas",
+      "Product": "printf",
+      "Version": "0.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:raitan:commandcenter_secure_gateway:5.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:raitan:commandcenter_secure_gateway:5.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "raitan",
+      "Product": "commandcenter_secure_gateway",
+      "Version": "5.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adobe:acrobat:9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:adobe:acrobat:9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adobe",
+      "Product": "acrobat",
+      "Version": "9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:klibc_project:klibc:0.172:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:klibc_project:klibc:0.172",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "klibc_project",
+      "Product": "klibc",
+      "Version": "0.172",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:luke_herrington:stickynote:7.x-1.x:dev:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:luke_herrington:stickynote:7.x-1.x:dev",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "luke_herrington",
+      "Product": "stickynote",
+      "Version": "7.x-1.x",
+      "Update": "dev",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oppia:oppia:2.6.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oppia:oppia:2.6.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oppia",
+      "Product": "oppia",
+      "Version": "2.6.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:abb:800xa_system:6.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:abb:800xa_system:6.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "abb",
+      "Product": "800xa_system",
+      "Version": "6.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:12.2\\(2\\)xb9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:12.2%282%29xb9",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "12.2(2)xb9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:perl:dbi:0.92:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:perl:dbi:0.92",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "perl",
+      "Product": "dbi",
+      "Version": "0.92",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:cordova:1.0.0:rc1:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:apache:cordova:1.0.0:rc1:~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "cordova",
+      "Version": "1.0.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:contiki-os:contiki:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:contiki-os:contiki:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "contiki-os",
+      "Product": "contiki",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:owncloud:owncloud_desktop_client:2.2.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:owncloud:owncloud_desktop_client:2.2.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "owncloud",
+      "Product": "owncloud_desktop_client",
+      "Version": "2.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:microsoft:windows_2000:-:sp2:*:*:server:*:*:*",
+    "cpe-url": "cpe:/o:microsoft:windows_2000:-:sp2:~~server~~~",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "microsoft",
+      "Product": "windows_2000",
+      "Version": "-",
+      "Update": "sp2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "server",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:simple-membership-plugin:simple_membership:1.8.4:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:simple-membership-plugin:simple_membership:1.8.4::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "simple-membership-plugin",
+      "Product": "simple_membership",
+      "Version": "1.8.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:f8b04a:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:f8b04a:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "f8b04a",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netsweeper:netsweeper:4.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netsweeper:netsweeper:4.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netsweeper",
+      "Product": "netsweeper",
+      "Version": "4.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.3.529:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.3.529",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.3.529",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sqlalchemy:sqlalchemy:0.9.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sqlalchemy:sqlalchemy:0.9.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sqlalchemy",
+      "Product": "sqlalchemy",
+      "Version": "0.9.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ctfd:ctfd:2.2.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ctfd:ctfd:2.2.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ctfd",
+      "Product": "ctfd",
+      "Version": "2.2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.4.447:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.4.447",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.4.447",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:iodata:hdl2-a_firmware:1.07:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:iodata:hdl2-a_firmware:1.07",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "iodata",
+      "Product": "hdl2-a_firmware",
+      "Version": "1.07",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:xeon_e5-1630_v3:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:xeon_e5-1630_v3:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "xeon_e5-1630_v3",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:cloud_foundry_uaa_bosh:24.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:cloud_foundry_uaa_bosh:24.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "cloud_foundry_uaa_bosh",
+      "Version": "24.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netflix:hollow:2.4.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netflix:hollow:2.4.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netflix",
+      "Product": "hollow",
+      "Version": "2.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:webmin:usermin:1.770:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:webmin:usermin:1.770",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "webmin",
+      "Product": "usermin",
+      "Version": "1.770",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:recon-ng_project:recon-ng:3.4.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:recon-ng_project:recon-ng:3.4.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "recon-ng_project",
+      "Product": "recon-ng",
+      "Version": "3.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spinnaker:orca:0.439:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:spinnaker:orca:0.439",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spinnaker",
+      "Product": "orca",
+      "Version": "0.439",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:r-consortium:rmysql:0.10.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:r-consortium:rmysql:0.10.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "r-consortium",
+      "Product": "rmysql",
+      "Version": "0.10.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wekan_project:wekan:4.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wekan_project:wekan:4.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wekan_project",
+      "Product": "wekan",
+      "Version": "4.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phpmyadmin:phpmyadmin:1.2.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:phpmyadmin:phpmyadmin:1.2.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phpmyadmin",
+      "Product": "phpmyadmin",
+      "Version": "1.2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zmanda:amanda:2.5.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zmanda:amanda:2.5.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zmanda",
+      "Product": "amanda",
+      "Version": "2.5.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:ips_sensor_software:5.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:ips_sensor_software:5.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "ips_sensor_software",
+      "Version": "5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:koha:koha:16.05.00:beta:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:koha:koha:16.05.00:beta",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "koha",
+      "Product": "koha",
+      "Version": "16.05.00",
+      "Update": "beta",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pizzashack:rssh:2.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pizzashack:rssh:2.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pizzashack",
+      "Product": "rssh",
+      "Version": "2.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:elastic:kibana_x-pack:5.4.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:elastic:kibana_x-pack:5.4.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "elastic",
+      "Product": "kibana_x-pack",
+      "Version": "5.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dropbox:dropbox:72.2:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:dropbox:dropbox:72.2::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dropbox",
+      "Product": "dropbox",
+      "Version": "72.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hygeia_project:hygeia:1.0.2:beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hygeia_project:hygeia:1.0.2:beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hygeia_project",
+      "Product": "hygeia",
+      "Version": "1.0.2",
+      "Update": "beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:12.3\\(8\\)jea:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:12.3%288%29jea",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "12.3(8)jea",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:quizandsurveymaster:quiz_and_survey_master:4.4.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:quizandsurveymaster:quiz_and_survey_master:4.4.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "quizandsurveymaster",
+      "Product": "quiz_and_survey_master",
+      "Version": "4.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:denx:u-boot:1.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:denx:u-boot:1.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "denx",
+      "Product": "u-boot",
+      "Version": "1.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.1.2374:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.1.2374",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.1.2374",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:avaya:aura_communication_manager:7.1.3.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:avaya:aura_communication_manager:7.1.3.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "avaya",
+      "Product": "aura_communication_manager",
+      "Version": "7.1.3.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:huawei:secospace_usg6600_firmware:v500r001c00spc050:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:huawei:secospace_usg6600_firmware:v500r001c00spc050",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "huawei",
+      "Product": "secospace_usg6600_firmware",
+      "Version": "v500r001c00spc050",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kiboit:phastpress:1.49:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:kiboit:phastpress:1.49::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kiboit",
+      "Product": "phastpress",
+      "Version": "1.49",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vercel:next.js:1.0.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:vercel:next.js:1.0.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vercel",
+      "Product": "next.js",
+      "Version": "1.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:scala-lang:scala:2.13.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:scala-lang:scala:2.13.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "scala-lang",
+      "Product": "scala",
+      "Version": "2.13.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:agilebits:knox:2.1.9:-:*:*:*:mac_os_x:*:*",
+    "cpe-url": "cpe:/a:agilebits:knox:2.1.9:-:~~~mac_os_x~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "agilebits",
+      "Product": "knox",
+      "Version": "2.1.9",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "mac_os_x",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sqreen:php_microagent:1.9.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sqreen:php_microagent:1.9.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sqreen",
+      "Product": "php_microagent",
+      "Version": "1.9.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:h5ai_project:h5ai:0.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:h5ai_project:h5ai:0.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "h5ai_project",
+      "Product": "h5ai",
+      "Version": "0.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:weechat:weechat:3.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:weechat:weechat:3.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "weechat",
+      "Product": "weechat",
+      "Version": "3.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:rabbitmq:1.9.8:*:*:*:*:pivotal_cloud_foundry:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:rabbitmq:1.9.8::~~~pivotal_cloud_foundry~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "rabbitmq",
+      "Version": "1.9.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "pivotal_cloud_foundry",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:12.1eu:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:12.1eu",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "12.1eu",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ntp:ntp:4.2.7:p349:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ntp:ntp:4.2.7:p349",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ntp",
+      "Product": "ntp",
+      "Version": "4.2.7",
+      "Update": "p349",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mariadb:mariadb:10.2.26:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mariadb:mariadb:10.2.26",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mariadb",
+      "Product": "mariadb",
+      "Version": "10.2.26",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudbees:jenkins:1.424.1:-:lts:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudbees:jenkins:1.424.1:-:lts",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudbees",
+      "Product": "jenkins",
+      "Version": "1.424.1",
+      "Update": "-",
+      "Edition": "lts",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:colossusxt:colossuscoinxt:0.3.23:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:colossusxt:colossuscoinxt:0.3.23:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "colossusxt",
+      "Product": "colossuscoinxt",
+      "Version": "0.3.23",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fortinet:fortianalyzer:6.4.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fortinet:fortianalyzer:6.4.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fortinet",
+      "Product": "fortianalyzer",
+      "Version": "6.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gaku:tablacus_explorer:17.6.15:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gaku:tablacus_explorer:17.6.15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gaku",
+      "Product": "tablacus_explorer",
+      "Version": "17.6.15",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netsweeper:netsweeper:6.3.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netsweeper:netsweeper:6.3.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netsweeper",
+      "Product": "netsweeper",
+      "Version": "6.3.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:18.0.1006.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:18.0.1006.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "18.0.1006.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxfoundation:containerd:1.0.1:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxfoundation:containerd:1.0.1:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxfoundation",
+      "Product": "containerd",
+      "Version": "1.0.1",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:convert\\:\\:asn1_project:convert\\:\\:asn1:0.27:*:*:*:*:perl:*:*",
+    "cpe-url": "cpe:/a:convert%3a%3aasn1_project:convert%3a%3aasn1:0.27::~~~perl~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "convert::asn1_project",
+      "Product": "convert::asn1",
+      "Version": "0.27",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "perl",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sandhillsdev:easy_digital_downloads:2.1.9:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:sandhillsdev:easy_digital_downloads:2.1.9::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sandhillsdev",
+      "Product": "easy_digital_downloads",
+      "Version": "2.1.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ffmpeg:ffmpeg:2.8.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ffmpeg:ffmpeg:2.8.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ffmpeg",
+      "Product": "ffmpeg",
+      "Version": "2.8.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:txjia:imcat:3.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:txjia:imcat:3.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "txjia",
+      "Product": "imcat",
+      "Version": "3.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spiffyplugins:spiffy_calendar:3.4.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:spiffyplugins:spiffy_calendar:3.4.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spiffyplugins",
+      "Product": "spiffy_calendar",
+      "Version": "3.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tryton:trytond:1.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tryton:trytond:1.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tryton",
+      "Product": "trytond",
+      "Version": "1.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:openpyxl:2.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:openpyxl:2.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "openpyxl",
+      "Version": "2.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:keybase:keybase:1.0.29:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:keybase:keybase:1.0.29",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "keybase",
+      "Product": "keybase",
+      "Version": "1.0.29",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mozilla:nss:3.60:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mozilla:nss:3.60",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mozilla",
+      "Product": "nss",
+      "Version": "3.60",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:designmodo:wp_maintenance_mode:1.8.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:designmodo:wp_maintenance_mode:1.8.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "designmodo",
+      "Product": "wp_maintenance_mode",
+      "Version": "1.8.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:brave:brave:0.15.314:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:brave:brave:0.15.314",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "brave",
+      "Product": "brave",
+      "Version": "0.15.314",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:iij:seil_b1_firmware:3.48:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:iij:seil_b1_firmware:3.48",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "iij",
+      "Product": "seil_b1_firmware",
+      "Version": "3.48",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:core_i7:4790s:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:core_i7:4790s",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "core_i7",
+      "Version": "4790s",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sophos:unified_threat_management_up2date:9.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sophos:unified_threat_management_up2date:9.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sophos",
+      "Product": "unified_threat_management_up2date",
+      "Version": "9.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:plainware:hitappoint:6.4.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:plainware:hitappoint:6.4.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "plainware",
+      "Product": "hitappoint",
+      "Version": "6.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zabbix:zabbix:1.8.4:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zabbix:zabbix:1.8.4:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zabbix",
+      "Product": "zabbix",
+      "Version": "1.8.4",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:espressif:esp32_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:espressif:esp32_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "espressif",
+      "Product": "esp32_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:signal:messenger:1.8.2:*:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:signal:messenger:1.8.2::~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "signal",
+      "Product": "messenger",
+      "Version": "1.8.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tendermint:tendermint:0.26.0:rc0:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tendermint:tendermint:0.26.0:rc0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tendermint",
+      "Product": "tendermint",
+      "Version": "0.26.0",
+      "Update": "rc0",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:brave:brave:1.27.107:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:brave:brave:1.27.107",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "brave",
+      "Product": "brave",
+      "Version": "1.27.107",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sumatrapdfreader:sumatrapdf:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sumatrapdfreader:sumatrapdf:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sumatrapdfreader",
+      "Product": "sumatrapdf",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:siemens:simatic_ipc647c:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:siemens:simatic_ipc647c:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "siemens",
+      "Product": "simatic_ipc647c",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:codiad:codiad:2.2.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:codiad:codiad:2.2.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "codiad",
+      "Product": "codiad",
+      "Version": "2.2.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:confluence_data_center:3.5.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlassian:confluence_data_center:3.5.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "confluence_data_center",
+      "Version": "3.5.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:iptanus:wordpress_file_upload:4.6.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:iptanus:wordpress_file_upload:4.6.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "iptanus",
+      "Product": "wordpress_file_upload",
+      "Version": "4.6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hp:nonstop_netbatch:j06.14.03:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hp:nonstop_netbatch:j06.14.03",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hp",
+      "Product": "nonstop_netbatch",
+      "Version": "j06.14.03",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.0412:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.0412",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.0412",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:emby:emby.releases:3.4.1.20:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:emby:emby.releases:3.4.1.20",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "emby",
+      "Product": "emby.releases",
+      "Version": "3.4.1.20",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:brave:brave:1.8.50:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:brave:brave:1.8.50",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "brave",
+      "Product": "brave",
+      "Version": "1.8.50",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apollosapp:data-connector-rock:2.3.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:apollosapp:data-connector-rock:2.3.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apollosapp",
+      "Product": "data-connector-rock",
+      "Version": "2.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:keyring:2.0.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:keyring:2.0.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "keyring",
+      "Version": "2.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sleuthkit:the_sleuth_kit:4.6.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sleuthkit:the_sleuth_kit:4.6.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sleuthkit",
+      "Product": "the_sleuth_kit",
+      "Version": "4.6.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adjam:rekonq:0.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:adjam:rekonq:0.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adjam",
+      "Product": "rekonq",
+      "Version": "0.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:unified_intelligence_center:11.6\\(1\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:unified_intelligence_center:11.6%281%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "unified_intelligence_center",
+      "Version": "11.6(1)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:5.0.332.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:5.0.332.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "5.0.332.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:pipeline_github_notify_step:1.0.5:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:pipeline_github_notify_step:1.0.5::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "pipeline_github_notify_step",
+      "Version": "1.0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netflix:hollow:4.8.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netflix:hollow:4.8.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netflix",
+      "Product": "hollow",
+      "Version": "4.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:impress:wp_rollback:1.2.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:impress:wp_rollback:1.2.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "impress",
+      "Product": "wp_rollback",
+      "Version": "1.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:concourse:0.6.0:rc21:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:concourse:0.6.0:rc21",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "concourse",
+      "Version": "0.6.0",
+      "Update": "rc21",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:nx-os:5.2\\(1\\)sm1\\(5.1\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:nx-os:5.2%281%29sm1%285.1%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "nx-os",
+      "Version": "5.2(1)sm1(5.1)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fortinet:fortiportal:4.2.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fortinet:fortiportal:4.2.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fortinet",
+      "Product": "fortiportal",
+      "Version": "4.2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:orbital:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:orbital:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "orbital",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:symantec:veritas_storage_foundation_for_windows:5.10.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:symantec:veritas_storage_foundation_for_windows:5.10.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "symantec",
+      "Product": "veritas_storage_foundation_for_windows",
+      "Version": "5.10.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jupyter:notebook:5.1.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jupyter:notebook:5.1.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jupyter",
+      "Product": "notebook",
+      "Version": "5.1.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:unity:web_player:4.5.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:unity:web_player:4.5.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "unity",
+      "Product": "web_player",
+      "Version": "4.5.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:m0p39a:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:m0p39a:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "m0p39a",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:knexjs:knex:0.7.5:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:knexjs:knex:0.7.5::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "knexjs",
+      "Product": "knex",
+      "Version": "0.7.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mailenable:mailenable:1.18:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:mailenable:mailenable:1.18::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mailenable",
+      "Product": "mailenable",
+      "Version": "1.18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:btcpayserver:btcpay_server:1.0.2.114:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:btcpayserver:btcpay_server:1.0.2.114",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "btcpayserver",
+      "Product": "btcpay_server",
+      "Version": "1.0.2.114",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:incubator_superset:0.34.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:incubator_superset:0.34.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "incubator_superset",
+      "Version": "0.34.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:asset_pipeline_project:asset-pipeline:2.13.0:*:*:*:*:grails:*:*",
+    "cpe-url": "cpe:/a:asset_pipeline_project:asset-pipeline:2.13.0::~~~grails~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "asset_pipeline_project",
+      "Product": "asset-pipeline",
+      "Version": "2.13.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "grails",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:flashbackrecorder:flashback:5.23.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:flashbackrecorder:flashback:5.23.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "flashbackrecorder",
+      "Product": "flashback",
+      "Version": "5.23.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:n9k-c9396tx_firmware:13.2\\(3n\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:n9k-c9396tx_firmware:13.2%283n%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "n9k-c9396tx_firmware",
+      "Version": "13.2(3n)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:flexense:diskboss:6.5:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:flexense:diskboss:6.5::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "flexense",
+      "Product": "diskboss",
+      "Version": "6.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dart:dart_software_development_kit:0.6.21.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:dart:dart_software_development_kit:0.6.21.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dart",
+      "Product": "dart_software_development_kit",
+      "Version": "0.6.21.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:activestate:activeperl:5.8.819:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:activestate:activeperl:5.8.819",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "activestate",
+      "Product": "activeperl",
+      "Version": "5.8.819",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:aedes_project:aedes:0.13.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:aedes_project:aedes:0.13.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "aedes_project",
+      "Product": "aedes",
+      "Version": "0.13.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:swoole:swoole_php_framework:1.13.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:swoole:swoole_php_framework:1.13.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "swoole",
+      "Product": "swoole_php_framework",
+      "Version": "1.13.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:credova:financial:1.4.9:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:credova:financial:1.4.9::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "credova",
+      "Product": "financial",
+      "Version": "1.4.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vmware:spring_integration_zip:1.0.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vmware:spring_integration_zip:1.0.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vmware",
+      "Product": "spring_integration_zip",
+      "Version": "1.0.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nokogiri:nokogiri:1.6.2:beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nokogiri:nokogiri:1.6.2:beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nokogiri",
+      "Product": "nokogiri",
+      "Version": "1.6.2",
+      "Update": "beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:multicorewareinc:x265:1.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:multicorewareinc:x265:1.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "multicorewareinc",
+      "Product": "x265",
+      "Version": "1.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:wago:750-8202:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:wago:750-8202:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "wago",
+      "Product": "750-8202",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:octobercms:october_cms:1.0.228:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:octobercms:october_cms:1.0.228",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "octobercms",
+      "Product": "october_cms",
+      "Version": "1.0.228",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:centreon:widget-host-monitoring:19.04.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:centreon:widget-host-monitoring:19.04.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "centreon",
+      "Product": "widget-host-monitoring",
+      "Version": "19.04.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sonatype:nexus_repository_manager:2.14.15:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sonatype:nexus_repository_manager:2.14.15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sonatype",
+      "Product": "nexus_repository_manager",
+      "Version": "2.14.15",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:12.2\\\\\\(25\\\\\\)seg2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:12.2%5c%2825%5c%29seg2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "12.2\\\\(25\\\\)seg2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:eq-3:ccu2_firmware:2.5.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:eq-3:ccu2_firmware:2.5.4",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "eq-3",
+      "Product": "ccu2_firmware",
+      "Version": "2.5.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nextcloud:end-to-end_encryption:1.7.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nextcloud:end-to-end_encryption:1.7.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nextcloud",
+      "Product": "end-to-end_encryption",
+      "Version": "1.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxfoundation:containerd:0.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxfoundation:containerd:0.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxfoundation",
+      "Product": "containerd",
+      "Version": "0.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wtfutil:wtf:0.0.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wtfutil:wtf:0.0.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wtfutil",
+      "Product": "wtf",
+      "Version": "0.0.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:maxthon:maxthon_browser:5.2.3.4000:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:maxthon:maxthon_browser:5.2.3.4000",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "maxthon",
+      "Product": "maxthon_browser",
+      "Version": "5.2.3.4000",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fasterxml:jackson-dataformats-binary:2.9.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fasterxml:jackson-dataformats-binary:2.9.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fasterxml",
+      "Product": "jackson-dataformats-binary",
+      "Version": "2.9.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:attachmate:reflection_for_secure_it_client:7.2.1163:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:attachmate:reflection_for_secure_it_client:7.2.1163",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "attachmate",
+      "Product": "reflection_for_secure_it_client",
+      "Version": "7.2.1163",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ea:origin_client:10.5.86:*:*:*:*:mac_os:*:*",
+    "cpe-url": "cpe:/a:ea:origin_client:10.5.86::~~~mac_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ea",
+      "Product": "origin_client",
+      "Version": "10.5.86",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "mac_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:paloaltonetworks:expedition:1.1.83:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:paloaltonetworks:expedition:1.1.83",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "paloaltonetworks",
+      "Product": "expedition",
+      "Version": "1.1.83",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:hp:hp-ux:8.04:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:hp:hp-ux:8.04",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "hp",
+      "Product": "hp-ux",
+      "Version": "8.04",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:exposure_notification_verification_server:0.23.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:exposure_notification_verification_server:0.23.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "exposure_notification_verification_server",
+      "Version": "0.23.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:drweb:web_security_space:6.0.0.03100:-:professional:*:*:*:*:*",
+    "cpe-url": "cpe:/a:drweb:web_security_space:6.0.0.03100:-:professional",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "drweb",
+      "Product": "web_security_space",
+      "Version": "6.0.0.03100",
+      "Update": "-",
+      "Edition": "professional",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:fortinet:fortiswitch:3.6.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:fortinet:fortiswitch:3.6.6",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "fortinet",
+      "Product": "fortiswitch",
+      "Version": "3.6.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kaseya:vsa:9.5.0.20:*:*:*:rmm:*:*:*",
+    "cpe-url": "cpe:/a:kaseya:vsa:9.5.0.20::~~rmm~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kaseya",
+      "Product": "vsa",
+      "Version": "9.5.0.20",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "rmm",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nghttp2:nghttp2:1.29.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nghttp2:nghttp2:1.29.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nghttp2",
+      "Product": "nghttp2",
+      "Version": "1.29.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tcoffee:t-coffee:11.00.8cbe486-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tcoffee:t-coffee:11.00.8cbe486-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tcoffee",
+      "Product": "t-coffee",
+      "Version": "11.00.8cbe486-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:hns2600bpq24r_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:hns2600bpq24r_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "hns2600bpq24r_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:belden:hirschmann_rsb20-0900mmm2taabe:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:belden:hirschmann_rsb20-0900mmm2taabe:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "belden",
+      "Product": "hirschmann_rsb20-0900mmm2taabe",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:npmjs:tar:4.4.3:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:npmjs:tar:4.4.3::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "npmjs",
+      "Product": "tar",
+      "Version": "4.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:microchip:atsama5d27c-cnrvao:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:microchip:atsama5d27c-cnrvao:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "microchip",
+      "Product": "atsama5d27c-cnrvao",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tryton:tryton:3.6.13:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tryton:tryton:3.6.13",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tryton",
+      "Product": "tryton",
+      "Version": "3.6.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ays-pro:quiz_maker:3.0.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ays-pro:quiz_maker:3.0.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ays-pro",
+      "Product": "quiz_maker",
+      "Version": "3.0.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:codeaurora:android-msm:3.12.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:codeaurora:android-msm:3.12.11",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "codeaurora",
+      "Product": "android-msm",
+      "Version": "3.12.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tiny.cloud:tinymce:3.4.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tiny.cloud:tinymce:3.4.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tiny.cloud",
+      "Product": "tinymce",
+      "Version": "3.4.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bracketspace:notification:2.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:bracketspace:notification:2.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bracketspace",
+      "Product": "notification",
+      "Version": "2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:lenovo:thinkpad_e565_bios:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:lenovo:thinkpad_e565_bios:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "lenovo",
+      "Product": "thinkpad_e565_bios",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:spi-inc:ganeti:2.1.0:beta0:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:spi-inc:ganeti:2.1.0:beta0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "spi-inc",
+      "Product": "ganeti",
+      "Version": "2.1.0",
+      "Update": "beta0",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:telegram:telegram_desktop:0.7.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:telegram:telegram_desktop:0.7.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "telegram",
+      "Product": "telegram_desktop",
+      "Version": "0.7.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:encode:uvicorn:0.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:encode:uvicorn:0.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "encode",
+      "Product": "uvicorn",
+      "Version": "0.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:linux:tizen:4.0:m3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:linux:tizen:4.0:m3",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "linux",
+      "Product": "tizen",
+      "Version": "4.0",
+      "Update": "m3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rancher:rancher:2.5.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rancher:rancher:2.5.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rancher",
+      "Product": "rancher",
+      "Version": "2.5.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:imagemagick:imagemagick:6.9.9-18:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:imagemagick:imagemagick:6.9.9-18",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "imagemagick",
+      "Product": "imagemagick",
+      "Version": "6.9.9-18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hp:system_management_homepage:2.1.3.132:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hp:system_management_homepage:2.1.3.132",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hp",
+      "Product": "system_management_homepage",
+      "Version": "2.1.3.132",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:http_server:2.2.33:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:http_server:2.2.33",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "http_server",
+      "Version": "2.2.33",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:unity3d:unity_editor:5.5.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:unity3d:unity_editor:5.5.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "unity3d",
+      "Product": "unity_editor",
+      "Version": "5.5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:xen-orchestra:xen_orchestra_server:4.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:xen-orchestra:xen_orchestra_server:4.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "xen-orchestra",
+      "Product": "xen_orchestra_server",
+      "Version": "4.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zuuse:beims_contractorweb_.net:5.18.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zuuse:beims_contractorweb_.net:5.18.0.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zuuse",
+      "Product": "beims_contractorweb_.net",
+      "Version": "5.18.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mailcow:mailcow\\:_dockerized:0.3.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mailcow:mailcow%3a_dockerized:0.3.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mailcow",
+      "Product": "mailcow:_dockerized",
+      "Version": "0.3.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:3cx:live_chat:8.0.32:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:3cx:live_chat:8.0.32::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "3cx",
+      "Product": "live_chat",
+      "Version": "8.0.32",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:unified_contact_center_enterprise:11.0\\(1\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:unified_contact_center_enterprise:11.0%281%29",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "unified_contact_center_enterprise",
+      "Version": "11.0(1)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:weseek:growi:3.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:weseek:growi:3.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "weseek",
+      "Product": "growi",
+      "Version": "3.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:enalean:tuleap:10.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:enalean:tuleap:10.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "enalean",
+      "Product": "tuleap",
+      "Version": "10.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:jf812a:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:jf812a:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "jf812a",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:webyog:sqlyog:3.52:-:enterprise:*:*:*:*:*",
+    "cpe-url": "cpe:/a:webyog:sqlyog:3.52:-:enterprise",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "webyog",
+      "Product": "sqlyog",
+      "Version": "3.52",
+      "Update": "-",
+      "Edition": "enterprise",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pidgin:pidgin:2.10.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pidgin:pidgin:2.10.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pidgin",
+      "Product": "pidgin",
+      "Version": "2.10.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libguestfs:libguestfs:1.33.17:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libguestfs:libguestfs:1.33.17",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libguestfs",
+      "Product": "libguestfs",
+      "Version": "1.33.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:urllib3:1.18:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:urllib3:1.18",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "urllib3",
+      "Version": "1.18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:jclouds:1.6.1:incubating-rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:jclouds:1.6.1:incubating-rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "jclouds",
+      "Version": "1.6.1",
+      "Update": "incubating-rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:appleple:a-blog_cms:2.7.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:appleple:a-blog_cms:2.7.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "appleple",
+      "Product": "a-blog_cms",
+      "Version": "2.7.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnu:libredwg:0.10.1.2670:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnu:libredwg:0.10.1.2670",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnu",
+      "Product": "libredwg",
+      "Version": "0.10.1.2670",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:postgresql:postgresql:8.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:postgresql:postgresql:8.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "postgresql",
+      "Product": "postgresql",
+      "Version": "8.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:open_stf:1.0.2:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:open_stf:1.0.2::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "open_stf",
+      "Version": "1.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:winwar:wp_ebay_product_feeds:0.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:winwar:wp_ebay_product_feeds:0.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "winwar",
+      "Product": "wp_ebay_product_feeds",
+      "Version": "0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:web-mv:resads:1.0.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:web-mv:resads:1.0.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "web-mv",
+      "Product": "resads",
+      "Version": "1.0.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:uglifyjs_project:uglifyjs:3.0.16:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:uglifyjs_project:uglifyjs:3.0.16::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "uglifyjs_project",
+      "Product": "uglifyjs",
+      "Version": "3.0.16",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:frontaccounting:frontaccounting:2.3.22:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:frontaccounting:frontaccounting:2.3.22",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "frontaccounting",
+      "Product": "frontaccounting",
+      "Version": "2.3.22",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apple:itunes:7.4.2:-:mac:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apple:itunes:7.4.2:-:mac",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apple",
+      "Product": "itunes",
+      "Version": "7.4.2",
+      "Update": "-",
+      "Edition": "mac",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fluentd:fluentd:1.12.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:fluentd:fluentd:1.12.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fluentd",
+      "Product": "fluentd",
+      "Version": "1.12.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sun:java_dynamic_management_kit:5.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sun:java_dynamic_management_kit:5.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sun",
+      "Product": "java_dynamic_management_kit",
+      "Version": "5.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:contao:contao:4.5.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:contao:contao:4.5.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "contao",
+      "Product": "contao",
+      "Version": "4.5.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gvectors:wpdiscuz:5.1.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:gvectors:wpdiscuz:5.1.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gvectors",
+      "Product": "wpdiscuz",
+      "Version": "5.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jupyterhub:kubespawner:0.8.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jupyterhub:kubespawner:0.8.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jupyterhub",
+      "Product": "kubespawner",
+      "Version": "0.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tracker-software:pdf-xchange_lite_printer:4.0.154:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tracker-software:pdf-xchange_lite_printer:4.0.154",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tracker-software",
+      "Product": "pdf-xchange_lite_printer",
+      "Version": "4.0.154",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:node-opencv_project:node-opencv:0.0.9:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:node-opencv_project:node-opencv:0.0.9::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "node-opencv_project",
+      "Product": "node-opencv",
+      "Version": "0.0.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:flarum:flarum:0.1.0:beta6:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:flarum:flarum:0.1.0:beta6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "flarum",
+      "Product": "flarum",
+      "Version": "0.1.0",
+      "Update": "beta6",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:php:pear:1.4.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:php:pear:1.4.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "php",
+      "Product": "pear",
+      "Version": "1.4.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:belwith-keeler:hickory_smart:01.01.05:*:*:*:*:iphone_os:*:*",
+    "cpe-url": "cpe:/a:belwith-keeler:hickory_smart:01.01.05::~~~iphone_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "belwith-keeler",
+      "Product": "hickory_smart",
+      "Version": "01.01.05",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "iphone_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:huawei:secospace_usg6600_firmware:v100r001c30spc500:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:huawei:secospace_usg6600_firmware:v100r001c30spc500",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "huawei",
+      "Product": "secospace_usg6600_firmware",
+      "Version": "v100r001c30spc500",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:trousers_project:trousers:0.3.13:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:trousers_project:trousers:0.3.13",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "trousers_project",
+      "Product": "trousers",
+      "Version": "0.3.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pterodactyl:panel:1.0.0:beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pterodactyl:panel:1.0.0:beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pterodactyl",
+      "Product": "panel",
+      "Version": "1.0.0",
+      "Update": "beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:laserjet_managed_flow_mfp_e67550_l3u70a:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:laserjet_managed_flow_mfp_e67550_l3u70a:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "laserjet_managed_flow_mfp_e67550_l3u70a",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:freedownloadmanager:freedownloadmanager:2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:freedownloadmanager:freedownloadmanager:2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "freedownloadmanager",
+      "Product": "freedownloadmanager",
+      "Version": "2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:db2:10.1.0.3:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:ibm:db2:10.1.0.3::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "db2",
+      "Version": "10.1.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openstack:oslo.middleware:3.30.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openstack:oslo.middleware:3.30.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openstack",
+      "Product": "oslo.middleware",
+      "Version": "3.30.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:simplenews_scheduler_project:simplenews_scheduler:6.x-2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:simplenews_scheduler_project:simplenews_scheduler:6.x-2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "simplenews_scheduler_project",
+      "Product": "simplenews_scheduler",
+      "Version": "6.x-2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpexpertdeveloper:wp_private_content_plus:1.7:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpexpertdeveloper:wp_private_content_plus:1.7::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpexpertdeveloper",
+      "Product": "wp_private_content_plus",
+      "Version": "1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:catchplugins:generate_child_theme:-:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:catchplugins:generate_child_theme:-::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "catchplugins",
+      "Product": "generate_child_theme",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:spa_502g_firmware:7.6.2:sr1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:spa_502g_firmware:7.6.2:sr1",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "spa_502g_firmware",
+      "Version": "7.6.2",
+      "Update": "sr1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cleverplugins:seo_booster:3.6.14:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:cleverplugins:seo_booster:3.6.14::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cleverplugins",
+      "Product": "seo_booster",
+      "Version": "3.6.14",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:go-jose_project:go-jose:2.1.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:go-jose_project:go-jose:2.1.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "go-jose_project",
+      "Product": "go-jose",
+      "Version": "2.1.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pdfinfo_project:pdfinfo:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pdfinfo_project:pdfinfo:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pdfinfo_project",
+      "Product": "pdfinfo",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pervasive:data_integrator_engine:9.0.3.30:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pervasive:data_integrator_engine:9.0.3.30",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pervasive",
+      "Product": "data_integrator_engine",
+      "Version": "9.0.3.30",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inmedias:questionaire:3.0.45:beta:*:*:*:typo3:*:*",
+    "cpe-url": "cpe:/a:inmedias:questionaire:3.0.45:beta:~~~typo3~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inmedias",
+      "Product": "questionaire",
+      "Version": "3.0.45",
+      "Update": "beta",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "typo3",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:webyog:sqlyog:8.15:-:community:*:*:*:*:*",
+    "cpe-url": "cpe:/a:webyog:sqlyog:8.15:-:community",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "webyog",
+      "Product": "sqlyog",
+      "Version": "8.15",
+      "Update": "-",
+      "Edition": "community",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:wildfly_core:3.0.0:beta3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:wildfly_core:3.0.0:beta3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "wildfly_core",
+      "Version": "3.0.0",
+      "Update": "beta3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pressified:sendpress:0.9.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:pressified:sendpress:0.9.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pressified",
+      "Product": "sendpress",
+      "Version": "0.9.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cakephp:cakephp:3.4.0:beta2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cakephp:cakephp:3.4.0:beta2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cakephp",
+      "Product": "cakephp",
+      "Version": "3.4.0",
+      "Update": "beta2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mobyproject:moby:1.12.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mobyproject:moby:1.12.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mobyproject",
+      "Product": "moby",
+      "Version": "1.12.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redmine:redmine:2.6.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redmine:redmine:2.6.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redmine",
+      "Product": "redmine",
+      "Version": "2.6.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:openui5:1.44.18:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:openui5:1.44.18",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "openui5",
+      "Version": "1.44.18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ikiwiki:ikiwiki:2.55:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ikiwiki:ikiwiki:2.55",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ikiwiki",
+      "Product": "ikiwiki",
+      "Version": "2.55",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:percona:xtrabackup:2.1.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:percona:xtrabackup:2.1.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "percona",
+      "Product": "xtrabackup",
+      "Version": "2.1.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libpng:libpng:1.7.0:beta01:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libpng:libpng:1.7.0:beta01",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libpng",
+      "Product": "libpng",
+      "Version": "1.7.0",
+      "Update": "beta01",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kentico:kentico_cms:12.0.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kentico:kentico_cms:12.0.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kentico",
+      "Product": "kentico_cms",
+      "Version": "12.0.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:aufs_project:aufs2:2.6.36:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:aufs_project:aufs2:2.6.36:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "aufs_project",
+      "Product": "aufs2",
+      "Version": "2.6.36",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnu:libredwg:0.8.1898:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnu:libredwg:0.8.1898",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnu",
+      "Product": "libredwg",
+      "Version": "0.8.1898",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:prost_project:prost:0.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:prost_project:prost:0.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "prost_project",
+      "Product": "prost",
+      "Version": "0.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mjml:mjml:3.3.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mjml:mjml:3.3.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mjml",
+      "Product": "mjml",
+      "Version": "3.3.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dotnetblogengine:blogengine.net:2.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:dotnetblogengine:blogengine.net:2.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dotnetblogengine",
+      "Product": "blogengine.net",
+      "Version": "2.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:iij:seil_b1_firmware:3.05:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:iij:seil_b1_firmware:3.05",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "iij",
+      "Product": "seil_b1_firmware",
+      "Version": "3.05",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.2.3210:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.2.3210",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.2.3210",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vfbpro:visual_form_builder:3.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:vfbpro:visual_form_builder:3.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vfbpro",
+      "Product": "visual_form_builder",
+      "Version": "3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gleamtech:fileultimate:6.5.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gleamtech:fileultimate:6.5.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gleamtech",
+      "Product": "fileultimate",
+      "Version": "6.5.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.0132:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.0132",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.0132",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:xeon_e3-1220:6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:xeon_e3-1220:6",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "xeon_e3-1220",
+      "Version": "6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:senecajs:seneca:2.0.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:senecajs:seneca:2.0.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "senecajs",
+      "Product": "seneca",
+      "Version": "2.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloud_foundry:bosh:263.9.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloud_foundry:bosh:263.9.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloud_foundry",
+      "Product": "bosh",
+      "Version": "263.9.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:harpjs:harp:0.11.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:harpjs:harp:0.11.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "harpjs",
+      "Product": "harp",
+      "Version": "0.11.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:totvs:fluig:1.7.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:totvs:fluig:1.7.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "totvs",
+      "Product": "fluig",
+      "Version": "1.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kramdown_project:kramdown:0.14.1:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:kramdown_project:kramdown:0.14.1::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kramdown_project",
+      "Product": "kramdown",
+      "Version": "0.14.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nullsoft:winamp:5.21:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nullsoft:winamp:5.21",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nullsoft",
+      "Product": "winamp",
+      "Version": "5.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hibara:attachecase:3.2.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hibara:attachecase:3.2.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hibara",
+      "Product": "attachecase",
+      "Version": "3.2.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sumatrapdfreader:sumatrapdf:2.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sumatrapdfreader:sumatrapdf:2.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sumatrapdfreader",
+      "Product": "sumatrapdf",
+      "Version": "2.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:owncloud:owncloud:1.1.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:owncloud:owncloud:1.1.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "owncloud",
+      "Product": "owncloud",
+      "Version": "1.1.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bundler:bundler:1.14.0:pre2:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:bundler:bundler:1.14.0:pre2:~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bundler",
+      "Product": "bundler",
+      "Version": "1.14.0",
+      "Update": "pre2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cyrus:imap:2.5.15:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cyrus:imap:2.5.15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cyrus",
+      "Product": "imap",
+      "Version": "2.5.15",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vaadin:vaadin-menu-bar:2.0.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vaadin:vaadin-menu-bar:2.0.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vaadin",
+      "Product": "vaadin-menu-bar",
+      "Version": "2.0.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:github:github:2.9.9:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:github:github:2.9.9::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "github",
+      "Product": "github",
+      "Version": "2.9.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:tomcat:10.0.0:milestone1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:tomcat:10.0.0:milestone1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "tomcat",
+      "Version": "10.0.0",
+      "Update": "milestone1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:dashboard_view:2.12:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:dashboard_view:2.12::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "dashboard_view",
+      "Version": "2.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:triple-game:triplea:2.0.17114:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:triple-game:triplea:2.0.17114",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "triple-game",
+      "Product": "triplea",
+      "Version": "2.0.17114",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:commons_compress:1.13:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:commons_compress:1.13",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "commons_compress",
+      "Version": "1.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cern:root:5-18-00:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cern:root:5-18-00",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cern",
+      "Product": "root",
+      "Version": "5-18-00",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:evolution-ews:3.24.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:evolution-ews:3.24.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "evolution-ews",
+      "Version": "3.24.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gradle:maven:1.2.3:*:*:*:*:gradle:*:*",
+    "cpe-url": "cpe:/a:gradle:maven:1.2.3::~~~gradle~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gradle",
+      "Product": "maven",
+      "Version": "1.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "gradle",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:contest_gallery:contest_gallery:9.3.8:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:contest_gallery:contest_gallery:9.3.8::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "contest_gallery",
+      "Product": "contest_gallery",
+      "Version": "9.3.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:interactivebrokers:ibapi:0.1.9:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:interactivebrokers:ibapi:0.1.9::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "interactivebrokers",
+      "Product": "ibapi",
+      "Version": "0.1.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tinyproxy_project:tinyproxy:1.6.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tinyproxy_project:tinyproxy:1.6.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tinyproxy_project",
+      "Product": "tinyproxy",
+      "Version": "1.6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tiki:tikiwiki_cms\\/groupware:15.4:*:*:*:lts:*:*:*",
+    "cpe-url": "cpe:/a:tiki:tikiwiki_cms%2fgroupware:15.4::~~lts~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tiki",
+      "Product": "tikiwiki_cms/groupware",
+      "Version": "15.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "lts",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sensu:sensu_core:5.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sensu:sensu_core:5.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sensu",
+      "Product": "sensu_core",
+      "Version": "5.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:advancestack_10base-t_switching_hub_j3210a:a.03.07:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:advancestack_10base-t_switching_hub_j3210a:a.03.07",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "advancestack_10base-t_switching_hub_j3210a",
+      "Version": "a.03.07",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:9.0.597.27:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:9.0.597.27",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "9.0.597.27",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:pivotal_cloud_cache:1.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:pivotal_cloud_cache:1.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "pivotal_cloud_cache",
+      "Version": "1.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:accurev:0.4:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:accurev:0.4::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "accurev",
+      "Version": "0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:maven:3.5.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:maven:3.5.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "maven",
+      "Version": "3.5.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:jabber_\\(xmpp\\)_notifier_and_control:1.9:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:jabber_%28xmpp%29_notifier_and_control:1.9::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "jabber_(xmpp)_notifier_and_control",
+      "Version": "1.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adaptivecomputing:torque_resource_manager:2.3.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:adaptivecomputing:torque_resource_manager:2.3.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adaptivecomputing",
+      "Product": "torque_resource_manager",
+      "Version": "2.3.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:26.0.1410.29:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:26.0.1410.29",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "26.0.1410.29",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:samba:samba:4.1.21:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:samba:samba:4.1.21",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "samba",
+      "Product": "samba",
+      "Version": "4.1.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kubernetes:kubernetes:1.16.0:alpha0:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kubernetes:kubernetes:1.16.0:alpha0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kubernetes",
+      "Product": "kubernetes",
+      "Version": "1.16.0",
+      "Update": "alpha0",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:python:setuptools:41.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:python:setuptools:41.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "python",
+      "Product": "setuptools",
+      "Version": "41.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gitlab:gitlab:12.1.5:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:gitlab:gitlab:12.1.5::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gitlab",
+      "Product": "gitlab",
+      "Version": "12.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:apple:mac_os_x:11.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:apple:mac_os_x:11.0.1",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "apple",
+      "Product": "mac_os_x",
+      "Version": "11.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:osgeo:mapserver:4.2.0:beta2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:osgeo:mapserver:4.2.0:beta2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "osgeo",
+      "Product": "mapserver",
+      "Version": "4.2.0",
+      "Update": "beta2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bitpay:copay_bitcoin_wallet:4.3.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bitpay:copay_bitcoin_wallet:4.3.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bitpay",
+      "Product": "copay_bitcoin_wallet",
+      "Version": "4.3.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bayashi:dopvstar\\*:0084:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bayashi:dopvstar%2a:0084",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bayashi",
+      "Product": "dopvstar\\*",
+      "Version": "0084",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:xyzscripts:newsletter_manager:1.1:-:-:*:-:wordpress:*:*",
+    "cpe-url": "cpe:/a:xyzscripts:newsletter_manager:1.1:-:~-~-~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "xyzscripts",
+      "Product": "newsletter_manager",
+      "Version": "1.1",
+      "Update": "-",
+      "Edition": "-",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gitlab:runner:9.0.0:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gitlab:runner:9.0.0:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gitlab",
+      "Product": "runner",
+      "Version": "9.0.0",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hygeia_project:hygeia:1.22.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hygeia_project:hygeia:1.22.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hygeia_project",
+      "Product": "hygeia",
+      "Version": "1.22.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bit_project:bit:0.5.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bit_project:bit:0.5.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bit_project",
+      "Product": "bit",
+      "Version": "0.5.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:freebsd:freebsd:10.2:p2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:freebsd:freebsd:10.2:p2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "freebsd",
+      "Product": "freebsd",
+      "Version": "10.2",
+      "Update": "p2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:grafana:agent:0.20.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:grafana:agent:0.20.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "grafana",
+      "Product": "agent",
+      "Version": "0.20.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ubports:unity8:7.84\\+14.04.20140314-0ubuntu1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ubports:unity8:7.84%2b14.04.20140314-0ubuntu1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ubports",
+      "Product": "unity8",
+      "Version": "7.84+14.04.20140314-0ubuntu1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mozilla:thunderbird:31.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mozilla:thunderbird:31.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mozilla",
+      "Product": "thunderbird",
+      "Version": "31.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gonitro:nitro_pro:10.5.9.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gonitro:nitro_pro:10.5.9.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gonitro",
+      "Product": "nitro_pro",
+      "Version": "10.5.9.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ntp:ntp:4.2.7:p216:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ntp:ntp:4.2.7:p216",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ntp",
+      "Product": "ntp",
+      "Version": "4.2.7",
+      "Update": "p216",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:xeon_w-2133:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:xeon_w-2133:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "xeon_w-2133",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxfoundation:fabric:1.4.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxfoundation:fabric:1.4.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxfoundation",
+      "Product": "fabric",
+      "Version": "1.4.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pixar:openusd:18.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pixar:openusd:18.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pixar",
+      "Product": "openusd",
+      "Version": "18.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ays-pro:quiz_maker:5.4.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ays-pro:quiz_maker:5.4.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ays-pro",
+      "Product": "quiz_maker",
+      "Version": "5.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpfastestcache:wp_fastest_cache:0.7.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpfastestcache:wp_fastest_cache:0.7.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpfastestcache",
+      "Product": "wp_fastest_cache",
+      "Version": "0.7.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:unified_computing_system_central_software:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:unified_computing_system_central_software:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "unified_computing_system_central_software",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nttdocomo:spmode_mail_android:5000:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nttdocomo:spmode_mail_android:5000",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nttdocomo",
+      "Product": "spmode_mail_android",
+      "Version": "5000",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:swi-prolog:swi-prolog:7.1.32:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:swi-prolog:swi-prolog:7.1.32",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "swi-prolog",
+      "Product": "swi-prolog",
+      "Version": "7.1.32",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:facebook:react:16.7.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:facebook:react:16.7.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "facebook",
+      "Product": "react",
+      "Version": "16.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:intel:xeon_e3:x3480:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:intel:xeon_e3:x3480",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "intel",
+      "Product": "xeon_e3",
+      "Version": "x3480",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vips:vips:7.11.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vips:vips:7.11.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vips",
+      "Product": "vips",
+      "Version": "7.11.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libpng:libpng:1.6.17:beta01:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libpng:libpng:1.6.17:beta01",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libpng",
+      "Product": "libpng",
+      "Version": "1.6.17",
+      "Update": "beta01",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:smartbear:swagger-ui:3.6.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:smartbear:swagger-ui:3.6.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "smartbear",
+      "Product": "swagger-ui",
+      "Version": "3.6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:1up:oneupuploaderbundle:0.9.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:1up:oneupuploaderbundle:0.9.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "1up",
+      "Product": "oneupuploaderbundle",
+      "Version": "0.9.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:lenovo:v310-15isk:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:lenovo:v310-15isk:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "lenovo",
+      "Product": "v310-15isk",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mozilla:thunderbird:3.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mozilla:thunderbird:3.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mozilla",
+      "Product": "thunderbird",
+      "Version": "3.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wp-dbmanager_project:wp-dbmanager:2.79:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wp-dbmanager_project:wp-dbmanager:2.79::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wp-dbmanager_project",
+      "Product": "wp-dbmanager",
+      "Version": "2.79",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apereo:opencast:1.4.2:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apereo:opencast:1.4.2:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apereo",
+      "Product": "opencast",
+      "Version": "1.4.2",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nette:latte:2.6.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nette:latte:2.6.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nette",
+      "Product": "latte",
+      "Version": "2.6.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:docker:engine:17.03.2:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:docker:engine:17.03.2:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "docker",
+      "Product": "engine",
+      "Version": "17.03.2",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudflare:octopki:1.1.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudflare:octopki:1.1.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudflare",
+      "Product": "octopki",
+      "Version": "1.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bestit:amazon_pay:7.0.1:*:*:*:*:shopware:*:*",
+    "cpe-url": "cpe:/a:bestit:amazon_pay:7.0.1::~~~shopware~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bestit",
+      "Product": "amazon_pay",
+      "Version": "7.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "shopware",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:otrs:otrs:3.0.0:beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:otrs:otrs:3.0.0:beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "otrs",
+      "Product": "otrs",
+      "Version": "3.0.0",
+      "Update": "beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libaacplus_project:libaacplus:1.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libaacplus_project:libaacplus:1.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libaacplus_project",
+      "Product": "libaacplus",
+      "Version": "1.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ammonia_project:ammonia:2.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ammonia_project:ammonia:2.0.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ammonia_project",
+      "Product": "ammonia",
+      "Version": "2.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:transloadit:uppy:0.28.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:transloadit:uppy:0.28.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "transloadit",
+      "Product": "uppy",
+      "Version": "0.28.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mit:kerberos:5-1.14:alpha1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mit:kerberos:5-1.14:alpha1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mit",
+      "Product": "kerberos",
+      "Version": "5-1.14",
+      "Update": "alpha1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:libvirt:0.4.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:libvirt:0.4.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "libvirt",
+      "Version": "0.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:itextpdf:itext:1.3.5:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:itextpdf:itext:1.3.5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "itextpdf",
+      "Product": "itext",
+      "Version": "1.3.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:strapi:strapi:3.0.0:beta15:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:strapi:strapi:3.0.0:beta15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "strapi",
+      "Product": "strapi",
+      "Version": "3.0.0",
+      "Update": "beta15",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:microsoft:windows_server_2008:-:sp2:hpc:*:*:*:*:*",
+    "cpe-url": "cpe:/o:microsoft:windows_server_2008:-:sp2:hpc",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "microsoft",
+      "Product": "windows_server_2008",
+      "Version": "-",
+      "Update": "sp2",
+      "Edition": "hpc",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:slf4j:slf4j-api:1.7.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:slf4j:slf4j-api:1.7.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "slf4j",
+      "Product": "slf4j-api",
+      "Version": "1.7.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oracle:e-business_suite_technology_stack:12.1.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oracle:e-business_suite_technology_stack:12.1.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oracle",
+      "Product": "e-business_suite_technology_stack",
+      "Version": "12.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:webfactoryltd:wp_reset_pro:5.81:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:webfactoryltd:wp_reset_pro:5.81::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "webfactoryltd",
+      "Product": "wp_reset_pro",
+      "Version": "5.81",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:docsifyjs:docsify:1.7.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:docsifyjs:docsify:1.7.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "docsifyjs",
+      "Product": "docsify",
+      "Version": "1.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:hp:envy_photo_7800_k7s00a_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:hp:envy_photo_7800_k7s00a_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "hp",
+      "Product": "envy_photo_7800_k7s00a_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zoom:zoom:4.4.55387.0716:*:*:*:*:mac_os:*:*",
+    "cpe-url": "cpe:/a:zoom:zoom:4.4.55387.0716::~~~mac_os~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zoom",
+      "Product": "zoom",
+      "Version": "4.4.55387.0716",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "mac_os",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wesnoth:the_battle_for_wesnoth:0.8.5:rc5:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wesnoth:the_battle_for_wesnoth:0.8.5:rc5",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wesnoth",
+      "Product": "the_battle_for_wesnoth",
+      "Version": "0.8.5",
+      "Update": "rc5",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:fortinet:fortios:6.0.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:fortinet:fortios:6.0.3",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "fortinet",
+      "Product": "fortios",
+      "Version": "6.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:processing:processing:2.0:beta4:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:processing:processing:2.0:beta4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "processing",
+      "Product": "processing",
+      "Version": "2.0",
+      "Update": "beta4",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:epson:px-m7050fp_firmware:2017-10-13:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:epson:px-m7050fp_firmware:2017-10-13",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "epson",
+      "Product": "px-m7050fp_firmware",
+      "Version": "2017-10-13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ntp:ntp:4.2.8:p1_beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ntp:ntp:4.2.8:p1_beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ntp",
+      "Product": "ntp",
+      "Version": "4.2.8",
+      "Update": "p1_beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:easycorp:zentao:13.0:beta4:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:easycorp:zentao:13.0:beta4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "easycorp",
+      "Product": "zentao",
+      "Version": "13.0",
+      "Update": "beta4",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:git-annex_project:git-annex:6.20160229:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:git-annex_project:git-annex:6.20160229",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "git-annex_project",
+      "Product": "git-annex",
+      "Version": "6.20160229",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:delivery_pipeline:0.7.5:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:delivery_pipeline:0.7.5::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "delivery_pipeline",
+      "Version": "0.7.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hp:c4100_help:70.0.231.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hp:c4100_help:70.0.231.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hp",
+      "Product": "c4100_help",
+      "Version": "70.0.231.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apple:cups:1.5.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apple:cups:1.5.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apple",
+      "Product": "cups",
+      "Version": "1.5.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:google_compute_engine:1.0.7:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:google_compute_engine:1.0.7::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "google_compute_engine",
+      "Version": "1.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:support-project:knowledge:1.6.0:pre4:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:support-project:knowledge:1.6.0:pre4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "support-project",
+      "Product": "knowledge",
+      "Version": "1.6.0",
+      "Update": "pre4",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gitlab:gitlab:13.6.1:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:gitlab:gitlab:13.6.1::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gitlab",
+      "Product": "gitlab",
+      "Version": "13.6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openmage:magento:1.9.1.1:*:*:*:lts:*:*:*",
+    "cpe-url": "cpe:/a:openmage:magento:1.9.1.1::~~lts~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openmage",
+      "Product": "magento",
+      "Version": "1.9.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "lts",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:socket:engine.io-client:1.8.2:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:socket:engine.io-client:1.8.2::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "socket",
+      "Product": "engine.io-client",
+      "Version": "1.8.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:b2evolution:b2evolution_cms:6.5.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:b2evolution:b2evolution_cms:6.5.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "b2evolution",
+      "Product": "b2evolution_cms",
+      "Version": "6.5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:linuxfoundation:harbor:2.1.0:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:linuxfoundation:harbor:2.1.0:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "linuxfoundation",
+      "Product": "harbor",
+      "Version": "2.1.0",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wekan_project:wekan:3.76:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wekan_project:wekan:3.76",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wekan_project",
+      "Product": "wekan",
+      "Version": "3.76",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:novell:edirectory:8.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:novell:edirectory:8.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "novell",
+      "Product": "edirectory",
+      "Version": "8.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnu:emacs:19.31:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnu:emacs:19.31",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnu",
+      "Product": "emacs",
+      "Version": "19.31",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vips:vips:7.7.14:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vips:vips:7.7.14",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vips",
+      "Product": "vips",
+      "Version": "7.7.14",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:hp:cq183a_firmware:1828b:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:hp:cq183a_firmware:1828b",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "hp",
+      "Product": "cq183a_firmware",
+      "Version": "1828b",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:editor-core:118.0.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:atlassian:editor-core:118.0.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "editor-core",
+      "Version": "118.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:lilypond:lilypond:2.19.44:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:lilypond:lilypond:2.19.44",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "lilypond",
+      "Product": "lilypond",
+      "Version": "2.19.44",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openstack:tripleo_heat_templates:6.2.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openstack:tripleo_heat_templates:6.2.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openstack",
+      "Product": "tripleo_heat_templates",
+      "Version": "6.2.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oracle:fusion_middleware:11.1.1.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oracle:fusion_middleware:11.1.1.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oracle",
+      "Product": "fusion_middleware",
+      "Version": "11.1.1.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tripleplay:onelan_cms:2.0.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tripleplay:onelan_cms:2.0.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tripleplay",
+      "Product": "onelan_cms",
+      "Version": "2.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:portainer:portainer:1.15.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:portainer:portainer:1.15.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "portainer",
+      "Product": "portainer",
+      "Version": "1.15.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:firefly-iii:firefly_iii:5.2.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:firefly-iii:firefly_iii:5.2.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "firefly-iii",
+      "Product": "firefly_iii",
+      "Version": "5.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:getkirby:kirby:2.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:getkirby:kirby:2.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "getkirby",
+      "Product": "kirby",
+      "Version": "2.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:auth0:auth0.js:9.3.2:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:auth0:auth0.js:9.3.2::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "auth0",
+      "Product": "auth0.js",
+      "Version": "9.3.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:spring_integration:4.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:spring_integration:4.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "spring_integration",
+      "Version": "4.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:btcpayserver:btcpayserver:1.0.1.38:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:btcpayserver:btcpayserver:1.0.1.38",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "btcpayserver",
+      "Product": "btcpayserver",
+      "Version": "1.0.1.38",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:octobercms:october:1.0.73:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:octobercms:october:1.0.73",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "octobercms",
+      "Product": "october",
+      "Version": "1.0.73",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ceph:ceph-ansible:4.0.34.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ceph:ceph-ansible:4.0.34.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ceph",
+      "Product": "ceph-ansible",
+      "Version": "4.0.34.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:cisco:asr_920-12sz-im_r:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:cisco:asr_920-12sz-im_r:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "cisco",
+      "Product": "asr_920-12sz-im_r",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apple:quicktime:7.3.0:-:mac:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apple:quicktime:7.3.0:-:mac",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apple",
+      "Product": "quicktime",
+      "Version": "7.3.0",
+      "Update": "-",
+      "Edition": "mac",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openpgpjs:openpgpjs:3.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openpgpjs:openpgpjs:3.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openpgpjs",
+      "Product": "openpgpjs",
+      "Version": "3.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:electronjs:electron:11.0.0:beta15:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:electronjs:electron:11.0.0:beta15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "electronjs",
+      "Product": "electron",
+      "Version": "11.0.0",
+      "Update": "beta15",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:invensys:wonderware_application_server:2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:invensys:wonderware_application_server:2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "invensys",
+      "Product": "wonderware_application_server",
+      "Version": "2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:contest_gallery:contest_gallery:1.18:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:contest_gallery:contest_gallery:1.18::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "contest_gallery",
+      "Product": "contest_gallery",
+      "Version": "1.18",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pajbot_project:pajbot:1.49:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pajbot_project:pajbot:1.49",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pajbot_project",
+      "Product": "pajbot",
+      "Version": "1.49",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:iobroker:iobroker.admin:3.5.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:iobroker:iobroker.admin:3.5.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "iobroker",
+      "Product": "iobroker.admin",
+      "Version": "3.5.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:maximo_for_oil_and_gas:7.5.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:maximo_for_oil_and_gas:7.5.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "maximo_for_oil_and_gas",
+      "Version": "7.5.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:firepower_management_center_firmware:6.0.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:firepower_management_center_firmware:6.0.0.0",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "firepower_management_center_firmware",
+      "Version": "6.0.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adobe:acrobat_reader_dc:15.000.0000:*:*:*:classic:*:*:*",
+    "cpe-url": "cpe:/a:adobe:acrobat_reader_dc:15.000.0000::~~classic~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adobe",
+      "Product": "acrobat_reader_dc",
+      "Version": "15.000.0000",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "classic",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:node-postgres:pg:0.10.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:node-postgres:pg:0.10.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "node-postgres",
+      "Product": "pg",
+      "Version": "0.10.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:infolific:real-time_find_and_replace:4.0.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:infolific:real-time_find_and_replace:4.0.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "infolific",
+      "Product": "real-time_find_and_replace",
+      "Version": "4.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:asyncos:11.1:hot_patch2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:asyncos:11.1:hot_patch2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "asyncos",
+      "Version": "11.1",
+      "Update": "hot_patch2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:nx-os:7.0\\(3\\)i3\\(0.170\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:nx-os:7.0%283%29i3%280.170%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "nx-os",
+      "Version": "7.0(3)i3(0.170)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:skype:skype:3.0.0.198:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:skype:skype:3.0.0.198",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "skype",
+      "Product": "skype",
+      "Version": "3.0.0.198",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:gui:7.70:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:gui:7.70:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "gui",
+      "Version": "7.70",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:0231a65t:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:0231a65t:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "0231a65t",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:progress:mixlib-archive:1.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:progress:mixlib-archive:1.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "progress",
+      "Product": "mixlib-archive",
+      "Version": "1.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tuxfamily:chrony:1.28:pre1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tuxfamily:chrony:1.28:pre1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tuxfamily",
+      "Product": "chrony",
+      "Version": "1.28",
+      "Update": "pre1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:custom_search_project:custom_search:6.x-1.10:*:*:*:*:drupal:*:*",
+    "cpe-url": "cpe:/a:custom_search_project:custom_search:6.x-1.10::~~~drupal~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "custom_search_project",
+      "Product": "custom_search",
+      "Version": "6.x-1.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "drupal",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dpl:product_feed_on_woocommerce_for_google\\,_awin\\,_shareasale\\,_bing\\,_and_more:3.5.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:dpl:product_feed_on_woocommerce_for_google%2c_awin%2c_shareasale%2c_bing%2c_and_more:3.5.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dpl",
+      "Product": "product_feed_on_woocommerce_for_google,_awin,_shareasale,_bing,_and_more",
+      "Version": "3.5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:pureapplication_system:2.1.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:pureapplication_system:2.1.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "pureapplication_system",
+      "Version": "2.1.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:traefik:traefik:2.3.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:traefik:traefik:2.3.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "traefik",
+      "Product": "traefik",
+      "Version": "2.3.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.3.662:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.3.662",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.3.662",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:i-doit:i-doit:1.10.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:i-doit:i-doit:1.10.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "i-doit",
+      "Product": "i-doit",
+      "Version": "1.10.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:supsystic:photo_gallery:1.2.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:supsystic:photo_gallery:1.2.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "supsystic",
+      "Product": "photo_gallery",
+      "Version": "1.2.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:elastic:kibana:1.0.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:elastic:kibana:1.0.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "elastic",
+      "Product": "kibana",
+      "Version": "1.0.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tgstation13:tgstation-server:4.0.1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tgstation13:tgstation-server:4.0.1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tgstation13",
+      "Product": "tgstation-server",
+      "Version": "4.0.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:2checkout:ithemes_2checkout:-:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:2checkout:ithemes_2checkout:-::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "2checkout",
+      "Product": "ithemes_2checkout",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dbd-mysql_project:dbd-mysql:4.022:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:dbd-mysql_project:dbd-mysql:4.022",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dbd-mysql_project",
+      "Product": "dbd-mysql",
+      "Version": "4.022",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jruby:jruby:1.5.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jruby:jruby:1.5.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jruby",
+      "Product": "jruby",
+      "Version": "1.5.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:alchemy-cms:alchemy_cms:3.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:alchemy-cms:alchemy_cms:3.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "alchemy-cms",
+      "Product": "alchemy_cms",
+      "Version": "3.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rankmath:seo:1.0.9:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:rankmath:seo:1.0.9::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rankmath",
+      "Product": "seo",
+      "Version": "1.0.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:media_library_assistant_project:media_library_assistant:2.54:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:media_library_assistant_project:media_library_assistant:2.54::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "media_library_assistant_project",
+      "Product": "media_library_assistant",
+      "Version": "2.54",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:theforeman:katello:0.1.209-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:theforeman:katello:0.1.209-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "theforeman",
+      "Product": "katello",
+      "Version": "0.1.209-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fancybox_project:fancybox:3.0.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:fancybox_project:fancybox:3.0.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fancybox_project",
+      "Product": "fancybox",
+      "Version": "3.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wp_domain_redirect_project:wp_domain_redirect:1.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wp_domain_redirect_project:wp_domain_redirect:1.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wp_domain_redirect_project",
+      "Product": "wp_domain_redirect",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:xen-orchestra:xen_orchestra_server:5.10.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:xen-orchestra:xen_orchestra_server:5.10.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "xen-orchestra",
+      "Product": "xen_orchestra_server",
+      "Version": "5.10.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:databaseschemaviewer_project:dbschemareader:2.7.4.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:databaseschemaviewer_project:dbschemareader:2.7.4.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "databaseschemaviewer_project",
+      "Product": "dbschemareader",
+      "Version": "2.7.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:intel:converged_security_and_manageability_engine:11.22.86:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:intel:converged_security_and_manageability_engine:11.22.86",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "intel",
+      "Product": "converged_security_and_manageability_engine",
+      "Version": "11.22.86",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fujitsu:interstage_application_server:9.1.0:*:*:*:enterprise:*:*:*",
+    "cpe-url": "cpe:/a:fujitsu:interstage_application_server:9.1.0::~~enterprise~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fujitsu",
+      "Product": "interstage_application_server",
+      "Version": "9.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "enterprise",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libinfinity_project:libinfinity:0.5.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libinfinity_project:libinfinity:0.5.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libinfinity_project",
+      "Product": "libinfinity",
+      "Version": "0.5.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:macpaw:cleanmymac_x:3.8.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:macpaw:cleanmymac_x:3.8.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "macpaw",
+      "Product": "cleanmymac_x",
+      "Version": "3.8.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pacman_project:pacman:3.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pacman_project:pacman:3.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pacman_project",
+      "Product": "pacman",
+      "Version": "3.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:tensorflow:2.1.0:-:*:*:lite:*:*:*",
+    "cpe-url": "cpe:/a:google:tensorflow:2.1.0:-:~~lite~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "tensorflow",
+      "Version": "2.1.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "lite",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apple:apple_application_support:1.4.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apple:apple_application_support:1.4.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apple",
+      "Product": "apple_application_support",
+      "Version": "1.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:schneider-electric:bmep582040s_firmware:2.90:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:schneider-electric:bmep582040s_firmware:2.90",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "schneider-electric",
+      "Product": "bmep582040s_firmware",
+      "Version": "2.90",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:morequick:greenbrowser:6.1.0117:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:morequick:greenbrowser:6.1.0117",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "morequick",
+      "Product": "greenbrowser",
+      "Version": "6.1.0117",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:freebsd:freebsd:9.3:p43:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:freebsd:freebsd:9.3:p43",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "freebsd",
+      "Product": "freebsd",
+      "Version": "9.3",
+      "Update": "p43",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:yamaha:rtv700:8.00.81:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:yamaha:rtv700:8.00.81",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "yamaha",
+      "Product": "rtv700",
+      "Version": "8.00.81",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:trihedral:vtscada:11.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:trihedral:vtscada:11.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "trihedral",
+      "Product": "vtscada",
+      "Version": "11.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnome:gtk:0.99.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnome:gtk:0.99.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnome",
+      "Product": "gtk",
+      "Version": "0.99.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:qpdf_project:qpdf:2.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:qpdf_project:qpdf:2.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "qpdf_project",
+      "Product": "qpdf",
+      "Version": "2.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:klibc_project:klibc:0.121:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:klibc_project:klibc:0.121",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "klibc_project",
+      "Product": "klibc",
+      "Version": "0.121",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kunena:kunena:4.0.4:*:*:*:*:joomla\\!:*:*",
+    "cpe-url": "cpe:/a:kunena:kunena:4.0.4::~~~joomla%21~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kunena",
+      "Product": "kunena",
+      "Version": "4.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "joomla!",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:tp-link:tl-wr840n_firmware:3.13.27:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:tp-link:tl-wr840n_firmware:3.13.27",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "tp-link",
+      "Product": "tl-wr840n_firmware",
+      "Version": "3.13.27",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:slf4j:slf4j-jdk14:1.6.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:slf4j:slf4j-jdk14:1.6.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "slf4j",
+      "Product": "slf4j-jdk14",
+      "Version": "1.6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nextscripts:social_networks_auto_poster:4.2.0:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:nextscripts:social_networks_auto_poster:4.2.0::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nextscripts",
+      "Product": "social_networks_auto_poster",
+      "Version": "4.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:koha:koha:16.05.03:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:koha:koha:16.05.03",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "koha",
+      "Product": "koha",
+      "Version": "16.05.03",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:opennms:opennms:25.2.1-1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:opennms:opennms:25.2.1-1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "opennms",
+      "Product": "opennms",
+      "Version": "25.2.1-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:formidableforms:formidable:3.03.01:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:formidableforms:formidable:3.03.01::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "formidableforms",
+      "Product": "formidable",
+      "Version": "3.03.01",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:lftp_project:lftp:2.4.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:lftp_project:lftp:2.4.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "lftp_project",
+      "Product": "lftp",
+      "Version": "2.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:bitcoin:bitcoin:0.13.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:bitcoin:bitcoin:0.13.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "bitcoin",
+      "Product": "bitcoin",
+      "Version": "0.13.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:groovy:3.0.0:alpha1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:groovy:3.0.0:alpha1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "groovy",
+      "Version": "3.0.0",
+      "Update": "alpha1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phoenix_media_rename_project:phoenix_media_rename:2.0.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:phoenix_media_rename_project:phoenix_media_rename:2.0.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phoenix_media_rename_project",
+      "Product": "phoenix_media_rename",
+      "Version": "2.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pivotal_software:operations_manager:1.12.20:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pivotal_software:operations_manager:1.12.20",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pivotal_software",
+      "Product": "operations_manager",
+      "Version": "1.12.20",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phpcheckz:phpcheckz:0.4.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:phpcheckz:phpcheckz:0.4.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phpcheckz",
+      "Product": "phpcheckz",
+      "Version": "0.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudfoundry:credhub:1.9.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudfoundry:credhub:1.9.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudfoundry",
+      "Product": "credhub",
+      "Version": "1.9.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gleamtech:filevista:5.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gleamtech:filevista:5.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gleamtech",
+      "Product": "filevista",
+      "Version": "5.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openvcloud_project:openvcloud:2.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openvcloud_project:openvcloud:2.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openvcloud_project",
+      "Product": "openvcloud",
+      "Version": "2.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpseeds:wp_database_backup:5.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpseeds:wp_database_backup:5.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpseeds",
+      "Product": "wp_database_backup",
+      "Version": "5.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:owasp:owasp_modsecurity_core_rule_set:3.0.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:owasp:owasp_modsecurity_core_rule_set:3.0.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "owasp",
+      "Product": "owasp_modsecurity_core_rule_set",
+      "Version": "3.0.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:four_kitchens:block_class:7.x-2.x:dev:*:*:*:drupal:*:*",
+    "cpe-url": "cpe:/a:four_kitchens:block_class:7.x-2.x:dev:~~~drupal~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "four_kitchens",
+      "Product": "block_class",
+      "Version": "7.x-2.x",
+      "Update": "dev",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "drupal",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mediacoderhq:mediacoder:0.8.5800:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mediacoderhq:mediacoder:0.8.5800",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mediacoderhq",
+      "Product": "mediacoder",
+      "Version": "0.8.5800",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:minimagick_project:minimagick:4.7.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:minimagick_project:minimagick:4.7.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "minimagick_project",
+      "Product": "minimagick",
+      "Version": "4.7.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phpmyadmin:phpmyadmin:4.1.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:phpmyadmin:phpmyadmin:4.1.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phpmyadmin",
+      "Product": "phpmyadmin",
+      "Version": "4.1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:logitech:harmony_hub:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:logitech:harmony_hub:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "logitech",
+      "Product": "harmony_hub",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:ecessa:shieldlink_sl175ehq_firmware:8.0.19:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:ecessa:shieldlink_sl175ehq_firmware:8.0.19",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "ecessa",
+      "Product": "shieldlink_sl175ehq_firmware",
+      "Version": "8.0.19",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:octopus:octopus_deploy:2018.12.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:octopus:octopus_deploy:2018.12.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "octopus",
+      "Product": "octopus_deploy",
+      "Version": "2018.12.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:alpinelinux:abuild:2.27.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:alpinelinux:abuild:2.27.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "alpinelinux",
+      "Product": "abuild",
+      "Version": "2.27.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:amazon:freertos:1.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:amazon:freertos:1.2.0",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "amazon",
+      "Product": "freertos",
+      "Version": "1.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:microsoft:systems_management_server:1.2:sp3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:microsoft:systems_management_server:1.2:sp3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "microsoft",
+      "Product": "systems_management_server",
+      "Version": "1.2",
+      "Update": "sp3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netty:netty:4.1.15:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netty:netty:4.1.15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netty",
+      "Product": "netty",
+      "Version": "4.1.15",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ntp:ntp:4.0.97:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ntp:ntp:4.0.97",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ntp",
+      "Product": "ntp",
+      "Version": "4.0.97",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:spss_statistics:24.0.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:spss_statistics:24.0.0.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "spss_statistics",
+      "Version": "24.0.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fenrir-inc:sleipnir_mobile:2.1.0:*:*:*:-:android:*:*",
+    "cpe-url": "cpe:/a:fenrir-inc:sleipnir_mobile:2.1.0::~~-~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fenrir-inc",
+      "Product": "sleipnir_mobile",
+      "Version": "2.1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:phoenixcontact:fl_switch_4008t-2gt-3fx_sm_firmware:1.21:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:phoenixcontact:fl_switch_4008t-2gt-3fx_sm_firmware:1.21",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "phoenixcontact",
+      "Product": "fl_switch_4008t-2gt-3fx_sm_firmware",
+      "Version": "1.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wp_svg_icons_project:wp_svg_icons:3.1.8.4:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wp_svg_icons_project:wp_svg_icons:3.1.8.4::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wp_svg_icons_project",
+      "Product": "wp_svg_icons",
+      "Version": "3.1.8.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:facebook:hiphop_virtual_machine:3.13.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:facebook:hiphop_virtual_machine:3.13.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "facebook",
+      "Product": "hiphop_virtual_machine",
+      "Version": "3.13.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jetbrains:kotlin:1.4.0:dev458:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:jetbrains:kotlin:1.4.0:dev458",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jetbrains",
+      "Product": "kotlin",
+      "Version": "1.4.0",
+      "Update": "dev458",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:linux:linux_kernel:2.6.13.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:linux:linux_kernel:2.6.13.2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "linux",
+      "Product": "linux_kernel",
+      "Version": "2.6.13.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:chef:chef:14.0.217:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:chef:chef:14.0.217",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "chef",
+      "Product": "chef",
+      "Version": "14.0.217",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:get-simple:getsimple_cms:3.3.14:b1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:get-simple:getsimple_cms:3.3.14:b1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "get-simple",
+      "Product": "getsimple_cms",
+      "Version": "3.3.14",
+      "Update": "b1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tcl:tcl:8.4.16:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tcl:tcl:8.4.16",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tcl",
+      "Product": "tcl",
+      "Version": "8.4.16",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gogs:gogs:0.6.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gogs:gogs:0.6.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gogs",
+      "Product": "gogs",
+      "Version": "0.6.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:postsrsd_prject:postsrsd:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:postsrsd_prject:postsrsd:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "postsrsd_prject",
+      "Product": "postsrsd",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:axis:c8033_firmware:1.81.040.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:axis:c8033_firmware:1.81.040.1",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "axis",
+      "Product": "c8033_firmware",
+      "Version": "1.81.040.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:huawei:mate_10_pro_firmware:bla-l29_8.0.0.148\\(c432\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:huawei:mate_10_pro_firmware:bla-l29_8.0.0.148%28c432%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "huawei",
+      "Product": "mate_10_pro_firmware",
+      "Version": "bla-l29_8.0.0.148(c432)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:netsarang:xshell:7:build_0065:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:netsarang:xshell:7:build_0065",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "netsarang",
+      "Product": "xshell",
+      "Version": "7",
+      "Update": "build_0065",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpdatatables:wpdatatables:2.0.16:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpdatatables:wpdatatables:2.0.16::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpdatatables",
+      "Product": "wpdatatables",
+      "Version": "2.0.16",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:clusterlabs:pacemaker:2.0.2:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:clusterlabs:pacemaker:2.0.2:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "clusterlabs",
+      "Product": "pacemaker",
+      "Version": "2.0.2",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:swi-prolog:swi-prolog:5.4.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:swi-prolog:swi-prolog:5.4.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "swi-prolog",
+      "Product": "swi-prolog",
+      "Version": "5.4.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wftpserver:wing_ftp_server:3.9.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wftpserver:wing_ftp_server:3.9.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wftpserver",
+      "Product": "wing_ftp_server",
+      "Version": "3.9.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpplugin:accept_donations_with_paypal:1.2.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpplugin:accept_donations_with_paypal:1.2.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpplugin",
+      "Product": "accept_donations_with_paypal",
+      "Version": "1.2.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:abcm2ps_project:abcm2ps:8.14.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:abcm2ps_project:abcm2ps:8.14.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "abcm2ps_project",
+      "Product": "abcm2ps",
+      "Version": "8.14.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:episerver:ektron_cms:8.00:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:episerver:ektron_cms:8.00:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "episerver",
+      "Product": "ektron_cms",
+      "Version": "8.00",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:laserjet_managed_e85055_t3u51a:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:laserjet_managed_e85055_t3u51a:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "laserjet_managed_e85055_t3u51a",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wallabag:wallabag:2.0.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wallabag:wallabag:2.0.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wallabag",
+      "Product": "wallabag",
+      "Version": "2.0.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:google:chrome:13.0.752.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:google:chrome:13.0.752.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "google",
+      "Product": "chrome",
+      "Version": "13.0.752.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:xeon_e5-2430_v2_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:xeon_e5-2430_v2_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "xeon_e5-2430_v2_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:url-parse_project:url-parse:1.4.3:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:url-parse_project:url-parse:1.4.3::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "url-parse_project",
+      "Product": "url-parse",
+      "Version": "1.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:crear.ne.jp:al-mail32:1.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:crear.ne.jp:al-mail32:1.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "crear.ne.jp",
+      "Product": "al-mail32",
+      "Version": "1.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:triplea-game:triplea:1.9.0.0.12537:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:triplea-game:triplea:1.9.0.0.12537",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "triplea-game",
+      "Product": "triplea",
+      "Version": "1.9.0.0.12537",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:yithemes:yith_woocommerce_request_a_quote:1.6.2:*:*:*:premium:wordpress:*:*",
+    "cpe-url": "cpe:/a:yithemes:yith_woocommerce_request_a_quote:1.6.2::~~premium~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "yithemes",
+      "Product": "yith_woocommerce_request_a_quote",
+      "Version": "1.6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "premium",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:eucalyptus:eucalyptus:3.0.0:beta2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:eucalyptus:eucalyptus:3.0.0:beta2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "eucalyptus",
+      "Product": "eucalyptus",
+      "Version": "3.0.0",
+      "Update": "beta2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:strategy11:formidable_form_builder:4.0.03:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:strategy11:formidable_form_builder:4.0.03::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "strategy11",
+      "Product": "formidable_form_builder",
+      "Version": "4.0.03",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:dhcpcd_project:dhcpcd:6.9.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:dhcpcd_project:dhcpcd:6.9.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "dhcpcd_project",
+      "Product": "dhcpcd",
+      "Version": "6.9.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rocket.chat:rocket.chat:3.4.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rocket.chat:rocket.chat:3.4.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rocket.chat",
+      "Product": "rocket.chat",
+      "Version": "3.4.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:fujitsu:m12-2_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:fujitsu:m12-2_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "fujitsu",
+      "Product": "m12-2_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:hp:proliant_bl460c_firmware:2.20:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:hp:proliant_bl460c_firmware:2.20",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "hp",
+      "Product": "proliant_bl460c_firmware",
+      "Version": "2.20",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openjsf:express:4.11.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:openjsf:express:4.11.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openjsf",
+      "Product": "express",
+      "Version": "4.11.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:huawei:usg2220bsr_firmware:v300r001c00:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:huawei:usg2220bsr_firmware:v300r001c00",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "huawei",
+      "Product": "usg2220bsr_firmware",
+      "Version": "v300r001c00",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:10web:photo_gallery:1.3.67:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:10web:photo_gallery:1.3.67::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "10web",
+      "Product": "photo_gallery",
+      "Version": "1.3.67",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:express-gateway:express-gateway_docker_image:1.16.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:express-gateway:express-gateway_docker_image:1.16.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "express-gateway",
+      "Product": "express-gateway_docker_image",
+      "Version": "1.16.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:zyxel:gs1900-24ep:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:zyxel:gs1900-24ep:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "zyxel",
+      "Product": "gs1900-24ep",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:llvm:compiler:2.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:llvm:compiler:2.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "llvm",
+      "Product": "compiler",
+      "Version": "2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:qos:logback:0.9.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:qos:logback:0.9.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "qos",
+      "Product": "logback",
+      "Version": "0.9.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:openui5:1.63.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:openui5:1.63.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "openui5",
+      "Version": "1.63.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sugarcrm:sugarcrm:6.5.8:*:*:*:community:*:*:*",
+    "cpe-url": "cpe:/a:sugarcrm:sugarcrm:6.5.8::~~community~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sugarcrm",
+      "Product": "sugarcrm",
+      "Version": "6.5.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "community",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wordpress:wordpress:4.1:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wordpress:wordpress:4.1:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wordpress",
+      "Product": "wordpress",
+      "Version": "4.1",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:psutil_project:psutil:5.4.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:psutil_project:psutil:5.4.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "psutil_project",
+      "Product": "psutil",
+      "Version": "5.4.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adobe:flash_player:11.2.202.291:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:adobe:flash_player:11.2.202.291",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adobe",
+      "Product": "flash_player",
+      "Version": "11.2.202.291",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:horde:kronolith:3.0.15:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:horde:kronolith:3.0.15",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "horde",
+      "Product": "kronolith",
+      "Version": "3.0.15",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gitlab:gitlab:9.4.0:*:*:*:-:*:*:*",
+    "cpe-url": "cpe:/a:gitlab:gitlab:9.4.0::~~-~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gitlab",
+      "Product": "gitlab",
+      "Version": "9.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:microsoft:windows_8:-:-:x86:*:*:*:*:*",
+    "cpe-url": "cpe:/o:microsoft:windows_8:-:-:x86",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "microsoft",
+      "Product": "windows_8",
+      "Version": "-",
+      "Update": "-",
+      "Edition": "x86",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:emberjs:ember.js:3.11.0:beta1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:emberjs:ember.js:3.11.0:beta1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "emberjs",
+      "Product": "ember.js",
+      "Version": "3.11.0",
+      "Update": "beta1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.1587:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.1587",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.1587",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cloudera:cloudera_manager:5.13.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cloudera:cloudera_manager:5.13.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cloudera",
+      "Product": "cloudera_manager",
+      "Version": "5.13.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:git-scm:git:1.5.5:rc3:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:git-scm:git:1.5.5:rc3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "git-scm",
+      "Product": "git",
+      "Version": "1.5.5",
+      "Update": "rc3",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:coder:code-server:3.9.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:coder:code-server:3.9.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "coder",
+      "Product": "code-server",
+      "Version": "3.9.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:piwik:piwik:0.2.19:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:piwik:piwik:0.2.19",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "piwik",
+      "Product": "piwik",
+      "Version": "0.2.19",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openconext:openconext_engineblock:3.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:openconext:openconext_engineblock:3.0.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openconext",
+      "Product": "openconext_engineblock",
+      "Version": "3.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:isc:bind:9.8.0:p1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:isc:bind:9.8.0:p1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "isc",
+      "Product": "bind",
+      "Version": "9.8.0",
+      "Update": "p1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wordfence:wordfence_security:5.0.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wordfence:wordfence_security:5.0.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wordfence",
+      "Product": "wordfence_security",
+      "Version": "5.0.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:canon:eos_m5_firmware:1.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:canon:eos_m5_firmware:1.0.1",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "canon",
+      "Product": "eos_m5_firmware",
+      "Version": "1.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:dell:poweredge_r940xa_firmware:2.11.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:dell:poweredge_r940xa_firmware:2.11.2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "dell",
+      "Product": "poweredge_r940xa_firmware",
+      "Version": "2.11.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:litespeedtech:litespeed_cache:1.0.9:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:litespeedtech:litespeed_cache:1.0.9::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "litespeedtech",
+      "Product": "litespeed_cache",
+      "Version": "1.0.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:koha:koha:3.20.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:koha:koha:3.20.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "koha",
+      "Product": "koha",
+      "Version": "3.20.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:elasticsearch:kibana:5.2.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:elasticsearch:kibana:5.2.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "elasticsearch",
+      "Product": "kibana",
+      "Version": "5.2.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:sony:nw-a47:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:sony:nw-a47:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "sony",
+      "Product": "nw-a47",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:puma:puma:4.3.4:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:puma:puma:4.3.4::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "puma",
+      "Product": "puma",
+      "Version": "4.3.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:modx:revolution:2.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:modx:revolution:2.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "modx",
+      "Product": "revolution",
+      "Version": "2.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:denx:u-boot:2017.05:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:denx:u-boot:2017.05:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "denx",
+      "Product": "u-boot",
+      "Version": "2017.05",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:blubrry:powerpress:1.0.10:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:blubrry:powerpress:1.0.10::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "blubrry",
+      "Product": "powerpress",
+      "Version": "1.0.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:editor-core:72.1.13:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:atlassian:editor-core:72.1.13::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "editor-core",
+      "Version": "72.1.13",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:silanis:approveit_desktop:7.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:silanis:approveit_desktop:7.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "silanis",
+      "Product": "approveit_desktop",
+      "Version": "7.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:telerik:ui_for_asp.net_core:2014.2.903:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:telerik:ui_for_asp.net_core:2014.2.903",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "telerik",
+      "Product": "ui_for_asp.net_core",
+      "Version": "2014.2.903",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:serve-here.js_project:serve-here.js:1.1.3:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:serve-here.js_project:serve-here.js:1.1.3::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "serve-here.js_project",
+      "Product": "serve-here.js",
+      "Version": "1.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ios:11.1\\(24c\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ios:11.1%2824c%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ios",
+      "Version": "11.1(24c)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:netgear:jgs524pe:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:netgear:jgs524pe:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "netgear",
+      "Product": "jgs524pe",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:facebook:nuclide:0.182.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:facebook:nuclide:0.182.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "facebook",
+      "Product": "nuclide",
+      "Version": "0.182.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:unified_customer_voice_portal:9.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:unified_customer_voice_portal:9.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "unified_customer_voice_portal",
+      "Version": "9.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:ui5:1.52.28:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:ui5:1.52.28",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "ui5",
+      "Version": "1.52.28",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:encs_5400_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:encs_5400_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "encs_5400_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:alpinelinux:aports:3.0.5:*:*:*:*:alpine:*:*",
+    "cpe-url": "cpe:/a:alpinelinux:aports:3.0.5::~~~alpine~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "alpinelinux",
+      "Product": "aports",
+      "Version": "3.0.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "alpine",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:soliddb:6.3.53:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:soliddb:6.3.53",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "soliddb",
+      "Version": "6.3.53",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:lenovo:yoga_530-14ikb_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:lenovo:yoga_530-14ikb_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "lenovo",
+      "Product": "yoga_530-14ikb_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:red-gate:smartassembly:6.6.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:red-gate:smartassembly:6.6.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "red-gate",
+      "Product": "smartassembly",
+      "Version": "6.6.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:underscorejs:underscore:1.3.2:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:underscorejs:underscore:1.3.2::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "underscorejs",
+      "Product": "underscore",
+      "Version": "1.3.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wp-property-hive:propertyhive:1.4.10:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wp-property-hive:propertyhive:1.4.10::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wp-property-hive",
+      "Product": "propertyhive",
+      "Version": "1.4.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:socusoft:flash_slideshow_maker:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:socusoft:flash_slideshow_maker:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "socusoft",
+      "Product": "flash_slideshow_maker",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rimarts:becky\\!_internet_mail:2.20.01:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rimarts:becky%21_internet_mail:2.20.01",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rimarts",
+      "Product": "becky!_internet_mail",
+      "Version": "2.20.01",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:invoiceninja:invoice_ninja:2.3.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:invoiceninja:invoice_ninja:2.3.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "invoiceninja",
+      "Product": "invoice_ninja",
+      "Version": "2.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:cisco:telepresence_system_500-37:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:cisco:telepresence_system_500-37:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "cisco",
+      "Product": "telepresence_system_500-37",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:autohotkey:autohotkey:1.1.30.00:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:autohotkey:autohotkey:1.1.30.00",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "autohotkey",
+      "Product": "autohotkey",
+      "Version": "1.1.30.00",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nih:ncbi_toolbox:2.2.26:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nih:ncbi_toolbox:2.2.26",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nih",
+      "Product": "ncbi_toolbox",
+      "Version": "2.2.26",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:xnview:xnview:1.99:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:xnview:xnview:1.99",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "xnview",
+      "Product": "xnview",
+      "Version": "1.99",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kernel:util-linux:2.25:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kernel:util-linux:2.25",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kernel",
+      "Product": "util-linux",
+      "Version": "2.25",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:hp:0231a65t:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:hp:0231a65t:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "hp",
+      "Product": "0231a65t",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pgp:e-business_server:7.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pgp:e-business_server:7.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pgp",
+      "Product": "e-business_server",
+      "Version": "7.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:electronjs:electron:10.0.0:beta9:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:electronjs:electron:10.0.0:beta9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "electronjs",
+      "Product": "electron",
+      "Version": "10.0.0",
+      "Update": "beta9",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:libpng:libpng:1.6.23:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:libpng:libpng:1.6.23",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "libpng",
+      "Product": "libpng",
+      "Version": "1.6.23",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:smackcoders:ultimate_csv_importer:3.2.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:smackcoders:ultimate_csv_importer:3.2.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "smackcoders",
+      "Product": "ultimate_csv_importer",
+      "Version": "3.2.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:cordova:1.8.1:*:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:apache:cordova:1.8.1::~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "cordova",
+      "Version": "1.8.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:ansible:2.8.0:-:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:ansible:2.8.0:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "ansible",
+      "Version": "2.8.0",
+      "Update": "-",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:intel:xeon_e7-8860_v4:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:intel:xeon_e7-8860_v4:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "intel",
+      "Product": "xeon_e7-8860_v4",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:misskey:misskey:10.82.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:misskey:misskey:10.82.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "misskey",
+      "Product": "misskey",
+      "Version": "10.82.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sprockets_project:sprockets:2.0.0:beta11:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sprockets_project:sprockets:2.0.0:beta11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sprockets_project",
+      "Product": "sprockets",
+      "Version": "2.0.0",
+      "Update": "beta11",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ip_phone_7800_firmware:10.2\\(2\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ip_phone_7800_firmware:10.2%282%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ip_phone_7800_firmware",
+      "Version": "10.2(2)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wire:wire-webapp:2020-02-24:staging0:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wire:wire-webapp:2020-02-24:staging0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wire",
+      "Product": "wire-webapp",
+      "Version": "2020-02-24",
+      "Update": "staging0",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:abap_platform:7.31:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:abap_platform:7.31",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "abap_platform",
+      "Version": "7.31",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:xen-orchestra:xen_orchestra_web:5.7.8:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:xen-orchestra:xen_orchestra_web:5.7.8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "xen-orchestra",
+      "Product": "xen_orchestra_web",
+      "Version": "5.7.8",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:socket:engine.io:1.0.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:socket:engine.io:1.0.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "socket",
+      "Product": "engine.io",
+      "Version": "1.0.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:rspamd_project:rspamd:0.6.10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:rspamd_project:rspamd:0.6.10",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "rspamd_project",
+      "Product": "rspamd",
+      "Version": "0.6.10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlantiswordprocessor:atlantis_word_processor:2.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlantiswordprocessor:atlantis_word_processor:2.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlantiswordprocessor",
+      "Product": "atlantis_word_processor",
+      "Version": "2.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:openlayers:closure-util:1.14.0:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:openlayers:closure-util:1.14.0::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "openlayers",
+      "Product": "closure-util",
+      "Version": "1.14.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:novell:nsure_audit:1.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:novell:nsure_audit:1.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "novell",
+      "Product": "nsure_audit",
+      "Version": "1.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:iceni:infix:6.1.9:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:iceni:infix:6.1.9",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "iceni",
+      "Product": "infix",
+      "Version": "6.1.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.0.009:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.0.009",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.0.009",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:tomcat:8.0.34:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:tomcat:8.0.34",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "tomcat",
+      "Version": "8.0.34",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:emqx:emq_x_broker:0.8.1:alpha:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:emqx:emq_x_broker:0.8.1:alpha",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "emqx",
+      "Product": "emq_x_broker",
+      "Version": "0.8.1",
+      "Update": "alpha",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:eclipse:business_intelligence_and_reporting_tools:4.3.1:rc2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:eclipse:business_intelligence_and_reporting_tools:4.3.1:rc2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "eclipse",
+      "Product": "business_intelligence_and_reporting_tools",
+      "Version": "4.3.1",
+      "Update": "rc2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phoenixcontact:pc_worx:1.50:hotfix1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:phoenixcontact:pc_worx:1.50:hotfix1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phoenixcontact",
+      "Product": "pc_worx",
+      "Version": "1.50",
+      "Update": "hotfix1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:lexmark:cx860_firmware:cxtpp.052.204:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:lexmark:cx860_firmware:cxtpp.052.204",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "lexmark",
+      "Product": "cx860_firmware",
+      "Version": "cxtpp.052.204",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:network_admission_control_manager_and_server_system_software:4.0.0.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:network_admission_control_manager_and_server_system_software:4.0.0.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "network_admission_control_manager_and_server_system_software",
+      "Version": "4.0.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:tivoli_directory_server:6.1.0.33:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:tivoli_directory_server:6.1.0.33",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "tivoli_directory_server",
+      "Version": "6.1.0.33",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zettlr:zettlr:1.7.0:beta12:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zettlr:zettlr:1.7.0:beta12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zettlr",
+      "Product": "zettlr",
+      "Version": "1.7.0",
+      "Update": "beta12",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ruby-lang:ruby:1.8.6.304:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ruby-lang:ruby:1.8.6.304",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ruby-lang",
+      "Product": "ruby",
+      "Version": "1.8.6.304",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:fusioncharts:apexcharts:3.17.1:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:fusioncharts:apexcharts:3.17.1::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "fusioncharts",
+      "Product": "apexcharts",
+      "Version": "3.17.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vercel:next.js:10.0.2:canary5:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:vercel:next.js:10.0.2:canary5:~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vercel",
+      "Product": "next.js",
+      "Version": "10.0.2",
+      "Update": "canary5",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:apple:iphone_os:14.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:apple:iphone_os:14.4",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "apple",
+      "Product": "iphone_os",
+      "Version": "14.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ruby-lang:ruby:1.8.5.31:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ruby-lang:ruby:1.8.5.31",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ruby-lang",
+      "Product": "ruby",
+      "Version": "1.8.5.31",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:avaya:ip_soft_phone:6.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:avaya:ip_soft_phone:6.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "avaya",
+      "Product": "ip_soft_phone",
+      "Version": "6.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:frostwire:frostwire:1.9.1:build353:*:*:*:android:*:*",
+    "cpe-url": "cpe:/a:frostwire:frostwire:1.9.1:build353:~~~android~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "frostwire",
+      "Product": "frostwire",
+      "Version": "1.9.1",
+      "Update": "build353",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "android",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:d-link:dir-885l:a1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:d-link:dir-885l:a1",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "d-link",
+      "Product": "dir-885l",
+      "Version": "a1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:search_meter_project:search_meter:2.13.1:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:search_meter_project:search_meter:2.13.1::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "search_meter_project",
+      "Product": "search_meter",
+      "Version": "2.13.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:s9y:serendipity_event_freetag:3.74:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:s9y:serendipity_event_freetag:3.74",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "s9y",
+      "Product": "serendipity_event_freetag",
+      "Version": "3.74",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sensiolabs:symfony:5.2.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sensiolabs:symfony:5.2.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sensiolabs",
+      "Product": "symfony",
+      "Version": "5.2.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:x:libxrandr:1.2.99.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:x:libxrandr:1.2.99.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "x",
+      "Product": "libxrandr",
+      "Version": "1.2.99.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inpsyde:backwpup:3.3.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:inpsyde:backwpup:3.3.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inpsyde",
+      "Product": "backwpup",
+      "Version": "3.3.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:websphere_application_server:20.0.0.7:*:*:*:liberty:*:*:*",
+    "cpe-url": "cpe:/a:ibm:websphere_application_server:20.0.0.7::~~liberty~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "websphere_application_server",
+      "Version": "20.0.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "liberty",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:microsoft:azure-iot-sdk-c:2017-09-08:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:microsoft:azure-iot-sdk-c:2017-09-08",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "microsoft",
+      "Product": "azure-iot-sdk-c",
+      "Version": "2017-09-08",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:pdqinc:laserwash_autoxpress_plus:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:pdqinc:laserwash_autoxpress_plus:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "pdqinc",
+      "Product": "laserwash_autoxpress_plus",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:deskpro:deskpro:2021.1.7:*:*:*:cloud:*:*:*",
+    "cpe-url": "cpe:/a:deskpro:deskpro:2021.1.7::~~cloud~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "deskpro",
+      "Product": "deskpro",
+      "Version": "2021.1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "cloud",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:nuuo:nvrsolo:1.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:nuuo:nvrsolo:1.3.0",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "nuuo",
+      "Product": "nvrsolo",
+      "Version": "1.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:httpclient:4.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:httpclient:4.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "httpclient",
+      "Version": "4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:qnap:photo_station:5.7.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:qnap:photo_station:5.7.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "qnap",
+      "Product": "photo_station",
+      "Version": "5.7.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ithemes:ithemes_security:7.3.2:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:ithemes:ithemes_security:7.3.2::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ithemes",
+      "Product": "ithemes_security",
+      "Version": "7.3.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpcharitable:charitable:1.6.17:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpcharitable:charitable:1.6.17::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpcharitable",
+      "Product": "charitable",
+      "Version": "1.6.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:pepperl-fuchs:pgv100-f200-b17-v1d-7477_firmware:2.0.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:pepperl-fuchs:pgv100-f200-b17-v1d-7477_firmware:2.0.0",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "pepperl-fuchs",
+      "Product": "pgv100-f200-b17-v1d-7477_firmware",
+      "Version": "2.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:arista:mos:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:arista:mos:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "arista",
+      "Product": "mos",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:blackberry:enterprise_service:12.2.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:blackberry:enterprise_service:12.2.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "blackberry",
+      "Product": "enterprise_service",
+      "Version": "12.2.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:triplea-game:triplea:1.9.0.0.11975:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:triplea-game:triplea:1.9.0.0.11975",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "triplea-game",
+      "Product": "triplea",
+      "Version": "1.9.0.0.11975",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:ip_phone_8861_firmware:10.3\\(1\\)sr4b:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:ip_phone_8861_firmware:10.3%281%29sr4b",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "ip_phone_8861_firmware",
+      "Version": "10.3(1)sr4b",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:symantec:security_information_manager:4.7.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:symantec:security_information_manager:4.7.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "symantec",
+      "Product": "security_information_manager",
+      "Version": "4.7.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vmware:vrealize_operations_for_published_applications:6.5.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vmware:vrealize_operations_for_published_applications:6.5.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vmware",
+      "Product": "vrealize_operations_for_published_applications",
+      "Version": "6.5.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:apple:watchos:3.1.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:apple:watchos:3.1.3",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "apple",
+      "Product": "watchos",
+      "Version": "3.1.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:etherpad:etherpad:1.6.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:etherpad:etherpad:1.6.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "etherpad",
+      "Product": "etherpad",
+      "Version": "1.6.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:apache:http_server:2.2.16:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:apache:http_server:2.2.16",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "apache",
+      "Product": "http_server",
+      "Version": "2.2.16",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:hikvision:ds-2cd2086g2-iu\\/sl_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:hikvision:ds-2cd2086g2-iu%2fsl_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "hikvision",
+      "Product": "ds-2cd2086g2-iu/sl_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:dell:latitude_5300_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:dell:latitude_5300_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "dell",
+      "Product": "latitude_5300_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:adobe:robohelp:2020.0.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:adobe:robohelp:2020.0.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "adobe",
+      "Product": "robohelp",
+      "Version": "2020.0.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sendio:sendio:7.1.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sendio:sendio:7.1.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sendio",
+      "Product": "sendio",
+      "Version": "7.1.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tendermint:tendermint:0.19.6:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tendermint:tendermint:0.19.6:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tendermint",
+      "Product": "tendermint",
+      "Version": "0.19.6",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kakaocorp:kakaotalk:2.7.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kakaocorp:kakaotalk:2.7.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kakaocorp",
+      "Product": "kakaotalk",
+      "Version": "2.7.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:betcash_project:betcash:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:betcash_project:betcash:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "betcash_project",
+      "Product": "betcash",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:jenkins:checkstyle:1.7:*:*:*:*:jenkins:*:*",
+    "cpe-url": "cpe:/a:jenkins:checkstyle:1.7::~~~jenkins~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "jenkins",
+      "Product": "checkstyle",
+      "Version": "1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "jenkins",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:yithemes:yith_woocommerce_pdf_invoice_and_shipping_list:1.4.17:*:*:*:premium:wordpress:*:*",
+    "cpe-url": "cpe:/a:yithemes:yith_woocommerce_pdf_invoice_and_shipping_list:1.4.17::~~premium~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "yithemes",
+      "Product": "yith_woocommerce_pdf_invoice_and_shipping_list",
+      "Version": "1.4.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "premium",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sass-lang:libsass:3.5.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sass-lang:libsass:3.5.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sass-lang",
+      "Product": "libsass",
+      "Version": "3.5.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:buffalo:wzr-hp-ag300h:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:buffalo:wzr-hp-ag300h:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "buffalo",
+      "Product": "wzr-hp-ag300h",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mailstore:mailstore_server:12.0.6:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mailstore:mailstore_server:12.0.6",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mailstore",
+      "Product": "mailstore_server",
+      "Version": "12.0.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:darwin:factor:3.0.17:*:*:*:*:node.js:*:*",
+    "cpe-url": "cpe:/a:darwin:factor:3.0.17::~~~node.js~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "darwin",
+      "Product": "factor",
+      "Version": "3.0.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "node.js",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inspireui:mstore_api:2.9.9:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:inspireui:mstore_api:2.9.9::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inspireui",
+      "Product": "mstore_api",
+      "Version": "2.9.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:edac-utils_project:edac-utils:0.12:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:edac-utils_project:edac-utils:0.12",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "edac-utils_project",
+      "Product": "edac-utils",
+      "Version": "0.12",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:huawei:jennifer-an00c:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:huawei:jennifer-an00c:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "huawei",
+      "Product": "jennifer-an00c",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:backup-guard:backup_guard:1.1.79:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:backup-guard:backup_guard:1.1.79::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "backup-guard",
+      "Product": "backup_guard",
+      "Version": "1.1.79",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:phpbb:phpbb:3.2.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:phpbb:phpbb:3.2.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "phpbb",
+      "Product": "phpbb",
+      "Version": "3.2.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nodejs:node.js:0.10.21:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nodejs:node.js:0.10.21",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nodejs",
+      "Product": "node.js",
+      "Version": "0.10.21",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:citrix:sd-wan:10.2.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:citrix:sd-wan:10.2.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "citrix",
+      "Product": "sd-wan",
+      "Version": "10.2.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cpanel:cpanel:58.0.25:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cpanel:cpanel:58.0.25",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cpanel",
+      "Product": "cpanel",
+      "Version": "58.0.25",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:codesys:control_for_plcnext:3.5.15.30:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:codesys:control_for_plcnext:3.5.15.30",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "codesys",
+      "Product": "control_for_plcnext",
+      "Version": "3.5.15.30",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:change_and_configuration_management_database:7.1.1.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:change_and_configuration_management_database:7.1.1.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "change_and_configuration_management_database",
+      "Version": "7.1.1.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:7.4.1529:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:7.4.1529",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "7.4.1529",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:alpinelinux:aports:3.13.0:rc5:*:*:*:alpine:*:*",
+    "cpe-url": "cpe:/a:alpinelinux:aports:3.13.0:rc5:~~~alpine~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "alpinelinux",
+      "Product": "aports",
+      "Version": "3.13.0",
+      "Update": "rc5",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "alpine",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tadtools_project:tadtools:3.04:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tadtools_project:tadtools:3.04",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tadtools_project",
+      "Product": "tadtools",
+      "Version": "3.04",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:katello_project:katello:3.3.0.1:*:*:*:*:foreman:*:*",
+    "cpe-url": "cpe:/a:katello_project:katello:3.3.0.1::~~~foreman~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "katello_project",
+      "Product": "katello",
+      "Version": "3.3.0.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "foreman",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:extremenetworks:extremewireless_wing:5.7.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:extremenetworks:extremewireless_wing:5.7.2",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "extremenetworks",
+      "Product": "extremewireless_wing",
+      "Version": "5.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cisco:nx-os:6.2\\(24\\):*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cisco:nx-os:6.2%2824%29",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cisco",
+      "Product": "nx-os",
+      "Version": "6.2(24)",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vmware:spring_security:5.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vmware:spring_security:5.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vmware",
+      "Product": "spring_security",
+      "Version": "5.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:panasonic:eluga_ray_530_firmware:2020-04-10:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:panasonic:eluga_ray_530_firmware:2020-04-10",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "panasonic",
+      "Product": "eluga_ray_530_firmware",
+      "Version": "2020-04-10",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:inedo:proget:4.8.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:inedo:proget:4.8.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "inedo",
+      "Product": "proget",
+      "Version": "4.8.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:redhat:ovirt-engine:4.3.0:alpha2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:redhat:ovirt-engine:4.3.0:alpha2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "redhat",
+      "Product": "ovirt-engine",
+      "Version": "4.3.0",
+      "Update": "alpha2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kde:paste_applet:4.1.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kde:paste_applet:4.1.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kde",
+      "Product": "paste_applet",
+      "Version": "4.1.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wpdownloadmanager:wordpress_download_manager:2.4.3:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:wpdownloadmanager:wordpress_download_manager:2.4.3::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wpdownloadmanager",
+      "Product": "wordpress_download_manager",
+      "Version": "2.4.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zohocorp:manageengine_remote_access_plus:10.0.256:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:zohocorp:manageengine_remote_access_plus:10.0.256",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zohocorp",
+      "Product": "manageengine_remote_access_plus",
+      "Version": "10.0.256",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:x2engine:x2crm:5.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:x2engine:x2crm:5.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "x2engine",
+      "Product": "x2crm",
+      "Version": "5.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:kubernetes:kubernetes:1.6.0:alpha1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:kubernetes:kubernetes:1.6.0:alpha1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "kubernetes",
+      "Product": "kubernetes",
+      "Version": "1.6.0",
+      "Update": "alpha1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:prestosql:presto:327:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:prestosql:presto:327",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "prestosql",
+      "Product": "presto",
+      "Version": "327",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:saltos:saltos:3.7:9160:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:saltos:saltos:3.7:9160",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "saltos",
+      "Product": "saltos",
+      "Version": "3.7",
+      "Update": "9160",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:hp:sgi_tempo:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:hp:sgi_tempo:-",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "hp",
+      "Product": "sgi_tempo",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mongodb:mongodb:3.6.17:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mongodb:mongodb:3.6.17",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mongodb",
+      "Product": "mongodb",
+      "Version": "3.6.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:wftpserver:wing_ftp_server:2.4:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:wftpserver:wing_ftp_server:2.4",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "wftpserver",
+      "Product": "wing_ftp_server",
+      "Version": "2.4",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:webkitgtk:webkitgtk:2.7.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:webkitgtk:webkitgtk:2.7.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "webkitgtk",
+      "Product": "webkitgtk",
+      "Version": "2.7.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ucweb:ucmobile_blovestorm:1.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ucweb:ucmobile_blovestorm:1.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ucweb",
+      "Product": "ucmobile_blovestorm",
+      "Version": "1.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cisco:finesse:9.1\\(1\\)_su1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cisco:finesse:9.1%281%29_su1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cisco",
+      "Product": "finesse",
+      "Version": "9.1(1)_su1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:oracle:collaboration_suite:10.1.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:oracle:collaboration_suite:10.1.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "oracle",
+      "Product": "collaboration_suite",
+      "Version": "10.1.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:huawei:s9300:v100r003:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:huawei:s9300:v100r003",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "huawei",
+      "Product": "s9300",
+      "Version": "v100r003",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sanitize_project:sanitize:4.4.0:*:*:*:*:ruby:*:*",
+    "cpe-url": "cpe:/a:sanitize_project:sanitize:4.4.0::~~~ruby~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sanitize_project",
+      "Product": "sanitize",
+      "Version": "4.4.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "ruby",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:vim:vim:8.0.0087:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:vim:vim:8.0.0087",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "vim",
+      "Product": "vim",
+      "Version": "8.0.0087",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:triplea-game:triplea:1.9.0.0.13066:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:triplea-game:triplea:1.9.0.0.13066",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "triplea-game",
+      "Product": "triplea",
+      "Version": "1.9.0.0.13066",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:telestar:imperial_i200:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:telestar:imperial_i200:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "telestar",
+      "Product": "imperial_i200",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:sap:openui5:1.56.17:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:sap:openui5:1.56.17",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "sap",
+      "Product": "openui5",
+      "Version": "1.56.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:tekmonks:monkshu:2.01:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:tekmonks:monkshu:2.01",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "tekmonks",
+      "Product": "monkshu",
+      "Version": "2.01",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:magentocommerce:magento:1.6.1.0:rc1:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:magentocommerce:magento:1.6.1.0:rc1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "magentocommerce",
+      "Product": "magento",
+      "Version": "1.6.1.0",
+      "Update": "rc1",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cantemo:portal:3.4.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:cantemo:portal:3.4.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cantemo",
+      "Product": "portal",
+      "Version": "3.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:torproject:tor:0.1.0.17:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:torproject:tor:0.1.0.17",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "torproject",
+      "Product": "tor",
+      "Version": "0.1.0.17",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:codeasily:grand_flagallery:5.1.5:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:codeasily:grand_flagallery:5.1.5::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "codeasily",
+      "Product": "grand_flagallery",
+      "Version": "5.1.5",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:cdatatec:fd1104b_firmware:2.4.04_001:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:cdatatec:fd1104b_firmware:2.4.04_001",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "cdatatec",
+      "Product": "fd1104b_firmware",
+      "Version": "2.4.04_001",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:simon_brown:pebble:2.0.0:m2:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:simon_brown:pebble:2.0.0:m2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "simon_brown",
+      "Product": "pebble",
+      "Version": "2.0.0",
+      "Update": "m2",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:npmjs:npm:1.0.0:rc8:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:npmjs:npm:1.0.0:rc8",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "npmjs",
+      "Product": "npm",
+      "Version": "1.0.0",
+      "Update": "rc8",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:opmantek:open-audit:1.12.2-1:*:*:*:-:*:*:*",
+    "cpe-url": "cpe:/a:opmantek:open-audit:1.12.2-1::~~-~~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "opmantek",
+      "Product": "open-audit",
+      "Version": "1.12.2-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "-",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:intel:xeon_processor_d-1577_firmware:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:intel:xeon_processor_d-1577_firmware:-",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "intel",
+      "Product": "xeon_processor_d-1577_firmware",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:atlassian:fisheye:3.5.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:atlassian:fisheye:3.5.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "atlassian",
+      "Product": "fisheye",
+      "Version": "3.5.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:yithemes:yith_woocommerce_request_a_quote:3.0.0:*:*:*:premium:wordpress:*:*",
+    "cpe-url": "cpe:/a:yithemes:yith_woocommerce_request_a_quote:3.0.0::~~premium~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "yithemes",
+      "Product": "yith_woocommerce_request_a_quote",
+      "Version": "3.0.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "premium",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:h:cisco:ncs_5502:-:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/h:cisco:ncs_5502:-",
+    "wfn": {
+      "Part": "h",
+      "Vendor": "cisco",
+      "Product": "ncs_5502",
+      "Version": "-",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:mediacoderhq:mediacoder:0.8.5802:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:mediacoderhq:mediacoder:0.8.5802",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "mediacoderhq",
+      "Product": "mediacoder",
+      "Version": "0.8.5802",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:contao:contao:2.3.0:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:contao:contao:2.3.0",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "contao",
+      "Product": "contao",
+      "Version": "2.3.0",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:zoom:zoom:4.5.9:*:*:*:*:macos:*:*",
+    "cpe-url": "cpe:/a:zoom:zoom:4.5.9::~~~macos~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "zoom",
+      "Product": "zoom",
+      "Version": "4.5.9",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "macos",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:elastic:x-pack:5.6.2:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:elastic:x-pack:5.6.2",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "elastic",
+      "Product": "x-pack",
+      "Version": "5.6.2",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:debian:apt:0.8.15.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:debian:apt:0.8.15.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "debian",
+      "Product": "apt",
+      "Version": "0.8.15.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:plainware:shiftcontroller:2.0.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:plainware:shiftcontroller:2.0.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "plainware",
+      "Product": "shiftcontroller",
+      "Version": "2.0.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:o:sgi:irix:6.5.9m:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/o:sgi:irix:6.5.9m",
+    "wfn": {
+      "Part": "o",
+      "Vendor": "sgi",
+      "Product": "irix",
+      "Version": "6.5.9m",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:nikola_posa:webfoliocms:1.0.7:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:nikola_posa:webfoliocms:1.0.7",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "nikola_posa",
+      "Product": "webfoliocms",
+      "Version": "1.0.7",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:katello_project:katello:0.2.55-1:*:*:*:*:foreman:*:*",
+    "cpe-url": "cpe:/a:katello_project:katello:0.2.55-1::~~~foreman~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "katello_project",
+      "Product": "katello",
+      "Version": "0.2.55-1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "foreman",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:chocolate-doom:crispy_doom:5.6.3:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:chocolate-doom:crispy_doom:5.6.3",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "chocolate-doom",
+      "Product": "crispy_doom",
+      "Version": "5.6.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:cmsmadesimple:bable\\:multilingual_site:0.3.3:*:*:*:*:cms_made_simple:*:*",
+    "cpe-url": "cpe:/a:cmsmadesimple:bable%3amultilingual_site:0.3.3::~~~cms_made_simple~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "cmsmadesimple",
+      "Product": "bable:multilingual_site",
+      "Version": "0.3.3",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "cms_made_simple",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pressified:sendpress:0.9.9.9.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:pressified:sendpress:0.9.9.9.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pressified",
+      "Product": "sendpress",
+      "Version": "0.9.9.9.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:ibm:tivoli_storage_manager_for_virtual_environments:6.4.3.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:ibm:tivoli_storage_manager_for_virtual_environments:6.4.3.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "ibm",
+      "Product": "tivoli_storage_manager_for_virtual_environments",
+      "Version": "6.4.3.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:debian:advanced_package_tool:0.7.11:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:debian:advanced_package_tool:0.7.11",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "debian",
+      "Product": "advanced_package_tool",
+      "Version": "0.7.11",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:triplea-game:triplea:1.10.13997:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:triplea-game:triplea:1.10.13997",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "triplea-game",
+      "Product": "triplea",
+      "Version": "1.10.13997",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:facebook:thrift:2018.02.05.00:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:facebook:thrift:2018.02.05.00",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "facebook",
+      "Product": "thrift",
+      "Version": "2018.02.05.00",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:qantumthemes:onair2:3.1.6:*:*:*:*:wordpress:*:*",
+    "cpe-url": "cpe:/a:qantumthemes:onair2:3.1.6::~~~wordpress~~",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "qantumthemes",
+      "Product": "onair2",
+      "Version": "3.1.6",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "wordpress",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:pimcore:pimcore:4.4.1:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:pimcore:pimcore:4.4.1",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "pimcore",
+      "Product": "pimcore",
+      "Version": "4.4.1",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  },
+  {
+    "cpe-string": "cpe:2.3:a:gnu:libredwg:0.8.1853:*:*:*:*:*:*:*",
+    "cpe-url": "cpe:/a:gnu:libredwg:0.8.1853",
+    "wfn": {
+      "Part": "a",
+      "Vendor": "gnu",
+      "Product": "libredwg",
+      "Version": "0.8.1853",
+      "Update": "",
+      "Edition": "",
+      "Language": "",
+      "SwEdition": "",
+      "TargetSw": "",
+      "TargetHw": "",
+      "Other": ""
+    }
+  }
+]

--- a/test/integration/encode_decode_cycle_test.go
+++ b/test/integration/encode_decode_cycle_test.go
@@ -33,7 +33,6 @@ func TestEncodeDecodeEncodeCycleComparison(t *testing.T) {
 
 			by1, err := syft.Encode(originalSBOM, test.format)
 			assert.NoError(t, err)
-
 			newSBOM, newFormat, err := syft.Decode(bytes.NewReader(by1))
 			assert.NoError(t, err)
 			assert.Equal(t, test.format, newFormat)


### PR DESCRIPTION
Fixes #712 
Fixes #426 

Currently syft seems to generate invalid CPEs which do not
conform with the official CPE spec. This is because the underlying
nvdtools library is not a completely spec compliant implementation
and has some interesting bugs/issues.

The following are the list of issues I have encountered with nvdtools:

1. It parses strings which are not CPEs incorrectly as valid CPEs. This
messes up our filter function which is supposed to filter out any
incorrect CPEs we generate. In order to fix this, I have introduced
a new regex in the NewCPE function which follows the upstream spec and
filters out any incorrect CPEs.

2. Introduce wfn.WFNize for any cpe attributes we infer from packages.
This ensures that we are escaping and quoting any special characters
before putting them into CPEs. Note that nvdtools has yet another bug
in the WFNize function, specifically the "addSlashesAt" part of the
function which stops the loop as soon as it encounters ":" a valid
character for a WFN attribute after quoting, but the way nvdtools
handles it causes it to truncate strings that container ":". As a result
strings like "prefix:1.2" which would have been quoted as "prefix\:1.2"
end up becoming "prefix" instead causing loss of information and
incorrect CPEs being generated. As a result in such cases, we remove out
strings containing ":" in any part entirely for now. This is similar
to the way we were handling CPE filtering in the past with http urls as
vendor strings

3. Add special handling for version which contain ":" due to epochs in
debian and rpm. In this case, we strip out the parts before ":" i.e.
the epoch and only output the actual function. This ensures we are not
discarding valid version strings due to pt #.2.

In the future we should look at moving to a more spec compliant cpe
parsing library to avoid such shenanigans.



Edit on Point 2 after the second commit - 

Remove WFNize for input strings
WFNize seems to not be part of the standard as per
pkg.go.dev/github.com/facebookincubator/nvdtools@v0.1.4/wfn#WFNize
and seems to have bugs/issues with encode/decode cycles, so I am
just removing it at this point and relying on the CPE regex to filter
out invalid CPEs for now.