### PR TITLE
Add `--name` option to override name in output

### DIFF
--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -124,7 +124,7 @@ func parseAttestationOutput(outputs []string) (format string) {
 }
 
 func parseImageSource(userInput string, app *config.Application) (s *source.Input, err error) {
-	si, err := source.ParseInput(userInput, app.Platform, false)
+	si, err := source.ParseInputWithName(userInput, app.Platform, false, app.Name)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate source input for attest command: %w", err)
 	}

--- a/cmd/syft/cli/options/packages.go
+++ b/cmd/syft/cli/options/packages.go
@@ -21,6 +21,7 @@ type PackagesOptions struct {
 	Platform           string
 	Exclude            []string
 	Catalogers         []string
+	Name               string
 }
 
 var _ Interface = (*PackagesOptions)(nil)
@@ -47,6 +48,9 @@ func (o *PackagesOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
 	cmd.Flags().StringArrayVarP(&o.Catalogers, "catalogers", "", nil,
 		"enable one or more package catalogers")
 
+	cmd.Flags().StringVarP(&o.Name, "name", "", "",
+		"set the name of the target being analyzed")
+
 	return bindPackageConfigOptions(cmd.Flags(), v)
 }
 
@@ -66,6 +70,10 @@ func bindPackageConfigOptions(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	if err := v.BindPFlag("catalogers", flags.Lookup("catalogers")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("name", flags.Lookup("name")); err != nil {
 		return err
 	}
 

--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -42,7 +42,7 @@ func Run(ctx context.Context, app *config.Application, args []string) error {
 
 	// could be an image or a directory, with or without a scheme
 	userInput := args[0]
-	si, err := source.ParseInput(userInput, app.Platform, true)
+	si, err := source.ParseInputWithName(userInput, app.Platform, true, app.Name)
 	if err != nil {
 		return fmt.Errorf("could not generate source input for packages command: %w", err)
 	}

--- a/cmd/syft/cli/poweruser/poweruser.go
+++ b/cmd/syft/cli/poweruser/poweruser.go
@@ -46,7 +46,7 @@ func Run(ctx context.Context, app *config.Application, args []string) error {
 	}()
 
 	userInput := args[0]
-	si, err := source.ParseInput(userInput, app.Platform, true)
+	si, err := source.ParseInputWithName(userInput, app.Platform, true, app.Name)
 	if err != nil {
 		return fmt.Errorf("could not generate source input for packages command: %w", err)
 	}

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -55,6 +55,7 @@ type Application struct {
 	Exclusions         []string           `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
 	Attest             attest             `yaml:"attest" json:"attest" mapstructure:"attest"`
 	Platform           string             `yaml:"platform" json:"platform" mapstructure:"platform"`
+	Name               string             `yaml:"name" json:"name" mapstructure:"name"`
 }
 
 func (cfg Application) ToCatalogerConfig() cataloger.Config {

--- a/syft/formats/common/cyclonedxhelpers/format.go
+++ b/syft/formats/common/cyclonedxhelpers/format.go
@@ -152,8 +152,12 @@ func toDependencies(relationships []artifact.Relationship) []cyclonedx.Dependenc
 }
 
 func toBomDescriptorComponent(srcMetadata source.Metadata) *cyclonedx.Component {
+	name := srcMetadata.Name
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
+		if name == "" {
+			name = srcMetadata.ImageMetadata.UserInput
+		}
 		bomRef, err := artifact.IDByHash(srcMetadata.ImageMetadata.ID)
 		if err != nil {
 			log.Warnf("unable to get fingerprint of image metadata=%s: %+v", srcMetadata.ImageMetadata.ID, err)
@@ -161,10 +165,13 @@ func toBomDescriptorComponent(srcMetadata source.Metadata) *cyclonedx.Component 
 		return &cyclonedx.Component{
 			BOMRef:  string(bomRef),
 			Type:    cyclonedx.ComponentTypeContainer,
-			Name:    srcMetadata.ImageMetadata.UserInput,
+			Name:    name,
 			Version: srcMetadata.ImageMetadata.ManifestDigest,
 		}
 	case source.DirectoryScheme, source.FileScheme:
+		if name == "" {
+			name = srcMetadata.Path
+		}
 		bomRef, err := artifact.IDByHash(srcMetadata.Path)
 		if err != nil {
 			log.Warnf("unable to get fingerprint of source metadata path=%s: %+v", srcMetadata.Path, err)
@@ -172,7 +179,7 @@ func toBomDescriptorComponent(srcMetadata source.Metadata) *cyclonedx.Component 
 		return &cyclonedx.Component{
 			BOMRef: string(bomRef),
 			Type:   cyclonedx.ComponentTypeFile,
-			Name:   srcMetadata.Path,
+			Name:   name,
 		}
 	}
 

--- a/syft/formats/common/spdxhelpers/document_name.go
+++ b/syft/formats/common/spdxhelpers/document_name.go
@@ -8,6 +8,10 @@ import (
 )
 
 func DocumentName(srcMetadata source.Metadata) string {
+	if srcMetadata.Name != "" {
+		return cleanName(srcMetadata.Name)
+	}
+
 	switch srcMetadata.Scheme {
 	case source.ImageScheme:
 		return cleanName(srcMetadata.ImageMetadata.UserInput)

--- a/syft/source/metadata.go
+++ b/syft/source/metadata.go
@@ -6,4 +6,5 @@ type Metadata struct {
 	Scheme        Scheme        // the source data scheme type (directory or image)
 	ImageMetadata ImageMetadata // all image info (image only)
 	Path          string        // the root path to be cataloged (directory only)
+	Name          string
 }

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -120,7 +120,7 @@ func TestSetID(t *testing.T) {
 					Path:   "test-fixtures/image-simple",
 				},
 			},
-			expected: artifact.ID("26e8f4daad203793"),
+			expected: artifact.ID("14b60020c4f9955"),
 		},
 	}
 


### PR DESCRIPTION
A small pain point for me when generating SBOMs is that I want to have fine-grained control over the output, and specifically attempt to cleanup the recorded source from which the SBOM was produced. For example, I might mount a container filesystem to `/mnt` and then scan it - or I might unpack it into the current directory and perform a scan - or I might scan it as part of a build step (and then push an image later to a different production location). For my use case, I'd like that to remain an implementation detail, and not be exposed to the end user - a detail as to where the original path was on my machine isn't relevant to my user, so ideally I'd like to be able to hide those details.

As a (very) naive attempt, I've added a new `--name` flag to the CLI, which is propagated through to the formatters, to then control the various "name" fields, which would otherwise be automatically derived from the path name, or container path passed.

E.g. in SPDX-JSON:

```json
{
 "SPDXID": "SPDXRef-DOCUMENT",
 "name": "<NAME GOES HERE>",
 "spdxVersion": "SPDX-2.2",
 ...
```

E.g. in CycloneDX-JSON:

```json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:d34c78cc-412b-4887-9db0-21450a667f5a",
  "version": 1,
  "metadata": {
    "timestamp": "2022-10-17T13:54:03+01:00",
    "tools": [
      {
        "vendor": "anchore",
        "name": "syft",
        "version": "[not provided]"
      }
    ],
    "component": {
      "bom-ref": "371840ed01a6c73f",
      "type": "file",
      "name": "<NAME GOES HERE>"
    }
  },
  ...
```

I'm opening this more as a proposal, with an attempt to find a solution :smile: -- I'm not particularly tied to the approach in here (it's quite messy), but I thought I'd show what I quickly hacked together, even though it's likely the actual solution would probably look quite different :eyes:. I can always modify the SBOM for now, but I'd love to have something in Syft