### PR TITLE
bug: remove chance for panic; provide default attestation path

### DIFF
--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -73,6 +73,11 @@ func Run(ctx context.Context, app *config.Application, ko sigopts.KeyOpts, args 
 	output := parseAttestationOutput(app.Outputs)
 
 	format := syft.FormatByName(output)
+
+	// user typo or unknown outputs provided
+	if format == nil {
+		format = syft.FormatByID(spdx22json.ID) // default attestation format
+	}
 	predicateType := formatPredicateType(format)
 	if predicateType == "" {
 		return fmt.Errorf(

--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -76,7 +76,7 @@ func Run(ctx context.Context, app *config.Application, ko sigopts.KeyOpts, args 
 
 	// user typo or unknown outputs provided
 	if format == nil {
-		format = syft.FormatByID(spdx22json.ID) // default attestation format
+		format = syft.FormatByID(syftjson.ID) // default attestation format
 	}
 	predicateType := formatPredicateType(format)
 	if predicateType == "" {
@@ -118,7 +118,7 @@ func Run(ctx context.Context, app *config.Application, ko sigopts.KeyOpts, args 
 
 func parseAttestationOutput(outputs []string) (format string) {
 	if len(outputs) == 0 {
-		outputs = append(outputs, string(spdx22json.ID))
+		outputs = append(outputs, string(syftjson.ID))
 	}
 
 	return outputs[0]

--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -70,7 +70,9 @@ func Run(ctx context.Context, app *config.Application, ko sigopts.KeyOpts, args 
 		return err
 	}
 
-	format := syft.FormatByName(app.Outputs[0])
+	output := parseAttestationOutput(app.Outputs)
+
+	format := syft.FormatByName(output)
 	predicateType := formatPredicateType(format)
 	if predicateType == "" {
 		return fmt.Errorf(
@@ -107,6 +109,14 @@ func Run(ctx context.Context, app *config.Application, ko sigopts.KeyOpts, args 
 		stereoscope.Cleanup,
 		ui.Select(options.IsVerbose(app), app.Quiet)...,
 	)
+}
+
+func parseAttestationOutput(outputs []string) (format string) {
+	if len(outputs) == 0 {
+		outputs = append(outputs, string(spdx22json.ID))
+	}
+
+	return outputs[0]
 }
 
 func parseImageSource(userInput string, app *config.Application) (s *source.Input, err error) {

--- a/test/cli/attest_cmd_test.go
+++ b/test/cli/attest_cmd_test.go
@@ -40,6 +40,14 @@ func TestAttestCmd(t *testing.T) {
 			},
 			pw: "",
 		},
+		{
+			name: "can encode syft.json as the predicate given a user format typo",
+			args: []string{"attest", "-o", "spdx-jsonx", "--key", "cosign.key", img},
+			assertions: []traitAssertion{
+				assertSuccessfulReturnCode,
+			},
+			pw: "",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Closes #1210 

Given a user could provide a typo value for their desired output, the `format` value in attest had a chance to be `nil`.
This PR adds a guard against `FormatByName` returning nil by adding a default format attestation path as `syft-json`.

Another option is we could error out and inform the user that their format is unrecognized rather than providing a default. I'm open to either approach but chose to try and provide a successful command rather than error case in this instance.

A CLI test has been added to cover this typo case.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>