### PR TITLE
fix: add php catalogers to all catalogers

### DIFF
--- a/syft/pkg/cataloger/cataloger.go
+++ b/syft/pkg/cataloger/cataloger.go
@@ -96,8 +96,8 @@ func AllCatalogers(cfg Config) []Cataloger {
 		rust.NewCargoLockCataloger(),
 		dart.NewPubspecLockCataloger(),
 		dotnet.NewDotnetDepsCataloger(),
-		php.NewPHPComposerLockCataloger(),
 		php.NewPHPComposerInstalledCataloger(),
+		php.NewPHPComposerLockCataloger(),
 	}, cfg.Catalogers)
 }
 

--- a/syft/pkg/cataloger/cataloger.go
+++ b/syft/pkg/cataloger/cataloger.go
@@ -96,6 +96,8 @@ func AllCatalogers(cfg Config) []Cataloger {
 		rust.NewCargoLockCataloger(),
 		dart.NewPubspecLockCataloger(),
 		dotnet.NewDotnetDepsCataloger(),
+		php.NewPHPComposerLockCataloger(),
+		php.NewPHPComposerInstalledCataloger(),
 	}, cfg.Catalogers)
 }
 


### PR DESCRIPTION
Add's the php catalogers to be used in the case of scanning a file or using all catalogers.

Closes: https://github.com/anchore/syft/issues/1064