### PR TITLE
improvements to rekor cataloger code

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,4 +672,4 @@ The rekor-cataloger searches Rekor by hash for binaries and performs verificatio
 
 This is an experimental feature. It uses external sources, a functionality that is new to Syft. The use of trusted builders to produce SBOMs has not yet been fully established, and more consideration of what external sources to trust is necessary. Currently, Syft accepts any SBOM attestation that has a valid certificate issued by Fulcio.   
 
-To enable the rekor-cataloger, use the flag ``` --catalogers rekor ```.
+To enable the rekor-cataloger, use the flag ``` --external-sources-enabled=true ```.

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -52,6 +52,7 @@ type Application struct {
 	FileMetadata       FileMetadata       `yaml:"file-metadata" json:"file-metadata" mapstructure:"file-metadata"`
 	FileClassification fileClassification `yaml:"file-classification" json:"file-classification" mapstructure:"file-classification"`
 	FileContents       fileContents       `yaml:"file-contents" json:"file-contents" mapstructure:"file-contents"`
+	RekorCataloger     rekorCataloger     `yaml:"rekor-cataloger" json:"rekor-cataloger" mapstructure:"rekor-cataloger"`
 	Secrets            secrets            `yaml:"secrets" json:"secrets" mapstructure:"secrets"`
 	Registry           registry           `yaml:"registry" json:"registry" mapstructure:"registry"`
 	Exclusions         []string           `yaml:"exclude" json:"exclude" mapstructure:"exclude"`

--- a/internal/config/rekor_cataloger.go
+++ b/internal/config/rekor_cataloger.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/anchore/syft/syft/source"
+	"github.com/spf13/viper"
+)
+
+var rekorCatalogerEnabledDefault bool = false
+
+type rekorCataloger struct {
+	Cataloger catalogerOptions `yaml:"cataloger" json:"cataloger" mapstructure:"cataloger"`
+}
+
+func (cfg rekorCataloger) loadDefaultValues(v *viper.Viper) {
+	v.SetDefault("rekor-cataloger.cataloger.enabled", rekorCatalogerEnabledDefault)
+	v.SetDefault("rekor-cataloger.cataloger.scope", source.SquashedScope)
+}
+
+func (cfg *rekorCataloger) parseConfigValues() error {
+	return cfg.Cataloger.parseConfigValues()
+}

--- a/internal/formats/spdx22json/to_format_model.go
+++ b/internal/formats/spdx22json/to_format_model.go
@@ -56,7 +56,7 @@ func isValidExternalRelationshipDocument(rel artifact.Relationship) (bool, error
 	}
 	if externalRef, ok := rel.To.(rekor.ExternalRef); ok {
 		relationshipType := artifact.DescribedByRelationship
-		if rel.Type == relationshipType && toChecksumAlgorithm(externalRef.SpdxRef.Alg) == "SHA1" {
+		if rel.Type == relationshipType && toChecksumAlgorithm(externalRef.SpdxRef.Alg) == "SHA1" { // spdx 2.2 spec requires an sha1 hash
 			return true, nil
 		}
 		return false, fmt.Errorf("syft cannot handle an ExternalRef with relationship type: %v", relationshipType)

--- a/syft/pkg/cataloger/cataloger.go
+++ b/syft/pkg/cataloger/cataloger.go
@@ -24,7 +24,6 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/php"
 	"github.com/anchore/syft/syft/pkg/cataloger/portage"
 	"github.com/anchore/syft/syft/pkg/cataloger/python"
-	"github.com/anchore/syft/syft/pkg/cataloger/rekor"
 	"github.com/anchore/syft/syft/pkg/cataloger/rpmdb"
 	"github.com/anchore/syft/syft/pkg/cataloger/ruby"
 	"github.com/anchore/syft/syft/pkg/cataloger/rust"
@@ -117,7 +116,6 @@ func AllCatalogers(cfg Config) []Cataloger {
 		cpp.NewConanfileCataloger(),
 		portage.NewPortageCataloger(),
 		haskell.NewHackageCataloger(),
-		rekor.NewRekorCataloger(),
 	}, cfg)
 }
 

--- a/syft/rekor/rekor.go
+++ b/syft/rekor/rekor.go
@@ -76,11 +76,6 @@ func NewExternalRef(docRef string, uri string, alg spdx.ChecksumAlgorithm, hash 
 	}
 }
 
