### PR TITLE
fix: add component list to prevent cyclone-dx panic

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/decoder.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder.go
@@ -31,7 +31,9 @@ func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 
 func GetDecoder(format cyclonedx.BOMFileFormat) sbom.Decoder {
 	return func(reader io.Reader) (*sbom.SBOM, error) {
-		bom := &cyclonedx.BOM{}
+		bom := &cyclonedx.BOM{
+			Components: &[]cyclonedx.Component{},
+		}
 		err := cyclonedx.NewBOMDecoder(reader, format).Decode(bom)
 		if err != nil {
 			return nil, err
@@ -45,8 +47,8 @@ func GetDecoder(format cyclonedx.BOMFileFormat) sbom.Decoder {
 }
 
 func toSyftModel(bom *cyclonedx.BOM) (*sbom.SBOM, error) {
-	if bom == nil || bom.Components == nil {
-		return nil, fmt.Errorf("no content or no components are defined in CycloneDX BOM")
+	if bom == nil {
+		return nil, fmt.Errorf("no content defined in CycloneDX BOM")
 	}
 
 	s := &sbom.SBOM{

--- a/internal/formats/common/cyclonedxhelpers/decoder.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder.go
@@ -45,8 +45,8 @@ func GetDecoder(format cyclonedx.BOMFileFormat) sbom.Decoder {
 }
 
 func toSyftModel(bom *cyclonedx.BOM) (*sbom.SBOM, error) {
-	if bom == nil {
-		return nil, fmt.Errorf("no content defined in CycloneDX BOM")
+	if bom == nil || bom.Components == nil {
+		return nil, fmt.Errorf("no content or no components are defined in CycloneDX BOM")
 	}
 
 	s := &sbom.SBOM{

--- a/internal/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder_test.go
@@ -283,3 +283,10 @@ func Test_missingDataDecode(t *testing.T) {
 
 	assert.Len(t, pkg.Licenses, 0)
 }
+
+func Test_missingComponentsDecode(t *testing.T) {
+	bom := &cyclonedx.BOM{}
+
+	_, err := toSyftModel(bom)
+	assert.Error(t, err)
+}

--- a/internal/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/internal/formats/common/cyclonedxhelpers/decoder_test.go
@@ -1,6 +1,8 @@
 package cyclonedxhelpers
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -286,7 +288,10 @@ func Test_missingDataDecode(t *testing.T) {
 
 func Test_missingComponentsDecode(t *testing.T) {
 	bom := &cyclonedx.BOM{}
+	bomBytes, _ := json.Marshal(&bom)
+	decode := GetDecoder(cyclonedx.BOMFileFormatJSON)
 
-	_, err := toSyftModel(bom)
-	assert.Error(t, err)
+	_, err := decode(bytes.NewReader(bomBytes))
+
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## 📝 Description
Add check for empty components in `toSyftFormat` method to catch potential panic

fixes https://github.com/anchore/syft/issues/1014