### PR TITLE
bump strset version to fix 386 builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,8 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/profile v1.5.0
-	github.com/scylladb/go-set v1.0.2
+	// pinned to pull in 386 arch fix: https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5
+	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
 	github.com/sergi/go-diff v1.2.0
 	github.com/sigstore/sigstore v1.1.1-0.20220217212907-e48ca03a5ba7
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1923,8 +1923,9 @@ github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74 h1:sUNzanSKA9z/h
 github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74/go.mod h1:YlB8wFIZmFLZ1JllNBfSURzz52fBxbliNgYALk1UDmk=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
-github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
+github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/secure-systems-lab/go-securesystemslib v0.2.0/go.mod h1:eIjBmIP8LD2MLBL/DkQWayLiz006Q4p+hCu79rvWleY=


### PR DESCRIPTION
Pull in fix from https://github.com/scylladb/go-set/commit/cc7b2070d91ebf40d233207b633e28f5bd8f03a5 to prevent compile issues on 32 bit architectures:

```bash
$ GOOS=linux GOARCH=386 go build  ...
# github.com/scylladb/go-set/strset
../../.gvm/pkgsets/go1.18/global/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:248:13: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in assignment (overflows)
../../.gvm/pkgsets/go1.18/global/pkg/mod/github.com/scylladb/go-set@v1.0.2/strset/strset.go:255:16: math.MaxInt64 (untyped int constant 9223372036854775807) overflows int

$ go get -d github.com/scylladb/go-set@master
go: downloading github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e
go: upgraded github.com/scylladb/go-set v1.0.2 => v1.0.3-0.20200225121959-cc7b2070d91e

$ GOOS=linux GOARCH=386 go build  ...
# success!
```