### PR TITLE
update goreleaser with windows checksums

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -54,8 +54,7 @@ archives:
     id: syft
     replacements:
       windows: Windows
-      386: i386
-      amd54: x86_64
+      amd64: x86_64
     format_overrides:
     - goos: windows
       format: zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -53,7 +53,6 @@ archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     id: syft
     replacements:
-      linux: Linux
       windows: Windows
       386: i386
       amd54: x86_64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,7 +50,7 @@ builds:
       -X github.com/anchore/syft/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     id: syft
     replacements:
       linux: Linux

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,28 +13,10 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-    goarch:
-      - amd64
-      - arm64
-    # Set the modified timestamp on the output binary to the git timestamp (to ensure a reproducible build)
-    mod_timestamp: '{{ .CommitTimestamp }}'
-    ldflags: |
-      -w
-      -s
-      -extldflags '-static'
-      -X github.com/anchore/syft/internal/version.version={{.Version}}
-      -X github.com/anchore/syft/internal/version.gitCommit={{.Commit}}
-      -X github.com/anchore/syft/internal/version.buildDate={{.Date}}
-      -X github.com/anchore/syft/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}
-
-  - binary: syft
-    id: syft-win
-    env:
-      - CGO_ENABLED=0
-    goos:
       - windows
     goarch:
       - amd64
+      - arm64
     # Set the modified timestamp on the output binary to the git timestamp (to ensure a reproducible build)
     mod_timestamp: '{{ .CommitTimestamp }}'
     ldflags: |
@@ -68,14 +50,21 @@ builds:
       -X github.com/anchore/syft/internal/version.gitTreeState={{.Env.BUILD_GIT_TREE_STATE}}
 
 archives:
-  - format: tar.gz
-    builds:
-      - syft # i.e. Linux only
+  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    id: syft
+    replacements:
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd54: x86_64
+    format_overrides:
+    - goos: windows
+      format: zip
+
   - format: zip # This is a hack for syft-macos! We don't actually intend to use _this_ ZIP file, we just need goreleaser to consider the ZIP file produced by gon (which will have the same file name) to be an artifact so we can use it downstream in publishing (e.g. to a homebrew tap)
-    id: syft-zip
+    id: syft-exception
     builds:
       - syft-macos
-      - syft-win
 
 signs:
   - artifacts: checksum
@@ -109,8 +98,11 @@ brews:
   - tap:
       owner: anchore
       name: homebrew-syft
+    ids:
+    - syft
     homepage: *website
     description: *description
+    license: "Apache License 2.0"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Refactor goreleaser syntax for checksums


### How to test
Run `make snapeshot` on this branch. Under `snapshot` there should be a file called `syft_0.35.0-SNAPSHOT-5e5312c_checksums.txt`

Below is the output for that file.

```
0059dc697bca9c0368b676a0feafe98367da762e463e88f89cb740d4cb3bc4a5  syft_0.35.0-SNAPSHOT-b308f74_darwin_amd64.zip
3a72bf458ff4684dc761a825045d1e688f3729ff6e4e29140a0343eacef3f2a5  syft_0.35.0-SNAPSHOT-b308f74_linux_arm64.rpm
4295acf62ae1cd3675bdc1321a045d2b2039e017ecbf229707d1ae92e6f2dfb9  syft_0.35.0-SNAPSHOT-b308f74_darwin_amd64.tar.gz
5277b46093d67ee310fcbbc0e6fc059abe4dfa4799ac6797e58997fec6482a2a  syft_0.35.0-SNAPSHOT-b308f74_darwin_arm64.zip
744b967ef6b15f0e222fdf483b8b852002a493b09837ae14cb426bc32040d872  syft_0.35.0-SNAPSHOT-b308f74_Linux_amd64.tar.gz
82bb6dd3ac03673fa4abd4b027f6969ee4eccc675fd9295c77ce19b79cac97dd  syft_0.35.0-SNAPSHOT-b308f74_Linux_arm64.tar.gz
8b7b5c7c4210feb9ddcda69d24bd8c77a0b881aa638f1be9ab1044d4d48d7655  syft_0.35.0-SNAPSHOT-b308f74_Windows_arm64.zip
9cc259f0e67b3731aecbf9bd191bd17e29085bd41467a2aff514e846894a4c96  syft_0.35.0-SNAPSHOT-b308f74_linux_amd64.deb
d45b648403e9ed328740df02f5de57c8ef9ab0bdb59bb292503bc1ae2dbc0359  syft_0.35.0-SNAPSHOT-b308f74_linux_arm64.deb
e3a0dd098e1484b69cb37176e50a820f061222c1fe81e90330948d7a94d5e9fd  syft_0.35.0-SNAPSHOT-b308f74_Windows_amd64.zip
e711ea296a99656e44ba7f8d9435cf1687d42244eb259d59f84652f23896721a  syft_0.35.0-SNAPSHOT-b308f74_darwin_arm64.tar.gz
f1359b46535584c827b04145b929beacdf4f286cb74cdd39565023ff324b6874  syft_0.35.0-SNAPSHOT-b308f74_linux_amd64.rpm

```

Previously you would only see:
```
  1 6d7eec5285535c2d5435e5024717ccfc3ee4135fc6b5dbfbc5c1435a209a3874  syft_0.35.0-SNAPSHOT-5e5312c_linux_amd64.deb
  1 7391beb8769e1804c80be0615be4f52ac9604f7be7846cd2befb55ff7eb56a89  syft_0.35.0-SNAPSHOT-5e5312c_darwin_amd64.zip
  2 75f154f40c0986c27fcbe1ee2edf455cf96c67b4bf79fb16a5028057b3d56ae7  syft_0.35.0-SNAPSHOT-5e5312c_darwin_arm64.zip
  3 77d6ef81651ba1681b6e338a6a1c006394a1f97c3d7301788f86cfd9cf83641d  syft_0.35.0-SNAPSHOT-5e5312c_windows_amd64.zip
  4 88cfba09e4111a484663853dddc3511e4e8dec94155b94874f7e8bb7693cba3d  syft_0.35.0-SNAPSHOT-5e5312c_linux_arm64.rpm
  5 9b22fbc06f33ee8ca8e52c459ab2e04f46f3264dd510f321b545d16dfca03638  syft_0.35.0-SNAPSHOT-5e5312c_linux_amd64.rpm
  6 c537e8db525d628f757fcfbf0a1cd789dc5884d1fbe70ac843cd50c3d32acbc1  syft_0.35.0-SNAPSHOT-5e5312c_linux_amd64.tar.gz
  7 d05b46d5df0aa9478e7da011fa9f99b0d241e9303094c0b27d4df5701899f706  syft_0.35.0-SNAPSHOT-5e5312c_linux_arm64.deb
  8 dc07c287d73469afd6a0aa275daf5e2044943953d9cd0a89d22ca03753191caf  syft_0.35.0-SNAPSHOT-5e5312c_linux_arm64.tar.gz
```


Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>