### PR TITLE
Fix potential race condition during event subscription

### DIFF
--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -98,11 +98,12 @@ func Run(ctx context.Context, app *config.Application, ko sign.KeyOpts, args []s
 	eventBus := partybus.NewBus()
 	stereoscope.SetBus(eventBus)
 	syft.SetBus(eventBus)
+	subscription := eventBus.Subscribe()
 
 	return eventloop.EventLoop(
 		execWorker(app, *si, format, predicateType, sv),
 		eventloop.SetupSignals(),
-		eventBus.Subscribe(),
+		subscription,
 		stereoscope.Cleanup,
 		ui.Select(options.IsVerbose(app), app.Quiet)...,
 	)

--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -49,11 +49,12 @@ func Run(ctx context.Context, app *config.Application, args []string) error {
 	eventBus := partybus.NewBus()
 	stereoscope.SetBus(eventBus)
 	syft.SetBus(eventBus)
+	subscription := eventBus.Subscribe()
 
 	return eventloop.EventLoop(
 		execWorker(app, *si, writer),
 		eventloop.SetupSignals(),
-		eventBus.Subscribe(),
+		subscription,
 		stereoscope.Cleanup,
 		ui.Select(options.IsVerbose(app), app.Quiet)...,
 	)

--- a/cmd/syft/cli/poweruser/poweruser.go
+++ b/cmd/syft/cli/poweruser/poweruser.go
@@ -53,7 +53,6 @@ func Run(ctx context.Context, app *config.Application, args []string) error {
 	eventBus := partybus.NewBus()
 	stereoscope.SetBus(eventBus)
 	syft.SetBus(eventBus)
-
 	subscription := eventBus.Subscribe()
 
 	return eventloop.EventLoop(

--- a/cmd/syft/cli/poweruser/poweruser.go
+++ b/cmd/syft/cli/poweruser/poweruser.go
@@ -54,10 +54,12 @@ func Run(ctx context.Context, app *config.Application, args []string) error {
 	stereoscope.SetBus(eventBus)
 	syft.SetBus(eventBus)
 
+	subscription := eventBus.Subscribe()
+
 	return eventloop.EventLoop(
 		execWorker(app, *si, writer),
 		eventloop.SetupSignals(),
-		eventBus.Subscribe(),
+		subscription,
 		stereoscope.Cleanup,
 		ui.Select(options.IsVerbose(app), app.Quiet)...,
 	)

--- a/test/cli/power_user_cmd_test.go
+++ b/test/cli/power_user_cmd_test.go
@@ -92,7 +92,7 @@ func TestPowerUserCmdFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cmd, stdout, stderr := runSyft(t, test.env, test.args...)
+			cmd, stdout, stderr := runSyftSafe(t, test.env, test.args...)
 			for _, traitFn := range test.assertions {
 				traitFn(t, stdout, stderr, cmd.ProcessState.ExitCode())
 			}

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -152,7 +152,7 @@ func assertVerifyAttestation(coverageImage string) traitAssertion {
 			coverageImage, // TODO which remote image to use?
 		)
 
-		stdout, stderr := runCommand(attachCmd, nil)
+		stdout, stderr, _ := runCommand(attachCmd, nil)
 		if attachCmd.ProcessState.ExitCode() != 0 {
 			tb.Log("STDOUT", stdout)
 			tb.Log("STDERR", stderr)
@@ -165,7 +165,7 @@ func assertVerifyAttestation(coverageImage string) traitAssertion {
 			coverageImage, // TODO which remote image to use?
 		)
 
-		stdout, stderr = runCommand(verifyCmd, nil)
+		stdout, stderr, _ = runCommand(verifyCmd, nil)
 		if attachCmd.ProcessState.ExitCode() != 0 {
 			tb.Log("STDOUT", stdout)
 			tb.Log("STDERR", stderr)

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -109,8 +109,8 @@ func runSyftSafe(t testing.TB, env map[string]string, args ...string) (*exec.Cmd
 }
 
 func runSyftCommand(t testing.TB, env map[string]string, expectError bool, args ...string) (*exec.Cmd, string, string) {
-	timeout := 1000 * time.Millisecond
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+100)
+	timeout := 90 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 
 	timer := make(chan bool, 1)
 	defer func() {
@@ -144,8 +144,6 @@ func runSyftCommand(t testing.TB, env map[string]string, expectError bool, args 
 		}
 		timer <- true
 	}()
-
-	_ = <-timer
 
 	stdout, stderr, err := runCommand(cmd, env)
 

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -118,7 +118,7 @@ func runSyftCommand(t testing.TB, env map[string]string, expectError bool, args 
 			// get a stack trace printed
 			err := cmd.Process.Signal(syscall.SIGABRT)
 			if err != nil {
-				fmt.Printf("error aborting: %+v", err)
+				t.Errorf("error aborting: %+v", err)
 			}
 		}
 	}
@@ -128,9 +128,9 @@ func runSyftCommand(t testing.TB, env map[string]string, expectError bool, args 
 	stdout, stderr, err := runCommand(cmd, env)
 
 	if !expectError && err != nil && stdout == "" {
-		fmt.Printf("error running syft: %+v\n", err)
-		fmt.Printf("STDOUT: %s\n", stdout)
-		fmt.Printf("STDERR: %s\n", stderr)
+		t.Errorf("error running syft: %+v", err)
+		t.Errorf("STDOUT: %s", stdout)
+		t.Errorf("STDERR: %s", stderr)
 
 		// this probably indicates a timeout
 		args = append(args, "-vv")
@@ -140,9 +140,9 @@ func runSyftCommand(t testing.TB, env map[string]string, expectError bool, args 
 		stdout, stderr, err = runCommand(cmd, env)
 
 		if err != nil {
-			fmt.Printf("error rerunning syft: %+v\n", err)
-			fmt.Printf("STDOUT: %s\n", stdout)
-			fmt.Printf("STDERR: %s\n", stderr)
+			t.Errorf("error rerunning syft: %+v", err)
+			t.Errorf("STDOUT: %s", stdout)
+			t.Errorf("STDERR: %s", stderr)
 		}
 	}
 
@@ -158,7 +158,7 @@ func runCosign(t testing.TB, env map[string]string, args ...string) (*exec.Cmd, 
 	stdout, stderr, err := runCommand(cmd, env)
 
 	if err != nil {
-		fmt.Printf("error running cosign: %+v", err)
+		t.Errorf("error running cosign: %+v", err)
 	}
 
 	return cmd, stdout, stderr

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -115,6 +115,8 @@ func runSyft(t testing.TB, env map[string]string, args ...string) (*exec.Cmd, st
 
 	if err != nil {
 		fmt.Printf("error running syft: %+v", err)
+		fmt.Printf("STDOUT: %s", stdout)
+		fmt.Printf("STDERR: %s", stderr)
 	}
 
 	if stdout == "" {
@@ -125,6 +127,8 @@ func runSyft(t testing.TB, env map[string]string, args ...string) (*exec.Cmd, st
 
 		if err != nil {
 			fmt.Printf("error running syft: %+v", err)
+			fmt.Printf("STDOUT: %s", stdout)
+			fmt.Printf("STDERR: %s", stderr)
 		}
 	}
 


### PR DESCRIPTION
I hastily merged #989 to try to work around a test timeout issue we've been seeing, but it did not seem to entirely solve the problem - only somewhat reduce it. This PR reverts those changes (which you could [compare to d2d532f](https://github.com/anchore/syft/compare/d2d532f4a852067c9ccba2329a8105ac5479e2ae...kzantow-anchore:root-cause-analysis-of-test-timeouts#diff-d71da09dda3dcb00b18044c8915e29aefc4ef51518792b7ce084924940e0f6cb) to see a more "accurate" diff of this PR) and instead adds a timeout that calls `cmd.Process.Signal(syscall.SIGABRT)`, which kills the process but ALSO includes a stack trace, so it is possible to determine where a CLI call is actually hung. It also adds a retry for these failed calls, which adds `-vv` to attempt to get more information. It was also identified that the most likely culprit is `eventBus.Subscribe()` being called _after_ an `exec*` call; this PR also corrects this order of operations for all `eventloop`s.