### PR TITLE
cataloger configuration is respected regardless of source

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ registry:yourrepo/yourimage:tag          pull image directly from a registry (no
 - hackage
 
 #### Non Default:
-- rust-audit-binary
+- cargo-auditable-binary
 
 ### Excluding file paths
 

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -48,24 +48,25 @@ func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Catalog, []
 		log.Info("could not identify distro")
 	}
 
-	// conditionally use the correct set of loggers based on the input type (container image or directory)
+	// if the catalogers have been configured, use them regardless of input type
 	var catalogers []cataloger.Cataloger
-	switch src.Metadata.Scheme {
-	case source.ImageScheme:
-		log.Info("cataloging image")
-		catalogers = cataloger.ImageCatalogers(cfg)
-	case source.FileScheme:
-		log.Info("cataloging file")
+	if len(cfg.Catalogers) > 0 {
 		catalogers = cataloger.AllCatalogers(cfg)
-	case source.DirectoryScheme:
-		log.Info("cataloging directory")
-		catalogers = cataloger.DirectoryCatalogers(cfg)
-	default:
-		return nil, nil, nil, fmt.Errorf("unable to determine cataloger set from scheme=%+v", src.Metadata.Scheme)
-	}
-
-	if cataloger.RequestedAllCatalogers(cfg) {
-		catalogers = cataloger.AllCatalogers(cfg)
+	} else {
+		// otherwise conditionally use the correct set of loggers based on the input type (container image or directory)
+		switch src.Metadata.Scheme {
+		case source.ImageScheme:
+			log.Info("cataloging image")
+			catalogers = cataloger.ImageCatalogers(cfg)
+		case source.FileScheme:
+			log.Info("cataloging file")
+			catalogers = cataloger.AllCatalogers(cfg)
+		case source.DirectoryScheme:
+			log.Info("cataloging directory")
+			catalogers = cataloger.DirectoryCatalogers(cfg)
+		default:
+			return nil, nil, nil, fmt.Errorf("unable to determine cataloger set from scheme=%+v", src.Metadata.Scheme)
+		}
 	}
 
 	catalog, relationships, err := cataloger.Catalog(resolver, release, catalogers...)

--- a/syft/pkg/cataloger/rust/audit_binary_cataloger.go
+++ b/syft/pkg/cataloger/rust/audit_binary_cataloger.go
@@ -12,7 +12,7 @@ import (
 	rustaudit "github.com/microsoft/go-rustaudit"
 )
 
-const catalogerName = "rust-audit-binary-cataloger"
+const catalogerName = "cargo-auditable-binary-cataloger"
 
 type Cataloger struct{}
 

--- a/syft/pkg/cataloger/rust/cataloger.go
+++ b/syft/pkg/cataloger/rust/cataloger.go
@@ -13,5 +13,5 @@ func NewCargoLockCataloger() *common.GenericCataloger {
 		"**/Cargo.lock": parseCargoLock,
 	}
 
-	return common.NewGenericCataloger(nil, globParsers, "rust-cataloger")
+	return common.NewGenericCataloger(nil, globParsers, "rust-cargo-lock-cataloger")
 }

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -229,9 +229,10 @@ func TestPackagesCmdFlags(t *testing.T) {
 		},
 		{
 			name: "catalogers-option",
+			// This will detect enable python-index-cataloger, python-package-cataloger and ruby-gemspec cataloger
 			args: []string{"packages", "-o", "json", "--catalogers", "python,ruby-gemspec", coverageImage},
 			assertions: []traitAssertion{
-				assertPackageCount(6),
+				assertPackageCount(13),
 				assertSuccessfulReturnCode,
 			},
 		},

