### PR TITLE
683 windows filepath

### DIFF
--- a/internal/file/zip_file_manifest_test.go
+++ b/internal/file/zip_file_manifest_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package file
 
 import (

--- a/internal/file/zip_file_traversal_test.go
+++ b/internal/file/zip_file_traversal_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package file
 
 import (

--- a/internal/file/zip_read_closer_test.go
+++ b/internal/file/zip_read_closer_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package file
 
 import (

--- a/internal/formats/common/testutils/utils.go
+++ b/internal/formats/common/testutils/utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/anchore/go-presenter"
@@ -51,6 +52,7 @@ func AssertPresenterAgainstGoldenImageSnapshot(t *testing.T, pres presenter.Pres
 	var expected = testutils.GetGoldenFileContents(t)
 
 	// remove dynamic values, which should be tested independently
+	redactors = append(redactors, carriageRedactor)
 	for _, r := range redactors {
 		actual = r(actual)
 		expected = r(expected)
@@ -79,6 +81,7 @@ func AssertPresenterAgainstGoldenSnapshot(t *testing.T, pres presenter.Presenter
 	var expected = testutils.GetGoldenFileContents(t)
 
 	// remove dynamic values, which should be tested independently
+	redactors = append(redactors, carriageRedactor)
 	for _, r := range redactors {
 		actual = r(actual)
 		expected = r(expected)
@@ -136,6 +139,11 @@ func ImageInput(t testing.TB, testImage string, options ...ImageOption) sbom.SBO
 			},
 		},
 	}
+}
+
+func carriageRedactor(s []byte) []byte {
+	msg := strings.ReplaceAll(string(s), "\r\n", "\n")
+	return []byte(msg)
 }
 
 func populateImageCatalog(catalog *pkg.Catalog, img *image.Image) {

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -22,6 +22,8 @@ import (
 	"github.com/wagoodman/go-progress"
 )
 
+const WindowsOS = "windows"
+
 var unixSystemRuntimePrefixes = []string{
 	"/proc",
 	"/dev",
@@ -145,7 +147,7 @@ func (r *directoryResolver) indexPath(path string, info os.FileInfo, err error) 
 	}
 
 	// here we check to see if we need to normalize paths to posix on the way in coming from windows
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == WindowsOS {
 		path = windowsToPosix(path)
 	}
 
@@ -265,7 +267,7 @@ func (r directoryResolver) requestPath(userPath string) (string, error) {
 
 func (r directoryResolver) responsePath(path string) string {
 	// check to see if we need to encode back to Windows from posix
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == WindowsOS {
 		path = posixToWindows(path)
 	}
 
@@ -325,7 +327,7 @@ func (r directoryResolver) FilesByPath(userPaths ...string) ([]Location, error) 
 			continue
 		}
 
-		if runtime.GOOS == "windows" {
+		if runtime.GOOS == WindowsOS {
 			userStrPath = windowsToPosix(userStrPath)
 		}
 
@@ -385,7 +387,7 @@ func (r directoryResolver) FileContentsByLocation(location Location) (io.ReadClo
 	// RealPath is posix so for windows directory resolver we need to translate
 	// to its true on disk path.
 	filePath := string(location.ref.RealPath)
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == WindowsOS {
 		filePath = posixToWindows(filePath)
 	}
 	return file.NewLazyReadCloser(filePath), nil

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -409,6 +409,10 @@ func (r *directoryResolver) FilesByMIMEType(types ...string) ([]Location, error)
 	return locations, nil
 }
 
+func windowsToPosix(windowsPath string) (posixPath string, err error) {
+	return windowsPath, err
+}
+
 func isUnixSystemRuntimePath(path string, _ os.FileInfo) bool {
 	return internal.HasAnyOfPrefixes(path, unixSystemRuntimePrefixes...)
 }

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -448,13 +448,13 @@ func windowsToPosix(windowsPath string) (posixPath string) {
 func posixToWindows(posixPath string) (windowsPath string) {
 	// decode the volume (e.g. /c/<path> --> C:\\) - There should always be a volume name.
 	pathFields := strings.Split(posixPath, "/")
-	volumeName := strings.ToUpper(pathFields[1]) + ":\\"
+	volumeName := strings.ToUpper(pathFields[1]) + `:\\`
 
 	// translate non-escaped forward slashes into backslashes
 	remainingTranslatedPath := strings.Join(pathFields[2:], "\\")
 
 	// combine volume name and backslash components
-	return filepath.Join(volumeName, remainingTranslatedPath)
+	return filepath.Clean(volumeName + remainingTranslatedPath)
 }
 
 func isUnixSystemRuntimePath(path string, _ os.FileInfo) bool {

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -649,7 +649,6 @@ func Test_IndexingNestedSymLinksOutsideOfRoot(t *testing.T) {
 	locations, err = resolver.FilesByPath("./link_to_link_to_readme")
 	require.NoError(t, err)
 	assert.Len(t, locations, 1)
-
 }
 
 func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
@@ -684,10 +683,9 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 			if test.err {
 				require.Error(t, err)
 				return
-			} else {
-				require.NoError(t, err)
 			}
 
+			require.NoError(t, err)
 			if test.expects != "" {
 				b, err := ioutil.ReadAll(actual)
 				require.NoError(t, err)

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -694,25 +694,6 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 	}
 }
 
-func Test_windowsToPosix(t *testing.T) {
-	tests := []struct {
-		windowsPath   string
-		expectedPosix string
-	}{
-		{
-			windowsPath:   `C:\\Users\my-package`,
-			expectedPosix: "/Users/my-package",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.windowsPath, func(t *testing.T) {
-			posixPath, err := windowsToPosix(test.windowsPath)
-			require.NoError(t, err)
-			assert.Equal(t, test.expectedPosix, posixPath)
-		})
-	}
-}
-
 func Test_isUnixSystemRuntimePath(t *testing.T) {
 	tests := []struct {
 		path     string

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package source
 
 import (

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -694,6 +694,25 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 	}
 }
 
+func Test_windowsToPosix(t *testing.T) {
+	tests := []struct {
+		windowsPath   string
+		expectedPosix string
+	}{
+		{
+			windowsPath:   `C:\\Users\my-package`,
+			expectedPosix: "/Users/my-package",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.windowsPath, func(t *testing.T) {
+			posixPath, err := windowsToPosix(test.windowsPath)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedPosix, posixPath)
+		})
+	}
+}
+
 func Test_isUnixSystemRuntimePath(t *testing.T) {
 	tests := []struct {
 		path     string

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -175,12 +175,12 @@ func TestDirectoryResolver_FilesByPath(t *testing.T) {
 			hasPath := resolver.HasPath(c.input)
 			if !c.forcePositiveHasPath {
 				if c.refCount != 0 && !hasPath {
-					t.Errorf("expected HasPath() to indicate existance, but did not")
+					t.Errorf("expected HasPath() to indicate existence, but did not")
 				} else if c.refCount == 0 && hasPath {
-					t.Errorf("expeced HasPath() to NOT indicate existance, but does")
+					t.Errorf("expected HasPath() to NOT indicate existence, but does")
 				}
 			} else if !hasPath {
-				t.Errorf("expected HasPath() to indicate existance, but did not (force path)")
+				t.Errorf("expected HasPath() to indicate existence, but did not (force path)")
 			}
 
 			refs, err := resolver.FilesByPath(c.input)
@@ -553,7 +553,6 @@ func Test_indexAllRoots(t *testing.T) {
 }
 
 func Test_directoryResolver_FilesByMIMEType(t *testing.T) {
-
 	tests := []struct {
 		fixturePath   string
 		mimeType      string
@@ -567,7 +566,6 @@ func Test_directoryResolver_FilesByMIMEType(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.fixturePath, func(t *testing.T) {
-
 			resolver, err := newDirectoryResolver(test.fixturePath)
 			assert.NoError(t, err)
 			locations, err := resolver.FilesByMIMEType(test.mimeType)

--- a/syft/source/directory_resolver_test_windows.go
+++ b/syft/source/directory_resolver_test_windows.go
@@ -1,20 +1,53 @@
 package source
 
-// only run this test on Windows
 func Test_windowsToPosix(t *testing.T) {
+	type args struct {
+		windowsPath string
+	}
 	tests := []struct {
-		windowsPath   string
-		expectedPosix string
+		name          string
+		args          args
+		wantPosixPath string
 	}{
 		{
-			windowsPath:   `C:\some\\windows\\Place`,
-			expectedPosix: "/c/some/windows/Place",
+			name: "basic case",
+			args: args{
+				windowsPath: `C:\\some\windows\place`,
+			},
+			wantPosixPath: "/c/some/windows/place",
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.windowsPath, func(t *testing.T) {
-			posixPath := windowsToPosix(test.windowsPath)
-			assert.Equal(t, test.expectedPosix, posixPath)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotPosixPath := windowsToPosix(tt.args.windowsPath); gotPosixPath != tt.wantPosixPath {
+				t.Errorf("windowsToPosix() = %v, want %v", gotPosixPath, tt.wantPosixPath)
+			}
+		})
+	}
+}
+
+func Test_posixToWindows(t *testing.T) {
+	type args struct {
+		posixPath string
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantWindowsPath string
+	}{
+		{
+			name: "basic case",
+			args: args{
+				posixPath: "/c/some/windows/place",
+			},
+			wantWindowsPath: `C:\\some\windows\place`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotWindowsPath := posixToWindows(tt.args.posixPath); gotWindowsPath != tt.wantWindowsPath {
+				t.Errorf("posixToWindows() = %v, want %v", gotWindowsPath, tt.wantWindowsPath)
+			}
 		})
 	}
 }

--- a/syft/source/directory_resolver_test_windows.go
+++ b/syft/source/directory_resolver_test_windows.go
@@ -1,5 +1,7 @@
 package source
 
+import "testing"
+
 func Test_windowsToPosix(t *testing.T) {
 	type args struct {
 		windowsPath string

--- a/syft/source/directory_resolver_test_windows.go
+++ b/syft/source/directory_resolver_test_windows.go
@@ -1,0 +1,20 @@
+package source
+
+// only run this test on Windows
+func Test_windowsToPosix(t *testing.T) {
+	tests := []struct {
+		windowsPath   string
+		expectedPosix string
+	}{
+		{
+			windowsPath:   `C:\some\\windows\\Place`,
+			expectedPosix: "/c/some/windows/Place",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.windowsPath, func(t *testing.T) {
+			posixPath := windowsToPosix(test.windowsPath)
+			assert.Equal(t, test.expectedPosix, posixPath)
+		})
+	}
+}

--- a/syft/source/directory_resolver_windows_test.go
+++ b/syft/source/directory_resolver_windows_test.go
@@ -18,7 +18,43 @@ func Test_windowsToPosix(t *testing.T) {
 			},
 			wantPosixPath: "/c/some/windows/place",
 		},
+		{
+			name: "escaped case",
+			args: args{
+				windowsPath: `C:\\some\\windows\\place`,
+			},
+			wantPosixPath: "/c/some/windows/place",
+		},
+		{
+			name: "forward slash",
+			args: args{
+				windowsPath: `C:/foo/bar`,
+			},
+			wantPosixPath: "/c/foo/bar",
+		},
+		{
+			name: "mix slash",
+			args: args{
+				windowsPath: `C:\foo/bar\`,
+			},
+			wantPosixPath: "/c/foo/bar",
+		},
+		{
+			name: "random case",
+			args: args{
+				windowsPath: `C:\Foo/bAr\`,
+			},
+			wantPosixPath: "/c/Foo/bAr",
+		},
+		{
+			name: "random case",
+			args: args{
+				windowsPath: `C:\ふー\バー`,
+			},
+			wantPosixPath: "/c/ふー/バー",
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotPosixPath := windowsToPosix(tt.args.windowsPath); gotPosixPath != tt.wantPosixPath {

--- a/syft/source/directory_resolver_windows_test.go
+++ b/syft/source/directory_resolver_windows_test.go
@@ -40,14 +40,14 @@ func Test_windowsToPosix(t *testing.T) {
 			wantPosixPath: "/c/foo/bar",
 		},
 		{
-			name: "random case",
+			name: "case sensitive case",
 			args: args{
 				windowsPath: `C:\Foo/bAr\`,
 			},
 			wantPosixPath: "/c/Foo/bAr",
 		},
 		{
-			name: "random case",
+			name: "special char case",
 			args: args{
 				windowsPath: `C:\ふー\バー`,
 			},
@@ -79,6 +79,41 @@ func Test_posixToWindows(t *testing.T) {
 				posixPath: "/c/some/windows/place",
 			},
 			wantWindowsPath: `C:\some\windows\place`,
+		},
+		{
+			name: "escaped case",
+			args: args{
+				posixPath: "/c/some/windows/place",
+			},
+			wantWindowsPath: `C:\\some\\windows\\place`,
+		},
+		{
+			name: "forward slash",
+			args: args{
+				posixPath: "/c/foo/bar",
+			},
+			wantWindowsPath: `C:/foo/bar`,
+		},
+		{
+			name: "mix slash",
+			args: args{
+				posixPath: "/c/foo/bar",
+			},
+			wantWindowsPath: `C:\foo/bar\`,
+		},
+		{
+			name: "case sensitive case",
+			args: args{
+				posixPath: "/c/Foo/bAr",
+			},
+			wantWindowsPath: `C:\Foo/bAr\`,
+		},
+		{
+			name: "special char case",
+			args: args{
+				posixPath: "/c/ふー/バー",
+			},
+			wantWindowsPath: `C:\ふー\バー`,
 		},
 	}
 	for _, tt := range tests {

--- a/syft/source/directory_resolver_windows_test.go
+++ b/syft/source/directory_resolver_windows_test.go
@@ -14,7 +14,7 @@ func Test_windowsToPosix(t *testing.T) {
 		{
 			name: "basic case",
 			args: args{
-				windowsPath: `C:\\some\windows\place`,
+				windowsPath: `C:\some\windows\place`,
 			},
 			wantPosixPath: "/c/some/windows/place",
 		},
@@ -42,7 +42,7 @@ func Test_posixToWindows(t *testing.T) {
 			args: args{
 				posixPath: "/c/some/windows/place",
 			},
-			wantWindowsPath: `C:\\some\windows\place`,
+			wantWindowsPath: `C:\some\windows\place`,
 		},
 	}
 	for _, tt := range tests {

--- a/syft/source/file_metadata_test.go
+++ b/syft/source/file_metadata_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package source
 
 import (

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package source
 
 import (


### PR DESCRIPTION
## Support Windows Directory Resolver
- Add function that converts windows to posix functionality
- Add function that converts posix to windows
- Add build tags to remove windows developer environment errors
- redact carriage return specific windows issues

### Summary
When scanning on windows using the `dir` directive the current directory resolver implementation cannot lookup file nodes that match glob patterns in the `filetree.` By converting Windows filepaths on the way in so that their locations match the `posix` standard, we allow for syft to match on directory resolver matching criteria.

Paths are then translated back into windows paths on the way out so the presentation layer shows users the correct on disk details for the given SBOM items.

#### Considertations
- Exclude functionality needs to be updated in a separate PR
- Location data regarding `Realpath` and `VirtualPath` is sometimes incorrect. I'm currently trying to track down where this bug exists. Should `VirtualPath` ever just be the `Posix` representation as found in the file tree or should we be converting these back?

#### Screenshot demo showing functionality on Windows 11:
![image](https://user-images.githubusercontent.com/32073428/148413716-36a23855-e2e5-4e47-9512-ce6bfa2614c3.png)