### PR TITLE
update config to correctly work with syft first try

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ package:
   # note: for now this only applies to the java package cataloger
   # SYFT_PACKAGE_SEARCH_UNINDEXED_ARCHIVES env var
   search-unindexed-archives: false
-   
+
   cataloger:
     # enable/disable cataloging of packages
     # SYFT_PACKAGE_CATALOGER_ENABLED env var
@@ -366,9 +366,9 @@ registry:
 
   # credentials for specific registries
   auth:
-    - # the URL to the registry (e.g. "docker.io", "localhost:5000", etc.)
+      # the URL to the registry (e.g. "docker.io", "localhost:5000", etc.)
       # SYFT_REGISTRY_AUTH_AUTHORITY env var
-      authority: ""
+    - authority: ""
       # SYFT_REGISTRY_AUTH_USERNAME env var
       username: ""
       # SYFT_REGISTRY_AUTH_PASSWORD env var
@@ -376,7 +376,7 @@ registry:
       # note: token and username/password are mutually exclusive
       # SYFT_REGISTRY_AUTH_TOKEN env var
       token: ""
-    - ... # note, more credentials can be provided via config file only
+      # - ... # note, more credentials can be provided via config file only
 
 log:
   # use structured logging
@@ -412,5 +412,4 @@ anchore:
   # (feature-preview) path to dockerfile to be uploaded with the syft results to Anchore Enterprise (supported on Enterprise 3.0+)
   # same as -d ; SYFT_ANCHORE_DOCKERFILE env var
   dockerfile: ""
-
 ```


### PR DESCRIPTION
This morning I needed a fresh `.syft.yaml` configuration and copied it from the README. On run I had to make edits on my local in order for it to run. These updates make it so that on first copy from the documentation syft runs successfully.

### Current
```
failed to load application config:
        unable to parse config: 1 error(s) decoding:

* 'registry.auth[1]' expected a map, got 'string'
```

### Changes
```
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [92 packages]
 ⠏ Cataloging secrets       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  [0 secrets]^C
 ✔ Cataloged file digests
 ✔ Cataloged file metadata
```

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>