### PR TITLE
Read Description from dpkg status files

### DIFF
--- a/syft/pkg/cataloger/deb/cataloger_test.go
+++ b/syft/pkg/cataloger/deb/cataloger_test.go
@@ -43,6 +43,10 @@ func TestDpkgCataloger(t *testing.T) {
 						Architecture:  "all",
 						Maintainer:    "Steve Langasek <vorlon@debian.org>",
 						InstalledSize: 1016,
+						Description: `Runtime support for the PAM library
+ Contains configuration files and  directories required for
+ authentication  to work on Debian systems.  This package is required
+ on almost all installations.`,
 						Files: []pkg.DpkgFileRecord{
 							{
 								Path: "/etc/pam.conf",

--- a/syft/pkg/cataloger/deb/parse_dpkg_status_test.go
+++ b/syft/pkg/cataloger/deb/parse_dpkg_status_test.go
@@ -39,6 +39,20 @@ func TestSinglePackage(t *testing.T) {
 				Architecture:  "amd64",
 				InstalledSize: 4064,
 				Maintainer:    "APT Development Team <deity@lists.debian.org>",
+				Description: `commandline package manager
+ This package provides commandline tools for searching and
+ managing as well as querying information about packages
+ as a low-level access to all features of the libapt-pkg library.
+ .
+ These include:
+ * apt-get for retrieval of packages and information about them
+ from authenticated sources and for installation, upgrade and
+ removal of packages together with their dependencies
+ * apt-cache for querying available information about installed
+ as well as installable packages
+ * apt-cdrom to use removable media as a source for packages
+ * apt-config as an interface to the configuration settings
+ * apt-key as an interface to manage authentication keys`,
 				Files: []pkg.DpkgFileRecord{
 					{
 						Path: "/etc/apt/apt.conf.d/01autoremove",
@@ -85,6 +99,20 @@ func TestSinglePackage(t *testing.T) {
 				Architecture:  "amd64",
 				InstalledSize: 4000,
 				Maintainer:    "APT Development Team <deity@lists.debian.org>",
+				Description: `commandline package manager
+ This package provides commandline tools for searching and
+ managing as well as querying information about packages
+ as a low-level access to all features of the libapt-pkg library.
+ .
+ These include:
+ * apt-get for retrieval of packages and information about them
+ from authenticated sources and for installation, upgrade and
+ removal of packages together with their dependencies
+ * apt-cache for querying available information about installed
+ as well as installable packages
+ * apt-cdrom to use removable media as a source for packages
+ * apt-config as an interface to the configuration settings
+ * apt-key as an interface to manage authentication keys`,
 			},
 		}}
 
@@ -132,7 +160,13 @@ func TestMultiplePackages(t *testing.T) {
 					Architecture:  "all",
 					InstalledSize: 3036,
 					Maintainer:    "GNU Libc Maintainers <debian-glibc@lists.debian.org>",
-					Files:         []pkg.DpkgFileRecord{},
+					Description: `time zone and daylight-saving time data
+ This package contains data required for the implementation of
+ standard local time for many representative locations around the
+ globe. It is updated periodically to reflect changes made by
+ political bodies to time zone boundaries, UTC offsets, and
+ daylight-saving rules.`,
+					Files: []pkg.DpkgFileRecord{},
 				},
 				{
 					Package:       "util-linux",
@@ -140,6 +174,12 @@ func TestMultiplePackages(t *testing.T) {
 					Architecture:  "amd64",
 					InstalledSize: 4327,
 					Maintainer:    "LaMont Jones <lamont@debian.org>",
+					Description: `miscellaneous system utilities
+ This package contains a number of important utilities, most of which
+ are oriented towards maintenance of your system. Some of the more
+ important utilities included in this package allow you to view kernel
+ messages, create new filesystems, view block device information,
+ interface with real time clock, etc.`,
 					Files: []pkg.DpkgFileRecord{
 						{
 							Path: "/etc/default/hwclock",

--- a/syft/pkg/dpkg_metadata.go
+++ b/syft/pkg/dpkg_metadata.go
@@ -28,6 +28,7 @@ type DpkgMetadata struct {
 	Architecture  string           `mapstructure:"Architecture" json:"architecture"`
 	Maintainer    string           `mapstructure:"Maintainer" json:"maintainer"`
 	InstalledSize int              `mapstructure:"InstalledSize" json:"installedSize" cyclonedx:"installedSize"`
+	Description   string           `mapstructure:"Description" hash:"ignore" json:"-"`
 	Files         []DpkgFileRecord `json:"files"`
 }
 


### PR DESCRIPTION
There are a number of fields that might appear in the status file for a Debian package. This PR adds the `Description` field to the set of fields parsed when cataloging Debian operating systems. This change does not include the addition of this field in any of the SBOM output formats (as far as I can tell), and is initially meant for consumption via library users taking advantage of Syft's package cataloging features. I'm not sure whether it makes sense to include it in SBOM output in the future. I don't specifically have a need for it, but I would like to see it parsed and returned within the `sbom.SBOM` object.