### PR TITLE
Reduce PR check failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,10 @@ name: "CodeQL Security Scan"
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
+    branches:
+      # only run when there are pushes to the main branch (not on PRs)
+      - main
+
   schedule:
     - cron: '0 0 * * 3'
 

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -2,6 +2,8 @@ name: "Validations"
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 env:
@@ -13,9 +15,6 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -53,9 +52,6 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -108,9 +104,6 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Integration tests"
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -159,9 +152,6 @@ jobs:
   Benchmark-Test:
     name: "Benchmark tests"
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     # note: we want benchmarks to run on pull_request events in order to publish results to a sticky comment, and
     # we also want to run on push such that merges to main are recorded to the cache. For this reason we don't filter
     # the job by event.
@@ -237,9 +227,6 @@ jobs:
   Build-Snapshot-Artifacts:
     name: "Build snapshot artifacts"
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -321,9 +308,6 @@ jobs:
     name: "Acceptance tests (Mac)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v2
 
@@ -350,9 +334,6 @@ jobs:
     name: "CLI tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04
-    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
-    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -13,6 +13,9 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Static analysis"
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -50,6 +53,9 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Unit tests"
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -102,6 +108,9 @@ jobs:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline
     name: "Integration tests"
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -150,6 +159,9 @@ jobs:
   Benchmark-Test:
     name: "Benchmark tests"
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     # note: we want benchmarks to run on pull_request events in order to publish results to a sticky comment, and
     # we also want to run on push such that merges to main are recorded to the cache. For this reason we don't filter
     # the job by event.
@@ -225,6 +237,9 @@ jobs:
   Build-Snapshot-Artifacts:
     name: "Build snapshot artifacts"
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:
@@ -306,6 +321,9 @@ jobs:
     name: "Acceptance tests (Mac)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: macos-latest
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/checkout@v2
 
@@ -332,6 +350,9 @@ jobs:
     name: "CLI tests (Linux)"
     needs: [Build-Snapshot-Artifacts]
     runs-on: ubuntu-20.04
+    # run only on push event (internal PRs) or on a pull_request event that is from a fork (external PR)
+    # skip if this is a pull_request event on an internal PR (which is already covered by push events)
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/test/install/test_harness.sh
+++ b/test/install/test_harness.sh
@@ -106,7 +106,6 @@ setup_snapshot_server() {
 
   echoerr "$(ls -1 $(snapshot_dir) | sed 's/^/  ▕―― /')"
 
-  # it takes some time for the server to be ready...
   check_snapshots_server_ready
 
   echoerr "snapshot server ready! (worker=${worker_pid})"

--- a/test/install/test_harness.sh
+++ b/test/install/test_harness.sh
@@ -5,6 +5,15 @@ TEST_INSTALL_SH=true
 . ../../install.sh
 set -u
 
+echoerr() {
+  echo "$@" 1>&2
+}
+
+printferr() {
+  printf "%s" "$*" >&2
+}
+
+
 assertTrue() {
   if eval "$1"; then
     echo "assertTrue failed: $2"
@@ -93,16 +102,35 @@ setup_snapshot_server() {
   python3 -m http.server --directory "$(snapshot_dir)" $serve_port &> /dev/null &
   worker_pid=$!
 
+  echoerr "serving up $(snapshot_dir) on port $serve_port"
+
+  echoerr "$(ls -1 $(snapshot_dir) | sed 's/^/  ▕―― /')"
+
   # it takes some time for the server to be ready...
-  sleep 3
+  check_snapshots_server_ready
+
+  echoerr "snapshot server ready! (worker=${worker_pid})"
 
   echo "$worker_pid"
 }
 
+check_snapshots_server_ready() {
+  i=0
+  until $(curl -m 3 --output /dev/null --silent --head --fail localhost:$serve_port/); do
+    sleep 1
+    ((i=i+1))
+    if [ "$i" -gt "30" ]; then
+      echoerr "could not connect to local snapshot server! bailing..."
+      exit 1
+    fi
+    printferr '.'
+  done
+}
+
 teardown_snapshot_server() {
   worker_pid="$1"
-
-  kill $worker_pid
+  echoerr "stopping worker=${worker_pid}"
+  kill "$worker_pid"
 }
 
 snapshot_version() {


### PR DESCRIPTION
- Adds polling check for install tests to ensure the snapshot server is up
- Elevates CodeQL to only run on main (not on PRs)
- De-duplicates checks as best as possible; CI checks only run on PRs and pushes to main. Pushes to feature branches will no longer trigger CI.