-func warnInfoForUser(uuids []string) {
-	s := fmt.Sprintf("%s\t%v\n", InfoForUser, uuids)
-	log.Warn(s)
-}
-
 // CreateRekorSbomRels searches Rekor by the hash of the file in the given location and creates external reference relationships
 // for any sboms that are found and verified
 func CreateRekorSbomRels(resolver source.FileResolver, location source.Location, client *Client) ([]artifact.Relationship, error) {
@@ -112,11 +107,10 @@ func CreateRekorSbomRels(resolver source.FileResolver, location source.Location,
 		}
 		rels = append(rels, *rel)
 		usedRekorEntries = append(usedRekorEntries, sbomWithDigest.rekorEntry)
-		log.Debug("relationship created for SBOM found on rekor")
+		log.Debugf("relationship created for SBOM found on rekor: %+v", *rel)
 	}
 	if len(rels) > 0 {
-		warnInfoForUser(usedRekorEntries)
+		log.Warn(fmt.Sprintf("%s\t%v\n", InfoForUser, usedRekorEntries))
 	}
-
 	return rels, nil
 }

--- a/syft/rekor/utils_test.go
+++ b/syft/rekor/utils_test.go
@@ -93,13 +93,8 @@ func Test_parseAndValidateAttestation(t *testing.T) {
 				Attestation: &models.LogEntryAnonAttestation{Data: bytes},
 			}
 
-			output, err := parseAndValidateAttestation(logEntryAnon)
-			assert.Equal(t, test.expectedOutput, output)
-			if test.expectedErr != "" {
-				assert.ErrorContains(t, err, test.expectedErr)
-			} else {
-				assert.NoError(t, err)
-			}
+			_, _, err = parseAndValidateAttestation(logEntryAnon)
+			assert.ErrorContains(t, err, test.expectedErr)
 		})
 	}
 }

--- a/test/integration/rekor_cataloger_test.go
+++ b/test/integration/rekor_cataloger_test.go
@@ -4,18 +4,31 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/rekor"
 	"github.com/anchore/syft/syft/source"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRekorCataloger(t *testing.T) {
-	sbom, _ := catalogFixtureImage(t, "image-rekor", source.SquashedScope, []string{"all"})
+	fixtureImageName := "image-rekor"
+	scope := source.SquashedScope
+
+	theSource := getImageSource(t, fixtureImageName)
+	resolver, err := theSource.FileResolver(scope)
+	assert.NoError(t, err)
+
+	client, err := rekor.NewClient()
+	assert.NoError(t, err)
+
+	cataloger := file.NewRekorCataloger(client)
+	rels, err := cataloger.Catalog(resolver)
+	assert.NoError(t, err)
 
 	expectedExternalRelationships := 1
 	var foundExternalRelationship artifact.Relationship
 	foundExternalRelationships := 0
-	for _, rel := range sbom.Relationships {
+	for _, rel := range rels {
 		if _, ok := rel.To.(rekor.ExternalRef); ok {
 			foundExternalRelationships += 1
 			foundExternalRelationship = rel
@@ -29,5 +42,4 @@ func TestRekorCataloger(t *testing.T) {
 			assert.FailNow(t, "the rekor-cataloger surfaced a relationship that is not FROM a coordinates")
 		}
 	}
-
 }

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Scope, catalogerCfg []string) (sbom.SBOM, *source.Source) {
+func getImageSource(t *testing.T, fixtureImageName string) *source.Source {
 	imagetest.GetFixtureImage(t, "docker-archive", fixtureImageName)
 	tarPath := imagetest.GetFixtureImageTarPath(t, fixtureImageName)
 	userInput := "docker-archive:" + tarPath
@@ -23,6 +23,12 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil)
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
+
+	return theSource
+}
+
+func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Scope, catalogerCfg []string) (sbom.SBOM, *source.Source) {
+	theSource := getImageSource(t, fixtureImageName)
 
 	c := cataloger.DefaultConfig()
 	c.Catalogers = catalogerCfg


### PR DESCRIPTION
This PR, to `kubecon-draft`, addresses many of the comments from the original PR for [SBOM discovery with Rekor](https://github.com/anchore/syft/pull/1157). 

One of the bigger changes is returning a `subject` and `sbomEntry` from `parseAndValidateAttestation` instead of a `InTotoAttestation`. This is to reduce the amount of validations that are needed in the code. 

Another change is adding a configuration for `rekor-cataloger`. As the cataloger is off-by-default, the following must be specified in a configuration file:
```yaml
rekor-cataloger:
  cataloger:
    enabled: true
``` 

To avoid this, a CLI flag specifically for the rekor-cataloger could be added. Alternatively, a more general CLI flag that filters the file catalogers or the non-package catalogers could be implemented, similar to the cli flag for package catalogers. 

I had some difficulty enabling the `rekor-cataloger` via the configuration when there were other configuration fields also specified. If this is encountered, use a configuration file containing only the rekor-cataloger configuration. I will look at this issue further.  


Signed-off-by: Marco Deicas <mdeicas@google.com>

