### PR TITLE
Longer CPEs for golang modules to avoid false positives

### DIFF
--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -535,6 +535,19 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 		},
 		{
+			name: "go product with vendor candidates and an extra sub-item",
+			p: pkg.Package{
+				Name:     "github.com/someone/something/more",
+				Version:  "3.2",
+				FoundBy:  "go-cataloger",
+				Language: pkg.Go,
+				Type:     pkg.GoModulePkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:someone:something\\/more:3.2:*:*:*:*:*:*:*",
+			},
+		},
+		{
 			name: "generate no CPEs for indeterminate golang package name",
 			p: pkg.Package{
 				Name:     "github.com/what",

--- a/syft/pkg/cataloger/common/cpe/go.go
+++ b/syft/pkg/cataloger/common/cpe/go.go
@@ -28,7 +28,7 @@ func candidateProductForGo(name string) string {
 		return ""
 	}
 
-	return pathElements[1]
+	return strings.Join(pathElements[1:], "/")
 }
 
 // candidateVendorForGo attempts to find a single vendor name in a best-effort attempt. This implementation prefers

--- a/syft/pkg/cataloger/common/cpe/go.go
+++ b/syft/pkg/cataloger/common/cpe/go.go
@@ -28,6 +28,8 @@ func candidateProductForGo(name string) string {
 		return ""
 	}
 
+	// returning the rest of the path here means longer CPEs, it helps avoiding false-positives
+	// ref: https://github.com/anchore/grype/issues/676
 	return strings.Join(pathElements[1:], "/")
 }
 

--- a/syft/pkg/cataloger/common/cpe/go_test.go
+++ b/syft/pkg/cataloger/common/cpe/go_test.go
@@ -41,7 +41,11 @@ func TestCandidateProductForGo(t *testing.T) {
 		},
 		{
 			pkg:      "github.com/someone/something/long/package/name",
-			expected: "something",
+			expected: "something/long/package/name",
+		},
+		{
+			pkg:      "",
+			expected: "",
 		},
 	}
 


### PR DESCRIPTION
This PR changes how CPEs are generated for golang modules, now their full path is used, and this is useful to avoid false positives as it happened with: https://github.com/anchore/grype/issues/676

Testing this change in grype, and using grype to analyze itself, the new report is:
```
$ go mod edit -replace github.com/anchore/syft=../syft
$ go run . (which grype) -v
NAME                        INSTALLED  FIXED-IN  TYPE       VULNERABILITY   SEVERITY
google.golang.org/protobuf  v1.28.0              go-module  CVE-2015-5237   High
google.golang.org/protobuf  v1.28.0              go-module  CVE-2021-22570  High
```
 
As compared with Grype's code from [April 21](https://github.com/anchore/grype/commit/523f5ce9c0b7362fbb0891ed5749d172285e4220):
```
NAME                            INSTALLED  FIXED-IN  TYPE       VULNERABILITY        SEVERITY
github.com/hashicorp/go-getter  v1.5.9               go-module  CVE-2022-29810       Medium
github.com/hashicorp/go-getter  v1.5.9     1.5.11    go-module  GHSA-27rq-4943-qcwp  Medium
google.golang.org/protobuf      v1.27.1              go-module  CVE-2021-22570       High
google.golang.org/protobuf      v1.27.1              go-module  CVE-2015-5237        High
```

**Conclusion**: vault false-positive was fixed with the use of longer CPEs.

Signed-off-by: Jonas Xavier <jonasx@anchore.com>