### PR TITLE
Add support for recording multiple CPEs in cyclonedx

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/cpe_test.go
+++ b/internal/formats/common/cyclonedxhelpers/cpe_test.go
@@ -7,9 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	testCPE  = pkg.MustCPE("cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*")
+	testCPE2 = pkg.MustCPE("cpe:2.3:a:name:name2:3.2:*:*:*:*:*:*:*")
+)
+
 func Test_CPE(t *testing.T) {
-	testCPE := pkg.MustCPE("cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*")
-	testCPE2 := pkg.MustCPE("cpe:2.3:a:name:name2:3.2:*:*:*:*:*:*:*")
 	tests := []struct {
 		name     string
 		input    pkg.Package

--- a/internal/formats/common/cyclonedxhelpers/external_references.go
+++ b/internal/formats/common/cyclonedxhelpers/external_references.go
@@ -5,10 +5,14 @@ import (
 
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/facebookincubator/nvdtools/wfn"
 )
 
 func ExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 	refs := []cyclonedx.ExternalReference{}
+	if len(p.CPEs) > 0 {
+		refs = append(refs, generateCPERefs(p.CPEs)...)
+	}
 	if hasMetadata(p) {
 		switch metadata := p.Metadata.(type) {
 		case pkg.ApkMetadata:
@@ -62,4 +66,16 @@ func ExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 		return &refs
 	}
 	return nil
+}
+
+func generateCPERefs(cpes []wfn.Attributes) []cyclonedx.ExternalReference {
+	cpeRefs := []cyclonedx.ExternalReference{}
+	for _, cpe := range cpes {
+		cpeRefs = append(cpeRefs, cyclonedx.ExternalReference{
+			URL:     pkg.CPEURI(cpe),
+			Type:    cyclonedx.ERTypeAdvisories,
+			Comment: "cpe",
+		})
+	}
+	return cpeRefs
 }

--- a/internal/formats/common/cyclonedxhelpers/external_references_test.go
+++ b/internal/formats/common/cyclonedxhelpers/external_references_test.go
@@ -20,6 +20,16 @@ func Test_ExternalReferences(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "cpes",
+			input: pkg.Package{
+				CPEs: []pkg.CPE{
+					testCPE,
+					testCPE2,
+				},
+			},
+			expected: &[]cyclonedx.ExternalReference{{URL: "cpe:/a:name:name:3.2", Comment: "cpe", Type: "advisories"}, {URL: "cpe:/a:name:name2:3.2", Comment: "cpe", Type: "advisories"}},
+		},
+		{
 			name: "from apk",
 			input: pkg.Package{
 				Metadata: pkg.ApkMetadata{

--- a/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:258d2616-5b1f-48cd-82a3-d6c95e262950",
+  "serialNumber": "urn:uuid:dc92128f-0c3c-44a5-ba74-7f79aa35065e",
   "version": 1,
   "metadata": {
-    "timestamp": "2022-01-14T22:47:00Z",
+    "timestamp": "2022-02-13T23:34:07Z",
     "tools": [
       {
         "vendor": "anchore",
@@ -13,6 +13,7 @@
       }
     ],
     "component": {
+      "bom-ref": "163686ac6e30c752",
       "type": "file",
       "name": "/some/path",
       "version": ""
@@ -32,6 +33,13 @@
       ],
       "cpe": "cpe:2.3:*:some:package:2:*:*:*:*:*:*:*",
       "purl": "a-purl-2",
+      "externalReferences": [
+        {
+          "url": "cpe:/:some:package:2",
+          "comment": "cpe",
+          "type": "advisories"
+        }
+      ],
       "properties": [
         {
           "name": "foundBy",
@@ -61,6 +69,13 @@
       "version": "2.0.1",
       "cpe": "cpe:2.3:*:some:package:2:*:*:*:*:*:*:*",
       "purl": "a-purl-2",
+      "externalReferences": [
+        {
+          "url": "cpe:/:some:package:2",
+          "comment": "cpe",
+          "type": "advisories"
+        }
+      ],
       "properties": [
         {
           "name": "foundBy",

--- a/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/internal/formats/cyclonedx13json/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.3",
-  "serialNumber": "urn:uuid:8a84b1cf-e918-4842-a6a8-c7fdafc55bc0",
+  "serialNumber": "urn:uuid:0ad4ecd6-903b-4a75-abbd-413de0d7452f",
   "version": 1,
   "metadata": {
-    "timestamp": "2022-01-14T22:47:00Z",
+    "timestamp": "2022-02-13T23:34:07Z",
     "tools": [
       {
         "vendor": "anchore",
@@ -13,6 +13,7 @@
       }
     ],
     "component": {
+      "bom-ref": "711095b1cdf90cce",
       "type": "container",
       "name": "user-image-input",
       "version": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368"
@@ -32,6 +33,13 @@
       ],
       "cpe": "cpe:2.3:*:some:package:1:*:*:*:*:*:*:*",
       "purl": "a-purl-1",
+      "externalReferences": [
+        {
+          "url": "cpe:/:some:package:1",
+          "comment": "cpe",
+          "type": "advisories"
+        }
+      ],
       "properties": [
         {
           "name": "foundBy",
@@ -65,6 +73,13 @@
       "version": "2.0.1",
       "cpe": "cpe:2.3:*:some:package:2:*:*:*:*:*:*:*",
       "purl": "a-purl-2",
+      "externalReferences": [
+        {
+          "url": "cpe:/:some:package:2",
+          "comment": "cpe",
+          "type": "advisories"
+        }
+      ],
       "properties": [
         {
           "name": "foundBy",

--- a/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:16a426e7-fcc7-4b94-abd2-66c67569cc44" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:f778df46-c76f-454f-ac38-34f5dcc24a04" version="1">
   <metadata>
-    <timestamp>2022-01-14T22:46:49Z</timestamp>
+    <timestamp>2022-02-13T23:34:27Z</timestamp>
     <tools>
       <tool>
         <vendor>anchore</vendor>
@@ -9,7 +9,7 @@
         <version>[not provided]</version>
       </tool>
     </tools>
-    <component type="file">
+    <component bom-ref="163686ac6e30c752" type="file">
       <name>/some/path</name>
       <version></version>
     </component>
@@ -25,6 +25,12 @@
       </licenses>
       <cpe>cpe:2.3:*:some:package:2:*:*:*:*:*:*:*</cpe>
       <purl>a-purl-2</purl>
+      <externalReferences>
+        <reference type="advisories">
+          <url>cpe:/:some:package:2</url>
+          <comment>cpe</comment>
+        </reference>
+      </externalReferences>
       <properties>
         <property name="foundBy">the-cataloger-1</property>
         <property name="language">python</property>
@@ -38,6 +44,12 @@
       <version>2.0.1</version>
       <cpe>cpe:2.3:*:some:package:2:*:*:*:*:*:*:*</cpe>
       <purl>a-purl-2</purl>
+      <externalReferences>
+        <reference type="advisories">
+          <url>cpe:/:some:package:2</url>
+          <comment>cpe</comment>
+        </reference>
+      </externalReferences>
       <properties>
         <property name="foundBy">the-cataloger-2</property>
         <property name="type">deb</property>

--- a/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/internal/formats/cyclonedx13xml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:a3d776c6-a2ca-4116-8b99-b3538dd1a460" version="1">
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:d68198cf-65d7-4d8b-bc8b-2671339befdb" version="1">
   <metadata>
-    <timestamp>2022-01-14T22:46:49Z</timestamp>
+    <timestamp>2022-02-13T23:34:27Z</timestamp>
     <tools>
       <tool>
         <vendor>anchore</vendor>
@@ -9,7 +9,7 @@
         <version>[not provided]</version>
       </tool>
     </tools>
-    <component type="container">
+    <component bom-ref="711095b1cdf90cce" type="container">
       <name>user-image-input</name>
       <version>sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368</version>
     </component>
@@ -25,6 +25,12 @@
       </licenses>
       <cpe>cpe:2.3:*:some:package:1:*:*:*:*:*:*:*</cpe>
       <purl>a-purl-1</purl>
+      <externalReferences>
+        <reference type="advisories">
+          <url>cpe:/:some:package:1</url>
+          <comment>cpe</comment>
+        </reference>
+      </externalReferences>
       <properties>
         <property name="foundBy">the-cataloger-1</property>
         <property name="language">python</property>
@@ -39,6 +45,12 @@
       <version>2.0.1</version>
       <cpe>cpe:2.3:*:some:package:2:*:*:*:*:*:*:*</cpe>
       <purl>a-purl-2</purl>
+      <externalReferences>
+        <reference type="advisories">
+          <url>cpe:/:some:package:2</url>
+          <comment>cpe</comment>
+        </reference>
+      </externalReferences>
       <properties>
         <property name="foundBy">the-cataloger-2</property>
         <property name="type">deb</property>

--- a/syft/pkg/cpe.go
+++ b/syft/pkg/cpe.go
@@ -99,6 +99,22 @@ func CPEString(c CPE) string {
 	return output.BindToFmtString()
 }
 
+func CPEURI(c CPE) string {
+	output := CPE{}
+	output.Vendor = sanitize(c.Vendor)
+	output.Product = sanitize(c.Product)
+	output.Language = sanitize(c.Language)
+	output.Version = sanitize(c.Version)
+	output.TargetSW = sanitize(c.TargetSW)
+	output.Part = sanitize(c.Part)
+	output.Edition = sanitize(c.Edition)
+	output.Other = sanitize(c.Other)
+	output.SWEdition = sanitize(c.SWEdition)
+	output.TargetHW = sanitize(c.TargetHW)
+	output.Update = sanitize(c.Update)
+	return output.BindToURI()
+}
+
 // sanitize is a modified version of WFNize function from nvdtools
 // that quotes all the allowed punctation chars with a slash and replaces
 // spaces with underscores. It differs from the upstream implmentation as

--- a/syft/pkg/cpe_test.go
+++ b/syft/pkg/cpe_test.go
@@ -50,6 +50,10 @@ func TestNewCPE(t *testing.T) {
 				t.Errorf("mismatched entries:\n\texpected:%+v\n\t  actual:%+v\n", CPEString(test.expected), CPEString(actual))
 			}
 
+			if CPEURI(test.expected) != test.input {
+				t.Errorf("mismatched entries:\n\texpected:%+v\n\t  actual:%+v\n", CPEURI(test.expected), test.input)
+			}
+
 		})
 	}
 }
@@ -105,6 +109,9 @@ func Test_CPEParser(t *testing.T) {
 			assert.Equal(t, c1, test.WFN)
 			assert.Equal(t, c2, test.WFN)
 			assert.Equal(t, CPEString(test.WFN), test.CPEString)
+			assert.Equal(t, CPEURI(c2), test.CPEUrl)
+			assert.Equal(t, CPEURI(c1), test.CPEUrl)
+			assert.Equal(t, must(NewCPE(CPEURI(c1))), test.WFN)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #818 

For reasoning and logic behind the CPE serialization decision please take a look at the issue. We still store our most specific CPE in the cyclonedx CPE field but for all the other CPEs, we store them as external references.