### PR TITLE
feat: add use-all-catalogers flag

### DIFF
--- a/syft/lib.go
+++ b/syft/lib.go
@@ -64,6 +64,10 @@ func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Catalog, []
 		return nil, nil, nil, fmt.Errorf("unable to determine cataloger set from scheme=%+v", src.Metadata.Scheme)
 	}
 
+	if cataloger.RequestedAllCatalogers(cfg) {
+		catalogers = cataloger.AllCatalogers(cfg)
+	}
+
 	catalog, relationships, err := cataloger.Catalog(resolver, release, catalogers...)
 	if err != nil {
 		return nil, nil, nil, err

--- a/syft/pkg/cataloger/cataloger.go
+++ b/syft/pkg/cataloger/cataloger.go
@@ -27,6 +27,8 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
+const AllCatalogersPattern = "all"
+
 // Cataloger describes behavior for an object to participate in parsing container image or file system
 // contents for the purpose of discovering Packages. Each concrete implementation should focus on discovering Packages
 // for a specific Package Type or ecosystem.
@@ -99,10 +101,24 @@ func AllCatalogers(cfg Config) []Cataloger {
 	}, cfg.Catalogers)
 }
 
+func RequestedAllCatalogers(cfg Config) bool {
+	for _, enableCatalogerPattern := range cfg.Catalogers {
+		if enableCatalogerPattern == AllCatalogersPattern {
+			return true
+		}
+	}
+	return false
+}
+
 func filterCatalogers(catalogers []Cataloger, enabledCatalogerPatterns []string) []Cataloger {
 	// if cataloger is not set, all applicable catalogers are enabled by default
 	if len(enabledCatalogerPatterns) == 0 {
 		return catalogers
+	}
+	for _, enableCatalogerPattern := range enabledCatalogerPatterns {
+		if enableCatalogerPattern == AllCatalogersPattern {
+			return catalogers
+		}
 	}
 	var keepCatalogers []Cataloger
 	for _, cataloger := range catalogers {


### PR DESCRIPTION
## Description
Add a new switch `--use-all-catalogers` that allows for the use of both image and file catalogers to run on the subject. This is useful when scanning an image built to use as a build environment, where artifacts may be installed using the files present soon.

Closes https://github.com/anchore/syft/issues/1049