### PR TITLE
Add a version flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/config"
+	"github.com/anchore/syft/internal/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -22,12 +24,14 @@ var rootCmd = &cobra.Command{
 	PreRunE:           packagesCmd.PreRunE,
 	RunE:              packagesCmd.RunE,
 	ValidArgsFunction: packagesCmd.ValidArgsFunction,
+	Version:           version.FromBuild().Version,
 }
 
 func init() {
 	// set universal flags
 	rootCmd.PersistentFlags().StringVarP(&persistentOpts.ConfigPath, "config", "c", "", "application config file")
-
+	// setting the version template to just print out the string since we already have a templatized version string
+	rootCmd.SetVersionTemplate(fmt.Sprintf("%s {{.Version}}\n", internal.ApplicationName))
 	flag := "quiet"
 	rootCmd.PersistentFlags().BoolP(
 		flag, "q", false,


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

Fixes #700 


Output -

```bash
go run main.go --version
syft [not provided]
```

When a version is set - 


```bash
syft-dev --version
syft 0.34.0
```

```
go run main.go --help
Generate a packaged-based Software Bill Of Materials (SBOM) from container images and filesystems

Usage:
   [flags]
   [command]

Examples:
  syft packages alpine:latest                a summary of discovered packages
  syft packages alpine:latest -o json        show all possible cataloging details
  syft packages alpine:latest -o cyclonedx   show a CycloneDX formatted SBOM
  syft packages alpine:latest -o spdx        show a SPDX 2.2 tag-value formatted SBOM
  syft packages alpine:latest -o spdx-json   show a SPDX 2.2 JSON formatted SBOM
  syft packages alpine:latest -vv            show verbose debug information

  Supports the following image sources:
    syft packages yourrepo/yourimage:tag     defaults to using images from a Docker daemon. If Docker is not present, the image is pulled directly from the registry.
    syft packages path/to/a/file/or/dir      a Docker tar, OCI tar, OCI directory, or generic filesystem directory

  You can also explicitly specify the scheme to use:
    syft packages docker:yourrepo/yourimage:tag          explicitly use the Docker daemon
    syft packages docker-archive:path/to/yourimage.tar   use a tarball from disk for archives created from "docker save"
    syft packages oci-archive:path/to/yourimage.tar      use a tarball from disk for OCI archives (from Skopeo or otherwise)
    syft packages oci-dir:path/to/yourimage              read directly from a path on disk for OCI layout directories (from Skopeo or otherwise)
    syft packages dir:path/to/yourproject                read directly from a path on disk (any directory)
    syft packages file:path/to/yourproject/file          read directly from a path on disk (any single file)
    syft packages registry:yourrepo/yourimage:tag        pull image directly from a registry (no container runtime required)


Available Commands:
  completion  Generate a shell completion for Syft (listing local docker images)
  help        Help about any command
  packages    Generate a package SBOM
  version     show the version

Flags:
  -c, --config string              application config file
  -d, --dockerfile string          include dockerfile for upload to Anchore Enterprise
      --exclude stringArray        exclude paths from being scanned using a glob expression
      --file string                file to write the report output to (default is STDOUT)
  -h, --help                       help for this command
  -H, --host string                the hostname or URL of the Anchore Enterprise instance to upload to
      --import-timeout uint        set a timeout duration (in seconds) for the upload to Anchore Enterprise (default 30)
  -o, --output string              report output formatter, options=[json text table cyclonedx cyclonedx-json spdx-tag-value spdx-json] (default "table")
      --overwrite-existing-image   overwrite an existing image during the upload to Anchore Enterprise
  -p, --password string            the password to authenticate against Anchore Enterprise
  -q, --quiet                      suppress all logging output
  -s, --scope string               selection of layers to catalog, options=[Squashed AllLayers] (default "Squashed")
  -u, --username string            the username to authenticate against Anchore Enterprise
  -v, --verbose count              increase verbosity (-v = info, -vv = debug)
      --version                    version for this command

Use " [command] --help" for more information about a command.
```
