### PR TITLE
change draft to false for release process

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 release:
   prerelease: auto
-  draft: true
+  draft: false
 
 env:
   # required to support multi architecture docker builds


### PR DESCRIPTION
In cases where a draft is released and not published, users will encounter brew install issues along with other friction regarding the new release.

Bumping this to just cut a release with note/artifact edits being done after the fact will reduce this friction.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>