### PR TITLE
update requires to use list; remove field

### DIFF
--- a/syft/pkg/cataloger/cpp/parse_conanlock.go
+++ b/syft/pkg/cataloger/cpp/parse_conanlock.go
@@ -16,15 +16,14 @@ var _ common.ParserFn = parseConanlock
 type conanLock struct {
 	GraphLock struct {
 		Nodes map[string]struct {
-			Ref            string `json:"ref"`
-			PackageID      string `json:"package_id"`
-			Context        string `json:"context"`
-			Prev           string `json:"prev"`
-			Requires       string `json:"requires"`
-			BuildRequires  string `json:"build_requires"`
-			PythonRequires string `json:"py_requires"`
-			Options        string `json:"options"`
-			Path           string `json:"path"`
+			Ref            string   `json:"ref"`
+			PackageID      string   `json:"package_id"`
+			Context        string   `json:"context"`
+			Prev           string   `json:"prev"`
+			Requires       []string `json:"requires"`
+			PythonRequires string   `json:"py_requires"`
+			Options        string   `json:"options"`
+			Path           string   `json:"path"`
 		} `json:"nodes"`
 	} `json:"graph_lock"`
 	Version     string `json:"version"`

--- a/syft/pkg/cataloger/cpp/test-fixtures/conan.lock
+++ b/syft/pkg/cataloger/cpp/test-fixtures/conan.lock
@@ -4,6 +4,7 @@
    "0": {
     "ref": "zlib/1.2.12",
     "options": "fPIC=True\nshared=False",
+    "requires": [],
     "path": "all/conanfile.py",
     "context": "host"
    }


### PR DESCRIPTION
Incorrect data type being used for requires. Was string ==> now slice of string.

`BuildRequires` was also not a part of the conan.lock spec anymore so removing

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>