### PR TITLE
Npm purl namespace decode error on dir target

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/anchore/go-rpmdb v0.0.0-20210914181456-a9c52348da63
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29
+	github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b
 	github.com/anchore/stereoscope v0.0.0-20220307154759-8a5a70c227d3
 	github.com/antihax/optional v1.0.0
 	github.com/bmatcuk/doublestar/v4 v4.0.2

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29 h1:K9LfnxwhqvihqU0+MF325FNy7fsKV9EGaUxdfR4gnWk=
-github.com/anchore/packageurl-go v0.0.0-20210922164639-b3fa992ebd29/go.mod h1:Oc1UkGaJwY6ND6vtAqPSlYrptKRJngHwkwB6W7l1uP0=
+github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b h1:YJWYt/6KQXR9JR46lLHrTTYi8rcye42tKcyjREA/hvA=
+github.com/anchore/packageurl-go v0.1.1-0.20220314153042-1bcd40e5206b/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.0-20220307154759-8a5a70c227d3 h1:Kx2jlMdENAf4cVjYGYLI+fiavVhzhtmU89GUYDITJ1w=
 github.com/anchore/stereoscope v0.0.0-20220307154759-8a5a70c227d3/go.mod h1:XESZQTgFETDBatmyoet6XZ0zVknoIMDSAhj2INj2a5w=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/syft/pkg/dpkg_metadata_test.go
+++ b/syft/pkg/dpkg_metadata_test.go
@@ -75,7 +75,7 @@ func TestDpkgMetadata_pURL(t *testing.T) {
 				Version:       "v",
 				SourceVersion: "2.3",
 			},
-			expected: "pkg:deb/debian/p@v?upstream=s@2.3&distro=debian-11",
+			expected: "pkg:deb/debian/p@v?upstream=s%402.3&distro=debian-11",
 		},
 	}
 

--- a/syft/pkg/npm_package_json_metadata_test.go
+++ b/syft/pkg/npm_package_json_metadata_test.go
@@ -1,18 +1,21 @@
 package pkg
 
 import (
+	"fmt"
+	"testing"
+
 	"github.com/anchore/packageurl-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestNpmPackageJSONMetadata_PackageURL(t *testing.T) {
 
 	tests := []struct {
-		name     string
-		metadata NpmPackageJSONMetadata
-		expected string
+		name      string
+		metadata  NpmPackageJSONMetadata
+		expected  string
+		namespace string
 	}{
 		{
 			name: "no namespace",
@@ -25,18 +28,35 @@ func TestNpmPackageJSONMetadata_PackageURL(t *testing.T) {
 		{
 			name: "split by namespace",
 			metadata: NpmPackageJSONMetadata{
+				Name:    "npmcli/arborist",
+				Version: "2.6.2",
+			},
+			expected:  "pkg:npm/npmcli/arborist@2.6.2",
+			namespace: "npmcli",
+		},
+		{
+			name: "encoding @ symobl",
+			metadata: NpmPackageJSONMetadata{
 				Name:    "@npmcli/arborist",
 				Version: "2.6.2",
 			},
-			expected: "pkg:npm/@npmcli/arborist@2.6.2",
+			expected:  "pkg:npm/%40npmcli/arborist@2.6.2",
+			namespace: "@npmcli",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := tt.metadata.PackageURL(nil)
 			assert.Equal(t, tt.expected, actual)
-			_, err := packageurl.FromString(actual)
+			decoded, err := packageurl.FromString(actual)
 			require.NoError(t, err)
+			assert.Equal(t, tt.namespace, decoded.Namespace)
+			if decoded.Namespace != "" {
+				assert.Equal(t, tt.metadata.Name, fmt.Sprintf("%s/%s", decoded.Namespace, decoded.Name))
+			} else {
+				assert.Equal(t, tt.metadata.Name, decoded.Name)
+			}
+			assert.Equal(t, tt.metadata.Version, decoded.Version)
 		})
 	}
 }

--- a/syft/pkg/python_package_metadata_test.go
+++ b/syft/pkg/python_package_metadata_test.go
@@ -27,7 +27,7 @@ func TestPythonPackageMetadata_pURL(t *testing.T) {
 					CommitID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
-			expected: "pkg:pypi/name@v0.1.0?vcs_url=git+https:%2F%2Fgithub.com%2Ftest%2Ftest.git@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			expected: "pkg:pypi/name@v0.1.0?vcs_url=git+https://github.com/test/test.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 		{
 			name: "should not respond to release info",

--- a/syft/pkg/url.go
+++ b/syft/pkg/url.go
@@ -50,8 +50,13 @@ func URL(p Package, release *linux.Release) string {
 		fields := re.Split(p.Name, -1)
 		namespace = fields[0]
 		name = strings.TrimPrefix(p.Name, namespace+"/")
+	case p.Type == NpmPkg:
+		fields := strings.SplitN(p.Name, "/", 2)
+		if len(fields) > 1 {
+			namespace = fields[0]
+			name = fields[1]
+		}
 	}
-
 	// generate a purl from the package data
 	return packageurl.NewPackageURL(
 		purlType,


### PR DESCRIPTION
Signed-off-by: houdini91 <mdstrauss91@gmail.com>

Seems that when running on a directory target the NPM purls does not split the namespace correctly.
For example a npm package `@aws-sdk/credential-provider-ini` version 3.41.0
 
**Dir target:**
PURL = pkg:npm/@aws-sdk%2Fcredential-provider-ini@3.41.0
**Image target**
PURL = pkg:npm/@aws-sdk/credential-provider-ini@3.41.0

Ps: i also think the `@` included in namespace or name be encoded (%40) if i am not mistaken.