### PR TITLE
Align SPDX export more with SPDX 2.2 specification

### DIFF
--- a/internal/formats/common/spdxhelpers/originator_test.go
+++ b/internal/formats/common/spdxhelpers/originator_test.go
@@ -75,7 +75,7 @@ func Test_Originator(t *testing.T) {
 					AuthorEmail: "auth@auth.gov",
 				},
 			},
-			expected: "Person: auth <auth@auth.gov>",
+			expected: "Person: auth (auth@auth.gov)",
 		},
 		{
 			name: "from rpm",

--- a/internal/formats/common/spdxhelpers/originator_test.go
+++ b/internal/formats/common/spdxhelpers/originator_test.go
@@ -29,7 +29,7 @@ func Test_Originator(t *testing.T) {
 					},
 				},
 			},
-			expected: "auth1",
+			expected: "Person: auth1",
 		},
 		{
 			name: "from npm",
@@ -38,7 +38,7 @@ func Test_Originator(t *testing.T) {
 					Author: "auth",
 				},
 			},
-			expected: "auth",
+			expected: "Person: auth",
 		},
 		{
 			name: "from apk",
@@ -47,7 +47,7 @@ func Test_Originator(t *testing.T) {
 					Maintainer: "auth",
 				},
 			},
-			expected: "auth",
+			expected: "Person: auth",
 		},
 		{
 			name: "from python - just name",
@@ -56,7 +56,7 @@ func Test_Originator(t *testing.T) {
 					Author: "auth",
 				},
 			},
-			expected: "auth",
+			expected: "Person: auth",
 		},
 		{
 			name: "from python - just email",
@@ -65,7 +65,7 @@ func Test_Originator(t *testing.T) {
 					AuthorEmail: "auth@auth.gov",
 				},
 			},
-			expected: "auth@auth.gov",
+			expected: "Person: auth@auth.gov",
 		},
 		{
 			name: "from python - both name and email",
@@ -75,7 +75,7 @@ func Test_Originator(t *testing.T) {
 					AuthorEmail: "auth@auth.gov",
 				},
 			},
-			expected: "auth <auth@auth.gov>",
+			expected: "Person: auth <auth@auth.gov>",
 		},
 		{
 			name: "from rpm",
@@ -84,7 +84,7 @@ func Test_Originator(t *testing.T) {
 					Vendor: "auth",
 				},
 			},
-			expected: "auth",
+			expected: "Organization: auth",
 		},
 		{
 			name: "from dpkg",
@@ -93,7 +93,7 @@ func Test_Originator(t *testing.T) {
 					Maintainer: "auth",
 				},
 			},
