### PR TITLE
[CycloneDX] Add artifactID and groupID to the cycloneDX properties (support lower level struct as properties)

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/component.go
+++ b/internal/formats/common/cyclonedxhelpers/component.go
@@ -9,6 +9,7 @@ func Component(p pkg.Package) cyclonedx.Component {
 	return cyclonedx.Component{
 		Type:               cyclonedx.ComponentTypeLibrary,
 		Name:               p.Name,
+		Group:              Group(p),
 		Version:            p.Version,
 		PackageURL:         p.PURL,
 		Licenses:           Licenses(p),

--- a/internal/formats/common/cyclonedxhelpers/group.go
+++ b/internal/formats/common/cyclonedxhelpers/group.go
@@ -4,11 +4,8 @@ import "github.com/anchore/syft/syft/pkg"
 
 func Group(p pkg.Package) string {
 	if hasMetadata(p) {
-		switch metadata := p.Metadata.(type) {
-		case pkg.JavaMetadata:
-			if metadata.PomProperties != nil {
-				return metadata.PomProperties.GroupID
-			}
+		if metadata, ok := p.Metadata.(pkg.JavaMetadata); ok && metadata.PomProperties != nil {
+			return metadata.PomProperties.GroupID
 		}
 	}
 	return ""

--- a/internal/formats/common/cyclonedxhelpers/group.go
+++ b/internal/formats/common/cyclonedxhelpers/group.go
@@ -1,0 +1,15 @@
+package cyclonedxhelpers
+
+import "github.com/anchore/syft/syft/pkg"
+
+func Group(p pkg.Package) string {
+	if hasMetadata(p) {
+		switch metadata := p.Metadata.(type) {
+		case pkg.JavaMetadata:
+			if metadata.PomProperties != nil {
+				return metadata.PomProperties.GroupID
+			}
+		}
+	}
+	return ""
+}

--- a/internal/formats/common/cyclonedxhelpers/group_test.go
+++ b/internal/formats/common/cyclonedxhelpers/group_test.go
@@ -1,0 +1,52 @@
+package cyclonedxhelpers
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    pkg.Package
+		expected string
+	}{
+		{
+			name:     "no metadata",
+			input:    pkg.Package{},
+			expected: "",
+		},
+		{
+			name: "metadata is not Java",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageJSONMetadata{},
+			},
+			expected: "",
+		},
+		{
+			name: "metadata is Java but pom properties is empty",
+			input: pkg.Package{
+				Metadata: pkg.JavaMetadata{},
+			},
+			expected: "",
+		},
+		{
+			name: "metadata is Java and contains pomProperties",
+			input: pkg.Package{
+				Metadata: pkg.JavaMetadata{
+					PomProperties: &pkg.PomProperties{
+						GroupID: "test",
+					},
+				},
+			},
+			expected: "test",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, Group(test.input))
+		})
+	}
+}

--- a/internal/formats/common/cyclonedxhelpers/properties.go
+++ b/internal/formats/common/cyclonedxhelpers/properties.go
@@ -34,8 +34,8 @@ func getCycloneDXProperties(m interface{}) *[]cyclonedx.Property {
 	structType := structValue.Type()
 	for i := 0; i < structValue.NumField(); i++ {
 		if name, value := getCycloneDXPropertyName(structType.Field(i)), getCycloneDXPropertyValue(structValue.Field(i)); name != "" && value != "" {
-			// n the case of the value is a struct and has cyclonedx tag with name "-"
-			//
+			// In the case of the value is a struct and has cyclonedx tag with name "-"
+			// call the getCycloneDXProperties recursively.
 			if name == "-" && reflect.ValueOf(value).Kind() == reflect.Struct {
 				props = append(props, *getCycloneDXProperties(value)...)
 			} else {

--- a/internal/formats/common/cyclonedxhelpers/properties.go
+++ b/internal/formats/common/cyclonedxhelpers/properties.go
@@ -38,10 +38,10 @@ func getCycloneDXProperties(m interface{}) *[]cyclonedx.Property {
 			// call the getCycloneDXProperties recursively.
 			if name == "-" && reflect.ValueOf(value).Kind() == reflect.Struct {
 				props = append(props, *getCycloneDXProperties(value)...)
-			} else {
+			} else if reflect.ValueOf(value).Kind() == reflect.String {
 				props = append(props, cyclonedx.Property{
 					Name:  name,
-					Value: fmt.Sprintf("%s", value),
+					Value: fmt.Sprint(value),
 				})
 			}
 		}
@@ -66,10 +66,13 @@ func getCycloneDXPropertyValue(field reflect.Value) interface{} {
 			return fmt.Sprint(field.Interface())
 		}
 		return ""
+	case reflect.Struct:
+		if field.CanInterface() {
+			return field.Interface()
+		}
+		return ""
 	case reflect.Ptr:
 		return getCycloneDXPropertyValue(reflect.Indirect(field))
-	case reflect.Struct:
-		return field.Interface()
 	}
 	return ""
 }

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -23,7 +23,7 @@ var JenkinsPluginPomPropertiesGroupIDs = []string{
 type JavaMetadata struct {
 	VirtualPath   string         `json:"virtualPath"`
 	Manifest      *JavaManifest  `mapstructure:"Manifest" json:"manifest,omitempty"`
-	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties,omitempty"`
+	PomProperties *PomProperties `mapstructure:"PomProperties" json:"pomProperties,omitempty" cyclonedx:"-"`
 	PomProject    *PomProject    `mapstructure:"PomProject" json:"pomProject,omitempty"`
 	Parent        *Package       `hash:"ignore" json:"-"` // note: the parent cannot be included in the minimal definition of uniqueness since this field is not reproducible in an encode-decode cycle (is lossy).
 }
@@ -32,8 +32,8 @@ type JavaMetadata struct {
 type PomProperties struct {
 	Path       string            `mapstructure:"path" json:"path"`
 	Name       string            `mapstructure:"name" json:"name"`
-	GroupID    string            `mapstructure:"groupId" json:"groupId"`
-	ArtifactID string            `mapstructure:"artifactId" json:"artifactId"`
+	GroupID    string            `mapstructure:"groupId" json:"groupId" cyclonedx:"groupID"`
+	ArtifactID string            `mapstructure:"artifactId" json:"artifactId" cyclonedx:"artifactID"`
 	Version    string            `mapstructure:"version" json:"version"`
 	Extra      map[string]string `mapstructure:",remain" json:"extraFields"`
 }


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

related: #685 , #710 
In the case of java add artifactID and groupID pomProperties to the cycloneDX properties.
- support adding lower level struct to the properties.
- add `groupID` as a `group` to the CDX component in the case of Java