### PR TITLE
Remove duplicate signing artifact

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,7 +71,6 @@ signs:
   - artifacts: archive
     ids:
       - darwin-archives
-    signature: "${artifact}"
     cmd: ./.github/scripts/apple-signing/sign.sh
     args:
       - "${artifact}"


### PR DESCRIPTION
Solves: https://github.com/anchore/syft/runs/5096001393?check_suite_focus=true
```
...
         • uploading to release      file=dist/syft_0.37.6_darwin_arm64.tar.gz name=syft_0.37.6_darwin_arm64.tar.gz
         • uploading to release      file=dist/syft_0.37.6_darwin_arm64.tar.gz name=syft_0.37.6_darwin_arm64.tar.gz
...
         • failed to upload artifact, will retry artifact=syft_0.37.6_darwin_arm64.tar.gz error=POST https://uploads.github.com/repos/anchore/syft/releases/58910722/assets?name=syft_0.37.6_darwin_arm64.tar.gz: 404 Not Found [] try=1
         • uploading to release      file=dist/syft_0.37.6_darwin_arm64.tar.gz name=syft_0.37.6_darwin_arm64.tar.gz
```