### PR TITLE
Correct SPDX-JSON checksum algorithm

### DIFF
--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -152,11 +152,17 @@ func toFiles(s sbom.SBOM) []model.File {
 func toFileChecksums(digests []file.Digest) (checksums []model.Checksum) {
 	for _, digest := range digests {
 		checksums = append(checksums, model.Checksum{
-			Algorithm:     digest.Algorithm,
+			Algorithm:     toChecksumAlgorithm(digest.Algorithm),
 			ChecksumValue: digest.Value,
 		})
 	}
 	return checksums
+}
+
+func toChecksumAlgorithm(algorithm string) string {
+	// basically, we need an uppercase version of our algorithm:
+	// https://github.com/spdx/spdx-spec/blob/development/v2.2.2/schemas/spdx-schema.json#L165
+	return strings.ToUpper(algorithm)
 }
 
 func toFileTypes(metadata *source.FileMetadata) (ty []string) {

--- a/internal/formats/spdx22json/to_format_model_test.go
+++ b/internal/formats/spdx22json/to_format_model_test.go
@@ -142,7 +142,7 @@ func Test_toFileChecksums(t *testing.T) {
 			name: "has digests",
 			digests: []file.Digest{
 				{
-					Algorithm: "sha256",
+					Algorithm: "SHA256",
 					Value:     "deadbeefcafe",
 				},
 				{
@@ -152,11 +152,11 @@ func Test_toFileChecksums(t *testing.T) {
 			},
 			expected: []model.Checksum{
 				{
-					Algorithm:     "sha256",
+					Algorithm:     "SHA256",
 					ChecksumValue: "deadbeefcafe",
 				},
 				{
-					Algorithm:     "md5",
+					Algorithm:     "MD5",
 					ChecksumValue: "meh",
 				},
 			},


### PR DESCRIPTION
Reported as https://github.com/anchore/grype/issues/655 with file metadata cataloger enabled, Syft is generating invalid SPDX documents