### PR TITLE
add case to decode BinMetadata

### DIFF
--- a/internal/formats/syftjson/model/package.go
+++ b/internal/formats/syftjson/model/package.go
@@ -124,6 +124,11 @@ func (p *Package) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		p.Metadata = payload
+	case pkg.GolangBinMetadataType:
+		var payload pkg.GolangBinMetadata
+		if err := json.Unmarshal(unpacker.Metadata, &payload); err != nil {
+			return err
+		}
 	default:
 		log.Warnf("unknown package metadata type=%q for packageID=%q", p.MetadataType, p.ID)
 	}

--- a/internal/formats/syftjson/model/package_test.go
+++ b/internal/formats/syftjson/model/package_test.go
@@ -1,0 +1,52 @@
+package model
+
+import "testing"
+
+func TestUnmarshalPackage(t *testing.T) {
+	tests := []struct {
+		name        string
+		p           *Package
+		packageData []byte
+	}{
+		{
+			name:        "Package.UnmarshalJSON will unmarshal blank json",
+			p:           &Package{},
+			packageData: []byte(`{}`),
+		},
+		{
+			name: "Package.UnmarshalJSON unmarshals PackageBasicData",
+			p:    &Package{},
+			packageData: []byte(`{
+				"id": "8b594519bc23da50",
+				"name": "gopkg.in/square/go-jose.v2",
+				"version": "v2.6.0",
+				"type": "go-module",
+				"foundBy": "go-module-binary-cataloger",
+				"locations": [
+				  {
+				    "path": "/Users/hal/go/bin/syft"
+				  }
+				],
+				"licenses": [],
+				"language": "go",
+				"cpes": [],
+				"purl": "pkg:golang/gopkg.in/square/go-jose.v2@v2.6.0",
+				"metadataType": "GolangBinMetadata",
+				"metadata": {
+				  "goCompiledVersion": "go1.18",
+				  "architecture": "amd64",
+				  "h1Digest": "h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI="
+				}
+			}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.p.UnmarshalJSON(test.packageData)
+			if err != nil {
+				t.Fatalf("could not unmarshal packageData: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add case where `pkg.GolangBinMetadataType` can be accounted for during `syftjson` model package unmarshal. See screenshot before after where a warning was firing because this case was not accounted for:

After shows the fix:

Before:
<img width="1626" alt="Screen Shot 2022-03-18 at 1 52 40 PM" src="https://user-images.githubusercontent.com/32073428/159057001-19e3d5a9-b0a8-45f5-a507-0f5afcc65072.png">


After:
<img width="1630" alt="Screen Shot 2022-03-18 at 1 51 25 PM" src="https://user-images.githubusercontent.com/32073428/159056869-ad975da9-6e87-46cb-bb9a-1b8968c0f1b1.png">

TODO:
- [ ]  Add unit coverage


Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>