### PR TITLE
disable release for docker assets

### DIFF
--- a/.goreleaser_docker.yaml
+++ b/.goreleaser_docker.yaml
@@ -4,6 +4,9 @@
 # https://github.com/anchore/syft/issues/577
 # https://github.com/anchore/syft/issues/519
 # https://github.com/anchore/syft/issues/576
+release:
+  disable: true
+
 env:
   # required to support multi architecture docker builds
   - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
Removes the error `error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN`

Since we're not using the release object for the second docker publish we need to explicitly disable that feature or goreleaser will fail expecting this environment variable to be present.

https://github.com/goreleaser/goreleaser/issues/669

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>