### PR TITLE
Preserve syft IDs on SBOM decode

### DIFF
--- a/internal/formats/syftjson/to_syft_model.go
+++ b/internal/formats/syftjson/to_syft_model.go
@@ -177,8 +177,12 @@ func toSyftPackage(p model.Package, idAliases map[string]string) pkg.Package {
 		Metadata:     p.Metadata,
 	}
 
-	out.SetID()
+	// we don't know if this package ID is truly unique, however, we need to trust the user input in case there are
+	// external references to it. That is, we can't derive our own ID (using pkg.SetID()) since consumers won't
+	// be able to historically interact with data that references the IDs from the original SBOM document being decoded now.
+	out.OverrideID(artifact.ID(p.ID))
 
+	// this alias mapping is currently defunct, but could be useful in the future.
 	id := string(out.ID())
 	if id != p.ID {
 		idAliases[p.ID] = id

--- a/syft/pkg/package.go
+++ b/syft/pkg/package.go
@@ -28,6 +28,10 @@ type Package struct {
 	Metadata     interface{}        // additional data found while parsing the package source
 }
 
+func (p *Package) OverrideID(id artifact.ID) {
+	p.id = id
+}
+
 func (p *Package) SetID() {
 	id, err := artifact.IDByHash(p)
 	if err != nil {


### PR DESCRIPTION
Today we derive package IDs from the contents of the package itself after cataloging packages. The same has historically applied to IDs from decoded SBOMs, where we recreate the ID from the contents of all of the package info. This PR changes this behavior, allowing the decode path to set an ID on a package, thus honoring the ID from the original SBOM document, allowing external references to still remain valid for downstream processing (e.g. in grype, so the SBOM IDs will always match the package IDs in grype output).

Implementation note: I've left the ID aliasing logic in since it does not affect the correctness of the answer and there is a change this mechanism may be useful in the future if we want this behavior to be configurable (TBD).