### PR TITLE
One more deprecated SPDX license: StandardML-NJ

### DIFF
--- a/internal/spdxlicense/generate/license.go
+++ b/internal/spdxlicense/generate/license.go
@@ -39,6 +39,8 @@ func (l License) canReplace(other License) bool {
 			return true
 		case l.ID == "bzip2-1.0.6" && other.ID == "bzip2-1.0.5":
 			return true
+		case l.ID == "SMLNJ" && other.ID == "StandardML-NJ":
+			return true
 		}
 	}
 


### PR DESCRIPTION
Follow up of #1179 

StandardML-NJ is deprecated and should be replaced by SMLNJ

https://spdx.org/licenses/StandardML-NJ.html

Signed-off-by: Marc-Etienne Vargenau <marc-etienne.vargenau@nokia.com>