### PR TITLE
Bump stereoscope version to use functional options-based API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
 	github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29
-	github.com/anchore/stereoscope v0.0.0-20220209160132-2e595043fa19
+	github.com/anchore/stereoscope v0.0.0-20220214165125-25ebd49a842b
 	github.com/antihax/optional v1.0.0
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/docker/docker v20.10.12+incompatible

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
 github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
-github.com/anchore/stereoscope v0.0.0-20220209160132-2e595043fa19 h1:INJWzjqSo4uF5NrYISnIfIpnmgV+nfYwbrL8nnmIz7g=
-github.com/anchore/stereoscope v0.0.0-20220209160132-2e595043fa19/go.mod h1:QpDHHV2h1NNfu7klzU75XC8RvSlaPK6HHgi0dy8A6sk=
+github.com/anchore/stereoscope v0.0.0-20220214165125-25ebd49a842b h1:PMMXpTEHVVLErrXQ6mH9ocLAQyvQu/LUhdstrhx7AC4=
+github.com/anchore/stereoscope v0.0.0-20220214165125-25ebd49a842b/go.mod h1:QpDHHV2h1NNfu7klzU75XC8RvSlaPK6HHgi0dy8A6sk=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=

--- a/internal/formats/syftjson/decoder_test.go
+++ b/internal/formats/syftjson/decoder_test.go
@@ -21,6 +21,10 @@ func TestEncodeDecodeCycle(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, d := range deep.Equal(originalSBOM.Source, actualSBOM.Source) {
+		if strings.HasSuffix(d, "<nil slice> != []") {
+			// semantically the same
+			continue
+		}
 		t.Errorf("metadata difference: %+v", d)
 	}
 

--- a/internal/formats/syftjson/to_format_model.go
+++ b/internal/formats/syftjson/to_format_model.go
@@ -217,9 +217,17 @@ func toRelationshipModel(relationships []artifact.Relationship) []model.Relation
 func toSourceModel(src source.Metadata) (model.Source, error) {
 	switch src.Scheme {
 	case source.ImageScheme:
+		metadata := src.ImageMetadata
+		// ensure that empty collections are not shown as null
+		if metadata.RepoDigests == nil {
+			metadata.RepoDigests = []string{}
+		}
+		if metadata.Tags == nil {
+			metadata.Tags = []string{}
+		}
 		return model.Source{
 			Type:   "image",
-			Target: src.ImageMetadata,
+			Target: metadata,
 		}, nil
 	case source.DirectoryScheme:
 		return model.Source{

--- a/internal/formats/syftjson/to_format_model_test.go
+++ b/internal/formats/syftjson/to_format_model_test.go
@@ -63,6 +63,8 @@ func Test_toSourceModel(t *testing.T) {
 					ID:             "id...",
 					ManifestDigest: "digest...",
 					MediaType:      "type...",
+					RepoDigests:    []string{},
+					Tags:           []string{},
 				},
 			},
 		},

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -90,7 +90,12 @@ func parseScheme(userInput string) string {
 func getImageWithRetryStrategy(userInput, location string, imageSource image.Source, registryOptions *image.RegistryOptions) (*image.Image, func(), error) {
 	ctx := context.TODO()
 
-	img, err := stereoscope.GetImageFromSource(ctx, location, imageSource, registryOptions)
+	var opts []stereoscope.Option
+	if registryOptions != nil {
+		opts = append(opts, stereoscope.WithRegistryOptions(*registryOptions))
+	}
+
+	img, err := stereoscope.GetImageFromSource(ctx, location, imageSource, opts...)
 	if err == nil {
 		// Success on the first try!
 		return img, stereoscope.Cleanup, nil
@@ -120,7 +125,7 @@ func getImageWithRetryStrategy(userInput, location string, imageSource image.Sou
 	// We need to determine the image source again, such that this determination
 	// doesn't take scheme parsing into account.
 	imageSource = image.DetermineImagePullSource(userInput)
-	img, err = stereoscope.GetImageFromSource(ctx, userInput, imageSource, registryOptions)
+	img, err = stereoscope.GetImageFromSource(ctx, userInput, imageSource, opts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Pulls in https://github.com/anchore/stereoscope/pull/103 . There is no functional difference or additional features, only a difference in the API expression.