### PR TITLE
Serialize notarization steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,11 @@ release: clean-dist CHANGELOG.md  ## Build and publish final binaries and packag
 
 	rm -f .github/scripts/apple-signing/log/*.txt
 
+	# note: notarization cannot be done in parallel, thus --parallelism 1
 	bash -c "\
 		$(RELEASE_CMD) \
 			--config $(TEMPDIR)/goreleaser.yaml \
+			--parallelism 1 \
 			--release-notes <(cat CHANGELOG.md)\
 				 || cat .github/scripts/apple-signing/log/*.txt && false"
 


### PR DESCRIPTION
As far as I can tell from https://github.com/anchore/syft/runs/5100741150?check_suite_focus=true it seems that the notarization succeeds for one asset and fails for another asset. Notarization is supported for all architectures and the archive being submitted is prepared by the same script in either case. This PR restricts the release process to have no parallelism, which should result in a single notarization occurring at a time.