### PR TITLE
Follow symlinks when searching for globs in all-layers scope

### DIFF
--- a/syft/source/all_layers_resolver.go
+++ b/syft/source/all_layers_resolver.go
@@ -120,8 +120,6 @@ func (r *allLayersResolver) FilesByPath(paths ...string) ([]Location, error) {
 }
 
 // FilesByGlob returns all file.References that match the given path glob pattern from any layer in the image.
-//
-//nolint:gocognit
 func (r *allLayersResolver) FilesByGlob(patterns ...string) ([]Location, error) {
 	uniqueFileIDs := file.NewFileReferenceSet()
 	uniqueLocations := make([]Location, 0)
@@ -134,14 +132,6 @@ func (r *allLayersResolver) FilesByGlob(patterns ...string) ([]Location, error) 
 			}
 
 			for _, result := range results {
-				found, _, err := r.img.Layers[layerIdx].Tree.File(result.RealPath)
-				if err != nil {
-					return nil, fmt.Errorf("failed to resolve file during glob resolution %s: %w", result.RealPath, err)
-				}
-				if !found {
-					// this file is not present in the layer
-					continue
-				}
 				// don't consider directories (special case: there is no path information for /)
 				if result.RealPath == "/" {
 					continue

--- a/syft/source/all_layers_resolver.go
+++ b/syft/source/all_layers_resolver.go
@@ -120,18 +120,28 @@ func (r *allLayersResolver) FilesByPath(paths ...string) ([]Location, error) {
 }
 
 // FilesByGlob returns all file.References that match the given path glob pattern from any layer in the image.
+//
+//nolint:gocognit
 func (r *allLayersResolver) FilesByGlob(patterns ...string) ([]Location, error) {
 	uniqueFileIDs := file.NewFileReferenceSet()
 	uniqueLocations := make([]Location, 0)
 
 	for _, pattern := range patterns {
 		for idx, layerIdx := range r.layers {
-			results, err := r.img.Layers[layerIdx].Tree.FilesByGlob(pattern, filetree.FollowBasenameLinks, filetree.DoNotFollowDeadBasenameLinks)
+			results, err := r.img.Layers[layerIdx].SquashedTree.FilesByGlob(pattern, filetree.FollowBasenameLinks, filetree.DoNotFollowDeadBasenameLinks)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve files by glob (%s): %w", pattern, err)
 			}
 
 			for _, result := range results {
+				found, _, err := r.img.Layers[layerIdx].Tree.File(result.RealPath)
+				if err != nil {
+					return nil, fmt.Errorf("failed to resolve file during glob resolution %s: %w", result.RealPath, err)
+				}
+				if !found {
+					// this file is not present in the layer
+					continue
+				}
 				// don't consider directories (special case: there is no path information for /)
 				if result.RealPath == "/" {
 					continue

--- a/test/integration/all_layers_squashed_comparison_test.go
+++ b/test/integration/all_layers_squashed_comparison_test.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/source"
+)
+
+func Test_AllLayersIncludesSquashed(t *testing.T) {
+	// This is a verification test for issue #894 (https://github.com/anchore/syft/issues/894)
+	allLayers, _ := catalogFixtureImage(t, "image-suse-all-layers", source.AllLayersScope, nil)
+	squashed, _ := catalogFixtureImage(t, "image-suse-all-layers", source.SquashedScope, nil)
+
+	lenAllLayers := len(allLayers.Artifacts.PackageCatalog.Sorted())
+	lenSquashed := len(squashed.Artifacts.PackageCatalog.Sorted())
+
+	if lenAllLayers < lenSquashed {
+		t.Errorf("squashed has more packages than all-layers: %d > %d", lenSquashed, lenAllLayers)
+	}
+}

--- a/test/integration/test-fixtures/image-suse-all-layers/Dockerfile
+++ b/test/integration/test-fixtures/image-suse-all-layers/Dockerfile
@@ -1,0 +1,2 @@
+FROM registry.suse.com/suse/sle15:15.3.17.20.20
+RUN zypper in -y wget


### PR DESCRIPTION
This PR modifies the behavior when using `all-layers` scope such that symlinks from prior layers work properly.

There was an issue reported where a SUSE RPM database was changed but the change was not identified because the symlink did not change and the SUSE location did not match the recognized location for the RPM database. Now, regardless of the layer a symlink is introduced in, it should work as expected to match globs.

Precursor for https://github.com/anchore/grype/issues/894 