### PR TITLE
add version info and remove double config call

### DIFF
--- a/cmd/syft/cli/attest.go
+++ b/cmd/syft/cli/attest.go
@@ -49,9 +49,6 @@ func Attest(v *viper.Viper, app *config.Application, ro *options.RootOptions) *c
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// this MUST be called first to make sure app config decodes
 			// the viper object correctly
-			newLogWrapper(app)
-			logApplicationConfig(app)
-
 			if app.CheckForAppUpdate {
 				checkForApplicationUpdate()
 			}

--- a/cmd/syft/cli/commands.go
+++ b/cmd/syft/cli/commands.go
@@ -123,6 +123,8 @@ func checkForApplicationUpdate() {
 }
 
 func logApplicationConfig(app *config.Application) {
+	versionInfo := version.FromBuild()
+	log.Infof("syft version: %+v", versionInfo.Version)
 	log.Debugf("application config:\n%+v", color.Magenta.Sprint(app.String()))
 }
 


### PR DESCRIPTION
Add back version info to `INFO` level logs and remove double call to config debug in attest

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>