### PR TITLE
feat: Add support for npm lockfile version 3

### DIFF
--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -43,13 +43,26 @@ func newPackageJSONPackage(u packageJSON, locations ...source.Location) pkg.Pack
 	return p
 }
 
-func newPackageLockPackage(resolver source.FileResolver, location source.Location, name string, u lockDependency, licenseMap map[string]string) pkg.Package {
-	var sb strings.Builder
-	sb.WriteString(u.Resolved)
-	sb.WriteString(u.Integrity)
+func newPackageLockV1Package(resolver source.FileResolver, location source.Location, name string, u lockDependency) pkg.Package {
+	return finalizeLockPkg(
+		resolver,
+		location,
+		pkg.Package{
+			Name:      name,
+			Version:   u.Version,
+			Locations: source.NewLocationSet(location),
+			PURL:      packageURL(name, u.Version),
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+		},
+	)
+}
+
+func newPackageLockV2Package(resolver source.FileResolver, location source.Location, name string, u lockPackage) pkg.Package {
 	var licenses []string
-	if l, exists := licenseMap[sb.String()]; exists {
-		licenses = append(licenses, l)
+
+	if u.License != "" {
+		licenses = append(licenses, u.License)
 	}
 
 	return finalizeLockPkg(

--- a/syft/pkg/cataloger/javascript/parse_package_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock_test.go
@@ -103,6 +103,13 @@ func TestParsePackageLockV2(t *testing.T) {
 	var expectedRelationships []artifact.Relationship
 	expectedPkgs := []pkg.Package{
 		{
+			Name:     "npm",
+			Version:  "6.14.6",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/npm@6.14.6",
+		},
+		{
 			Name:     "@types/prop-types",
 			Version:  "15.7.5",
 			PURL:     "pkg:npm/%40types/prop-types@15.7.5",
@@ -133,6 +140,52 @@ func TestParsePackageLockV2(t *testing.T) {
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
 			Licenses: []string{"MIT"},
+		},
+	}
+	for i := range expectedPkgs {
+		expectedPkgs[i].Locations.Add(source.NewLocation(fixture))
+	}
+	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+}
+
+func TestParsePackageLockV3(t *testing.T) {
+	fixture := "test-fixtures/pkg-lock/package-lock-3.json"
+	var expectedRelationships []artifact.Relationship
+	expectedPkgs := []pkg.Package{
+		{
+			Name:     "lock-v3-fixture",
+			Version:  "1.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/lock-v3-fixture@1.0.0",
+		},
+		{
+			Name:     "@types/prop-types",
+			Version:  "15.7.5",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/prop-types@15.7.5",
+		},
+		{
+			Name:     "@types/react",
+			Version:  "18.0.20",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/react@18.0.20",
+		},
+		{
+			Name:     "@types/scheduler",
+			Version:  "0.16.2",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/scheduler@0.16.2",
+		},
+		{
+			Name:     "csstype",
+			Version:  "3.1.1",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/csstype@3.1.1",
 		},
 	}
 	for i := range expectedPkgs {

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-lock/package-lock-3.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-lock/package-lock-3.json
@@ -1,0 +1,40 @@
+{
+  "name": "lock-v3-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lock-v3-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/react": "^18.0.9"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.20.tgz",
+      "integrity": "sha512-MWul1teSPxujEHVwZl4a5HxQ9vVNsjTchVA+xRqv/VYGCuKGAU6UhfrTdF5aBefwD1BHUD8i/zq+O/vyCm/FrA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for npm lockfile version 3, which drops the "dependencies" key and uses "packages" instead. I've refactored the lockfile parser to make the distinction between the versions explicit rather than the implicit behaviour before. It _might_ be worth splitting into separate files at some point, but the logic is so minimal that I haven't done it.

Some open questions;

- Does the code look vaguely correct? I don't know Go well at all
- I can't find good documentation around the presence of the "license" key under the "packages" entries. It seems to be present in the v2 fixture, but I couldn't recreate that locally.
- Are there other places that I need to add / update tests?

Fixes #1203