### PR TITLE
fix: add glob to filter list to ensure rpm metadata files are matched…

### DIFF
--- a/syft/pkg/relationships_by_file_ownership.go
+++ b/syft/pkg/relationships_by_file_ownership.go
@@ -13,6 +13,7 @@ var globsForbiddenFromBeingOwned = []string{
 	ApkDBGlob,
 	DpkgDBGlob,
 	RpmDBGlob,
+	"**/rpm/{Packages,Packages.db,rpmdb.sqlite}",
 	// DEB packages share common copyright info between, this does not mean that sharing these paths implies ownership.
 	"/usr/share/doc/**/copyright",
 }


### PR DESCRIPTION
… when var/lib/rpm is a softlinked (#1077)

Signed-off-by: Daniel Nurmi <nurmi@anchore.com>