### PR TITLE
Correctly populate hasFiles field for spdx-json output

### DIFF
--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -112,8 +112,10 @@ func fileIDsForPackage(packageSpdxID string, relationships []artifact.Relationsh
 			continue
 		}
 
-		if string(relationship.From.ID()) == packageSpdxID {
-			fileIDs = append(fileIDs, string(relationship.To.ID()))
+		from := model.ElementID(relationship.From.ID()).String()
+		to := model.ElementID(relationship.To.ID()).String()
+		if from == packageSpdxID {
+			fileIDs = append(fileIDs, to)
 		}
 	}
 	return fileIDs

--- a/internal/formats/spdx22json/to_format_model_test.go
+++ b/internal/formats/spdx22json/to_format_model_test.go
@@ -188,7 +188,7 @@ func Test_fileIDsForPackage(t *testing.T) {
 	}{
 		{
 			name: "find file IDs for packages with package-file relationships",
-			id:   string(p.ID()),
+			id:   model.ElementID(p.ID()).String(),
 			relationships: []artifact.Relationship{
 				{
 					From: p,
@@ -197,12 +197,12 @@ func Test_fileIDsForPackage(t *testing.T) {
 				},
 			},
 			expected: []string{
-				string(c.ID()),
+				model.ElementID(c.ID()).String(),
 			},
 		},
 		{
 			name: "ignore package-to-package",
-			id:   string(p.ID()),
+			id:   model.ElementID(p.ID()).String(),
 			relationships: []artifact.Relationship{
 				{
 					From: p,
@@ -214,7 +214,7 @@ func Test_fileIDsForPackage(t *testing.T) {
 		},
 		{
 			name: "ignore file-to-file",
-			id:   string(p.ID()),
+			id:   model.ElementID(p.ID()).String(),
 			relationships: []artifact.Relationship{
 				{
 					From: c,
@@ -226,7 +226,7 @@ func Test_fileIDsForPackage(t *testing.T) {
 		},
 		{
 			name: "ignore file-to-package",
-			id:   string(p.ID()),
+			id:   model.ElementID(p.ID()).String(),
 			relationships: []artifact.Relationship{
 				{
 					From: c,
@@ -238,7 +238,7 @@ func Test_fileIDsForPackage(t *testing.T) {
 		},
 		{
 			name: "filter by relationship type",
-			id:   string(p.ID()),
+			id:   model.ElementID(p.ID()).String(),
 			relationships: []artifact.Relationship{
 				{
 					From: p,


### PR DESCRIPTION
Heya :wave: Have been playing around with Syft recently, and came across some odd behavior! It looks like the `hasFiles` field isn't populating correctly, despite the relationships being in-place as expected, and there being logic to extract for this field.

Previously, extracting relationships between packages and files was not completing correctly, as SPDXRef- ElementIDs were being compared to raw IDs, and so never matched. This PR fixes this behavior, by ensuring that we always compare
ElementIDs.

I think the original behavior was introduced in https://github.com/anchore/syft/pull/634, and while the unit tests pass, I can't find any integration tests that check the behavior - but would be happy to add one, if you have any pointers on where might be the best place! :tada:

Let me know if there's anything else you need, happy to contribute!