-			expected: "auth",
+			expected: "Person: auth",
 		},
 		{
 			// note: since this is an optional field, no value is preferred over NONE or NOASSERTION

--- a/internal/formats/common/spdxhelpers/origintor.go
+++ b/internal/formats/common/spdxhelpers/origintor.go
@@ -22,7 +22,7 @@ func Originator(p pkg.Package) string {
 			if author == "" {
 				author = metadata.AuthorEmail
 			} else if metadata.AuthorEmail != "" {
-				author = fmt.Sprintf("%s <%s>", author, metadata.AuthorEmail)
+				author = fmt.Sprintf("%s (%s)", author, metadata.AuthorEmail)
 			}
 		case pkg.GemMetadata:
 			if len(metadata.Authors) > 0 {

--- a/internal/formats/common/spdxhelpers/origintor.go
+++ b/internal/formats/common/spdxhelpers/origintor.go
@@ -1,36 +1,39 @@
 package spdxhelpers
 
 import (
-	"fmt"
-
 	"github.com/anchore/syft/syft/pkg"
 )
 
+// Originator needs to conform to the SPDX spec here:
+// https://spdx.github.io/spdx-spec/package-information/#76-package-originator-field
+// Available options are: <omit>, NOASSERTION, Person: <person>, Organization: <org>
 func Originator(p pkg.Package) string {
 	if hasMetadata(p) {
+		author := ""
 		switch metadata := p.Metadata.(type) {
 		case pkg.ApkMetadata:
-			return metadata.Maintainer
+			author = metadata.Maintainer
 		case pkg.NpmPackageJSONMetadata:
-			return metadata.Author
+			author = metadata.Author
 		case pkg.PythonPackageMetadata:
-			author := metadata.Author
+			author = metadata.Author
 			if author == "" {
-				return metadata.AuthorEmail
+				author = metadata.AuthorEmail
 			}
 			if metadata.AuthorEmail != "" {
-				author += fmt.Sprintf(" <%s>", metadata.AuthorEmail)
+				author += " " + metadata.AuthorEmail
 			}
-			return author
 		case pkg.GemMetadata:
 			if len(metadata.Authors) > 0 {
-				return metadata.Authors[0]
+				author = metadata.Authors[0]
 			}
-			return ""
 		case pkg.RpmdbMetadata:
-			return metadata.Vendor
+			return "Organization: " + metadata.Vendor
 		case pkg.DpkgMetadata:
-			return metadata.Maintainer
+			author = metadata.Maintainer
+		}
+		if author != "" {
+			return "Person: " + author
 		}
 	}
 	return ""

--- a/internal/formats/common/spdxhelpers/origintor.go
+++ b/internal/formats/common/spdxhelpers/origintor.go
@@ -1,6 +1,8 @@
 package spdxhelpers
 
 import (
+	"fmt"
+
 	"github.com/anchore/syft/syft/pkg"
 )
 
@@ -19,9 +21,8 @@ func Originator(p pkg.Package) string {
 			author = metadata.Author
 			if author == "" {
 				author = metadata.AuthorEmail
-			}
-			if metadata.AuthorEmail != "" {
-				author += " " + metadata.AuthorEmail
+			} else if metadata.AuthorEmail != "" {
+				author = fmt.Sprintf("%s <%s>", author, metadata.AuthorEmail)
 			}
 		case pkg.GemMetadata:
 			if len(metadata.Authors) > 0 {

--- a/internal/formats/spdx22json/model/element.go
+++ b/internal/formats/spdx22json/model/element.go
@@ -3,7 +3,7 @@ package model
 type Element struct {
 	SPDXID string `json:"SPDXID"`
 	// Identify name of this SpdxElement.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// Relationships referenced in the SPDX document
 	Relationships []Relationship `json:"relationships,omitempty"`
 	// Provide additional information about an SpdxElement.

--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -2,7 +2,6 @@ package spdx22json
 
 import (
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -131,8 +130,8 @@ func toFiles(s sbom.SBOM) []model.File {
 		results = append(results, model.File{
 			Item: model.Item{
 				Element: model.Element{
-					SPDXID:  string(coordinates.ID()),
-					Name:    filepath.Base(coordinates.RealPath),
+					SPDXID: model.ElementID(coordinates.ID()).String(),
+					// Name:    filepath.Base(coordinates.RealPath),
 					Comment: comment,
 				},
 				// required, no attempt made to determine license information
@@ -206,9 +205,9 @@ func toRelationships(relationships []artifact.Relationship) (result []model.Rela
 		}
 
 		result = append(result, model.Relationship{
-			SpdxElementID:      string(r.From.ID()),
+			SpdxElementID:      model.ElementID(r.From.ID()).String(),
 			RelationshipType:   relationshipType,
-			RelatedSpdxElement: string(r.To.ID()),
+			RelatedSpdxElement: model.ElementID(r.To.ID()).String(),
 			Comment:            comment,
 		})
 	}

--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -130,8 +130,7 @@ func toFiles(s sbom.SBOM) []model.File {
 		results = append(results, model.File{
 			Item: model.Item{
 				Element: model.Element{
-					SPDXID: model.ElementID(coordinates.ID()).String(),
-					// Name:    filepath.Base(coordinates.RealPath),
+					SPDXID:  model.ElementID(coordinates.ID()).String(),
 					Comment: comment,
 				},
 				// required, no attempt made to determine license information


### PR DESCRIPTION
This aligns the SPDX output more correctly with the SPDX 2.2 spec.

These changes are required for Syft's generated SPDX to import properly using the [spdx/tools-golang jsonloader](https://github.com/spdx/tools-golang/blob/main/jsonloader/jsonloader.go#L15)

Links to some pertinent resources:
* https://spdx.github.io/spdx-spec/package-information
* https://github.com/spdx/spdx-spec/blob/master/schemas/spdx-schema.json