### PR TITLE
remove prefixed v from tag to match release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: docker-practice/actions-setup-docker@v1.0.8
+      - uses: docker-practice/actions-setup-docker@1.0.8
 
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Looks like only v1 conforms to having a prefixed v.

```
Getting action download info
Error: Unable to resolve action `docker-practice/actions-setup-docker@v1.0.8`, unable to find version `v1.0.8`
```
Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>