### PR TITLE
Fix apkdb checksum representation

### DIFF
--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -41,7 +42,7 @@ func TestExtraFileAttributes(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1M0C9qfC/+kdRiOodeihG2GMRtkE=",
 						},
 					},
@@ -110,7 +111,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
 						},
 					},
@@ -126,7 +127,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
 						},
 					},
@@ -136,7 +137,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
 						},
 					},
@@ -146,7 +147,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
 						},
 					},
@@ -156,7 +157,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
 						},
 					},
@@ -195,49 +196,49 @@ func TestSinglePackageDetails(t *testing.T) {
 					{
 						Path: "/etc/fstab",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q11Q7hNe8QpDS531guqCdrXBzoA/o=",
 						},
 					},
 					{
 						Path: "/etc/group",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1oJ16xWudgKOrXIEquEDzlF2Lsm4=",
 						},
 					},
 					{
 						Path: "/etc/hostname",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q16nVwYVXP/tChvUPdukVD2ifXOmc=",
 						},
 					},
 					{
 						Path: "/etc/hosts",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1BD6zJKZTRWyqGnPi4tSfd3krsMU=",
 						},
 					},
 					{
 						Path: "/etc/inittab",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1TsthbhW7QzWRe1E/NKwTOuD4pHc=",
 						},
 					},
 					{
 						Path: "/etc/modules",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1toogjUipHGcMgECgPJX64SwUT1M=",
 						},
 					},
 					{
 						Path: "/etc/motd",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1XmduVVNURHQ27TvYp1Lr5TMtFcA=",
 						},
 					},
@@ -247,35 +248,35 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "777",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1kiljhXXH1LlQroHsEJIkPZg2eiw=",
 						},
 					},
 					{
 						Path: "/etc/passwd",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1TchuuLUfur0izvfZQZxgN/LJhB8=",
 						},
 					},
 					{
 						Path: "/etc/profile",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1KpFb8kl5LvwXWlY3e58FNsjrI34=",
 						},
 					},
 					{
 						Path: "/etc/protocols",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q13FqXUnvuOpMDrH/6rehxuYAEE34=",
 						},
 					},
 					{
 						Path: "/etc/services",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1C6HJNgQvLWqt5VY+n7MZJ1rsDuY=",
 						},
 					},
@@ -285,21 +286,21 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "42",
 						Permissions: "640",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1ltrPIAW2zHeDiajsex2Bdmq3uqA=",
 						},
 					},
 					{
 						Path: "/etc/shells",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1ojm2YdpCJ6B/apGDaZ/Sdb2xJkA=",
 						},
 					},
 					{
 						Path: "/etc/sysctl.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q14upz3tfnNxZkIEsUhWn7Xoiw96g=",
 						},
 					},
@@ -318,7 +319,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "600",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1vfk1apUWI4yLJGhhNRd0kJixfvY=",
 						},
 					},
@@ -331,28 +332,28 @@ func TestSinglePackageDetails(t *testing.T) {
 					{
 						Path: "/etc/modprobe.d/aliases.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1WUbh6TBYNVK7e4Y+uUvLs/7viqk=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/blacklist.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1xxYGU6S6TLQvb7ervPrWWwAWqMg=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/i386.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1pnay/njn6ol9cCssL7KiZZ8etlc=",
 						},
 					},
 					{
 						Path: "/etc/modprobe.d/kms.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1ynbLn3GYDpvajba/ldp1niayeog=",
 						},
 					},
@@ -401,14 +402,14 @@ func TestSinglePackageDetails(t *testing.T) {
 					{
 						Path: "/etc/profile.d/color_prompt",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q10wL23GuSCVfumMRgakabUI6EsSk=",
 						},
 					},
 					{
 						Path: "/etc/profile.d/locale",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1R4bIEpnKxxOSrlnZy9AoawqZ5DU=",
 						},
 					},
@@ -436,7 +437,7 @@ func TestSinglePackageDetails(t *testing.T) {
 					{
 						Path: "/lib/sysctl.d/00-alpine.conf",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1HpElzW1xEgmKfERtTy7oommnq6c=",
 						},
 					},
@@ -479,7 +480,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "755",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1YeuSmC7iDbEWrusPzA/zUQF6YSg=",
 						},
 					},
@@ -537,7 +538,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "777",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q11/SNZz/8cK2dSKK+cJpVrZIuF4Q=",
 						},
 					},
@@ -586,7 +587,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "777",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1dzbdazYZA2nTzSIG3YyNw7d4Juc=",
 						},
 					},
@@ -599,7 +600,7 @@ func TestSinglePackageDetails(t *testing.T) {
 						OwnerGID:    "0",
 						Permissions: "777",
 						Digest: &file.Digest{
-							Algorithm: "sha1",
+							Algorithm: "'Q1'+base64(sha1)",
 							Value:     "Q1OFZt+ZMp7j0Gny0rqSKuWJyqYmA=",
 						},
 					},
@@ -704,7 +705,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerGID:    "0",
 								Permissions: "755",
 								Digest: &file.Digest{
-									Algorithm: "sha1",
+									Algorithm: "'Q1'+base64(sha1)",
 									Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
 								},
 							},
@@ -720,7 +721,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerGID:    "0",
 								Permissions: "755",
 								Digest: &file.Digest{
-									Algorithm: "sha1",
+									Algorithm: "'Q1'+base64(sha1)",
 									Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
 								},
 							},
@@ -730,7 +731,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerGID:    "0",
 								Permissions: "755",
 								Digest: &file.Digest{
-									Algorithm: "sha1",
+									Algorithm: "'Q1'+base64(sha1)",
 									Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
 								},
 							},
@@ -740,7 +741,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerGID:    "0",
 								Permissions: "755",
 								Digest: &file.Digest{
-									Algorithm: "sha1",
+									Algorithm: "'Q1'+base64(sha1)",
 									Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
 								},
 							},
@@ -750,7 +751,7 @@ func TestMultiplePackages(t *testing.T) {
 								OwnerGID:    "0",
 								Permissions: "755",
 								Digest: &file.Digest{
-									Algorithm: "sha1",
+									Algorithm: "'Q1'+base64(sha1)",
 									Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
 								},
 							},
@@ -792,6 +793,36 @@ func TestMultiplePackages(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func Test_processChecksum(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  file.Digest
+	}{
+		{
+			name:  "md5",
+			value: "38870ede8700535d7382ff66a46fcc2f",
+			want: file.Digest{
+				Algorithm: "md5",
+				Value:     "38870ede8700535d7382ff66a46fcc2f",
+			},
+		},
+		{
+			name:  "sha1",
+			value: "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
+			want: file.Digest{
+				Algorithm: "'Q1'+base64(sha1)",
+				Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, &tt.want, processChecksum(tt.value))
 		})
 	}
 }


### PR DESCRIPTION
The apkdb checksum digest algorithm is currently misleading. Today we always list `sha1`, however, the apk-tools indicates that two values are possible: `md5` and `sha1`. In the case where the checksum is a `sha1` a `Q1` value is prepended to the base64 representation of the checksum value.

This PR adds the md5 algorithm indication when found and additionally adds more annotations to the `sha1` case to indicate  the value has additional processing.