### PR TITLE
support .par for java ecosystems

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -113,7 +113,7 @@ func (a archiveFilename) extension() string {
 
 func (a archiveFilename) pkgType() pkg.Type {
 	switch strings.ToLower(a.extension()) {
-	case "jar", "war", "ear", "lpkg":
+	case "jar", "war", "ear", "lpkg", "par":
 		return pkg.JavaPkg
 	case "jpi", "hpi":
 		return pkg.JenkinsPluginPkg

--- a/syft/pkg/cataloger/java/archive_filename_test.go
+++ b/syft/pkg/cataloger/java/archive_filename_test.go
@@ -51,6 +51,13 @@ func TestExtractInfoFromJavaArchiveFilename(t *testing.T) {
 			ty:        pkg.JavaPkg,
 		},
 		{
+			filename:  "pkg-extra-field-maven-4.3.2-rc1.par",
+			version:   "4.3.2-rc1",
+			extension: "par",
+			name:      "pkg-extra-field-maven",
+			ty:        pkg.JavaPkg,
+		},
+		{
 			filename:  "/some/path/pkg-extra-field-maven-4.3.2-rc1.jpi",
 			version:   "4.3.2-rc1",
 			extension: "jpi",

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -20,6 +20,7 @@ var archiveFormatGlobs = []string{
 	"**/*.jar",
 	"**/*.war",
 	"**/*.ear",
+	"**/*.par",
 	"**/*.jpi",
 	"**/*.hpi",
 	"**/*.lpkg", // Zip-compressed package used to deploy applications

--- a/syft/pkg/cataloger/java/cataloger.go
+++ b/syft/pkg/cataloger/java/cataloger.go
@@ -1,5 +1,5 @@
 /*
-Package java provides a concrete Cataloger implementation for Java archives (jar, war, ear, jpi, hpi formats).
+Package java provides a concrete Cataloger implementation for Java archives (jar, war, ear, par, jpi, hpi formats).
 */
 package java
 


### PR DESCRIPTION
Support .par format for #728.  This succesfully detects log4j in the sample .par file at https://github.com/palantir/log4j-sniffer/blob/develop/examples/inside_a_par/wrapped_in_a_par.par.

Signed-off-by: Weston Steimel <weston.steimel@gmail.com>