### PR TITLE
Suggestion/egg files metadata

### DIFF
--- a/syft/pkg/cataloger/python/package_cataloger.go
+++ b/syft/pkg/cataloger/python/package_cataloger.go
@@ -119,7 +119,6 @@ func (c *PackageCataloger) fetchInstalledFiles(resolver source.FileResolver, met
 		}
 
 		files = append(files, installedFiles...)
-
 	}
 	return files, sources, nil
 }

--- a/syft/pkg/cataloger/python/parse_wheel_egg_record.go
+++ b/syft/pkg/cataloger/python/parse_wheel_egg_record.go
@@ -1,9 +1,11 @@
 package python
 
 import (
+	"bufio"
 	"encoding/csv"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/anchore/syft/internal/log"
@@ -58,4 +60,36 @@ func parseWheelOrEggRecord(reader io.Reader) ([]pkg.PythonFileRecord, error) {
 	}
 
 	return records, nil
+}
+
+func parseInstalledFiles(reader io.Reader, location, sitePackagesRootPath string) ([]pkg.PythonFileRecord, error) {
+	var installedFiles []pkg.PythonFileRecord
+	r := bufio.NewReader(reader)
+	// scanner := bufio.NewScanner(file)
+
+	for {
+		line, err := r.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("unable to read python installed-files file: %w", err)
+		}
+
+		if location != "" && sitePackagesRootPath != "" {
+			joinedPath := filepath.Join(filepath.Dir(location), line)
+			line, err = filepath.Rel(sitePackagesRootPath, joinedPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		installedFile := pkg.PythonFileRecord{
+			Path: line,
+		}
+
+		installedFiles = append(installedFiles, installedFile)
+	}
+
+	return installedFiles, nil
 }


### PR DESCRIPTION
Suggesting enhancement to the python cataloger.
Catalog package files for legacy egg 'installed-files.txt' metadata.
For example `psycopg2` does not have linux wheel so it uses egg, then django uses `psycopg2` and so one...

[https://github.com/pypa/pip/blob/1cda23bd6bd0066ad557e4f7ca7c670744357b2b/src/pip/_internal/operations/install/legacy.py](url)

Note: It seemed that EGG `installed-files.txt` and wheel `RECORD` use paths that are relative to different base dirs.
I added a normalization flow for the `installed-fiels.txt` to the one used by `RECORD`.

* `Installed-files.txt` - relative to egg Info dir.
* `RECORD` - relative to site-packages root dir.