### PR TITLE
Fix file creation for output options

### DIFF
--- a/cmd/attest.go
+++ b/cmd/attest.go
@@ -153,11 +153,11 @@ func attestExec(ctx context.Context, _ *cobra.Command, args []string) error {
 		return fmt.Errorf("attest command can only be used with image sources fetch directly from the registry, but discovered an image source of %q when given %q", si.ImageSource, userInput)
 	}
 
-	if len(appConfig.Output) > 1 {
+	if len(appConfig.Outputs) > 1 {
 		return fmt.Errorf("unable to generate attestation for more than one output")
 	}
 
-	format := syft.FormatByName(appConfig.Output[0])
+	format := syft.FormatByName(appConfig.Outputs[0])
 	predicateType := formatPredicateType(format)
 	if predicateType == "" {
 		return fmt.Errorf("could not produce attestation predicate for given format: %q. Available formats: %+v", formatAliases(format.ID()), formatAliases(attestFormats...))

--- a/cmd/output_writer.go
+++ b/cmd/output_writer.go
@@ -58,10 +58,7 @@ func parseOptions(outputs []string, defaultFile string) (out []sbom.WriterOption
 			continue
 		}
 
-		out = append(out, sbom.WriterOption{
-			Format: format,
-			Path:   file,
-		})
+		out = append(out, sbom.NewWriterOption(format, file))
 	}
 	return out, errs
 }

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -222,7 +222,7 @@ func validateInputArgs(cmd *cobra.Command, args []string) error {
 }
 
 func packagesExec(_ *cobra.Command, args []string) error {
-	writer, err := makeWriter(appConfig.Output, appConfig.File)
+	writer, err := makeWriter(appConfig.Outputs, appConfig.File)
 	if err != nil {
 		return err
 	}

--- a/cmd/power_user.go
+++ b/cmd/power_user.go
@@ -73,10 +73,12 @@ func powerUserExec(_ *cobra.Command, args []string) error {
 	// could be an image or a directory, with or without a scheme
 	userInput := args[0]
 
-	writer, err := sbom.NewWriter(sbom.WriterOption{
-		Format: syftjson.Format(),
-		Path:   appConfig.File,
-	})
+	writer, err := sbom.NewWriter(
+		sbom.NewWriterOption(
+			syftjson.Format(),
+			appConfig.File,
+		),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -30,7 +30,7 @@ type parser interface {
 // Application is the main syft application configuration.
 type Application struct {
 	ConfigPath         string             `yaml:",omitempty" json:"configPath"`                                                         // the location where the application config was read from (either from -c or discovered while loading)
-	Output             []string           `yaml:"output" json:"output" mapstructure:"output"`                                           // -o, the format to use for output
+	Outputs            []string           `yaml:"output" json:"output" mapstructure:"output"`                                           // -o, the format to use for output
 	File               string             `yaml:"file" json:"file" mapstructure:"file"`                                                 // --file, the file to write report output to
 	Quiet              bool               `yaml:"quiet" json:"quiet" mapstructure:"quiet"`                                              // -q, indicates to not show any status output to stderr (ETUI or logging UI)
 	CheckForAppUpdate  bool               `yaml:"check-for-app-update" json:"check-for-app-update" mapstructure:"check-for-app-update"` // whether to check for an application update on start up or not
@@ -104,6 +104,7 @@ func (cfg *Application) parseConfigValues() error {
 	for _, optionFn := range []func() error{
 		cfg.parseUploadOptions,
 		cfg.parseLogLevelOption,
+		cfg.parseFile,
 	} {
 		if err := optionFn(); err != nil {
 			return err
@@ -122,6 +123,17 @@ func (cfg *Application) parseConfigValues() error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+func (cfg *Application) parseFile() error {
+	if cfg.File != "" {
+		expandedPath, err := homedir.Expand(cfg.File)
+		if err != nil {
+			return fmt.Errorf("unable to expand file path=%q: %w", cfg.File, err)
+		}
+		cfg.File = expandedPath
 	}
 	return nil
 }

--- a/internal/config/application_test.go
+++ b/internal/config/application_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"path/filepath"
+	"testing"
+)
+
+func TestApplication_parseFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Application
+		expected string
+		wantErr  require.ErrorAssertionFunc
+	}{
+		{
+			name: "expand home dir",
+			config: Application{
+				File: "~/place.txt",
+			},
+			expected: filepath.Join(homedir.Get(), "place.txt"),
+		},
+		{
+			name: "passthrough other paths",
+			config: Application{
+				File: "/other/place.txt",
+			},
+			expected: "/other/place.txt",
+		},
+		{
+			name: "no path",
+			config: Application{
+				File: "",
+			},
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config
+
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+
+			tt.wantErr(t, cfg.parseFile())
+			assert.Equal(t, tt.expected, cfg.File)
+		})
+	}
+}

--- a/internal/config/attest.go
+++ b/internal/config/attest.go
@@ -1,19 +1,29 @@
 package config
 
 import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
 	"os"
 
 	"github.com/spf13/viper"
 )
 
 type attest struct {
-	Key string `yaml:"key" json:"key" mapstructure:"key"`
+	Key string `yaml:"key" json:"key" mapstructure:"key"` // same as --key, file path to the private key
 	// IMPORTANT: do not show the password in any YAML/JSON output (sensitive information)
-	Password string `yaml:"-" json:"-" mapstructure:"password"`
+	Password string `yaml:"-" json:"-" mapstructure:"password"` // password for the private key
 }
 
 //nolint:unparam
 func (cfg *attest) parseConfigValues() error {
+	if cfg.Key != "" {
+		expandedPath, err := homedir.Expand(cfg.Key)
+		if err != nil {
+			return fmt.Errorf("unable to expand key path=%q: %w", cfg.Key, err)
+		}
+		cfg.Key = expandedPath
+	}
+
 	if cfg.Password == "" {
 		// we allow for configuration via syft config/env vars and additionally interop with known cosign config env vars
 		if pw, ok := os.LookupEnv("COSIGN_PASSWORD"); ok {

--- a/internal/config/attest.go
+++ b/internal/config/attest.go
@@ -2,9 +2,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/mitchellh/go-homedir"
 	"os"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
 
@@ -14,7 +14,6 @@ type attest struct {
 	Password string `yaml:"-" json:"-" mapstructure:"password"` // password for the private key
 }
 
-//nolint:unparam
 func (cfg *attest) parseConfigValues() error {
 	if cfg.Key != "" {
 		expandedPath, err := homedir.Expand(cfg.Key)

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -11,6 +13,17 @@ type logging struct {
 	LevelOpt     logrus.Level `yaml:"-" json:"-"`                                             // the native log level object used by the logger
 	Level        string       `yaml:"level" json:"level" mapstructure:"level"`                // the log level string hint
 	FileLocation string       `yaml:"file" json:"file-location" mapstructure:"file"`          // the file path to write logs to
+}
+
+func (cfg *logging) parseConfigValues() error {
+	if cfg.FileLocation != "" {
+		expandedPath, err := homedir.Expand(cfg.FileLocation)
+		if err != nil {
+			return fmt.Errorf("unable to expand log file path=%q: %w", cfg.FileLocation, err)
+		}
+		cfg.FileLocation = expandedPath
+	}
+	return nil
 }
 
 func (cfg logging) loadDefaultValues(v *viper.Viper) {

--- a/syft/sbom/multi_writer_test.go
+++ b/syft/sbom/multi_writer_test.go
@@ -2,9 +2,11 @@ package sbom
 
 import (
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/pkg/homedir"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -167,6 +169,36 @@ func TestOutputWriter(t *testing.T) {
 					assert.Nil(t, w.close)
 				}
 			}
+		})
+	}
+}
+
+func TestNewWriterOption(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "expand home dir",
+			path:     "~/place.txt",
+			expected: filepath.Join(homedir.Get(), "place.txt"),
+		},
+		{
+			name:     "passthrough other paths",
+			path:     "/other/place.txt",
+			expected: "/other/place.txt",
+		},
+		{
+			name:     "no path",
+			path:     "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := NewWriterOption(dummyFormat("table"), tt.path)
+			assert.Equal(t, tt.expected, o.Path)
 		})
 	}
 }

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -190,6 +191,26 @@ func TestPackagesCmdFlags(t *testing.T) {
 			assertions: []traitAssertion{
 				assertInOutput("sha256:1ee006886991ad4689838d3a288e0dd3fd29b70e276622f16b67a8922831a853"), // linux/arm64 image digest
 				assertSuccessfulReturnCode,
+			},
+		},
+		{
+			name: "json-file-flag",
+			args: []string{"packages", "-o", "json", "--file", filepath.Join(tmp, "output-1.json"), coverageImage},
+			assertions: []traitAssertion{
+				assertSuccessfulReturnCode,
+				assertFileOutput(t, filepath.Join(tmp, "output-1.json"),
+					assertJsonReport,
+				),
+			},
+		},
+		{
+			name: "json-output-flag-to-file",
+			args: []string{"packages", "-o", fmt.Sprintf("json=%s", filepath.Join(tmp, "output-2.json")), coverageImage},
+			assertions: []traitAssertion{
+				assertSuccessfulReturnCode,
+				assertFileOutput(t, filepath.Join(tmp, "output-2.json"),
+					assertJsonReport,
+				),
 			},
 		},
 	}

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -10,9 +10,25 @@ import (
 	"testing"
 
 	"github.com/acarl005/stripansi"
+	"github.com/stretchr/testify/require"
 )
 
 type traitAssertion func(tb testing.TB, stdout, stderr string, rc int)
+
+func assertFileOutput(tb testing.TB, path string, assertions ...traitAssertion) traitAssertion {
+	tb.Helper()
+
+	return func(tb testing.TB, _, stderr string, rc int) {
+		content, err := os.ReadFile(path)
+		require.NoError(tb, err)
+		contentStr := string(content)
+
+		for _, assertion := range assertions {
+			// treat the file content as stdout
+			assertion(tb, contentStr, stderr, rc)
+		}
+	}
+}
 
 func assertJsonReport(tb testing.TB, stdout, _ string, _ int) {
 	tb.Helper()


### PR DESCRIPTION
This PR makes a few fixes:
- only closes the `sbom.Writer` when there are errors opening files (I missed an `if` statement on the port)
- perform tilde-expansion for any user-provided paths in the application config
- add CLI tests that assert the content for files created with `-o` and `--file` options 

Closes #874 
