### PR TITLE
fix: add missing javascript-lock-cataloger in docker image catalogers

### DIFF
--- a/syft/pkg/cataloger/cataloger.go
+++ b/syft/pkg/cataloger/cataloger.go
@@ -40,6 +40,7 @@ func ImageCatalogers(cfg Config) []Cataloger {
 		python.NewPythonPackageCataloger(),
 		php.NewPHPComposerInstalledCataloger(),
 		javascript.NewJavascriptPackageCataloger(),
+		javascript.NewJavascriptLockCataloger(),
 		deb.NewDpkgdbCataloger(),
 		rpmdb.NewRpmdbCataloger(),
 		java.NewJavaCataloger(cfg.Java()),


### PR DESCRIPTION
example use case:

- build react app
- static content is generated in build/ folder
- add yarn.lock or package-lock.json into build/ folder to enable dependency analysis on image
- node_modules is dev-only, and intentionally not included in image

without javascript-lock-cataloger, syft ignores this layout, and depedencies are not recognized.

I am not aware of other valid aproach to support this layout.

Also:

`syft build/` properly detects lock file and dependencies in buid/ folder

but if the same build/ folder is just copied to docker image, `syft $myimage` behaves differently (ignores lock file and fails to populate dependencies)