### PR TITLE
Fix panic on empty sbom

### DIFF
--- a/internal/formats/common/spdxhelpers/to_syft_model.go
+++ b/internal/formats/common/spdxhelpers/to_syft_model.go
@@ -1,6 +1,7 @@
 package spdxhelpers
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -17,6 +18,10 @@ import (
 )
 
 func ToSyftModel(doc *spdx.Document2_2) (*sbom.SBOM, error) {
+	if doc == nil {
+		return nil, errors.New("cannot convert SPDX document to Syft model because document is nil")
+	}
+
 	spdxIDMap := make(map[string]interface{})
 
 	s := &sbom.SBOM{

--- a/syft/formats_test.go
+++ b/syft/formats_test.go
@@ -1,6 +1,7 @@
 package syft
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"testing"
@@ -37,6 +38,31 @@ func TestIdentify(t *testing.T) {
 			frmt := IdentifyFormat(by)
 			assert.NotNil(t, frmt)
 			assert.Equal(t, test.expected, frmt.ID())
+		})
+	}
+}
+
+func TestFormats_EmptyInput(t *testing.T) {
+	for _, format := range formats {
+		t.Run(format.ID().String(), func(t *testing.T) {
+			t.Run("format.Decode", func(t *testing.T) {
+				input := bytes.NewReader(nil)
+
+				assert.NotPanics(t, func() {
+					decodedSBOM, err := format.Decode(input)
+					assert.Error(t, err)
+					assert.Nil(t, decodedSBOM)
+				})
+			})
+
+			t.Run("format.Validate", func(t *testing.T) {
+				input := bytes.NewReader(nil)
+
+				assert.NotPanics(t, func() {
+					err := format.Validate(input)
+					assert.Error(t, err)
+				})
+			})
 		})
 	}
 }

--- a/syft/sbom/format.go
+++ b/syft/sbom/format.go
@@ -13,6 +13,11 @@ var (
 
 type FormatID string
 
+// String returns a string representation of the FormatID.
+func (f FormatID) String() string {
+	return string(f)
+}
+
 type Format interface {
 	ID() FormatID
 	Encode(io.Writer, SBOM) error


### PR DESCRIPTION
In this PR:

1. I added a failing test that loops through all `formats` used by the `syft` package to ensure that no formats panic when trying to decode or validate an empty SBOM.
2. I fixed the failing test by adding a `nil` check to the SPDX document processing logic.

Additionally, for convenience, I implemented `fmt.Stringer` on the `format.ID` type for use in string descriptions of format operations. This can be undone if needed!

This prevents the panic shown in https://github.com/anchore/grype/issues/693, but a separate Grype PR will catch the "empty SBOM" case even earlier to provide a more direct error message to the user. So this PR isn't strictly necessary with regard to https://github.com/anchore/grype/issues/693, but it still fixes a panic case for the Syft library.