### PR TITLE
fix: purl generation for pom.xml

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -63,6 +63,11 @@ func newPackageFromPom(dep gopom.Dependency) *pkg.Package {
 		Type:         pkg.JavaPkg, // TODO: should we differentiate between packages from jar/war/zip versus packages from a pom.xml that were not installed yet?
 		MetadataType: pkg.JavaMetadataType,
 		FoundBy:      javaPomCataloger,
+		Metadata: pkg.JavaMetadata{
+			PomProperties: &pkg.PomProperties{
+				GroupID: dep.GroupID,
+			},
+		},
 	}
 
 	p.Metadata = pkg.JavaMetadata{PURL: packageURL(*p)}

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -26,7 +26,10 @@ func Test_parserPomXML(t *testing.T) {
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
-						PURL: "pkg:maven/joda-time/joda-time@2.9.2",
+						PURL: "pkg:maven/joda/joda-time@2.9.2",
+						PomProperties: &pkg.PomProperties{
+							GroupID: "joda",
+						},
 					},
 				},
 				{
@@ -38,6 +41,9 @@ func Test_parserPomXML(t *testing.T) {
 					MetadataType: pkg.JavaMetadataType,
 					Metadata: pkg.JavaMetadata{
 						PURL: "pkg:maven/junit/junit@4.12",
+						PomProperties: &pkg.PomProperties{
+							GroupID: "junit",
+						},
 					},
 				},
 			},

--- a/syft/pkg/cataloger/java/test-fixtures/pom/pom.xml
+++ b/syft/pkg/cataloger/java/test-fixtures/pom/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.anchore</groupId>
@@ -16,7 +15,7 @@
 	<dependencies>
 		<!-- tag::joda[] -->
 		<dependency>
-			<groupId>joda-time</groupId>
+			<groupId>joda</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.9.2</version>
 		</dependency>


### PR DESCRIPTION
## 📝 Description
Fixes `pom.xml` PURL generation to include GroupID  in the following format `pkg:maven/<groupID>/<artifactId>@<version>`

Closes https://github.com/anchore/syft/issues/1075