### PR TITLE
Tput requires explicit terminal type in CI

### DIFF
--- a/.github/scripts/apple-signing/utils.sh
+++ b/.github/scripts/apple-signing/utils.sh
@@ -2,7 +2,7 @@
 PURPLE='\033[0;35m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-BOLD=$(tput bold)
+BOLD=$(tput -T linux bold)
 RESET='\033[0m'
 
 function success() {


### PR DESCRIPTION
To account for the failure here: https://github.com/anchore/syft/runs/5070522994?check_suite_focus=true

```
   ⨯ release failed after 176.55s error=sign: ./.github/scripts/apple-signing/run.sh failed: exit status 2: tput: No value for $TERM and no -T specified

```