### PR TITLE
Fix `github-json` output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Where the `formats` available are:
 - `cyclonedx-json`: A JSON report conforming to the [CycloneDX 1.4 specification](https://cyclonedx.org/specification/overview/).
 - `spdx-tag-value`: A tag-value formatted report conforming to the [SPDX 2.2 specification](https://spdx.github.io/spdx-spec/).
 - `spdx-json`: A JSON report conforming to the [SPDX 2.2 JSON Schema](https://github.com/spdx/spdx-spec/blob/v2.2/schemas/spdx-schema.json).
+- `github`: A JSON report conforming to GitHub's dependency snapshot format.
 - `table`: A columnar summary (default).
 
 #### Multiple outputs

--- a/syft/formats.go
+++ b/syft/formats.go
@@ -74,7 +74,7 @@ func FormatByName(name string) sbom.Format {
 		return FormatByID(cyclonedxxml.ID)
 	case "cyclonedxjson":
 		return FormatByID(cyclonedxjson.ID)
-	case "github":
+	case "github", "githubjson":
 		return FormatByID(github.ID)
 	case "spdx", "spdxtv", "spdxtagvalue":
 		return FormatByID(spdx22tagvalue.ID)

--- a/syft/formats_test.go
+++ b/syft/formats_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/anchore/syft/internal/formats/cyclonedxjson"
 	"github.com/anchore/syft/internal/formats/cyclonedxxml"
+	"github.com/anchore/syft/internal/formats/github"
 	"github.com/anchore/syft/internal/formats/spdx22json"
 	"github.com/anchore/syft/internal/formats/spdx22tagvalue"
 	"github.com/anchore/syft/internal/formats/syftjson"
@@ -169,6 +170,18 @@ func TestFormatByName(t *testing.T) {
 			name: "syft-json",
 			want: syftjson.ID,
 		},
+
+		// GitHub JSON
+		{
+			name: "github",
+			want: github.ID,
+		},
+
+		{
+			name: "github-json",
+			want: github.ID,
+		},
+
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/syft/formats_test.go
+++ b/syft/formats_test.go
@@ -181,7 +181,6 @@ func TestFormatByName(t *testing.T) {
 			name: "github-json",
 			want: github.ID,
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes the following problem in Syft 0.44.1:

```
$ syft packages . -o github-json
1 error occurred:
	* bad output format: 'github-json'
```