### PR TITLE
Update GitHub format package_url and correlator

### DIFF
--- a/internal/formats/github/encoder.go
+++ b/internal/formats/github/encoder.go
@@ -130,7 +130,7 @@ func toGithubManifests(s *sbom.SBOM) Manifests {
 
 		name := dependencyName(p)
 		manifest.Resolved[name] = DependencyNode{
-			Purl:         p.PURL,
+			PackageURL:   p.PURL,
 			Metadata:     toDependencyMetadata(p),
 			Relationship: toDependencyRelationshipType(p),
 			Scope:        toDependencyScope(p),

--- a/internal/formats/github/encoder_test.go
+++ b/internal/formats/github/encoder_test.go
@@ -104,12 +104,12 @@ func Test_toGithubModel(t *testing.T) {
 				},
 				Resolved: DependencyGraph{
 					"pkg:generic/pkg-1@1.0.1": DependencyNode{
-						Purl:         "pkg:generic/pkg-1@1.0.1",
+						PackageURL:   "pkg:generic/pkg-1@1.0.1",
 						Scope:        DependencyScopeRuntime,
 						Relationship: DependencyRelationshipDirect,
 					},
 					"pkg:generic/pkg-2@2.0.2": DependencyNode{
-						Purl:         "pkg:generic/pkg-2@2.0.2",
+						PackageURL:   "pkg:generic/pkg-2@2.0.2",
 						Scope:        DependencyScopeRuntime,
 						Relationship: DependencyRelationshipDirect,
 					},
@@ -125,7 +125,7 @@ func Test_toGithubModel(t *testing.T) {
 				},
 				Resolved: DependencyGraph{
 					"pkg:generic/pkg-3@3.0.3": DependencyNode{
-						Purl:         "pkg:generic/pkg-3@3.0.3",
+						PackageURL:   "pkg:generic/pkg-3@3.0.3",
 						Scope:        DependencyScopeRuntime,
 						Relationship: DependencyRelationshipDirect,
 					},

--- a/internal/formats/github/github_dependency_api.go
+++ b/internal/formats/github/github_dependency_api.go
@@ -14,9 +14,9 @@ type DependencySnapshot struct {
 }
 
 type Job struct {
-	Name    string `json:"name,omitempty"` // !omitempty
-	ID      string `json:"id,omitempty"`   // !omitempty
-	HTMLURL string `json:"html_url,omitempty"`
+	Correlator string `json:"correlator,omitempty"` // !omitempty
+	ID         string `json:"id,omitempty"`         // !omitempty
+	HTMLURL    string `json:"html_url,omitempty"`
 }
 
 type DetectorMetadata struct {
@@ -62,7 +62,7 @@ const (
 )
 
 type DependencyNode struct {
-	Purl         string                 `json:"purl,omitempty"`
+	PackageURL   string                 `json:"package_url,omitempty"`
 	Metadata     Metadata               `json:"metadata,omitempty"`
 	Relationship DependencyRelationship `json:"relationship,omitempty"`
 	Scope        DependencyScope        `json:"scope,omitempty"`


### PR DESCRIPTION
The GitHub dependency snapshot format has a couple updates encompassed here: changing the `purl` field to `package_url`, `detector.name` is required (but we are already providing that as `syft`), and `job.name` has been deprecated in favor of `job.correlator`. The latter will be filled out by the `sbom-action`, as it requires action run information.