### PR TITLE
Include root path in directory resolve index

### DIFF
--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -848,3 +848,20 @@ func testWithTimeout(t *testing.T, timeout time.Duration, test func(*testing.T))
 	case <-done:
 	}
 }
+
+func Test_IncludeRootPathInIndex(t *testing.T) {
+	filterFn := func(path string, _ os.FileInfo) bool {
+		return path != "/"
+	}
+
+	resolver, err := newDirectoryResolver("/", filterFn)
+	require.NoError(t, err)
+
+	exists, ref, err := resolver.fileTree.File(file.Path("/"))
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	assert.True(t, exists)
+
+	_, exists = resolver.metadata[ref.ID()]
+	require.True(t, exists)
+}


### PR DESCRIPTION
The root path (`/`) is included by default in stereoscope filetree objects. During indexing we need to account for this by additionally checking if we have captured metadata for paths being indexed, not just check for their existence in the filetree.

Note: this has no impact on the output from the syft CLI, only the API itself.

Related to #861 