### PR TITLE
reduce noise of log output

### DIFF
--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -146,7 +146,7 @@ func (cfg *Application) parseLogLevelOption() error {
 			cfg.Verbosity = 1
 		}
 	default:
-		cfg.Log.LevelOpt = logrus.InfoLevel
+		cfg.Log.LevelOpt = logrus.WarnLevel
 	}
 
 	if cfg.Log.Level == "" {

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -338,7 +338,7 @@ func (r directoryResolver) FilesByPath(userPaths ...string) ([]Location, error) 
 		// we should be resolving symlinks and preserving this information as a VirtualPath to the real file
 		evaluatedPath, err := filepath.EvalSymlinks(userStrPath)
 		if err != nil {
-			log.Warnf("directory resolver unable to evaluate symlink for path=%q : %+v", userPath, err)
+			log.Debugf("directory resolver unable to evaluate symlink for path=%q : %+v", userPath, err)
 			continue
 		}
 


### PR DESCRIPTION
This PR dials down the severity of log entries that tend to be hit during common scanning scenarios.

For example, during any project (directory) scans on my macOS machine, I see these log entries every time:

```console
[0008]  WARN directory resolver unable to evaluate symlink for path="/etc/os-release" : lstat /Users/dan/Source/grype-vscode/etc: no such file or directory
[0008]  WARN directory resolver unable to evaluate symlink for path="/usr/lib/os-release" : lstat /Users/dan/Source/grype-vscode/usr: no such file or directory
[0008]  WARN directory resolver unable to evaluate symlink for path="/etc/system-release-cpe" : lstat /Users/dan/Source/grype-vscode/etc: no such file or directory
[0008]  WARN directory resolver unable to evaluate symlink for path="/etc/redhat-release" : lstat /Users/dan/Source/grype-vscode/etc: no such file or directory
[0008]  WARN directory resolver unable to evaluate symlink for path="/bin/busybox" : lstat /Users/dan/Source/grype-vscode/bin: no such file or directory
```

Additionally, since we're now showing `INFO` lines by default, Syft has been showing some log lines even with the TUI view that probably don't need to be exposed to users during every run. I've reduced these log instances to `DEBUG`.

Helps with https://github.com/anchore/grype/issues/684 by removing Syft log entries from routine scanning use cases.