--- a/test/integration/convert_test.go
+++ b/test/integration/convert_test.go
@@ -36,7 +36,7 @@ var convertibleFormats = []sbom.Format{
 func TestConvertCmd(t *testing.T) {
 	for _, format := range convertibleFormats {
 		t.Run(format.ID().String(), func(t *testing.T) {
-			sbom, _ := catalogFixtureImage(t, "image-pkg-coverage", source.SquashedScope, false)
+			sbom, _ := catalogFixtureImage(t, "image-pkg-coverage", source.SquashedScope, nil)
 			format := syft.FormatByID(syftjson.ID)
 
 			f, err := ioutil.TempFile("", "test-convert-sbom-")

--- a/test/integration/distro_test.go
+++ b/test/integration/distro_test.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
-	"github.com/anchore/syft/syft/source"
 	"testing"
+
+	"github.com/anchore/syft/syft/source"
 
 	"github.com/stretchr/testify/assert"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func TestDistroImage(t *testing.T) {
-	sbom, _ := catalogFixtureImage(t, "image-distro-id", source.SquashedScope, false)
+	sbom, _ := catalogFixtureImage(t, "image-distro-id", source.SquashedScope, nil)
 
 	expected := &linux.Release{
 		PrettyName: "BusyBox v1.31.1",

--- a/test/integration/encode_decode_cycle_test.go
+++ b/test/integration/encode_decode_cycle_test.go
@@ -3,13 +3,14 @@ package integration
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/anchore/syft/internal/formats/cyclonedxjson"
 	"github.com/anchore/syft/internal/formats/cyclonedxxml"
 	"github.com/anchore/syft/internal/formats/syftjson"
 	"github.com/anchore/syft/syft/source"
 	"github.com/google/go-cmp/cmp"
-	"regexp"
-	"testing"
 
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/stretchr/testify/require"
@@ -64,7 +65,7 @@ func TestEncodeDecodeEncodeCycleComparison(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s", test.formatOption), func(t *testing.T) {
 			for _, image := range images {
-				originalSBOM, _ := catalogFixtureImage(t, image, source.SquashedScope, false)
+				originalSBOM, _ := catalogFixtureImage(t, image, source.SquashedScope, nil)
 
 				format := syft.FormatByID(test.formatOption)
 				require.NotNil(t, format)

--- a/test/integration/mariner_distroless_test.go
+++ b/test/integration/mariner_distroless_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMarinerDistroless(t *testing.T) {
-	sbom, _ := catalogFixtureImage(t, "image-mariner-distroless", source.SquashedScope, false)
+	sbom, _ := catalogFixtureImage(t, "image-mariner-distroless", source.SquashedScope, nil)
 
 	expectedPkgs := 12
 	actualPkgs := 0

--- a/test/integration/package_deduplication_test.go
+++ b/test/integration/package_deduplication_test.go
@@ -2,10 +2,11 @@ package integration
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/anchore/syft/syft/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPackageDeduplication(t *testing.T) {
@@ -56,7 +57,7 @@ func TestPackageDeduplication(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.scope), func(t *testing.T) {
-			sbom, _ := catalogFixtureImage(t, "image-vertical-package-dups", tt.scope, false)
+			sbom, _ := catalogFixtureImage(t, "image-vertical-package-dups", tt.scope, nil)
 
 			assert.Equal(t, tt.packageCount, sbom.Artifacts.PackageCatalog.PackageCount())
 			for name, expectedInstanceCount := range tt.instanceCount {

--- a/test/integration/package_ownership_relationship_test.go
+++ b/test/integration/package_ownership_relationship_test.go
@@ -3,8 +3,9 @@ package integration
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/anchore/syft/syft/source"
 	"testing"
+
+	"github.com/anchore/syft/syft/source"
 
 	"github.com/anchore/syft/internal/formats/syftjson"
 	syftjsonModel "github.com/anchore/syft/internal/formats/syftjson/model"
@@ -23,7 +24,7 @@ func TestPackageOwnershipRelationships(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.fixture, func(t *testing.T) {
-			sbom, _ := catalogFixtureImage(t, test.fixture, source.SquashedScope, false)
+			sbom, _ := catalogFixtureImage(t, test.fixture, source.SquashedScope, nil)
 
 			output := bytes.NewBufferString("")
 			err := syftjson.Format().Encode(output, sbom)

--- a/test/integration/regression_apk_scanner_buffer_size_test.go
+++ b/test/integration/regression_apk_scanner_buffer_size_test.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
-	"github.com/anchore/syft/syft/source"
 	"testing"
+
+	"github.com/anchore/syft/syft/source"
 
 	"github.com/anchore/syft/syft/pkg"
 )
@@ -10,7 +11,7 @@ import (
 func TestRegression212ApkBufferSize(t *testing.T) {
 	// This is a regression test for issue #212 (https://github.com/anchore/syft/issues/212) in which the apk db could
 	// not be processed due to a scanner buffer that was too small
-	sbom, _ := catalogFixtureImage(t, "image-large-apk-data", source.SquashedScope, false)
+	sbom, _ := catalogFixtureImage(t, "image-large-apk-data", source.SquashedScope, nil)
 
 	expectedPkgs := 58
 	actualPkgs := 0

--- a/test/integration/regression_go_bin_scanner_arch_test.go
+++ b/test/integration/regression_go_bin_scanner_arch_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
-	"github.com/anchore/syft/syft/source"
 	"strings"
 	"testing"
+
+	"github.com/anchore/syft/syft/source"
 
 	"github.com/anchore/syft/syft/pkg"
 )
@@ -16,7 +17,7 @@ func TestRegressionGoArchDiscovery(t *testing.T) {
 	)
 	// This is a regression test to make sure the way we detect go binary packages
 	// stays consistent and reproducible as the tool chain evolves
-	sbom, _ := catalogFixtureImage(t, "image-go-bin-arch-coverage", source.SquashedScope, false)
+	sbom, _ := catalogFixtureImage(t, "image-go-bin-arch-coverage", source.SquashedScope, nil)
 
 	var actualELF, actualWIN, actualMACOS int
 

--- a/test/integration/regression_java_no_main_package_test.go
+++ b/test/integration/regression_java_no_main_package_test.go
@@ -1,10 +1,11 @@
 package integration
 
 import (
-	"github.com/anchore/syft/syft/source"
 	"testing"
+
+	"github.com/anchore/syft/syft/source"
 )
 
 func TestRegressionJavaNoMainPackage(t *testing.T) { // Regression: https://github.com/anchore/syft/issues/252
-	catalogFixtureImage(t, "image-java-no-main-package", source.SquashedScope, false)
+	catalogFixtureImage(t, "image-java-no-main-package", source.SquashedScope, nil)
 }

--- a/test/integration/rust_audit_binary_test.go
+++ b/test/integration/rust_audit_binary_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRustAudit(t *testing.T) {
-	sbom, _ := catalogFixtureImage(t, "image-rust-auditable", source.SquashedScope, true)
+	sbom, _ := catalogFixtureImage(t, "image-rust-auditable", source.SquashedScope, []string{"all"})
 
 	expectedPkgs := 2
 	actualPkgs := 0

--- a/test/integration/sqlite_rpmdb_test.go
+++ b/test/integration/sqlite_rpmdb_test.go
@@ -11,7 +11,7 @@ import (
 func TestSqliteRpm(t *testing.T) {
 	// This is a regression test for issue #469 (https://github.com/anchore/syft/issues/469). Recent RPM
 	// based distribution store package data in an sqlite database
-	sbom, _ := catalogFixtureImage(t, "image-sqlite-rpmdb", source.SquashedScope, false)
+	sbom, _ := catalogFixtureImage(t, "image-sqlite-rpmdb", source.SquashedScope, nil)
 
 	expectedPkgs := 139
 	actualPkgs := 0

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/syft/syft/pkg/cataloger"
 
@@ -13,7 +14,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Scope, allCatalogers bool) (sbom.SBOM, *source.Source) {
+func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Scope, catalogerCfg []string) (sbom.SBOM, *source.Source) {
 	imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
 	tarPath := imagetest.GetFixtureImageTarPath(t, fixtureImageName)
 	userInput := "docker-archive:" + tarPath
@@ -23,11 +24,9 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
 
-	// TODO: this would be better with functional options (after/during API refactor)
 	c := cataloger.DefaultConfig()
-	if allCatalogers {
-		c.Catalogers = []string{"all"}
-	}
+	c.Catalogers = catalogerCfg
+
 	c.Search.Scope = scope
 	pkgCatalog, relationships, actualDistro, err := syft.CatalogPackages(theSource, c)
 	if err != nil {


### PR DESCRIPTION
If the user specifies catalogers via configuration, then use the
requested catalogers regardless of source type.

This makes it possible to enable an off-by-default cataloger on an image or directory without
using "--all" catalogers.

Signed-off-by: Tom Fay <tomfay@microsoft.com>

Fixes https://github.com/anchore/syft/issues/1141