### PR TITLE
Fix nil pointer dereference in directory resolver's `indexPath` method

### DIFF
--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -865,3 +865,24 @@ func Test_IncludeRootPathInIndex(t *testing.T) {
 	_, exists = resolver.metadata[ref.ID()]
 	require.True(t, exists)
 }
+
+func TestDirectoryResolver_indexPath(t *testing.T) {
+	// TODO: Ideally we can use an OS abstraction, which would obviate the need for real FS setup.
+	tempFile, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+
+	resolver, err := newDirectoryResolver(tempFile.Name())
+	require.NoError(t, err)
+
+	t.Run("filtering path with nil os.FileInfo", func(t *testing.T) {
+		// We use one of these prefixes in order to trigger a pathFilterFn
+		filteredPath := unixSystemRuntimePrefixes[0]
+
+		var fileInfo os.FileInfo = nil
+
+		assert.NotPanics(t, func() {
+			_, err := resolver.indexPath(filteredPath, fileInfo, nil)
+			assert.NoError(t, err)
+		})
+	})
+}


### PR DESCRIPTION
This PR:

- Fixes #872 by checking for a `nil` value before dereferencing an instance of `os.FileInfo`
- Writes a test to prove the panic is fixed
- Moves the check for a pre-existing path index earlier in execution per a discussion w/ @wagoodman 

**Thought for the future:** It'd be nice to see the `directoryResolver` depend on an `io.FS`-style abstraction of the filesystem, rather than directly on queries directly about the local filesystem via the standard library's `os` package. This would make it easier to write certain kinds of tests, specifically when there's a unique scenario like abnormal file permissions. This would also open the door to more exhaustive testing with fuzzing down the road.