### PR TITLE
Extract language and package type from pURLs on SBOM decode

### DIFF
--- a/syft/pkg/cargo_package_metadata.go
+++ b/syft/pkg/cargo_package_metadata.go
@@ -1,5 +1,12 @@
 package pkg
 
+import (
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/linux"
+)
+
+var _ urlIdentifier = (*CargoPackageMetadata)(nil)
+
 type CargoPackageMetadata struct {
 	Name         string   `toml:"name" json:"name"`
 	Version      string   `toml:"version" json:"version"`
@@ -18,4 +25,16 @@ func (p CargoPackageMetadata) Pkg() *Package {
 		MetadataType: RustCargoPackageMetadataType,
 		Metadata:     p,
 	}
+}
+
+// PackageURL returns the PURL for the specific rust package (see https://github.com/package-url/purl-spec)
+func (p CargoPackageMetadata) PackageURL(_ *linux.Release) string {
+	return packageurl.NewPackageURL(
+		"cargo",
+		"",
+		p.Name,
+		p.Version,
+		nil,
+		"",
+	).ToString()
 }

--- a/syft/pkg/cataloger/javascript/parse_package_json_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json_test.go
@@ -24,6 +24,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "npm",
+					Version:  "6.14.6",
 					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
 					Homepage: "https://docs.npmjs.com/",
 					URL:      "https://github.com/npm/cli",
@@ -41,6 +43,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "npm",
+					Version:  "6.14.6",
 					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
 					Homepage: "https://docs.npmjs.com/",
 					URL:      "https://github.com/npm/cli",
@@ -58,6 +62,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "npm",
+					Version:  "6.14.6",
 					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
 					Homepage: "https://docs.npmjs.com/",
 					URL:      "https://github.com/npm/cli",
@@ -75,6 +81,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "npm",
+					Version:  "6.14.6",
 					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
 					Homepage: "https://docs.npmjs.com/",
 					URL:      "https://github.com/npm/cli",
@@ -92,6 +100,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "npm",
+					Version:  "6.14.6",
 					Author:   "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
 					Homepage: "https://docs.npmjs.com/",
 					URL:      "https://github.com/npm/cli",
