### PR TITLE
Docker auth must occur after setting up prod keychain

### DIFF
--- a/.github/scripts/apple-signing/setup-prod.sh
+++ b/.github/scripts/apple-signing/setup-prod.sh
@@ -11,6 +11,14 @@ fi
 if [ -z "$APPLE_DEVELOPER_ID_CERT_PASS" ]; then
   exit_with_error "APPLE_DEVELOPER_ID_CERT_PASS not set"
 fi
+
+if [ -z "$DOCKER_USERNAME" ]; then
+  exit_with_error "DOCKER_USERNAME not set"
+fi
+
+if [ -z "$DOCKER_PASSWORD" ]; then
+  exit_with_error "DOCKER_PASSWORD not set"
+fi
 set -u
 
 # setup_signing
@@ -42,4 +50,7 @@ setup_signing() {
   # TODO: extract this from the certificate material itself
   export MAC_SIGNING_IDENTITY="Developer ID Application: ANCHORE, INC. (9MJHKYX5AT)"
   commentary "setting MAC_SIGNING_IDENTITY=${MAC_SIGNING_IDENTITY}"
+
+  commentary "log into docker -- required for publishing (since the default keychain has now been replaced)"
+  echo "${DOCKER_PASSWORD}" | docker login docker.io -u "${DOCKER_USERNAME}"  --password-stdin
 }

--- a/Makefile
+++ b/Makefile
@@ -309,9 +309,6 @@ CHANGELOG.md:
 .PHONY: release
 release: clean-dist CHANGELOG.md  ## Build and publish final binaries and packages. Intended to be run only on macOS.
 	$(call title,Publishing release artifacts)
-	# login to docker
-	# note: the previous step creates a new keychain, so it is important to reauth into docker.io
-	@echo $${DOCKER_PASSWORD} | docker login docker.io -u $${DOCKER_USERNAME}  --password-stdin
 
 	# create a config with the dist dir overridden
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml


### PR DESCRIPTION
Accounts for: https://github.com/anchore/syft/actions/runs/1797291966https://github.com/anchore/syft/actions/runs/1797291966

Now that we setup the keychain later, we must move the docker auth step as well. Otherwise we load the docker credentials into a keychain that gets replaced.