### PR TITLE
Revert "Bump goreleaser to v1.2"

### DIFF
--- a/.github/scripts/goreleaser-install.sh
+++ b/.github/scripts/goreleaser-install.sh
@@ -338,7 +338,7 @@ hash_sha256_verify() {
 		return 1
 	fi
 	BASENAME=${TARGET##*/}
-	want=$(grep "${BASENAME}\$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+	want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
 	if [ -z "$want" ]; then
 		log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
 		return 1

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.42.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.2.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
-	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v1.2.2
+	.github/scripts/goreleaser-install.sh -b $(TEMPDIR)/ v0.177.0
 	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/neilpa/yajsv@v1.4.0
 
 .PHONY: bootstrap-go


### PR DESCRIPTION
The latest release did not properly update the checksums for all of the darwin-related assets. This appears to be due to the specific goreleaser configuration we have, however, testing changes to this is non-obvious since it overlaps with behavior in the signing section (which is notoriously hard to test). 

We need to get the mac signing process into a state where we can confidently test process changes without needing production secrets or testing on a real release. I can follow up with details in a future PR, however, for the meantime we should fallback to the old release of goreleaser until we have made the proper configuration updates.