### PR TITLE
feat: enable formatters to take in external library structs

### DIFF
--- a/internal/formats/common/cyclonedxhelpers/parser.go
+++ b/internal/formats/common/cyclonedxhelpers/parser.go
@@ -1,0 +1,17 @@
+package cyclonedxhelpers
+
+import (
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+func GetParser() sbom.Parser {
+	return func(input interface{}) (*sbom.SBOM, error) {
+		switch input := input.(type) {
+		case *cyclonedx.BOM:
+			return toSyftModel(input)
+		default:
+			return nil, sbom.ErrParsingNotSupported
+		}
+	}
+}

--- a/internal/formats/common/spdxhelpers/parser.go
+++ b/internal/formats/common/spdxhelpers/parser.go
@@ -1,0 +1,17 @@
+package spdxhelpers
+
+import (
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/spdx/tools-golang/spdx"
+)
+
+func GetParser() sbom.Parser {
+	return func(input interface{}) (*sbom.SBOM, error) {
+		switch input := input.(type) {
+		case *spdx.Document2_2:
+			return ToSyftModel(input)
+		default:
+			return nil, sbom.ErrParsingNotSupported
+		}
+	}
+}

--- a/internal/formats/cyclonedxjson/format.go
+++ b/internal/formats/cyclonedxjson/format.go
@@ -14,6 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		cyclonedxhelpers.GetDecoder(cyclonedx.BOMFileFormatJSON),
 		cyclonedxhelpers.GetValidator(cyclonedx.BOMFileFormatJSON),
-		nil,
+		cyclonedxhelpers.GetParser(),
 	)
 }

--- a/internal/formats/cyclonedxjson/format.go
+++ b/internal/formats/cyclonedxjson/format.go
@@ -14,5 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		cyclonedxhelpers.GetDecoder(cyclonedx.BOMFileFormatJSON),
 		cyclonedxhelpers.GetValidator(cyclonedx.BOMFileFormatJSON),
+		nil,
 	)
 }

--- a/internal/formats/cyclonedxxml/format.go
+++ b/internal/formats/cyclonedxxml/format.go
@@ -14,6 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		cyclonedxhelpers.GetDecoder(cyclonedx.BOMFileFormatXML),
 		cyclonedxhelpers.GetValidator(cyclonedx.BOMFileFormatXML),
-		nil,
+		cyclonedxhelpers.GetParser(),
 	)
 }

--- a/internal/formats/cyclonedxxml/format.go
+++ b/internal/formats/cyclonedxxml/format.go
@@ -14,5 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		cyclonedxhelpers.GetDecoder(cyclonedx.BOMFileFormatXML),
 		cyclonedxhelpers.GetValidator(cyclonedx.BOMFileFormatXML),
+		nil,
 	)
 }

--- a/internal/formats/github/format.go
+++ b/internal/formats/github/format.go
@@ -25,5 +25,6 @@ func Format() sbom.Format {
 		},
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/internal/formats/spdx22json/format.go
+++ b/internal/formats/spdx22json/format.go
@@ -1,6 +1,7 @@
 package spdx22json
 
 import (
+	"github.com/anchore/syft/internal/formats/common/spdxhelpers"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -13,6 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		decoder,
 		validator,
-		nil,
+		spdxhelpers.GetParser(),
 	)
 }

--- a/internal/formats/spdx22json/format.go
+++ b/internal/formats/spdx22json/format.go
@@ -13,5 +13,6 @@ func Format() sbom.Format {
 		encoder,
 		decoder,
 		validator,
+		nil,
 	)
 }

--- a/internal/formats/spdx22tagvalue/format.go
+++ b/internal/formats/spdx22tagvalue/format.go
@@ -1,6 +1,7 @@
 package spdx22tagvalue
 
 import (
+	"github.com/anchore/syft/internal/formats/common/spdxhelpers"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -13,6 +14,6 @@ func Format() sbom.Format {
 		encoder,
 		decoder,
 		validator,
-		nil,
+		spdxhelpers.GetParser(),
 	)
 }

--- a/internal/formats/spdx22tagvalue/format.go
+++ b/internal/formats/spdx22tagvalue/format.go
@@ -13,5 +13,6 @@ func Format() sbom.Format {
 		encoder,
 		decoder,
 		validator,
+		nil,
 	)
 }

--- a/internal/formats/syftjson/format.go
+++ b/internal/formats/syftjson/format.go
@@ -12,5 +12,6 @@ func Format() sbom.Format {
 		encoder,
 		decoder,
 		validator,
+		nil,
 	)
 }

--- a/internal/formats/table/format.go
+++ b/internal/formats/table/format.go
@@ -12,5 +12,6 @@ func Format() sbom.Format {
 		encoder,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/internal/formats/template/format.go
+++ b/internal/formats/template/format.go
@@ -41,6 +41,10 @@ func (f OutputFormat) Validate(reader io.Reader) error {
 	return sbom.ErrValidationNotSupported
 }
 
+func (f OutputFormat) Parse(input interface{}) (*sbom.SBOM, error) {
+	return nil, sbom.ErrParsingNotSupported
+}
+
 // SetTemplatePath sets path for template file
 func (f *OutputFormat) SetTemplatePath(filePath string) {
 	f.templateFilePath = filePath

--- a/internal/formats/text/format.go
+++ b/internal/formats/text/format.go
@@ -12,5 +12,6 @@ func Format() sbom.Format {
 		encoder,
 		nil,
 		nil,
+		nil,
 	)
 }

--- a/syft/sbom/multi_writer_test.go
+++ b/syft/sbom/multi_writer_test.go
@@ -15,7 +15,7 @@ func dummyEncoder(io.Writer, SBOM) error {
 }
 
 func dummyFormat(name string) Format {
-	return NewFormat(FormatID(name), dummyEncoder, nil, nil)
+	return NewFormat(FormatID(name), dummyEncoder, nil, nil, nil)
 }
 
 type writerConfig struct {


### PR DESCRIPTION
## Description
This pr enables the `spdx` and `cyclonedx` formatters to be called directly with those external libraries objects. Currently, if you build an sbom using these structs, you have to marshal it into json and then pass the reader to be un-marshaled and parsed into Syft's intermediate representation, causing wasted computations, especially when working with large SBOMs. 
The often comes into play when calling Syft to produces packages for Grype's api methods. 

Considerations:
**Don't use `interface{}`**: I agree, but generics got a bit out of hand considering the `Format` struct is quite widely used. Happy to refactor as desired



