### PR TITLE
fix: use generic instead of not generating purl

### DIFF
--- a/syft/pkg/url.go
+++ b/syft/pkg/url.go
@@ -41,9 +41,7 @@ func URL(p Package, release *linux.Release) string {
 
 	switch {
 	case purlType == "":
-		// there is no purl type, don't attempt to craft a purl
-		// TODO: should this be a "generic" purl type instead?
-		return ""
+		purlType = packageurl.TypeGeneric
 	case p.Type == GoModulePkg:
 		re := regexp.MustCompile(`(/)[^/]*$`)
 		fields := re.Split(p.Name, -1)


### PR DESCRIPTION
Closes: https://github.com/anchore/syft/issues/1118