### PR TITLE
Fix notarization: use repackaged archive, not original archive

### DIFF
--- a/.github/scripts/apple-signing/notarize.sh
+++ b/.github/scripts/apple-signing/notarize.sh
@@ -62,7 +62,7 @@ notarize() {
 
   cat <<EOF > "$tmp_file"
 notarize {
-  path = "$archive_path"
+  path = "$payload_archive_path"
   bundle_id = "com.anchore.toolbox.syft"
 }
 


### PR DESCRIPTION
Failure: https://github.com/anchore/syft/runs/5071442335?check_suite_focus=true
```
<string>ERROR ITMS-4064: "File extension of file 'syft_0.37.2_darwin_arm64.tar.gz' is invalid for this software; use 'zip,pkg,dmg' instead." at SoftwareAssets/EnigmaSoftwareAsset</string>
```