### PR TITLE
use filepath.Base() instead of path.Base() for temp files

### DIFF
--- a/syft/pkg/cataloger/java/save_archive_to_tmp.go
+++ b/syft/pkg/cataloger/java/save_archive_to_tmp.go
@@ -5,14 +5,13 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/anchore/syft/internal/log"
 )
 
 func saveArchiveToTmp(archiveVirtualPath string, reader io.Reader) (string, string, func(), error) {
-	name := path.Base(archiveVirtualPath)
+	name := filepath.Base(archiveVirtualPath)
 	tempDir, err := ioutil.TempDir("", "syft-archive-contents-")
 	if err != nil {
 		return "", "", func() {}, fmt.Errorf("unable to create tempdir for archive processing: %w", err)


### PR DESCRIPTION
`path.Base()` returns the entire input path if operating system is Windows.
this is resolved by using `filepath.Base()` instead.

using `path.Base()` produces multiple instances of "Path could not be found", due to the fact that the temporary directory:
`archivePath := filepath.Join(tempDir, "archive-"+name)`
is faulty, `name` contains the entire path of the input archive instead of the base name.
![path](https://user-images.githubusercontent.com/17103300/157680394-fed4ceac-d9d1-4df7-9830-e8928703ac07.png)


switching to using `filepath.Base()` resolves this issue by return the correct base name for the package.
![filepath](https://user-images.githubusercontent.com/17103300/157680382-1d2e6f07-fa66-4720-af70-9d4d70d53be3.png)

An issue with symlinks still remains however.

It also seems like `path.Base()` and other functions from `path` are bein used in multiple places.
I unfortunately don't know enough about Go to know if these also should be changed in favor of `filepath`.



