### PR TITLE
refactor: replace ioutil=>io; update linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -31,20 +30,18 @@ linters:
     - nakedret
     - nolintlint
     - revive
-    - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 # do not enable...
 #    - gochecknoglobals
 #    - gochecknoinits    # this is too aggressive
+#    - rowserrcheck disabled per generics https://github.com/golangci/golangci-lint/issues/2649
 #    - godot
 #    - godox
 #    - goerr113

--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -3,7 +3,7 @@ package packages
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/wagoodman/go-partybus"
@@ -162,7 +162,7 @@ func runPackageSbomUpload(src *source.Source, s sbom.SBOM, app *config.Applicati
 			return fmt.Errorf("unable to open dockerfile=%q: %w", app.Anchore.Dockerfile, err)
 		}
 
-		dockerfileContents, err = ioutil.ReadAll(fh)
+		dockerfileContents, err = io.ReadAll(fh)
 		if err != nil {
 			return fmt.Errorf("unable to read dockerfile=%q: %w", app.Anchore.Dockerfile, err)
 		}

--- a/syft/file/classifier.go
+++ b/syft/file/classifier.go
@@ -3,7 +3,7 @@ package file
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"text/template"
 
@@ -84,7 +84,7 @@ func (c Classifier) Classify(resolver source.FileResolver, location source.Locat
 	defer internal.CloseAndLogError(contentReader, location.VirtualPath)
 
 	// TODO: there is room for improvement here, as this may use an excessive amount of memory. Alternate approach is to leverage a RuneReader.
-	contents, err := ioutil.ReadAll(contentReader)
+	contents, err := io.ReadAll(contentReader)
 	if err != nil {
 		return nil, err
 	}

--- a/syft/file/secrets_cataloger.go
+++ b/syft/file/secrets_cataloger.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"sort"
 
@@ -111,7 +110,7 @@ func extractValue(resolver source.FileResolver, location source.Location, start,
 	}
 	defer internal.CloseAndLogError(readCloser, location.VirtualPath)
 
-	n, err := io.CopyN(ioutil.Discard, readCloser, start)
+	n, err := io.CopyN(io.Discard, readCloser, start)
 	if err != nil {
 		return "", fmt.Errorf("unable to read contents for location=%q : %w", location, err)
 	}

--- a/syft/file/secrets_search_by_line_strategy.go
+++ b/syft/file/secrets_search_by_line_strategy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 
 	"github.com/anchore/syft/internal"
@@ -79,7 +78,7 @@ func readerAtPosition(resolver source.FileResolver, location source.Location, se
 		return nil, fmt.Errorf("unable to fetch reader for location=%q : %w", location, err)
 	}
 	if seekPosition > 0 {
-		n, err := io.CopyN(ioutil.Discard, readCloser, seekPosition)
+		n, err := io.CopyN(io.Discard, readCloser, seekPosition)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read contents for location=%q while searching for secrets: %w", location, err)
 		}

--- a/syft/pkg/cataloger/golang/internal/xcoff/file.go
+++ b/syft/pkg/cataloger/golang/internal/xcoff/file.go
@@ -4,7 +4,7 @@
 
 // Package xcoff implements access to XCOFF (Extended Common Object File Format) files.
 
-//nolint //this is an internal golang lib
+//nolint:all
 package xcoff
 
 import (

--- a/syft/pkg/cataloger/golang/internal/xcoff/xcoff.go
+++ b/syft/pkg/cataloger/golang/internal/xcoff/xcoff.go
@@ -7,7 +7,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//nolint // this is an internal golang lib
+//nolint:all
 package xcoff
 
 // File Header.

--- a/syft/pkg/cataloger/java/save_archive_to_tmp.go
+++ b/syft/pkg/cataloger/java/save_archive_to_tmp.go
@@ -3,7 +3,6 @@ package java
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -12,7 +11,7 @@ import (
 
 func saveArchiveToTmp(archiveVirtualPath string, reader io.Reader) (string, string, func(), error) {
 	name := filepath.Base(archiveVirtualPath)
-	tempDir, err := ioutil.TempDir("", "syft-archive-contents-")
+	tempDir, err := os.MkdirTemp("", "syft-archive-contents-")
 	if err != nil {
 		return "", "", func() {}, fmt.Errorf("unable to create tempdir for archive processing: %w", err)
 	}

--- a/syft/pkg/cataloger/python/package_cataloger.go
+++ b/syft/pkg/cataloger/python/package_cataloger.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"github.com/anchore/syft/internal"
@@ -169,7 +169,7 @@ func (c *PackageCataloger) fetchDirectURLData(resolver source.FileResolver, meta
 	}
 	defer internal.CloseAndLogError(directURLContents, directURLLocation.VirtualPath)
 
-	buffer, err := ioutil.ReadAll(directURLContents)
+	buffer, err := io.ReadAll(directURLContents)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/syft/pkg/cataloger/rpm/parse_rpmdb.go
+++ b/syft/pkg/cataloger/rpm/parse_rpmdb.go
@@ -3,7 +3,6 @@ package rpm
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
@@ -17,7 +16,7 @@ import (
 
 // parseRpmDb parses an "Packages" RPM DB and returns the Packages listed within it.
 func parseRpmDB(resolver source.FilePathResolver, dbLocation source.Location, reader io.Reader) ([]pkg.Package, error) {
-	f, err := ioutil.TempFile("", internal.ApplicationName+"-rpmdb")
+	f, err := os.CreateTemp("", internal.ApplicationName+"-rpmdb")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp rpmdb file: %w", err)
 	}

--- a/syft/pkg/cataloger/swift/parse_podfile_lock.go
+++ b/syft/pkg/cataloger/swift/parse_podfile_lock.go
@@ -3,7 +3,6 @@ package swift
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -18,7 +17,7 @@ var _ common.ParserFn = parsePodfileLock
 
 // parsePodfileLock is a parser function for Podfile.lock contents, returning all cocoapods pods discovered.
 func parsePodfileLock(_ string, reader io.Reader) ([]*pkg.Package, []artifact.Relationship, error) {
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to read file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Syft's `DEVELOPING.md` instructs the user to boostrap tools and run `make`

The default make step has a couple of errors when running out of the box.

The first is `make lint`:
![Screen Shot 2022-09-16 at 1 29 53 PM](https://user-images.githubusercontent.com/32073428/190698089-a01e3930-e0ec-4ca2-a19c-8d1febd4568f.png)

These errors are correct by changing the directives at the top of these files to the newer `nolint:all`

The second is where `io/util` is considered deprecated in the latest Golang release. These instances have been updated to their latest `os` or `io` equivlants.

Abandoned linters have also been disabled per the warnings from the `golangci` tool:
![Screen Shot 2022-09-16 at 1 32 08 PM](https://user-images.githubusercontent.com/32073428/190698802-3af2542d-c78b-4642-b569-319c05ab0821.png)

### Changes
- remove deprecated linters that have been abandoned
- replace usage of ioutil => io/os upgrades
- update std library copied files to new lint directive

### Follow up
- updating developer.md with better flow diagrams, explanation of what default  `make` does, and shorter introduction commands to get new users up to speed

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>