### PR TITLE
Add exception for handlebars java package to generate nodejs CPE

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -45,7 +45,13 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "apache-cassandra"}, // , Vendor: "apache"},
 			candidateAddition{AdditionalProducts: []string{"cassandra"}},
 		},
-
+		{
+			// example image: cloudbees/cloudbees-core-mm:2.319.3.4
+			// this is a wrapped packaging of the handlebars.js node module
+			pkg.JavaPkg,
+			candidateKey{PkgName: "handlebars"},
+			candidateAddition{AdditionalVendors: []string{"handlebarsjs"}},
+		},
 		// NPM packages
 		{
 			pkg.NpmPkg,

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -545,6 +545,81 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "regression: handlebars within java archive",
+			p: pkg.Package{
+				Name:         "handlebars",
+				Version:      "3.0.8",
+				Type:         pkg.JavaPkg,
+				Language:     pkg.Java,
+				FoundBy:      "java-cataloger",
+				MetadataType: pkg.JavaMetadataType,
+				Metadata: pkg.JavaMetadata{
+					Manifest: &pkg.JavaManifest{
+						Main: map[string]string{
+							"Extension-Name":         "handlebars",
+							"Group-Id":               "org.jenkins-ci.ui",
+							"Hudson-Version":         "2.204",
+							"Implementation-Title":   "handlebars",
+							"Implementation-Version": "3.0.8",
+							"Plugin-Version":         "3.0.8",
+							"Short-Name":             "handlebars",
+						},
+					},
+					PomProperties: &pkg.PomProperties{
+						GroupID:    "org.jenkins-ci.ui",
+						ArtifactID: "handlebars",
+						Version:    "3.0.8",
+					},
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:handlebars:handlebars:3.0.8:*:*:*:*:*:*:*",
+				"cpe:2.3:a:handlebarsjs:handlebars:3.0.8:*:*:*:*:*:*:*", // important!
+				"cpe:2.3:a:jenkins-ci:handlebars:3.0.8:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:handlebars:3.0.8:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins_ci:handlebars:3.0.8:*:*:*:*:*:*:*",
+				"cpe:2.3:a:ui:handlebars:3.0.8:*:*:*:*:*:*:*",
+			},
+		},
+		{
+			name: "regression: jenkins plugin active-directory",
+			p: pkg.Package{
+				Name:         "active-directory",
+				Version:      "2.25.1",
+				Type:         pkg.JenkinsPluginPkg,
+				FoundBy:      "java-cataloger",
+				Language:     pkg.Java,
+				MetadataType: pkg.JavaMetadataType,
+				Metadata: pkg.JavaMetadata{
+					Manifest: &pkg.JavaManifest{
+						Main: map[string]string{
+							"Extension-Name": "active-directory",
+							"Group-Id":       "org.jenkins-ci.plugins",
+						},
+					},
+					PomProperties: &pkg.PomProperties{
+						GroupID:    "org.jenkins-ci.plugins",
+						ArtifactID: "org.jenkins-ci.plugins",
+						Version:    "2.25.1",
+					},
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:active-directory:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:active-directory:active_directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:active:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:active:active_directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:active_directory:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:active_directory:active_directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins-ci:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins-ci:active_directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:active-directory:2.25.1:*:*:*:*:*:*:*", // important!
+				"cpe:2.3:a:jenkins:active_directory:2.25.1:*:*:*:*:*:*:*", // important!
+				"cpe:2.3:a:jenkins_ci:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins_ci:active_directory:2.25.1:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR accounts for an edge case for a java package that wraps a javascript node module. Within `cloudbees/cloudbees-core-mm:2.319.3.4` the `handlebars@3.0.8` package does not have enough packaging metadata to uncover the vendor of the wrapped package (which is `handlebarsjs`). Here we add an exception to additionally add a vendor of `handlebarsjs` for any java package with a name of `handlebars`. 

Regression tests have been added for this and for a `active-directory` case that requires no action.