### PR TITLE
Port apk cataloger to new generic cataloger pattern

### DIFF
--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -5,17 +5,12 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 
-	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/file"
-	"github.com/anchore/syft/syft/linux"
 )
 
 const ApkDBGlob = "**/lib/apk/db/installed"
 
-var (
-	_ FileOwner     = (*ApkMetadata)(nil)
-	_ urlIdentifier = (*ApkMetadata)(nil)
-)
+var _ FileOwner = (*ApkMetadata)(nil)
 
 // ApkMetadata represents all captured data for a Alpine DB package entry.
 // See the following sources for more information:
@@ -46,31 +41,6 @@ type ApkFileRecord struct {
 	OwnerGID    string       `json:"ownerGid,omitempty"`
 	Permissions string       `json:"permissions,omitempty"`
 	Digest      *file.Digest `json:"digest,omitempty"`
-}
-
-// PackageURL returns the PURL for the specific Alpine package (see https://github.com/package-url/purl-spec)
-func (m ApkMetadata) PackageURL(distro *linux.Release) string {
-	qualifiers := map[string]string{
-		PURLQualifierArch: m.Architecture,
-	}
-
-	if m.OriginPackage != "" {
-		qualifiers[PURLQualifierUpstream] = m.OriginPackage
-	}
-
-	return packageurl.NewPackageURL(
-		// note: this is currently a candidate and not technically within spec
-		// see https://github.com/package-url/purl-spec#other-candidate-types-to-define
-		"alpine",
-		"",
-		m.Package,
-		m.Version,
-		PURLQualifiers(
-			qualifiers,
-			distro,
-		),
-		"",
-	).ToString()
 }
 
 func (m ApkMetadata) OwnedFiles() (result []string) {

--- a/syft/pkg/cataloger/apkdb/cataloger.go
+++ b/syft/pkg/cataloger/apkdb/cataloger.go
@@ -5,14 +5,13 @@ package apkdb
 
 import (
 	"github.com/anchore/syft/syft/pkg"
-	"github.com/anchore/syft/syft/pkg/cataloger/common"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
 )
 
-// NewApkdbCataloger returns a new Alpine DB cataloger object.
-func NewApkdbCataloger() *common.GenericCataloger {
-	globParsers := map[string]common.ParserFn{
-		pkg.ApkDBGlob: parseApkDB,
-	}
+const catalogerName = "apkdb-cataloger"
 
-	return common.NewGenericCataloger(nil, globParsers, "apkdb-cataloger")
+// NewApkdbCataloger returns a new Alpine DB cataloger object.
+func NewApkdbCataloger() *generic.Cataloger {
+	return generic.NewCataloger(catalogerName).
+		WithParserByGlobs(parseApkDB, pkg.ApkDBGlob)
 }

--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -1,0 +1,57 @@
+package apkdb
+
+import (
+	"strings"
+
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/linux"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
+)
+
+func newPackage(d pkg.ApkMetadata, release *linux.Release, locations ...source.Location) pkg.Package {
+	p := pkg.Package{
+		Name:         d.Package,
+		Version:      d.Version,
+		Locations:    source.NewLocationSet(locations...),
+		Licenses:     strings.Split(d.License, " "),
+		PURL:         packageURL(d, release),
+		Type:         pkg.ApkPkg,
+		MetadataType: pkg.ApkMetadataType,
+		Metadata:     d,
+	}
+
+	p.SetID()
+
+	return p
+}
+
+// packageURL returns the PURL for the specific Alpine package (see https://github.com/package-url/purl-spec)
+func packageURL(m pkg.ApkMetadata, distro *linux.Release) string {
+	if distro == nil || distro.ID != "alpine" {
+		// note: there is no namespace variation (like with debian ID_LIKE for ubuntu ID, for example)
+		return ""
+	}
+
+	qualifiers := map[string]string{
+		pkg.PURLQualifierArch: m.Architecture,
+	}
+
+	if m.OriginPackage != "" {
+		qualifiers[pkg.PURLQualifierUpstream] = m.OriginPackage
+	}
+
+	return packageurl.NewPackageURL(
+		// note: this is currently a candidate and not technically within spec
+		// see https://github.com/package-url/purl-spec#other-candidate-types-to-define
+		"alpine",
+		"",
+		m.Package,
+		m.Version,
+		pkg.PURLQualifiers(
+			qualifiers,
+			distro,
+		),
+		"",
+	).ToString()
+}

--- a/syft/pkg/url_test.go
+++ b/syft/pkg/url_test.go
@@ -142,24 +142,6 @@ func TestPackageURL(t *testing.T) {
 			expected: "pkg:cargo/name@v0.1.0",
 		},
 		{
-			name: "apk",
-			distro: &linux.Release{
-				ID:        "alpine",
-				VersionID: "3.4.6",
-			},
-			pkg: Package{
-				Name:    "bad-name",
-				Version: "bad-v0.1.0",
-				Type:    ApkPkg,
-				Metadata: ApkMetadata{
-					Package:      "name",
-					Version:      "v0.1.0",
-					Architecture: "amd64",
-				},
-			},
-			expected: "pkg:alpine/name@v0.1.0?arch=amd64&distro=alpine-3.4.6",
-		},
-		{
 			name: "php-composer",
 			pkg: Package{
 				Name:    "bad-name",
@@ -271,6 +253,7 @@ func TestPackageURL(t *testing.T) {
 	expectedTypes.Remove(string(KbPkg))
 	expectedTypes.Remove(string(PortagePkg))
 	expectedTypes.Remove(string(AlpmPkg))
+	expectedTypes.Remove(string(ApkPkg))
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Follow up to #1281 , porting the APK cataloger to the new `generic.Cataloger`