### PR TITLE
fix: add manual vendor/product removal to fix false flags

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type_test.go
@@ -153,3 +153,81 @@ func Test_additionalVendors(t *testing.T) {
 		})
 	}
 }
+
+func Test_findVendorsToRemove(t *testing.T) {
+	//GIVEN
+	tests := []struct {
+		name     string
+		ty       pkg.Type
+		pkgName  string
+		expected []string
+	}{
+		{
+			name:     "vendor removal match by input package name",
+			ty:       pkg.JavaPkg,
+			pkgName:  "my-package-name",
+			expected: []string{"awesome-vendor-addition"},
+		},
+		{
+			name:    "vendor removal miss by input package name",
+			ty:      pkg.JavaPkg,
+			pkgName: "my-package-name-1",
+		},
+	}
+
+	allRemovals := map[pkg.Type]map[candidateKey]candidateRemovals{
+		pkg.JavaPkg: {
+			candidateKey{
+				PkgName: "my-package-name",
+			}: {
+				VendorsToRemove: []string{"awesome-vendor-addition"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			//WHEN + THEN
+			assert.Equal(t, test.expected, findVendorsToRemove(allRemovals, test.ty, test.pkgName))
+		})
+	}
+}
+
+func Test_findProductsToRemove(t *testing.T) {
+	//GIVEN
+	tests := []struct {
+		name     string
+		ty       pkg.Type
+		pkgName  string
+		expected []string
+	}{
+		{
+			name:     "vendor removal match by input package name",
+			ty:       pkg.JavaPkg,
+			pkgName:  "my-package-name",
+			expected: []string{"awesome-vendor-addition"},
+		},
+		{
+			name:    "vendor removal miss by input package name",
+			ty:      pkg.JavaPkg,
+			pkgName: "my-package-name-1",
+		},
+	}
+
+	allRemovals := map[pkg.Type]map[candidateKey]candidateRemovals{
+		pkg.JavaPkg: {
+			candidateKey{
+				PkgName: "my-package-name",
+			}: {
+				ProductsToRemove: []string{"awesome-vendor-addition"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			//WHEN + THEN
+			assert.Equal(t, test.expected, findProductsToRemove(allRemovals, test.ty, test.pkgName))
+		})
+	}
+}

--- a/syft/pkg/cataloger/common/cpe/generate.go
+++ b/syft/pkg/cataloger/common/cpe/generate.go
@@ -110,6 +110,9 @@ func candidateVendors(p pkg.Package) []string {
 		vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, p.Type, p.Name, vendor)...)
 	}
 
+	// remove known mis
+	vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, p.Type, p.Name)...)
+
 	return vendors.uniqueValues()
 }
 
@@ -141,6 +144,9 @@ func candidateProducts(p pkg.Package) []string {
 
 	// add known candidate additions
 	products.addValue(findAdditionalProducts(defaultCandidateAdditions, p.Type, p.Name)...)
+
+	// remove known candidate removals
+	products.removeByValue(findProductsToRemove(defaultCandidateRemovals, p.Type, p.Name)...)
 
 	return products.uniqueValues()
 }

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -665,6 +665,27 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:stephanie_morillo:bundler:2.1.4:*:*:*:*:*:*:*",
 			},
 		},
+		{
+			name: "regression: python redis shadows normal redis",
+			p: pkg.Package{
+				Name:     "redis",
+				Version:  "2.1.4",
+				Type:     pkg.PythonPkg,
+				FoundBy:  "some-analyzer",
+				Language: pkg.Python,
+			},
+			expected: []string{
+				"cpe:2.3:a:python-redis:python-redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python-redis:python_redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python-redis:redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python:python-redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python:python_redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python:redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python_redis:python-redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python_redis:python_redis:2.1.4:*:*:*:*:*:*:*",
+				"cpe:2.3:a:python_redis:redis:2.1.4:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## 📝 Description
Not a great solution, but it at least removes these false flagging events and matches the current practices of manual vendor/product additions by adding support for manual vendor/product removals

Closes https://github.com/anchore/syft/issues/1066
Closes https://github.com/anchore/grype/issues/800
Closes https://github.com/anchore/grype/issues/491