### PR TITLE
update help formatting

### DIFF
--- a/cmd/syft/cli/packages.go
+++ b/cmd/syft/cli/packages.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	packagesExample = `  {{.appName}} {{.command}} alpine:latest                    a summary of discovered packages
+	packagesExample = `  {{.appName}} {{.command}} alpine:latest                                a summary of discovered packages
   {{.appName}} {{.command}} alpine:latest -o json                        show all possible cataloging details
   {{.appName}} {{.command}} alpine:latest -o cyclonedx                   show a CycloneDX formatted SBOM
   {{.appName}} {{.command}} alpine:latest -o cyclonedx-json              show a CycloneDX JSON formatted SBOM


### PR DESCRIPTION
The latest release introduced a change where the help formatting was askew.

Before:
![Screen Shot 2022-07-19 at 10 22 41 AM](https://user-images.githubusercontent.com/32073428/179774332-4afea500-b1cf-4763-ba1a-fd66fcf8c670.png)

After:
![Screen Shot 2022-07-19 at 10 22 32 AM](https://user-images.githubusercontent.com/32073428/179774355-44c690d9-3b8b-4f16-aaec-d40c50cf33be.png)

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>