### PR TITLE
Bump release timeout

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,8 +43,9 @@ builds:
     ldflags: *build-ldflags
     hooks:
       post:
-        # we must have signing as a build hook instead of the signs section. The signs section must register a new asset, where we want to replace an existing asset.
-        # a post-build hook has the advantage of not needing to unpackage and repackage a tar.gz with a signed binary
+        # we must have signing as a build hook instead of the signs section. The signs section must register a new
+        # asset, where we want to replace an existing asset. A post-build hook has the advantage of not needing to
+        # unpackage and repackage a tar.gz with a signed binary
         - ./.github/scripts/apple-signing/sign.sh "{{ .Path }}" "{{ .IsSnapshot }}" "{{ .Target }}"
 
   - id: windows-build

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RESULTSDIR = test/results
 COVER_REPORT = $(RESULTSDIR)/unit-coverage-details.txt
 COVER_TOTAL = $(RESULTSDIR)/unit-coverage-summary.txt
 LINTCMD = $(TEMPDIR)/golangci-lint run --tests=false --timeout=4m --config .golangci.yaml
-RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist
+RELEASE_CMD=$(TEMPDIR)/goreleaser release --rm-dist --timeout 60m
 SNAPSHOT_CMD=$(RELEASE_CMD) --skip-publish --snapshot
 VERSION=$(shell git describe --dirty --always --tags)
 COMPARE_TEST_IMAGE = centos:8.2.2004


### PR DESCRIPTION
In an attempt to troubleshoot the release failure I'm bumping the goreleaser timeout:
```
• building binaries
      • building                  binary=/Users/runner/work/syft/syft/dist/linux-build_linux_amd64/syft
      • building                  binary=/Users/runner/work/syft/syft/dist/linux-build_linux_arm64/syft
      • building                  binary=/Users/runner/work/syft/syft/dist/darwin-build_darwin_amd64/syft
      • running hook              hook=./.github/scripts/apple-signing/sign.sh "/Users/runner/work/syft/syft/dist/darwin-build_darwin_amd64/syft" "false" "darwin_amd64"
      ⨯ release failed after 1800.10s error=context deadline exceeded

# assuming production setup...

Task: setting up production certificate material
1 identity imported.
keychain: "/Users/runner/Library/Keychains/ci-ephemeral-keychain-db"
version: 512
class: 0x00000010 
attributes:
    0x00000000 <uint32>=0x00000010 
    0x00000001 <blob>="Mac Developer ID Application: ANCHORE, INC."
    0x00000002 <blob>=<NULL>
    0x00000003 <uint32>=0x00000001 
    0x00000004 <uint32>=0x00000000 
    0x00000005 <uint32>=0x00000000 
    0x00000006 <blob>=0xC747C50F1EC7C2BE2FF20D4969B20894E5C98951  "\307G\305\017\036\307\302\276/\362\015Ii\262\010\224\345\311\211Q"
    0x00000007 <blob>=<NULL>
    0x00000008 <blob>=0x7B38373139316361322D306663392D313164342D383439612D3030303530326235323132327D00  "{87191ca2-0fc9-11d4-849a-000502b52[122](https://github.com/anchore/syft/runs/5335387771?check_suite_focus=true#step:8:122)}\000"
    0x00000009 <uint32>=0x0000002A  "\000\000\000*"
    0x0000000A <uint32>=0x00000800 
    0x0000000B <uint32>=0x00000800 
    0x0000000C <blob>=0x0000000000000000 
    0x0000000D <blob>=0x0000000000000000 
    0x0000000E <uint32>=0x00000001 
    0x0000000F <uint32>=0x00000001 
    0x00000010 <uint32>=0x00000001 
    0x00000011 <uint32>=0x00000000 
    0x00000012 <uint32>=0x00000001 
    0x00000013 <uint32>=0x00000001 
    0x00000014 <uint32>=0x00000001 
    0x00000015 <uint32>=0x00000001 
    0x00000016 <uint32>=0x00000001 
    0x00000017 <uint32>=0x00000001 
    0x00000018 <uint32>=0x00000001 
    0x00000019 <uint32>=0x00000001 
    0x0000001A <uint32>=0x00000001 

# setting MAC_SIGNING_IDENTITY=Developer ID Application: ANCHORE, INC. (9MJHKYX5AT)

# log into docker -- required for publishing (since the default keychain has now been replaced)
Login Succeeded

# enabling notarization...
signing /Users/runner/work/syft/syft/dist/darwin-build_darwin_amd64/syft ...
```

Why? A couple of reasons:
- The build itself is taking much longer due to pulling in cosign as a dependency
- We must have parallelism set to 1 since we cannot notarize similar artifacts in parallel (Apple limitation)

The odd thing about this is that the log seems to indicate the signing step and not notarization that is taking a while. 