### PR TITLE
Bump goreleaser to v1.2

### DIFF
--- a/.github/scripts/goreleaser-install.sh
+++ b/.github/scripts/goreleaser-install.sh
@@ -338,7 +338,7 @@ hash_sha256_verify() {
 		return 1
 	fi
 	BASENAME=${TARGET##*/}
-	want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+	want=$(grep "${BASENAME}\$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
 	if [ -z "$want" ]; then
 		log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
 		return 1

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.42.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.2.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
-	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v0.177.0
+	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v1.2.2
 	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/neilpa/yajsv@v1.4.0
 
 .PHONY: bootstrap-go


### PR DESCRIPTION
The new goreleaser releases have SBOMs attached, so we need to make certain the checksum validation keeps that in mind when looking for the right asset.