### PR TITLE
Fix panic when CycloneDX BOM missing metadata.component

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/decoder.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder.go
@@ -46,7 +46,7 @@ func GetDecoder(format cyclonedx.BOMFileFormat) sbom.Decoder {
 
 func toSyftModel(bom *cyclonedx.BOM) (*sbom.SBOM, error) {
 	meta := source.Metadata{}
-	if bom.Metadata != nil {
+	if bom.Metadata != nil && bom.Metadata.Component != nil {
 		meta = decodeMetadata(bom.Metadata.Component)
 	}
 	s := &sbom.SBOM{

--- a/internal/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder_test.go
@@ -258,3 +258,18 @@ func Test_decode(t *testing.T) {
 		})
 	}
 }
+
+func Test_missingDataDecode(t *testing.T) {
+	bom := &cyclonedx.BOM{
+		Metadata:   nil,
+		Components: &[]cyclonedx.Component{},
+	}
+
+	_, err := toSyftModel(bom)
+	assert.NoError(t, err)
+
+	bom.Metadata = &cyclonedx.Metadata{}
+
+	_, err = toSyftModel(bom)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
There is a case where a community member is merging Syft-generated CycloneDX SBOMs using `cyclonedx-cli`, which results in a missing `metadata.component`, causing a panic.