### PR TITLE
feat: attest support for Singularity images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -334,7 +334,7 @@ require (
 	// we are hinting brotli to latest due to warning when installing archiver v3:
 	// go: warning: github.com/andybalholm/brotli@v1.0.1: retracted by module author: occasional panics and data corruption
 	github.com/andybalholm/brotli v1.0.4 // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
 )
 


### PR DESCRIPTION
Add support for `syft attest` with Singularity images. Re-factor the attestation code to separate the steps to generate and publish the signed attestation.

To test, I'm generating a test image with [Singularity](https://github.com/sylabs/singularity), for example:

```sh
$ singularity build alpine.sif docker://alpine
...
```

Then generating a signed attestation with Syft (requires the changes in this PR):

```sh
$ syft attest --output syft-json --key cosign.key singularity:alpine.sif > attestation.json
 ✔ Parsed image            
 ✔ Cataloged packages      [14 packages]
```

And finally, to verify the attestation and scan the SBOM with Grype:

```sh
$ grype attestation.json --key cosign.pub
 ✔ Vulnerability DB        [no update available]
 ✔ Attestation verified    
 ✔ Scanned image           [0 vulnerabilities]
No vulnerabilities found
```

Closes #1193