### PR TITLE
Find version numbers from jars with different naming conventions

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename_test.go
+++ b/syft/pkg/cataloger/java/archive_filename_test.go
@@ -23,6 +23,20 @@ func TestExtractInfoFromJavaArchiveFilename(t *testing.T) {
 			ty:        pkg.UnknownPkg,
 		},
 		{
+			filename:  "pkg-maven.4.3.2.blerg",
+			version:   "4.3.2",
+			extension: "blerg",
+			name:      "pkg-maven",
+			ty:        pkg.UnknownPkg,
+		},
+		{
+			filename:  "pkg-maven_4.3.2.blerg",
+			version:   "4.3.2",
+			extension: "blerg",
+			name:      "pkg-maven",
+			ty:        pkg.UnknownPkg,
+		},
+		{
 			filename:  "pkg-maven-4.3.2.jar",
 			version:   "4.3.2",
 			extension: "jar",


### PR DESCRIPTION
This PR adds support for different JAR naming conventions -- specifically `<name>.<version>` and `<name>_<version>`.

Closes #466 