### PR TITLE
Update spdx22json to only take uppercase checksum algorithm

### DIFF
--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -67,7 +67,7 @@ func toPackages(catalog *pkg.Catalog, relationships []artifact.Relationship) []m
 				filesAnalyzed = true
 				for _, digest := range javaMetadata.ArchiveDigests {
 					checksums = append(checksums, model.Checksum{
-						Algorithm:     digest.Algorithm,
+						Algorithm:     strings.ToUpper(digest.Algorithm),
 						ChecksumValue: digest.Value,
 					})
 				}


### PR DESCRIPTION
When doing validation against SPDXJSON2.2 an error would be thrown saying `sha1` was not a valid algorithm.

This change updates the encoding for `spdx22json` so that algorithm is now uppercased according to the specification.

https://spdx.dev/wp-content/uploads/sites/41/2020/08/SPDX-specification-2-2.pdf
See page 35 Package checksum 3.10.4

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>