### PR TITLE
Migrate mac binary signing as post-build step

### DIFF
--- a/.github/scripts/apple-signing/notarize.sh
+++ b/.github/scripts/apple-signing/notarize.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -ue
 
 set +xu
 if [ -z "$AC_USERNAME" ]; then
@@ -11,58 +10,30 @@ if [ -z "$AC_PASSWORD" ]; then
 fi
 set -u
 
-# repackage [archive-path]
-#
-# returns an archive compatible for Apple's notarization process, repackaging the input archive as needed
-#
-repackage() {
-  archive=$1
-
-  case "$archive" in
-    *.tar.gz)
-      new_archive=${archive%.tar.gz}.zip
-      (
-        tmp_dir=$(mktemp -d)
-        cd "$tmp_dir"
-        # redirect stdout to stderr to preserve the return value
-        tar xzf "$archive" && zip "$new_archive" ./* 1>&2
-        rm -rf "$tmp_dir"
-      )
-      echo "$new_archive"
-      ;;
-    *.zip)
-      echo "$archive"
-      ;;
-    *) return 1
-      ;;
-  esac
-}
 
 # notarize [archive-path]
 #
 notarize() {
-  archive_path=$1
+  binary_path=$1
+  archive_path=${binary_path}-archive-for-notarization.zip
 
-  title "notarizing binaries found in the release archive"
+  title "archiving release binary into ${archive_path}"
 
-  payload_archive_path=$(repackage "$archive_path")
-  if [ "$?" != "0" ]; then
-    exit_with_error "cannot prepare payload for notarization: $archive_path"
-  fi
+  zip "${archive_path}" "${binary_path}"
 
-  if [ ! -f "$payload_archive_path" ]; then
-    exit_with_error "cannot find payload for notarization: $payload_archive_path"
+  if [ ! -f "$archive_path" ]; then
+    exit_with_error "cannot find payload for notarization: $archive_path"
   fi
 
   # install gon
   which gon || (brew tap mitchellh/gon && brew install mitchellh/gon/gon)
 
   # create config (note: json via stdin with gon is broken, can only use HCL from file)
-  tmp_file=$(mktemp).hcl
+  hcl_file=$(mktemp).hcl
 
-  cat <<EOF > "$tmp_file"
+  cat <<EOF > "$hcl_file"
 notarize {
-  path = "$payload_archive_path"
+  path = "$archive_path"
   bundle_id = "com.anchore.toolbox.syft"
 }
 
@@ -72,14 +43,8 @@ apple_id {
 }
 EOF
 
-  gon -log-level info "$tmp_file"
+  gon -log-level info "$hcl_file"
 
-  result="$?"
-
-  rm "$tmp_file"
-
-  if [ "$result" -ne "0" ]; then
-      exit_with_error "notarization failed"
-  fi
+  rm "${hcl_file}" "${archive_path}"
 }
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,11 @@ builds:
     mod_timestamp: *build-timestamp
     env: *build-env
     ldflags: *build-ldflags
+    hooks:
+      post:
+        # we must have signing as a build hook instead of the signs section. The signs section must register a new asset, where we want to replace an existing asset.
+        # a post-build hook has the advantage of not needing to unpackage and repackage a tar.gz with a signed binary
+        - ./.github/scripts/apple-signing/sign.sh "{{ .Path }}" "{{ .IsSnapshot }}" "{{ .Target }}"
 
   - id: windows-build
     binary: syft
@@ -66,15 +71,6 @@ archives:
     format: zip
     builds:
       - windows-build
-
-signs:
-  - artifacts: archive
-    ids:
-      - darwin-archives
-    cmd: ./.github/scripts/apple-signing/sign.sh
-    args:
-      - "${artifact}"
-      - "{{ .IsSnapshot }}"
 
 nfpms:
   - license: "Apache 2.0"

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ bootstrap-tools: $(TEMPDIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.42.1
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
-	.github/scripts/goreleaser-install.sh -d -b $(TEMPDIR)/ v1.3.1
+	.github/scripts/goreleaser-install.sh -d -b $(TEMPDIR)/ v1.4.1
 	GOBIN="$(shell realpath $(TEMPDIR))" go install github.com/neilpa/yajsv@v1.4.0
 
 .PHONY: bootstrap-go


### PR DESCRIPTION
The goreleaser signs step will not work for us as expected since:
1) we are releasing archives and not binaries, so we need to repackage the archive that contains the release binary
2) the signs step expects a signature file as output --replacing an existing asset will result in duplicate assets. 