### PR TITLE
Normalize syft-json output

### DIFF
--- a/internal/formats/syftjson/to_format_model.go
+++ b/internal/formats/syftjson/to_format_model.go
@@ -215,6 +215,15 @@ func toRelationshipModel(relationships []artifact.Relationship) []model.Relation
 			Metadata: r.Data,
 		}
 	}
+	sort.Slice(result, func(i, j int) bool {
+		if iParent, jParent := result[i].Parent, result[j].Parent; iParent != jParent {
+			return iParent < jParent
+		}
+		if iChild, jChild := result[i].Child, result[j].Child; iChild != jChild {
+			return iChild < jChild
+		}
+		return result[i].Type < result[j].Type
+	})
 	return result
 }
 

--- a/syft/pkg/catalog.go
+++ b/syft/pkg/catalog.go
@@ -203,6 +203,10 @@ func (c *Catalog) Sorted(types ...Type) (pkgs []Package) {
 				iLocations := pkgs[i].Locations.ToSlice()
 				jLocations := pkgs[j].Locations.ToSlice()
 				if pkgs[i].Type == pkgs[j].Type && len(iLocations) > 0 && len(jLocations) > 0 {
+					if iLocations[0].String() == jLocations[0].String() {
+						// compare IDs as a final fallback
+						return pkgs[i].ID() < pkgs[j].ID()
+					}
 					return iLocations[0].String() < jLocations[0].String()
 				}
 				return pkgs[i].Type < pkgs[j].Type

--- a/syft/pkg/relationships_by_file_ownership.go
+++ b/syft/pkg/relationships_by_file_ownership.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"sort"
+
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/bmatcuk/doublestar/v4"
@@ -34,12 +36,14 @@ func RelationshipsByFileOwnership(catalog *Catalog) []artifact.Relationship {
 	var edges []artifact.Relationship
 	for parentID, children := range relationships {
 		for childID, files := range children {
+			fs := files.List()
+			sort.Strings(fs)
 			edges = append(edges, artifact.Relationship{
 				From: catalog.byID[parentID],
 				To:   catalog.byID[childID],
 				Type: artifact.OwnershipByFileOverlapRelationship,
 				Data: ownershipByFilesMetadata{
-					Files: files.List(),
+					Files: fs,
 				},
 			})
 		}


### PR DESCRIPTION
There are numerous places within syft where a map is iterated over to create a list. Since map iteration is non-deterministic, the order of items within the list is also non-deterministic. While this doesn't impact the semantic meaning of the output, it makes it harder to compare the output of two independent runs of syft.

```sh
syft ghcr.io/jenkins-x/jx-scm -o syft-json > a.json
syft ghcr.io/jenkins-x/jx-scm -o syft-json > b.json
diff a.json b.json
```

Without this PR there is a diff, with this PR the diff is empty.

This PR is a band-aid to address the most common sources of drift. There are certainly other sources that are not addressed.

Related #331 #292

Signed-off-by: Scott Andrews <andrewssc@vmware.com>