### PR TITLE
Stabilize CI behavior

### DIFF
--- a/.github/scripts/apple-signing/setup.sh
+++ b/.github/scripts/apple-signing/setup.sh
@@ -6,6 +6,7 @@ IS_SNAPSHOT="$1"
 ## grab utilities
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "$SCRIPT_DIR"/utils.sh
+mkdir -p "$SCRIPT_DIR/log"
 
 main() {
 
@@ -33,17 +34,13 @@ main() {
   echo -n "$MAC_SIGNING_IDENTITY" > "$SCRIPT_DIR/$SIGNING_IDENTITY_FILENAME"
 }
 
-set +u
-if [ -z "$SCRIPT" ]
-then
+# capture all output from a subshell to log output additionally to a file (as well as the terminal)
+( (
+  set +u
+  if [ -n "$SKIP_SIGNING" ]; then
+      commentary "skipping signing setup..."
+  else
     set -u
-    # log all output
-    mkdir -p "$SCRIPT_DIR/log"
-    /usr/bin/script "$SCRIPT_DIR/log/setup.txt" /bin/bash -c "$0 $*"
-    exit $?
-elif [ -n "$SKIP_SIGNING" ]; then
-    commentary "skipping signing setup..."
-else
-  set -u
-  main
-fi
+    main
+  fi
+) 2>&1) | tee "$SCRIPT_DIR/log/setup.txt"

--- a/.github/scripts/apple-signing/sign.sh
+++ b/.github/scripts/apple-signing/sign.sh
@@ -7,6 +7,7 @@ IS_SNAPSHOT="$2"
 ## grab utilities
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "$SCRIPT_DIR"/utils.sh
+mkdir -p "$SCRIPT_DIR/log"
 
 
 # sign_binary [binary-path] [signing-identity]
@@ -124,17 +125,13 @@ main() {
   fi
 }
 
-set +u
-if [ -z "$SCRIPT" ]
-then
+# capture all output from a subshell to log output additionally to a file (as well as the terminal)
+( (
+  set +u
+  if [ -n "$SKIP_SIGNING" ]; then
+      commentary "skipping signing setup..."
+  else
     set -u
-    # log all output
-    mkdir -p "$SCRIPT_DIR/log"
-    /usr/bin/script "$SCRIPT_DIR/log/signing-$(basename $ARCHIVE_PATH).txt" /bin/bash -c "$0 $*"
-    exit $?
-elif [ -n "$SKIP_SIGNING" ]; then
-    commentary "skipping signing..."
-else
-  set -u
-  main
-fi
+    main
+  fi
+) 2>&1) | tee "$SCRIPT_DIR/log/signing-$(basename $ARCHIVE_PATH).txt"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
-RELEASE_CMD=$(TEMPDIR)/goreleaser --version && $(TEMPDIR)/goreleaser release --rm-dist --parallelism=2
+RELEASE_CMD=$(TEMPDIR)/goreleaser --version && $(TEMPDIR)/goreleaser release --rm-dist
 SNAPSHOT_CMD=$(RELEASE_CMD) --skip-publish --snapshot
 COMPARE_TEST_IMAGE = centos:8.2.2004
 COMPARE_DIR = ./test/compare

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
-RELEASE_CMD=$(TEMPDIR)/goreleaser --version && $(TEMPDIR)/goreleaser release --rm-dist
+RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist
 SNAPSHOT_CMD=$(RELEASE_CMD) --skip-publish --snapshot
 COMPARE_TEST_IMAGE = centos:8.2.2004
 COMPARE_DIR = ./test/compare

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
-RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist
+RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist --parallelism=2
 SNAPSHOT_CMD=$(RELEASE_CMD) --skip-publish --snapshot
 COMPARE_TEST_IMAGE = centos:8.2.2004
 COMPARE_DIR = ./test/compare

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=2m --config .golangci.yaml
-RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist --parallelism=2
+RELEASE_CMD=$(TEMPDIR)/goreleaser --version && $(TEMPDIR)/goreleaser release --rm-dist --parallelism=2
 SNAPSHOT_CMD=$(RELEASE_CMD) --skip-publish --snapshot
 COMPARE_TEST_IMAGE = centos:8.2.2004
 COMPARE_DIR = ./test/compare

--- a/test/install/test_harness.sh
+++ b/test/install/test_harness.sh
@@ -94,7 +94,7 @@ setup_snapshot_server() {
   worker_pid=$!
 
   # it takes some time for the server to be ready...
-  sleep 0.5
+  sleep 3
 
   echo "$worker_pid"
 }


### PR DESCRIPTION
There are multiple instance of:
1. OOM during snapshot builds (https://github.com/anchore/syft/actions/runs/1799784721/attempts/2)
2. install.sh tests failing periodically due to http server not being ready (https://github.com/anchore/syft/runs/5078759447?check_suite_focus=true)

This PR ~reduces the build parallelism~ fixes the signing bash script logging to not hang in CI and increases the wait time after setting up the http server for install.sh testing (which ideally would be event driven and not a sleep --happy to take suggestions here).