### PR TITLE
Support exclude patterns on Windows

### DIFF
--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -392,6 +392,9 @@ func getDirectoryExclusionFunctions(root string, exclusions []string) ([]pathFil
 		return nil, err
 	}
 
+	// this handles Windows file paths by converting them to C:/something/else format
+	root = filepath.ToSlash(root)
+
 	if !strings.HasSuffix(root, "/") {
 		root += "/"
 	}
@@ -414,6 +417,8 @@ func getDirectoryExclusionFunctions(root string, exclusions []string) ([]pathFil
 	return []pathFilterFn{
 		func(path string, _ os.FileInfo) bool {
 			for _, exclusion := range exclusions {
+				// this is required to handle Windows filepaths
+				path = filepath.ToSlash(path)
 				matches, err := doublestar.Match(exclusion, path)
 				if err != nil {
 					return false

--- a/syft/source/source_win_test.go
+++ b/syft/source/source_win_test.go
@@ -1,0 +1,54 @@
+//go:build windows
+// +build windows
+
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_crossPlatformExclusions(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		root    string
+		path    string
+		exclude string
+		match   bool
+	}{
+		{
+			desc:    "windows doublestar",
+			root:    "C:\\User\\stuff",
+			path:    "C:\\User\\stuff\\thing.txt",
+			exclude: "**/*.txt",
+			match:   true,
+		},
+		{
+			desc:    "windows relative",
+			root:    "C:\\User\\stuff",
+			path:    "C:\\User\\stuff\\thing.txt",
+			exclude: "./*.txt",
+			match:   true,
+		},
+		{
+			desc:    "windows one level",
+			root:    "C:\\User\\stuff",
+			path:    "C:\\User\\stuff\\thing.txt",
+			exclude: "*/*.txt",
+			match:   false,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			fns, err := getDirectoryExclusionFunctions(test.root, []string{test.exclude})
+			require.NoError(t, err)
+
+			for _, f := range fns {
+				result := f(test.path, nil)
+				require.Equal(t, test.match, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes `--exclude` patterns on Windows along with adding some additional testing. However, since we are not utilizing any Windows runners, the test will not run as part of CI currently, so there is an approximation of it that runs on Linux.

Fixes #1024 