### PR TITLE
Fix panic in reqs txt parsing

### DIFF
--- a/syft/pkg/cataloger/python/parse_pipfile_lock.go
+++ b/syft/pkg/cataloger/python/parse_pipfile_lock.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/anchore/syft/syft/artifact"
@@ -59,6 +60,11 @@ func parsePipfileLock(_ string, reader io.Reader) ([]*pkg.Package, []artifact.Re
 			})
 		}
 	}
+
+	// Without sorting the packages slice, the order of packages will be unstable, due to ranging over a map.
+	sort.Slice(packages, func(i, j int) bool {
+		return packages[i].String() < packages[j].String()
+	})
 
 	return packages, nil, nil
 }

--- a/syft/pkg/cataloger/python/parse_pipfile_lock_test.go
+++ b/syft/pkg/cataloger/python/parse_pipfile_lock_test.go
@@ -4,36 +4,39 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/anchore/syft/syft/pkg"
 )
 
 func TestParsePipFileLock(t *testing.T) {
-	expected := map[string]pkg.Package{
-		"aio-pika": {
+	expected := []*pkg.Package{
+		{
 			Name:     "aio-pika",
 			Version:  "6.8.0",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"aiodns": {
+		{
 			Name:     "aiodns",
 			Version:  "2.0.0",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"aiohttp": {
+		{
 			Name:     "aiohttp",
 			Version:  "3.7.4.post0",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"aiohttp-jinja2": {
+		{
 			Name:     "aiohttp-jinja2",
 			Version:  "1.4.2",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
 	}
+
 	fixture, err := os.Open("test-fixtures/pipfile-lock/Pipfile.lock")
 	if err != nil {
 		t.Fatalf("failed to open fixture: %+v", err)
@@ -45,6 +48,7 @@ func TestParsePipFileLock(t *testing.T) {
 		t.Fatalf("failed to parse requirements: %+v", err)
 	}
 
-	assertPackagesEqual(t, actual, expected)
-
+	if diff := cmp.Diff(expected, actual, cmp.AllowUnexported(pkg.Package{})); diff != "" {
+		t.Errorf("unexpected result from parsing (-expected +actual)\n%s", diff)
+	}
 }

--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -24,34 +24,32 @@ func parseRequirementsTxt(_ string, reader io.Reader) ([]*pkg.Package, []artifac
 		line := scanner.Text()
 		line = trimRequirementsTxtLine(line)
 
-		switch {
-		case len(line) == 0:
+		if line == "" {
 			// nothing to parse on this line
 			continue
-		case strings.HasPrefix(line, "-e"):
+		}
+
+		if strings.HasPrefix(line, "-e") {
 			// editable packages aren't parsed (yet)
 			continue
-		case len(strings.Split(line, "==")) < 2:
-			// a package without a version, or a range (unpinned) which
-			// does not tell us exactly what will be installed
-			// XXX only needed if we want to log this, otherwise the next case catches it
-			continue
-		case len(strings.Split(line, "==")) == 2:
-			// remove comments if present
-			uncommented := removeTrailingComment(line)
-			// parse a new requirement
-			parts := strings.Split(uncommented, "==")
-			name := strings.TrimSpace(parts[0])
-			version := strings.TrimSpace(parts[1])
-			packages = append(packages, &pkg.Package{
-				Name:     name,
-				Version:  version,
-				Language: pkg.Python,
-				Type:     pkg.PythonPkg,
-			})
-		default:
+		}
+
+		if !strings.Contains(line, "==") {
+			// a package without a version, or a range (unpinned) which does not tell us
+			// exactly what will be installed.
 			continue
 		}
+
+		// parse a new requirement
+		parts := strings.Split(line, "==")
+		name := strings.TrimSpace(parts[0])
+		version := strings.TrimSpace(parts[1])
+		packages = append(packages, &pkg.Package{
+			Name:     name,
+			Version:  version,
+			Language: pkg.Python,
+			Type:     pkg.PythonPkg,
+		})
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -4,47 +4,27 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/anchore/syft/syft/pkg"
 )
 
-func assertPackagesEqual(t *testing.T, actual []*pkg.Package, expected map[string]pkg.Package) {
-	t.Helper()
-	if len(actual) != len(expected) {
-		for _, a := range actual {
-			t.Log("   ", a)
-		}
-		t.Fatalf("unexpected package count: %d!=%d", len(actual), len(expected))
-	}
-
-	for _, a := range actual {
-		expectedPkg, ok := expected[a.Name]
-		assert.True(t, ok)
-
-		for _, d := range deep.Equal(a, &expectedPkg) {
-			t.Errorf("diff: %+v", d)
-		}
-	}
-}
-
 func TestParseRequirementsTxt(t *testing.T) {
-	expected := map[string]pkg.Package{
-		"foo": {
-			Name:     "foo",
-			Version:  "1.0.0",
-			Language: pkg.Python,
-			Type:     pkg.PythonPkg,
-		},
-		"flask": {
+	expected := []*pkg.Package{
+		{
 			Name:     "flask",
 			Version:  "4.0.0",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
+		{
+			Name:     "foo",
+			Version:  "1.0.0",
+			Language: pkg.Python,
+			Type:     pkg.PythonPkg,
+		},
 	}
+
 	fixture, err := os.Open("test-fixtures/requires/requirements.txt")
 	if err != nil {
 		t.Fatalf("failed to open fixture: %+v", err)
@@ -56,6 +36,7 @@ func TestParseRequirementsTxt(t *testing.T) {
 		t.Fatalf("failed to parse requirements: %+v", err)
 	}
 
-	assertPackagesEqual(t, actual, expected)
-
+	if diff := cmp.Diff(expected, actual, cmp.AllowUnexported(pkg.Package{})); diff != "" {
+		t.Errorf("unexpected result from parsing (-expected +actual)\n%s", diff)
+	}
 }

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -23,6 +23,12 @@ func TestParseRequirementsTxt(t *testing.T) {
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
+		{
+			Name:     "SomeProject",
+			Version:  "5.4",
+			Language: pkg.Python,
+			Type:     pkg.PythonPkg,
+		},
 	}
 
 	fixture, err := os.Open("test-fixtures/requires/requirements.txt")

--- a/syft/pkg/cataloger/python/parse_setup_test.go
+++ b/syft/pkg/cataloger/python/parse_setup_test.go
@@ -4,52 +4,57 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/anchore/syft/syft/pkg"
 )
 
 func TestParseSetup(t *testing.T) {
-	expected := map[string]pkg.Package{
-		"pathlib3": {
+	expected := []*pkg.Package{
+		{
 			Name:     "pathlib3",
 			Version:  "2.2.0",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"mypy": {
+		{
 			Name:     "mypy",
 			Version:  "v0.770",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"mypy1": {
+		{
 			Name:     "mypy1",
 			Version:  "v0.770",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"mypy2": {
+		{
 			Name:     "mypy2",
 			Version:  "v0.770",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
-		"mypy3": {
+		{
 			Name:     "mypy3",
 			Version:  "v0.770",
 			Language: pkg.Python,
 			Type:     pkg.PythonPkg,
 		},
 	}
+
 	fixture, err := os.Open("test-fixtures/setup/setup.py")
 	if err != nil {
 		t.Fatalf("failed to open fixture: %+v", err)
 	}
 
+	// TODO: no relationships are under test yet
 	actual, _, err := parseSetup(fixture.Name(), fixture)
 	if err != nil {
 		t.Fatalf("failed to parse requirements: %+v", err)
 	}
 
-	assertPackagesEqual(t, actual, expected)
-
+	if diff := cmp.Diff(expected, actual, cmp.AllowUnexported(pkg.Package{})); diff != "" {
+		t.Errorf("unexpected result from parsing (-expected +actual)\n%s", diff)
+	}
 }

--- a/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
+++ b/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
@@ -5,3 +5,8 @@ sqlalchemy >= 1.0.0
 -e https://github.com/pecan/pecan.git
 -r other-requirements.txt
 --requirements super-secretrequirements.txt
+SomeProject ==5.4 ; python_version < '3.8'
+coverage != 3.5 # Version Exclusion. Anything except version 3.5
+numpyNew; sys_platform == 'win32'
+numpy >= 3.4.1; sys_platform == 'win32'
+Mopidy-Dirble ~= 1.1 # Compatible release. Same as >= 1.1, == 1.*


### PR DESCRIPTION
Fixes #831

This PR fixes an "index out of range" panic that was occurring while parsing a `requirements.txt` file.

### Diving into the problem

The root cause of the panic was that the code was splitting a line on `==` and trying to access `parts[1]` without confirming that `parts` contained a second item. This was able to happen because we were removing comments from the line **in between** the check for two parts (from a split on `==`) and splitting the original line on `==` another time to find the package's name and version.

This is the line that caused the panic:

```
Mopidy-Dirble ~= 1.1 # Compatible release. Same as >= 1.1, == 1.*
```

Value of `parts` — at the initial length check:
```js
[
  "Mopidy-Dirble ~= 1.1 # Compatible release. Same as >= 1.1, ",
  "1.*",
]
```

Value of `parts` — at the access of `parts[1]`:
```js
[
  "Mopidy-Dirble ~= 1.1 ",
]
```

### Additional changes

1. There were additional cases for `requirements.txt` lines surfaced in #831 that were not being explicitly tested, so I added those cases into the test fixture. (e.g. lines with environment markers)

2. I adjusted the Python parser tests to use [go-cmp](https://github.com/google/go-cmp). I noticed we've started using this library more in our tests, and I can see why... It's much easier to interpret the diff that's reported for a failing test than with other diffing implementations I've seen, and it also means we don't need to write our own diff implementations as often (go-cmp seems to handle a large set of cases). I had originally started off this PR by writing a failing test case, but it was difficult to figure out what the actual problem was when a test failed. Once I put in go-cmp, it become significantly easier. To leave the code in a more consistent state, I adjusted the other two Python parsers that had been using `assertPackagesEqual` to instead use go-cmp.

3. The switch to go-cmp surfaced an issue where our parsing of `pipfile.lock` was nondeterministic, due to _ranging over a map_ that was decoded from JSON. I noticed that go-cmp was diffing the set of packages in an order-sensitive manner, and so `TestParsePipFileLock` would sometimes pass and sometimes fail, depending on the order of the packages returned by `parsePipfileLock`. I added sorting to `parsePipfileLock` to have the result slice have a stable sort order.

4. I refactored `parseRequirementsTxt` in an attempt to make the logical conditions of interest more explicit in the code.