### PR TITLE
Do not fail if unable to parse `.rpm` file

### DIFF
--- a/syft/pkg/cataloger/rpm/file_cataloger.go
+++ b/syft/pkg/cataloger/rpm/file_cataloger.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sassoftware/go-rpmutils"
 
 	"github.com/anchore/syft/internal"
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -28,6 +29,7 @@ func (c *FileCataloger) Name() string {
 }
 
 // Catalog is given an object to resolve file references and content, this function returns any discovered Packages after analyzing rpm files
+//nolint:funlen
 func (c *FileCataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, []artifact.Relationship, error) {
 	fileMatches, err := resolver.FilesByGlob("**/*.rpm")
 	if err != nil {
@@ -43,7 +45,8 @@ func (c *FileCataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, []
 
 		rpm, err := rpmutils.ReadRpm(contentReader)
 		if err != nil {
-			return nil, nil, err
+			log.Debugf("RPM file found but unable to read: %s (%v)", location.RealPath, err)
+			continue
 		}
 
 		nevra, err := rpm.Header.GetNEVRA()

--- a/syft/pkg/cataloger/rpm/file_cataloger.go
+++ b/syft/pkg/cataloger/rpm/file_cataloger.go
@@ -29,6 +29,7 @@ func (c *FileCataloger) Name() string {
 }
 
 // Catalog is given an object to resolve file references and content, this function returns any discovered Packages after analyzing rpm files
+//
 //nolint:funlen
 func (c *FileCataloger) Catalog(resolver source.FileResolver) ([]pkg.Package, []artifact.Relationship, error) {
 	fileMatches, err := resolver.FilesByGlob("**/*.rpm")

--- a/syft/pkg/cataloger/rpm/file_cataloger_test.go
+++ b/syft/pkg/cataloger/rpm/file_cataloger_test.go
@@ -79,6 +79,9 @@ func TestParseRpmFiles(t *testing.T) {
 				},
 			},
 		},
+		{
+			fixture: "test-fixtures/bad",
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/rpm/test-fixtures/bad/bad.rpm
+++ b/syft/pkg/cataloger/rpm/test-fixtures/bad/bad.rpm
@@ -1,0 +1,1 @@
+this is not a real RPM file


### PR DESCRIPTION
This PR allows cataloging to continue if a file with `.rpm` extension is found but unable to be parsed as an RPM file.

Fixes: #1231 