### PR TITLE
golang cataloger - main module version as is

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_bin.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin.go
@@ -29,13 +29,11 @@ var (
 func makeGoMainPackage(mod *debug.BuildInfo, arch string, location source.Location) pkg.Package {
 	gbs := getBuildSettings(mod.Settings)
 	main := newGoBinaryPackage(&mod.Main, mod.GoVersion, arch, location, gbs)
-	main.Version = "(devel)"
 
 	if v, ok := gbs["vcs.revision"]; ok {
 		main.Version = v
 	}
 
-	main.SetID()
 	return main
 }
 

--- a/syft/pkg/cataloger/golang/parse_go_bin_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_bin_test.go
@@ -213,7 +213,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			arch: archDetails,
 			mod: &debug.BuildInfo{
 				GoVersion: goCompiledVersion,
-				Main:      debug.Module{Path: "github.com/anchore/syft"},
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
 				Settings: []debug.BuildSetting{
 					{Key: "GOARCH", Value: archDetails},
 					{Key: "GOOS", Value: "darwin"},
@@ -227,7 +227,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			arch: archDetails,
 			mod: &debug.BuildInfo{
 				GoVersion: goCompiledVersion,
-				Main:      debug.Module{Path: "github.com/anchore/syft"},
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
 				Settings: []debug.BuildSetting{
 					{Key: "GOARCH", Value: archDetails},
 					{Key: "GOOS", Value: "darwin"},
@@ -297,7 +297,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			arch: archDetails,
 			mod: &debug.BuildInfo{
 				GoVersion: goCompiledVersion,
-				Main:      debug.Module{Path: "github.com/anchore/syft"},
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
 				Settings: []debug.BuildSetting{
 					{Key: "GOARCH", Value: archDetails},
 					{Key: "GOOS", Value: "darwin"},


### PR DESCRIPTION
https://github.com/anchore/syft/pull/981 overwrites the main version, which doesn't follow Syft's design philosophy of reading data fields as they are. It just so happens that we know the version and it is a constant.

This PR fixes that behavior by reading the main module version as provided by go's BuildInfo.

Signed-off-by: Jonas Xavier <jonasx@anchore.com>