### PR TITLE
reduce logging severity for non-Go binaries

### DIFF
--- a/syft/pkg/cataloger/golang/scan_bin.go
+++ b/syft/pkg/cataloger/golang/scan_bin.go
@@ -41,7 +41,11 @@ func scanFile(reader unionReader, filename string) ([]*debug.BuildInfo, []string
 			}
 			// in this case we could not read the or parse the file, but not explicitly because it is not a
 			// go-compiled binary (though it still might be).
-			log.Warnf("golang cataloger: failed to read buildinfo (file=%q): %v", filename, err)
+			// TODO: We should change this back to "warn" eventually.
+			//  But right now it's catching too many cases where the reader IS NOT a Go binary at all.
+			//  It'd be great to see how we can get those cases to be detected and handled above before we get to
+			//  this point in execution.
+			log.Infof("golang cataloger: unable to read buildinfo (file=%q): %v", filename, err)
 			return nil, nil
 		}
 


### PR DESCRIPTION
This is intended to be a temporary fix to the problem of excessive `WARN` logging when the Go binary cataloger encounters a non-Go binary.

Examples of noisy logging:

```console
[0011]  WARN golang cataloger: failed to read buildinfo (file="/usr/lib/python3.9/site-packages/orjson.libs/libgcc_s-eedded4b.so.1"): EOF
```

```console
[0012]  WARN golang cataloger: failed to read buildinfo (file=".vscode-test/vscode-1.48.1/Visual Studio Code.app/Contents/Resources/app/out/vs/platform/files/node/watcher/win32/CodeHelper.exe"): unrecognized file format
```

It should be noted that this change reduces the prominence of legitimate issues parsing real Go binaries. But from my experience, those cases seem to be in the minority, and what's been happening more often is that we're hitting non-Go binaries and then printing **_warnings_** to the user, when ideally we wouldn't be.

Fixes #978