### PR TITLE
Fix repackaging of release archive for notarization

### DIFF
--- a/.github/scripts/apple-signing/notarize.sh
+++ b/.github/scripts/apple-signing/notarize.sh
@@ -25,7 +25,7 @@ repackage() {
         tmp_dir=$(mktemp -d)
         cd "$tmp_dir"
         # redirect stdout to stderr to preserve the return value
-        tar xzf "$archive" && zip "$new_archive" $(tar tf "$archive") 1>&2
+        tar xzf "$archive" && zip "$new_archive" ./* 1>&2
         rm -rf "$tmp_dir"
       )
       echo "$new_archive"


### PR DESCRIPTION
To prevent: https://github.com/anchore/syft/runs/5070963673?check_suite_focus=true
```
Task: notarizing binaries found in the release archive

zip error: Internal logic error (empty name without -j or -r)
error: cannot find payload for notarization: /Users/runner/work/syft/syft/dist/syft_0.37.1_darwin_amd64.zip
```
