### PR TITLE
fix: -o output option to include formats

### DIFF
--- a/cmd/syft/cli/options/writer.go
+++ b/cmd/syft/cli/options/writer.go
@@ -53,7 +53,7 @@ func parseOutputs(outputs []string, defaultFile, templateFilePath string) (out [
 
 		format := syft.FormatByName(name)
 		if format == nil {
-			errs = multierror.Append(errs, fmt.Errorf("bad output format: '%s'", name))
+			errs = multierror.Append(errs, fmt.Errorf(`unsupported output format "%s", supported formats are: %+v`, name, FormatAliases(syft.FormatIDs()...)))
 			continue
 		}
 

--- a/cmd/syft/cli/options/writer_test.go
+++ b/cmd/syft/cli/options/writer_test.go
@@ -22,7 +22,7 @@ func TestIsSupportedFormat(t *testing.T) {
 		{
 			outputs: []string{"unknown"},
 			wantErr: func(t assert.TestingT, err error, bla ...interface{}) bool {
-				return assert.ErrorContains(t, err, "bad output format: 'unknown'")
+				return assert.ErrorContains(t, err, `unsupported output format "unknown", supported formats are: [`)
 			},
 		},
 	}


### PR DESCRIPTION
## 📝 Description
Updates the `-o` option for packages to list all the possible options when failing and formats the error response to be in sync with Grype.

Closes https://github.com/anchore/syft/issues/1101