### PR TITLE
Fix RPM DB license handling

### DIFF
--- a/internal/formats/common/spdxhelpers/to_syft_model.go
+++ b/internal/formats/common/spdxhelpers/to_syft_model.go
@@ -322,13 +322,17 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 		} else {
 			epoch = &converted
 		}
+		license := p.PackageLicenseDeclared
+		if license == "" {
+			license = p.PackageLicenseConcluded
+		}
 		return pkg.RpmdbMetadataType, pkg.RpmdbMetadata{
 			Name:      p.PackageName,
 			Version:   p.PackageVersion,
 			Epoch:     epoch,
 			Arch:      arch,
 			SourceRpm: upstreamValue,
-			License:   p.PackageLicenseConcluded,
+			License:   license,
 			Vendor:    p.PackageOriginatorOrganization,
 		}
 	case pkg.DebPkg:

--- a/syft/pkg/cataloger/rpmdb/parse_rpmdb.go
+++ b/syft/pkg/cataloger/rpmdb/parse_rpmdb.go
@@ -92,6 +92,10 @@ func newPkg(resolver source.FilePathResolver, dbLocation source.Location, entry 
 		Metadata:     metadata,
 	}
 
+	if entry.License != "" {
+		p.Licenses = append(p.Licenses, entry.License)
+	}
+
 	p.SetID()
 	return &p, nil
 }

--- a/syft/pkg/cataloger/rpmdb/parse_rpmdb_test.go
+++ b/syft/pkg/cataloger/rpmdb/parse_rpmdb_test.go
@@ -75,6 +75,7 @@ func TestParseRpmDB(t *testing.T) {
 					FoundBy:      catalogerName,
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmdbMetadataType,
+					Licenses:     []string{"MIT"},
 					Metadata: pkg.RpmdbMetadata{
 						Name:      "dive",
 						Epoch:     nil,
@@ -102,6 +103,7 @@ func TestParseRpmDB(t *testing.T) {
 					FoundBy:      catalogerName,
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmdbMetadataType,
+					Licenses:     []string{"MIT"},
 					Metadata: pkg.RpmdbMetadata{
 						Name:      "dive",
 						Epoch:     nil,


### PR DESCRIPTION
This PR corrects handling of licenses with RPM DB parsing by including licenses in the `Package.Licenses`.

Fixes #660 