### PR TITLE
fix: add new languages found in cpes

### DIFF
--- a/syft/pkg/language.go
+++ b/syft/pkg/language.go
@@ -58,7 +58,7 @@ func LanguageByName(name string) Language {
 		return PHP
 	case packageurl.TypeGolang, string(GoModulePkg), string(Go):
 		return Go
-	case packageurl.TypeNPM, string(JavaScript):
+	case packageurl.TypeNPM, string(JavaScript), "nodejs", "node.js":
 		return JavaScript
 	case packageurl.TypePyPi, string(Python):
 		return Python

--- a/syft/pkg/language_test.go
+++ b/syft/pkg/language_test.go
@@ -128,6 +128,14 @@ func TestLanguageByName(t *testing.T) {
 			language: JavaScript,
 		},
 		{
+			name:     "node.js",
+			language: JavaScript,
+		},
+		{
+			name:     "nodejs",
+			language: JavaScript,
+		},
+		{
 			name:     "pypi",
 			language: Python,
 		},


### PR DESCRIPTION
## 📝 Description
In the complete list of all cpes ever found, `node.js` and `nodejs` appear as target software. I'm working on making a PR to Grype which checks if a target_sw is supported by Syft, so I'd like to add these so they map to Javascript as the supported base