### PR TITLE
Give the contributing guide a substantial rework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,57 @@
 
 If you are looking to contribute to this project and want to open a GitHub pull request ("PR"), there are a few guidelines of what we are looking for in patches. Make sure you go through this document and ensure that your code proposal is aligned.
 
+## Setting up your environment
+
+Before you can contribute to Syft, you need to configure your development environment.
+
+### Debian setup
+
+You will need to install Go. The version on https://go.dev works best, using the system golang doesn't always work the way you might expect.
+
+At the time of writing, Go 1.19 does not work correctly with Syft. Please use Go 1.18 for now.
+
+You will also need Docker. There's no reason the system packages shouldn't work, but we used the official Docker package. You can find instructions for installing Docker in Debian [here](https://docs.docker.com/engine/install/debian/).
+
+You also need to install some Debian packages
+
+```sh
+sudo apt-get install build-essential zip bc libxml2-utils git
+```
+
+## Configuring Git
+
+You will need to configure your git client with your name and email address. This is easily done from the command line.
+
+```text
+$ git config --global user.name "John Doe"
+$ git config --global user.email "john.doe@example.com"
+```
+
+This username and email address will matter later in this guide.
+
+## Fork the repo
+
+You should fork the Syft repo using the "Fork" button at the top right of the Syft GitHub [site](https://github.com/anchore/syft/). You will be doing your development in your fork, then submit a pull request to Syft. There are many resources how to use GitHub effectively, we will not cover those here.
+
+## Adding a feature or fix
+
+If you look at the Syft [Issue](https://github.com/anchore/syft/issues) there are plenty of bugs and feature requests. Maybe look at the [good first issue](https://github.com/anchore/syft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) list if you're not sure where to start.
+
+## Commit guidelines
+
+In the Syft project we like commits and pull requests (PR) to be easy to understand and review. Open source thrives best when everything happening is over documented and small enough to be understood.
+
+### Granular commits
+
+Please try to make every commit as simple as possible, but no simpler. The idea is that each commit should be a logical unit of code. Try not to commit too many tiny changes, for example every line changed in a file as a separate commit. And also try not to make a commit enormous, for example committing all your work at the end of the day.
+
+Rather than try to follow a strict guide on what is or is not best, we try to be flexible and simple in this space. Do what makes the most sense for the changes you are trying to include.
+
+### Commit title and description
+
+Remember that the message you leave for a commit is for the reviewer in the present, and for someone (maybe you) changing something in the future. Please make sure the title and description used is easy to understand and explains what was done. Jokes and clever comments generally don't age well in commit messages. Just the facts please.
+
 ## Sign off your work
 
 The `sign-off` is an added line at the end of the explanation for the commit, certifying that you wrote it or otherwise have the right to submit it as an open-source patch. By submitting a contribution, you agree to be bound by the terms of the DCO Version 1.1 and Apache License Version 2.0.
@@ -44,13 +95,6 @@ When committing your change, you can add the required line manually so that it l
 Signed-off-by: John Doe <john.doe@example.com>
 ```
 
-Alternatively, configure your Git client with your name and email to use the `-s` flag when creating a commit:
-
-```text
-$ git config --global user.name "John Doe"
-$ git config --global user.email "john.doe@example.com"
-```
-
 Creating a signed-off commit is then possible with `-s` or `--signoff`:
 
 ```text
@@ -70,21 +114,9 @@ Date:   Mon Aug 1 11:27:13 2020 -0400
     Signed-off-by: John Doe <john.doe@example.com>
 ```
 
-
-[//]: # (TODO: Commit guidelines, granular commits)
-
-
-[//]: # (TODO: Commit guidelines, descriptive messages)
-
-
-[//]: # (TODO: Commit guidelines, commit title, extra body description)
-
-
-[//]: # (TODO: PR title and description)
-
 ## Test your changes
 
-This project has a `Makefile` which includes many helpers running both unit and integration tests. Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes. Ensure you've bootstrapped once before running tests:
+This project has a `Makefile` which includes many helpers running both unit and integration tests. You can run `make help` to see all the options. Although PRs will have automatic checks for these, it is useful to run them locally, ensuring they pass before submitting changes. Ensure you've bootstrapped once before running tests:
 
 ```text
 $ make bootstrap
@@ -97,6 +129,26 @@ $ make unit
 $ make integration
 ```
 
+You can also run `make all` to run a more extensive test suite, but there is additional configuration that will be needed for those tests to run correctly. We will not cover the extra steps here.
+
+## Pull Request
+
+If you made it this far and all the tests are passing, it's time to submit a Pull Request (PR) for Syft. Submitting a PR is always a scary moment as what happens next can be an unknown. The Syft project strives to be easy to work with, we appreciate all contributions. Nobody is going to yell at you or try to make you feel bad. We love contributions and know how scary that first PR can be.
+
+### PR Title and Description
+
+Just like the commit title and description mentioned above, the PR title and description is very important for letting others know what's happening. Please include any details you think a reviewer will need to more properly review your PR.
+
+A PR that is very large or poorly described has a higher likelihood of being pushed to the end of the list. Reviewers like PRs they can understand and quickly review.
+
+### What to expect next
+
+Please be patient with the project. We try to review PRs in a timely manner, but this is highly dependent on all the other tasks we have going on. It's OK to ask for a status update every week or two, it's not OK to ask for a status update every day.
+
+It's very likely the reviewer will have questions and suggestions for changes to your PR. If your changes don't match the current style and flow of the other code, expect a request to change what you've done.
+
 ## Document your changes
 
-When proposed changes are modifying user-facing functionality or output, it is expected the PR will include updates to the documentation as well.
+And lastly, when proposed changes are modifying user-facing functionality or output, it is expected the PR will include updates to the documentation as well. Syft is not a project that is heavy on documentation. This will mostly be updating the README and help for the tool.
+
+If nobody knows new features exist, they can't use them!


### PR DESCRIPTION
This changes the entire flow of the contributing guide. Please consider this a first draft (it still needs more details).

I tried to put the guide into a logical order for completing and understanding how to best start to contribute to Syft. I would value any feedback on the structure and if the current order makes sense.

The setup instructions are only for Debian at the moment. I will include at least OSX at some point in the near future (it takes a lot longer than one would expect to setup a clean machine).

Signed-off-by: Josh Bressers <josh@bress.net>