@@ -109,6 +119,8 @@ func TestParsePackageJSON(t *testing.T) {
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
+					Name:     "function-bind",
+					Version:  "1.1.1",
 					Author:   "Raynos <raynos2@gmail.com>",
 					Homepage: "https://github.com/Raynos/function-bind",
 					URL:      "git://github.com/Raynos/function-bind.git",

--- a/syft/pkg/java_metadata.go
+++ b/syft/pkg/java_metadata.go
@@ -72,7 +72,7 @@ type JavaManifest struct {
 	NamedSections map[string]map[string]string `json:"namedSections,omitempty"`
 }
 
-// PackageURL returns the PURL for the specific Alpine package (see https://github.com/package-url/purl-spec)
+// PackageURL returns the PURL for the specific Maven package (see https://github.com/package-url/purl-spec)
 func (m JavaMetadata) PackageURL(_ *linux.Release) string {
 	if m.PomProperties != nil {
 		pURL := packageurl.NewPackageURL(

--- a/syft/pkg/language.go
+++ b/syft/pkg/language.go
@@ -1,5 +1,7 @@
 package pkg
 
+import "github.com/anchore/packageurl-go"
+
 // Language represents a single programming language.
 type Language string
 
@@ -29,4 +31,30 @@ var AllLanguages = []Language{
 // String returns the string representation of the language.
 func (l Language) String() string {
 	return string(l)
+}
+
+func LanguageFromPURL(p string) Language {
+	purl, err := packageurl.FromString(p)
+	if err != nil {
+		return UnknownLanguage
+	}
+
+	switch purl.Type {
+	case packageurl.TypeMaven, "gradle":
+		return Java
+	case packageurl.TypeComposer:
+		return PHP
+	case packageurl.TypeGolang:
+		return Go
+	case packageurl.TypeNPM:
+		return JavaScript
+	case packageurl.TypePyPi:
+		return Python
+	case packageurl.TypeGem:
+		return Ruby
+	case "cargo":
+		return Rust
+	default:
+		return UnknownLanguage
+	}
 }

--- a/syft/pkg/language.go
+++ b/syft/pkg/language.go
@@ -40,7 +40,7 @@ func LanguageFromPURL(p string) Language {
 	}
 
 	switch purl.Type {
-	case packageurl.TypeMaven, "gradle":
+	case packageurl.TypeMaven, purlGradlePkgType:
 		return Java
 	case packageurl.TypeComposer:
 		return PHP
@@ -52,7 +52,7 @@ func LanguageFromPURL(p string) Language {
 		return Python
 	case packageurl.TypeGem:
 		return Ruby
-	case "cargo":
+	case purlCargoPkgType:
 		return Rust
 	default:
 		return UnknownLanguage

--- a/syft/pkg/language_test.go
+++ b/syft/pkg/language_test.go
@@ -1,0 +1,66 @@
+package pkg
+
+import (
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLanguageFromPURL(t *testing.T) {
+
+	tests := []struct {
+		purl string
+		want Language
+	}{
+
+		{
+			purl: "pkg:npm/util@2.32",
+			want: JavaScript,
+		},
+		{
+			purl: "pkg:pypi/util-linux@2.32.1-27.el8",
+			want: Python,
+		},
+		{
+			purl: "pkg:gem/ruby-advisory-db-check@0.12.4",
+			want: Ruby,
+		},
+		{
+			purl: "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c",
+			want: Go,
+		},
+		{
+			purl: "pkg:cargo/clap@2.33.0",
+			want: Rust,
+		},
+		{
+			purl: "pkg:composer/laravel/laravel@5.5.0",
+			want: PHP,
+		},
+		{
+			purl: "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?type=zip&classifier=dist",
+			want: Java,
+		},
+	}
+
+	var languages []string
+	var expectedLanguages = strset.New()
+	for _, ty := range AllLanguages {
+		expectedLanguages.Add(string(ty))
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.purl, func(t *testing.T) {
+			actual := LanguageFromPURL(tt.purl)
+
+			if actual != "" {
+				languages = append(languages, string(actual))
+			}
+
+			assert.Equalf(t, tt.want, actual, "LanguageFromPURL(%v)", tt.purl)
+		})
+	}
+
+	assert.ElementsMatch(t, expectedLanguages.List(), languages, "missing one or more languages to test against (maybe a package type was added?)")
+
+}

--- a/syft/pkg/npm_package_json_metadata.go
+++ b/syft/pkg/npm_package_json_metadata.go
@@ -1,11 +1,32 @@
 package pkg
 
+import (
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/linux"
+)
+
+var _ urlIdentifier = (*NpmPackageJSONMetadata)(nil)
+
 // NpmPackageJSONMetadata holds extra information that is used in pkg.Package
 type NpmPackageJSONMetadata struct {
+	Name        string   `mapstructure:"name" json:"name"`
+	Version     string   `mapstructure:"version" json:"version"`
 	Files       []string `mapstructure:"files" json:"files,omitempty"`
 	Author      string   `mapstructure:"author" json:"author"`
 	Licenses    []string `mapstructure:"licenses" json:"licenses"`
 	Homepage    string   `mapstructure:"homepage" json:"homepage"`
 	Description string   `mapstructure:"description" json:"description"`
 	URL         string   `mapstructure:"url" json:"url"`
+}
+
+// PackageURL returns the PURL for the specific NPM package (see https://github.com/package-url/purl-spec)
+func (p NpmPackageJSONMetadata) PackageURL(_ *linux.Release) string {
+	return packageurl.NewPackageURL(
+		packageurl.TypeNPM,
+		"",
+		p.Name,
+		p.Version,
+		nil,
+		"",
+	).ToString()
 }

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -66,3 +66,35 @@ func (t Type) PackageURLType() string {
 		return ""
 	}
 }
+
+func TypeFromPURL(p string) Type {
+	purl, err := packageurl.FromString(p)
+	if err != nil {
+		return UnknownPkg
+	}
+
+	switch purl.Type {
+	case packageurl.TypeDebian, "deb":
+		return DebPkg
+	case packageurl.TypeRPM:
+		return RpmPkg
+	case "alpine":
+		return ApkPkg
+	case packageurl.TypeMaven:
+		return JavaPkg
+	case packageurl.TypeComposer:
+		return PhpComposerPkg
+	case packageurl.TypeGolang:
+		return GoModulePkg
+	case packageurl.TypeNPM:
+		return NpmPkg
+	case packageurl.TypePyPi:
+		return PythonPkg
+	case packageurl.TypeGem:
+		return GemPkg
+	case "cargo", "crate":
+		return RustPkg
+	default:
+		return UnknownPkg
+	}
+}

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -1,0 +1,83 @@
+package pkg
+
+import (
+	"github.com/scylladb/go-set/strset"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeFromPURL(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		purl     string
+		expected Type
+	}{
+		{
+			purl:     "pkg:rpm/fedora/util-linux@2.32.1-27.el8-?arch=amd64",
+			expected: RpmPkg,
+		},
+		{
+			purl:     "pkg:alpine/util-linux@2.32.1",
+			expected: ApkPkg,
+		},
+		{
+			purl:     "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
+			expected: DebPkg,
+		},
+		{
+			purl:     "pkg:npm/util@2.32",
+			expected: NpmPkg,
+		},
+		{
+			purl:     "pkg:pypi/util-linux@2.32.1-27.el8",
+			expected: PythonPkg,
+		},
+		{
+			purl:     "pkg:gem/ruby-advisory-db-check@0.12.4",
+			expected: GemPkg,
+		},
+		{
+			purl:     "pkg:golang/github.com/gorilla/context@234fd47e07d1004f0aed9c",
+			expected: GoModulePkg,
+		},
+		{
+			purl:     "pkg:cargo/clap@2.33.0",
+			expected: RustPkg,
+		},
+		{
+			purl:     "pkg:composer/laravel/laravel@5.5.0",
+			expected: PhpComposerPkg,
+		},
+		{
+			purl:     "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?type=zip&classifier=dist",
+			expected: JavaPkg,
+		},
+	}
+
+	var pkgTypes []string
+	var expectedTypes = strset.New()
+	for _, ty := range AllPkgs {
+		expectedTypes.Add(string(ty))
+	}
+
+	// testing microsoft packages and jenkins-plugins is not valid for purl at this time
+	expectedTypes.Remove(string(KbPkg))
+	expectedTypes.Remove(string(JenkinsPluginPkg))
+
+	for _, test := range tests {
+		t.Run(string(test.expected), func(t *testing.T) {
+			actual := TypeFromPURL(test.purl)
+
+			if actual != "" {
+				pkgTypes = append(pkgTypes, string(actual))
+			}
+
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+
+	assert.ElementsMatch(t, expectedTypes.List(), pkgTypes, "missing one or more package types to test against (maybe a package type was added?)")
+
+}

--- a/syft/pkg/url.go
+++ b/syft/pkg/url.go
@@ -18,6 +18,9 @@ const (
 
 	// this qualifier is not in the pURL spec, but is used by grype to perform indirect matching based on source information
 	purlUpstreamQualifier = "upstream"
+
+	purlCargoPkgType  = "cargo"
+	purlGradlePkgType = "gradle"
 )
 
 type urlIdentifier interface {


### PR DESCRIPTION
This PR paves the way to use pURLs as a way to indicate package language and package type, two attributes that are not easily encoded into in-spec properties for CycloneDX and SPDX. This will be useful when decoding SBOM documents that did not necessarily originate from Syft, but do have pURL information available.

Possible future SPDX decode function:
```golang
func toSyftPackage(p model.Package) pkg.Package {
	purl := spdxhelpers.ExtractPURL(p.ExternalRefs)
	sP := pkg.Package{
		Type:     pkg.TypeFromPURL(purl), //  <---- new function 
		Name:     p.Name,
		Version:  p.VersionInfo,
		Licenses: spdxhelpers.ParseLicense(p.LicenseDeclared),
		CPEs:     spdxhelpers.ExtractCPEs(p.ExternalRefs),
		PURL:     purl,
		Language: pkg.LanguageFromPURL(purl),  //  <---- new function 
	}

	sP.SetID()

	return sP
}

```

Additionally adds pURL support for cargo and npm package types.

Related to anchore/grype#395