### PR TITLE
Fix intermittent slow CLI tests

### DIFF
--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -201,6 +202,10 @@ func TestPackagesCmdFlags(t *testing.T) {
 }
 
 func TestRegistryAuth(t *testing.T) {
+	host := "localhost:17"
+	image := fmt.Sprintf("%s/something:latest", host)
+	args := []string{"packages", "-vv", fmt.Sprintf("registry:%s", image)}
+
 	tests := []struct {
 		name       string
 		args       []string
@@ -209,55 +214,55 @@ func TestRegistryAuth(t *testing.T) {
 	}{
 		{
 			name: "fallback to keychain",
-			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
+			args: args,
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:17/something:latest"),
+				assertInOutput(image),
 				assertInOutput("no registry credentials configured, using the default keychain"),
 			},
 		},
 		{
 			name: "use creds",
-			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
+			args: args,
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": host,
 				"SYFT_REGISTRY_AUTH_USERNAME":  "username",
 				"SYFT_REGISTRY_AUTH_PASSWORD":  "password",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:17/something:latest"),
-				assertInOutput(`using basic auth for registry "localhost:17"`),
+				assertInOutput(image),
+				assertInOutput(fmt.Sprintf(`using basic auth for registry "%s"`, host)),
 			},
 		},
 		{
 			name: "use token",
-			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
+			args: args,
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": host,
 				"SYFT_REGISTRY_AUTH_TOKEN":     "token",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:17/something:latest"),
-				assertInOutput(`using token for registry "localhost:17"`),
+				assertInOutput(image),
+				assertInOutput(fmt.Sprintf(`using token for registry "%s"`, host)),
 			},
 		},
 		{
 			name: "not enough info fallsback to keychain",
-			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
+			args: args,
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": host,
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:17/something:latest"),
+				assertInOutput(image),
 				assertInOutput(`no registry credentials configured, using the default keychain`),
 			},
 		},
 		{
 			name: "allows insecure http flag",
-			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
+			args: args,
 			env: map[string]string{
 				"SYFT_REGISTRY_INSECURE_USE_HTTP": "true",
 			},

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -209,55 +209,55 @@ func TestRegistryAuth(t *testing.T) {
 	}{
 		{
 			name: "fallback to keychain",
-			args: []string{"packages", "-vv", "registry:localhost:5000/something:latest"},
+			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:5000/something:latest"),
+				assertInOutput("localhost:17/something:latest"),
 				assertInOutput("no registry credentials configured, using the default keychain"),
 			},
 		},
 		{
 			name: "use creds",
-			args: []string{"packages", "-vv", "registry:localhost:5000/something:latest"},
+			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:5000",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
 				"SYFT_REGISTRY_AUTH_USERNAME":  "username",
 				"SYFT_REGISTRY_AUTH_PASSWORD":  "password",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using basic auth for registry "localhost:5000"`),
+				assertInOutput("localhost:17/something:latest"),
+				assertInOutput(`using basic auth for registry "localhost:17"`),
 			},
 		},
 		{
 			name: "use token",
-			args: []string{"packages", "-vv", "registry:localhost:5000/something:latest"},
+			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:5000",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
 				"SYFT_REGISTRY_AUTH_TOKEN":     "token",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:5000/something:latest"),
-				assertInOutput(`using token for registry "localhost:5000"`),
+				assertInOutput("localhost:17/something:latest"),
+				assertInOutput(`using token for registry "localhost:17"`),
 			},
 		},
 		{
 			name: "not enough info fallsback to keychain",
-			args: []string{"packages", "-vv", "registry:localhost:5000/something:latest"},
+			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
 			env: map[string]string{
-				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:5000",
+				"SYFT_REGISTRY_AUTH_AUTHORITY": "localhost:17",
 			},
 			assertions: []traitAssertion{
 				assertInOutput("source=OciRegistry"),
-				assertInOutput("localhost:5000/something:latest"),
+				assertInOutput("localhost:17/something:latest"),
 				assertInOutput(`no registry credentials configured, using the default keychain`),
 			},
 		},
 		{
 			name: "allows insecure http flag",
-			args: []string{"packages", "-vv", "registry:localhost:5000/something:latest"},
+			args: []string{"packages", "-vv", "registry:localhost:17/something:latest"},
 			env: map[string]string{
 				"SYFT_REGISTRY_INSECURE_USE_HTTP": "true",
 			},


### PR DESCRIPTION
CLI tests may run considerably slower (several minutes) on the registry auth tests when there is a non-registry service running on port 5000 (the same port that the registry tests reference). Turning off the offending service solves the problem, however, 5000 tends to be a commonly used port. Swapping to a port that is (probably) not in use speeds up the tests from minutes to seconds (~2 seconds). The test now references the extremely useful [QOTD port](https://en.wikipedia.org/wiki/QOTD) in the hopes to glean occasional wisdom.