### PR TITLE
Correct ID handling during syftjson decoding

### DIFF
--- a/internal/formats/syftjson/model/package.go
+++ b/internal/formats/syftjson/model/package.go
@@ -129,6 +129,7 @@ func (p *Package) UnmarshalJSON(b []byte) error {
 		if err := json.Unmarshal(unpacker.Metadata, &payload); err != nil {
 			return err
 		}
+		p.Metadata = payload
 	default:
 		log.Warnf("unknown package metadata type=%q for packageID=%q", p.MetadataType, p.ID)
 	}

--- a/internal/formats/syftjson/model/package_test.go
+++ b/internal/formats/syftjson/model/package_test.go
@@ -1,18 +1,18 @@
 package model
 
-import "testing"
+import (
+	"testing"
 
-func TestUnmarshalPackage(t *testing.T) {
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalPackageGolang(t *testing.T) {
 	tests := []struct {
 		name        string
 		p           *Package
 		packageData []byte
 	}{
-		{
-			name:        "Package.UnmarshalJSON will unmarshal blank json",
-			p:           &Package{},
-			packageData: []byte(`{}`),
-		},
 		{
 			name: "Package.UnmarshalJSON unmarshals PackageBasicData",
 			p:    &Package{},
@@ -47,6 +47,11 @@ func TestUnmarshalPackage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("could not unmarshal packageData: %v", err)
 			}
+
+			assert.NotNil(t, test.p.Metadata)
+			golangMetadata := test.p.Metadata.(pkg.GolangBinMetadata)
+			assert.NotEmpty(t, golangMetadata)
+			assert.Equal(t, "go1.18", golangMetadata.GoCompiledVersion)
 		})
 	}
 }

--- a/internal/formats/syftjson/to_syft_model_test.go
+++ b/internal/formats/syftjson/to_syft_model_test.go
@@ -114,10 +114,12 @@ func Test_idsHaveChanged(t *testing.T) {
 	assert.Len(t, s.Relationships, 1)
 
 	r := s.Relationships[0]
+
 	from := s.Artifacts.PackageCatalog.Package(r.From.ID())
 	assert.NotNil(t, from)
+	assert.Equal(t, "pkg-1", from.Name)
+
 	to := s.Artifacts.PackageCatalog.Package(r.To.ID())
 	assert.NotNil(t, to)
-	assert.Equal(t, "pkg-1", from.Name)
 	assert.Equal(t, "pkg-2", to.Name)
 }

--- a/internal/formats/syftjson/to_syft_model_test.go
+++ b/internal/formats/syftjson/to_syft_model_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/internal/formats/syftjson/model"
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/source"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
@@ -78,4 +79,45 @@ func Test_toSyftSourceData(t *testing.T) {
 
 	// assert all possible schemes were under test
 	assert.ElementsMatch(t, allSchemes.List(), testedSchemes.List(), "not all source.Schemes are under test")
+}
+
+func Test_idsHaveChanged(t *testing.T) {
+	s, err := toSyftModel(model.Document{
+		Source: model.Source{
+			Type:   "file",
+			Target: "some/path",
+		},
+		Artifacts: []model.Package{
+			{
+				PackageBasicData: model.PackageBasicData{
+					ID:   "1",
+					Name: "pkg-1",
+				},
+			},
+			{
+				PackageBasicData: model.PackageBasicData{
+					ID:   "2",
+					Name: "pkg-2",
+				},
+			},
+		},
+		ArtifactRelationships: []model.Relationship{
+			{
+				Parent: "1",
+				Child:  "2",
+				Type:   string(artifact.ContainsRelationship),
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Len(t, s.Relationships, 1)
+
+	r := s.Relationships[0]
+	from := s.Artifacts.PackageCatalog.Package(r.From.ID())
+	assert.NotNil(t, from)
+	to := s.Artifacts.PackageCatalog.Package(r.To.ID())
+	assert.NotNil(t, to)
+	assert.Equal(t, "pkg-1", from.Name)
+	assert.Equal(t, "pkg-2", to.Name)
 }


### PR DESCRIPTION
During Syft JSON decoding, an ID is not being set by calling `pkg.SetID()`, however this may differ from the ID in the file. To fix this, we use the same semantics to call `SetID` but also track aliases where these IDs have changed in order to properly decode relationships.

This corrects the issue where users importing Syft JSON see warnings such as:

```
WARN found package with empty ID while adding to the catalog: Pkg(name="Django" version="3.2.12" type="python" id="") from-lib=syft
WARN found package with empty ID while adding to the catalog: Pkg(name="HikariCP" version="2.5.1" type="java-archive" id="") from-lib=syft
...
```