### PR TITLE
Add rekor-cataloger parsing JSON SPDX document

### DIFF
--- a/syft/rekor/utils.go
+++ b/syft/rekor/utils.go
@@ -151,13 +151,13 @@ func parseAndValidateAttestation(entry *models.LogEntryAnon) (in_toto.Subject, s
 
 func parseSbom(spdxBytes *[]byte) (*spdx.Document2_2, error) {
 	// Check format of SPDX document (for now assume either JSON or tag value)
-	isJson := json.Valid(*spdxBytes)
+	isJSON := json.Valid(*spdxBytes)
 
 	var (
 		sbom *spdx.Document2_2
 		err  error
 	)
-	if isJson {
+	if isJSON {
 		sbom, err = jsonloader.Load2_2(bytes.NewReader(*spdxBytes))
 		if err != nil {
 			return nil, fmt.Errorf("error loading sbomBytes into spdx.Document2_2 type: %w", err)

--- a/syft/rekor/utils_test.go
+++ b/syft/rekor/utils_test.go
@@ -2,6 +2,7 @@ package rekor
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -97,6 +98,43 @@ func Test_parseAndValidateAttestation(t *testing.T) {
 			assert.ErrorContains(t, err, test.expectedErr)
 		})
 	}
+}
+
+func Test_getSbom(t *testing.T) {
+
+	tests := []struct {
+		name      string
+		sbomFile  string
+		expectErr bool
+	}{
+		{
+			name:     "simple SPDX tag-value",
+			sbomFile: "test-fixtures/sboms/sbom-1.txt",
+		},
+		{
+			name:     "simple SPDX JSON",
+			sbomFile: "test-fixtures/sboms/sbom-4.json",
+		},
+		{
+			name:      "invalid SPDX file",
+			sbomFile:  "test-fixtures/sboms/sbom-invalid.txt",
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := ioutil.ReadFile(tt.sbomFile)
+			if err != nil {
+				assert.FailNow(t, "error reading test data")
+			}
+
+			_, err = parseSbom(&b)
+			if (err != nil) != tt.expectErr {
+				assert.FailNow(t, "expected error: got %v, expected %v", err != nil, tt.expectErr)
+			}
+		})
+	}
+
 }
 
 // do validation of hash in subject


### PR DESCRIPTION
For the SBOM discovered via rekor cataloger, it was assumed that the file is SPDX Tag-Value. Added support for SPDX JSON.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>