### PR TITLE
add additional vendors for springframework

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -19,12 +19,12 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		{
 			pkg.JavaPkg,
 			candidateKey{PkgName: "springframework"},
-			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
+			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}, AdditionalVendors: []string{"pivotal_software", "springsource", "vmware"}},
 		},
 		{
 			pkg.JavaPkg,
 			candidateKey{PkgName: "spring-core"},
-			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}},
+			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}, AdditionalVendors: []string{"pivotal_software", "springsource", "vmware"}},
 		},
 		{
 			// example image: docker.io/nuxeo:latest


### PR DESCRIPTION
The Official CPE dictionary currently contains entries for springframework with three different vendors: `springsource`, `pivotal_software`, and `vmware`.  This appears to be because ownership has changed over time.

Signed-off-by: Weston Steimel <weston.steimel@anchore.com>