### PR TITLE
Continue - Option to enable specific language or ecosystem cataloger

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,29 @@ package:
     # same as -s ; SYFT_PACKAGE_CATALOGER_SCOPE env var
     scope: "squashed"
 
+  # Cataloger group select 
+  # When Empty default select for each scheme - Dir:Index, Image:installed
+  # Options: [index install all].
+  # cataloger-group: ""
+
+  # enable specific language or ecosystem cataloger
+  # default: select catalogers out of group
+  # catalogers:
+  # - "ruby-gemfile-cataloger"
+  # - "ruby-gemspec-cataloger"
+  # - "python-index-cataloger"
+  # - "python-package-cataloger"
+  # - "javascript-lock-cataloger"
+  # - "javascript-package-cataloger"
+  # - "php-composer-installed-cataloger"
+  # - "php-composer-lock-cataloger"
+  # - "dpkgdb-cataloger"
+  # - "rpmdb-cataloger"
+  # - "java-cataloger"
+  # - "apkdb-cataloger"
+  # - "go-module-binary-cataloger"
+  catalogers:
+
 # cataloging file classifications is exposed through the power-user subcommand
 file-classification:
   cataloger:

--- a/cmd/packages.go
+++ b/cmd/packages.go
@@ -137,18 +137,23 @@ func setPackageFlags(flags *pflag.FlagSet) {
 	)
 
 	flags.StringArrayP(
-		"exclude", "", nil,
-		"exclude paths from being scanned using a glob expression",
+		"exclude", "", nil, "exclude paths from being scanned using a glob expression",
+	)
+
+	flags.StringArrayP(
+		"cataloger", "C", nil, "enable specific language or ecosystem cataloger",
+	)
+
+	flags.StringP(
+		"cataloger-group", "", "", fmt.Sprintf("selection cataloger group, options=%v", cataloger.AllGroups),
 	)
 
 	flags.Bool(
-		"overwrite-existing-image", false,
-		"overwrite an existing image during the upload to Anchore Enterprise",
+		"overwrite-existing-image", false, "overwrite an existing image during the upload to Anchore Enterprise",
 	)
 
 	flags.Uint(
-		"import-timeout", 30,
-		"set a timeout duration (in seconds) for the upload to Anchore Enterprise",
+		"import-timeout", 30, "set a timeout duration (in seconds) for the upload to Anchore Enterprise",
 	)
 }
 
@@ -177,6 +182,14 @@ func bindExclusivePackagesConfigOptions(flags *pflag.FlagSet) error {
 	}
 
 	if err := viper.BindPFlag("exclude", flags.Lookup("exclude")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("package.catalogers", flags.Lookup("cataloger")); err != nil {
+		return err
+	}
+
+	if err := viper.BindPFlag("package.cataloger-group", flags.Lookup("cataloger-group")); err != nil {
 		return err
 	}
 

--- a/internal/config/pkg.go
+++ b/internal/config/pkg.go
@@ -9,6 +9,8 @@ type pkg struct {
 	Cataloger               catalogerOptions `yaml:"cataloger" json:"cataloger" mapstructure:"cataloger"`
 	SearchUnindexedArchives bool             `yaml:"search-unindexed-archives" json:"search-unindexed-archives" mapstructure:"search-unindexed-archives"`
 	SearchIndexedArchives   bool             `yaml:"search-indexed-archives" json:"search-indexed-archives" mapstructure:"search-indexed-archives"`
+	Catalogers              []string         `yaml:"catalogers" json:"catalogers" mapstructure:"catalogers"`
+	CatalogerGroup          cataloger.Group  `yaml:"cataloger-group" json:"cataloger-group" mapstructure:"cataloger-group"`
 }
 
 func (cfg pkg) loadDefaultValues(v *viper.Viper) {
@@ -29,5 +31,7 @@ func (cfg pkg) ToConfig() cataloger.Config {
 			IncludeUnindexedArchives: cfg.SearchUnindexedArchives,
 			Scope:                    cfg.Cataloger.ScopeOpt,
 		},
+		Catalogers:     cfg.Catalogers,
+		CatalogerGroup: cfg.CatalogerGroup,
 	}
 }

--- a/syft/pkg/cataloger/config.go
+++ b/syft/pkg/cataloger/config.go
@@ -5,7 +5,9 @@ import (
 )
 
 type Config struct {
-	Search SearchConfig
+	Search         SearchConfig
+	Catalogers     []string
+	CatalogerGroup Group
 }
 
 func DefaultConfig() Config {

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -22,7 +22,7 @@ func BenchmarkImagePackageCatalogers(b *testing.B) {
 	tarPath := imagetest.GetFixtureImageTarPath(b, fixtureImageName)
 
 	var pc *pkg.Catalog
-	for _, c := range cataloger.ImageCatalogers(cataloger.DefaultConfig()) {
+	for _, c := range cataloger.InstallationCatalogers(cataloger.DefaultConfig()) {
 		// in case of future alteration where state is persisted, assume no dependency is safe to reuse
 		userInput := "docker-archive:" + tarPath
 		sourceInput, err := source.ParseInput(userInput, "", false)


### PR DESCRIPTION
Hi PR is the continue work on https://github.com/anchore/syft/pull/843.
* Rename flag from `enable-catalogers` to `catalogers` configuration
* Add `-C` `--cataloger` command line argument.
* Flags support remove of cataloger suffix.
```
syft packages busybox:latest -C java-cataloger -C apkdb
```

* Added `cataloger-group` flag which selects the group catalogers.
  Supported group `Index, installed, all`.
* Empty group - select default group ( Dir:Index, Image:installed)
```
syft packages busybox:latest -C javascript-lock-cataloger --cataloger-group all -vv
syft packages dir:./cmd --cataloger-group install -vv
```