### PR TITLE
Update write permissions and log into ghcr.io for release

### DIFF
--- a/.github/scripts/apple-signing/setup-prod.sh
+++ b/.github/scripts/apple-signing/setup-prod.sh
@@ -21,6 +21,14 @@ fi
 if [ -z "$DOCKER_PASSWORD" ]; then
   exit_with_error "DOCKER_PASSWORD not set"
 fi
+
+if [ -z "$GHCR_USERNAME" ]; then
+  exit_with_error "GHCR_USERNAME not set"
+fi
+
+if [ -z "$GHCR_PASSWORD" ]; then
+  exit_with_error "GHCR_PASSWORD not set"
+fi
 set -u
 
 # setup_signing
@@ -41,4 +49,5 @@ setup_signing() {
 
   commentary "log into docker -- required for publishing (since the default keychain has now been replaced)"
   echo "${DOCKER_PASSWORD}" | docker login docker.io -u "${DOCKER_USERNAME}"  --password-stdin
+  echo "${GHCR_PASSWORD}" | docker login ghcr.io -u "${GHCR_USERNAME}"  --password-stdin
 }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,8 @@ jobs:
     needs: [quality-gate]
     # due to our code signing process, it's vital that we run our release steps on macOS
     runs-on: macos-latest
+    permissions:
+      packages: write
     steps:
       - uses: docker-practice/actions-setup-docker@v1
 
@@ -128,6 +130,8 @@ jobs:
       - name: Build & publish release artifacts
         run: make release
         env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.TOOLBOX_DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.TOOLBOX_DOCKER_PASS }}
           # we use a different token than GITHUB_SECRETS to additionally allow updating the homebrew repos


### PR DESCRIPTION
The last release failed with:
```
   ⨯ release failed after 1192.75s error=docker images: failed to publish artifacts: failed to push ghcr.io/anchore/syft:latest: exit status 1: The push refers to repository [ghcr.io/anchore/syft]
```

This PR addresses the gap by:
- adding GHCR creds specifically for release
- explicitly running `docker login` for ghcr.io
- enabling package write permissions for the release job