### PR TITLE
feat: add identifiable field to source object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/google/go-containerregistry v0.11.0
 	github.com/in-toto/in-toto-golang v0.3.4-0.20220709202702-fa494aaa0add
 	github.com/knqyf263/go-rpmdb v0.0.0-20220629110411-9a3bd2ebb923
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/sassoftware/go-rpmutils v0.2.0
 	github.com/sigstore/cosign v1.12.1
 	github.com/sigstore/rekor v0.12.1-0.20220915152154-4bb6f441c1b2
@@ -218,7 +219,6 @@ require (
 	github.com/mozillazg/docker-credential-acr-helper v0.3.0 // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -307,7 +307,10 @@ func NewFromImage(img *image.Image, userImageStr string) (Source, error) {
 	}, nil
 }
 
-func (s *Source) ID() artifact.ID {
+func (s Source) ID() artifact.ID {
+	if s.id == "" {
+		s.SetID()
+	}
 	return s.id
 }
 

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -350,7 +350,6 @@ func (s *Source) SetID() {
 	}
 
 	s.id = artifact.ID(strings.TrimPrefix(d, "sha256:"))
-	return
 }
 
 func calculateChainID(img *image.Image) string {

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -65,6 +65,44 @@ func TestNewFromImageFails(t *testing.T) {
 	})
 }
 
+func TestSetID(t *testing.T) {
+	img := imagetest.GetFixtureImage(t, "oci-archive", "image-simple")
+	tests := []struct {
+		name     string
+		input    *Source
+		expected string
+	}{
+		{
+			name: "source.SetID sets the ID for non image sources",
+			input: &Source{
+				Metadata: Metadata{
+					Scheme: FileScheme,
+					Path:   "test-fixtures/image-simple/file-1.txt",
+				},
+			},
+			expected: "sha256:fbfb0730f4306b27c118715998ba58f1ad350f0451513c36c267dc4b9d3b688d",
+		},
+		{
+			name: "source.SetID sets the ID for image sources",
+			input: &Source{
+				Image: img,
+				Metadata: Metadata{
+					Scheme:        ImageScheme,
+					ImageMetadata: NewImageMetadata(img, "image-simple"),
+				},
+			},
+			expected: "sha256:e6d9f87981af1a1007a42be43b21ba6abe7c1608b1541e877c69052af5356669",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.input.SetID()
+			assert.Equal(t, test.expected, test.input.ID())
+		})
+	}
+}
+
 func TestNewFromImage(t *testing.T) {
 	layer := image.NewLayer(nil)
 	img := image.Image{


### PR DESCRIPTION
Allow source.Source struct to set reproducible id for the following scheme:

- DirectoryScheme
- FileScheme
- ImageScheme
- UnknownScheme 

This ID is calculated in the following ways: 
- a digest from the given directory path
- the digest of the file contents or file path 
- the digest of the image manifest 
    - if this cannot be found it is calculated as a ChainID: https://github.com/opencontainers/image-spec/blob/main/config.md#layer-chainid
- If the scheme is unknown then the ID is calculated as a Hash of the source struct.

Followups coming in separate smaller PR:
- [ ] Add ID field to source and generate a relationship to packages
- [ ] Update SPDX format to reflect this relationship of source --> package via [OCI PURL](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci)

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>