### PR TITLE
Fix CycloneDX license decoding

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder_test.go
@@ -272,4 +272,14 @@ func Test_missingDataDecode(t *testing.T) {
 
 	_, err = toSyftModel(bom)
 	assert.NoError(t, err)
+
+	pkg := decodeComponent(&cyclonedx.Component{
+		Licenses: &cyclonedx.Licenses{
+			{
+				License: nil,
+			},
+		},
+	})
+
+	assert.Len(t, pkg.Licenses, 0)
 }

--- a/internal/formats/common/cyclonedxhelpers/licenses.go
+++ b/internal/formats/common/cyclonedxhelpers/licenses.go
@@ -26,7 +26,9 @@ func encodeLicenses(p pkg.Package) *cyclonedx.Licenses {
 func decodeLicenses(c *cyclonedx.Component) (out []string) {
 	if c.Licenses != nil {
 		for _, l := range *c.Licenses {
-			out = append(out, l.License.ID)
+			if l.License != nil {
+				out = append(out, l.License.ID)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
Working through more CycloneDX decoding issues, another nil pointer dereference was identified.