### PR TITLE
Bump golangci-lint to 1.45.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,16 +34,6 @@ jobs:
           checkName: "Static analysis"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Check static analysis results - golangci-lint
-        uses: fountainhead/action-wait-for-check@v1.0.0
-        id: static-analysis-golangci-lint
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # This check name is defined as the github action job name (in .github/workflows/testing.yaml)
-          checkName: "Static analysis - golangci-lint"
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-
       - name: Check unit test results
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: unit
@@ -90,10 +80,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.static-analysis-golangci-lint.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.cli-linux.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
+        if: steps.static-analysis.outputs.conclusion != 'success' || steps.unit.outputs.conclusion != 'success' || steps.integration.outputs.conclusion != 'success' || steps.cli-linux.outputs.conclusion != 'success' || steps.acceptance-linux.outputs.conclusion != 'success' || steps.acceptance-mac.outputs.conclusion != 'success'
         run: |
           echo "Static Analysis Status: ${{ steps.static-analysis.conclusion }}"
-          echo "Static Analysis Status - Golangci-Lint: ${{ steps.static-analysis-golangci-lint.conclusion }}"
           echo "Unit Test Status: ${{ steps.unit.outputs.conclusion }}"
           echo "Integration Test Status: ${{ steps.integration.outputs.conclusion }}"
           echo "Acceptance Test (Linux) Status: ${{ steps.acceptance-linux.outputs.conclusion }}"

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -11,45 +11,6 @@ env:
   GO_STABLE_VERSION: true
 
 jobs:
-# TODO: remove this job once golanci-lint is compatible with g01.18+
-  Static-Analysis-Golanci-lint:
-    name: "Static analysis - golangci-lint"
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: "1.17" # NOTE: please use GO_VERSION once golangci supports go1.18+
-          stable: ${{ env.GO_STABLE_VERSION }}
-
-      - uses: actions/checkout@v2
-
-      - name: Restore tool cache
-        id: tool-cache
-        uses: actions/cache@v2.1.3
-        with:
-          path: ${{ github.workspace }}/.tmp
-          key: ${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
-
-      - name: Restore go cache
-        id: go-cache
-        uses: actions/cache@v2.1.3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-${{ env.GO_VERSION }}-
-
-      - name: (cache-miss) Bootstrap all project dependencies
-        if: steps.tool-cache.outputs.cache-hit != 'true' || steps.go-cache.outputs.cache-hit != 'true'
-        run: make bootstrap
-
-      - name: Bootstrap CI environment dependencies
-        run: make ci-bootstrap
-
-      - name: Run static analysis
-        run: make static-analysis-golanci-lint
-
-
 
   Static-Analysis:
     # Note: changing this job name requires making the same update in the .github/workflows/release.yaml pipeline

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(TEMPDIR):
 .PHONY: bootstrap-tools
 bootstrap-tools: $(TEMPDIR)
 	GO111MODULE=off GOBIN=$(shell realpath $(TEMPDIR)) go get -u golang.org/x/perf/cmd/benchstat
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.42.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TEMPDIR)/ v1.45.0
 	curl -sSfL https://raw.githubusercontent.com/wagoodman/go-bouncer/master/bouncer.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
 	curl -sSfL https://raw.githubusercontent.com/anchore/chronicle/main/install.sh | sh -s -- -b $(TEMPDIR)/ v0.3.0
 	.github/scripts/goreleaser-install.sh -d -b $(TEMPDIR)/ v1.4.1
@@ -122,12 +122,7 @@ bootstrap: $(RESULTSDIR) bootstrap-go bootstrap-tools ## Download and install al
 	$(call title,Bootstrapping dependencies)
 
 .PHONY: static-analysis
-static-analysis: check-go-mod-tidy check-licenses
-
- # NOTE: isolating golanci-lint so it runs over go1.17 in CI, since it is not compatible with
- # go1.18+
-.PHONY: static-analysis-golanci-lint
-static-analysis-golanci-lint: lint
+static-analysis: check-go-mod-tidy check-licenses lint
 
 .PHONY: lint
 lint: ## Run gofmt + golangci lint checks

--- a/internal/anchore/import.go
+++ b/internal/anchore/import.go
@@ -56,7 +56,7 @@ func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 	authedCtx := c.newRequestContext(ctxWithTimeout)
 
 	stage.Current = "starting session"
-	startOperation, _, err := c.client.ImportsApi.CreateOperation(authedCtx)
+	startOperation, createResponse, err := c.client.ImportsApi.CreateOperation(authedCtx)
 	if err != nil {
 		var detail = "no details given"
 		var openAPIErr external.GenericOpenAPIError
@@ -65,6 +65,8 @@ func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 		}
 		return fmt.Errorf("unable to start import session: %w: %s", err, detail)
 	}
+	defer createResponse.Body.Close()
+
 	prog.N++
 	sessionID := startOperation.Uuid
 
@@ -98,7 +100,7 @@ func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 		Force: optional.NewBool(cfg.OverwriteExistingUpload),
 	}
 
-	_, _, err = c.client.ImagesApi.AddImage(authedCtx, imageModel, &opts)
+	_, addResponse, err := c.client.ImagesApi.AddImage(authedCtx, imageModel, &opts)
 	if err != nil {
 		var detail = "no details given"
 		var openAPIErr external.GenericOpenAPIError
@@ -107,6 +109,8 @@ func (c *Client) Import(ctx context.Context, cfg ImportConfig) error {
 		}
 		return fmt.Errorf("unable to complete import session=%q: %w: %s", sessionID, err, detail)
 	}
+	defer addResponse.Body.Close()
+
 	prog.N++
 
 	stage.Current = ""

--- a/syft/pkg/cataloger/golang/parse_go_bin.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin.go
@@ -1,4 +1,3 @@
-//nolint
 package golang
 
 import (

--- a/syft/pkg/cataloger/golang/scan_bin.go
+++ b/syft/pkg/cataloger/golang/scan_bin.go
@@ -1,4 +1,3 @@
-//nolint
 package golang
 
 import (


### PR DESCRIPTION
Given that https://github.com/golangci/golangci-lint/pull/2438 has been merged (🎉 🌮 ) we can now keep our linter on the same go version we are releasing with.