### PR TITLE
Update cataloger tests to use pkgtest utils

### DIFF
--- a/syft/pkg/cataloger/alpm/parse_alpm_db_test.go
+++ b/syft/pkg/cataloger/alpm/parse_alpm_db_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -89,33 +90,21 @@ func TestDatabaseParser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			file, err := os.Open("test-fixtures/files")
-			if err != nil {
-				t.Fatal("Unable to read test-fixtures/file: ", err)
-			}
-			defer func() {
-				err := file.Close()
-				if err != nil {
-					t.Fatal("closing file failed:", err)
-				}
-			}()
+			f, err := os.Open("test-fixtures/files")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, f.Close()) })
 
-			reader := bufio.NewReader(file)
+			reader := bufio.NewReader(f)
 
 			entry, err := parseAlpmDBEntry(reader)
-			if err != nil {
-				t.Fatal("Unable to read file contents: ", err)
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(entry.Files, test.expected.Files); diff != "" {
+				t.Errorf("Files mismatch (-want +got):\n%s", diff)
 			}
 
-			if diff := deep.Equal(entry.Files, test.expected.Files); diff != nil {
-				for _, d := range diff {
-					t.Errorf("files diff: %+v", d)
-				}
-			}
-			if diff := deep.Equal(entry.Backup, test.expected.Backup); diff != nil {
-				for _, d := range diff {
-					t.Errorf("backup diff: %+v", d)
-				}
+			if diff := cmp.Diff(entry.Backup, test.expected.Backup); diff != "" {
+				t.Errorf("Backup mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -167,28 +156,17 @@ func TestMtreeParse(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			file, err := os.Open("test-fixtures/mtree")
-			if err != nil {
-				t.Fatal("Unable to read test-fixtures/mtree: ", err)
-			}
-			defer func() {
-				err := file.Close()
-				if err != nil {
-					t.Fatal("closing file failed:", err)
-				}
-			}()
+			f, err := os.Open("test-fixtures/mtree")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, f.Close()) })
 
-			reader := bufio.NewReader(file)
+			reader := bufio.NewReader(f)
 
 			entry, err := parseMtree(reader)
-			if err != nil {
-				t.Fatal("Unable to read file contents: ", err)
-			}
+			require.NoError(t, err)
 
-			if diff := deep.Equal(entry, test.expected); diff != nil {
-				for _, d := range diff {
-					t.Errorf("files diff: %+v", d)
-				}
+			if diff := cmp.Diff(entry, test.expected); diff != "" {
+				t.Errorf("Files mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -5,14 +5,16 @@ import (
 	"os"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
 	"github.com/anchore/syft/syft/source"
 )
 
@@ -57,28 +59,17 @@ func TestExtraFileAttributes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			file, err := os.Open("test-fixtures/extra-file-attributes")
-			if err != nil {
-				t.Fatal("Unable to read test-fixtures/extra-file-attributes: ", err)
-			}
-			defer func() {
-				err := file.Close()
-				if err != nil {
-					t.Fatal("closing file failed:", err)
-				}
-			}()
+			f, err := os.Open("test-fixtures/extra-file-attributes")
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, f.Close()) })
 
-			reader := bufio.NewReader(file)
+			reader := bufio.NewReader(f)
 
 			entry, err := parseApkDBEntry(reader)
-			if err != nil {
-				t.Fatal("Unable to read file contents: ", err)
-			}
+			require.NoError(t, err)
 
-			if diff := deep.Equal(entry.Files, test.expected.Files); diff != nil {
-				for _, d := range diff {
-					t.Errorf("diff: %+v", d)
-				}
+			if diff := cmp.Diff(entry.Files, test.expected.Files); diff != "" {
+				t.Errorf("Files mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -623,135 +614,131 @@ func TestSinglePackageDetails(t *testing.T) {
 		t.Run(test.fixture, func(t *testing.T) {
 			f, err := os.Open(test.fixture)
 			require.NoError(t, err)
-			t.Cleanup(func() { f.Close() })
+			t.Cleanup(func() { require.NoError(t, f.Close()) })
 
 			reader := bufio.NewReader(f)
 
 			entry, err := parseApkDBEntry(reader)
 			require.NoError(t, err)
+			require.NotNil(t, entry)
 
-			if diff := deep.Equal(*entry, test.expected); diff != nil {
-				for _, d := range diff {
-					t.Errorf("diff: %+v", d)
-				}
+			if diff := cmp.Diff(*entry, test.expected); diff != "" {
+				t.Errorf("Entry mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
 func TestMultiplePackages(t *testing.T) {
-	tests := []struct {
-		fixture  string
-		expected []pkg.Package
-	}{
+
+	fixture := "test-fixtures/multiple"
+	fixtureLocationSet := source.NewLocationSet(source.NewLocation(fixture))
+	expected := []pkg.Package{
 		{
-			fixture: "test-fixtures/multiple",
-			expected: []pkg.Package{
-				{
-					Name:         "libc-utils",
-					Version:      "0.7.2-r0",
-					Licenses:     []string{"BSD"},
-					Type:         pkg.ApkPkg,
-					PURL:         "pkg:alpine/libc-utils@0.7.2-r0?arch=x86_64&upstream=libc-dev&distro=alpine",
-					MetadataType: pkg.ApkMetadataType,
-					Metadata: pkg.ApkMetadata{
-						Package:          "libc-utils",
-						OriginPackage:    "libc-dev",
-						Maintainer:       "Natanael Copa <ncopa@alpinelinux.org>",
-						Version:          "0.7.2-r0",
-						License:          "BSD",
-						Architecture:     "x86_64",
-						URL:              "http://alpinelinux.org",
-						Description:      "Meta package to pull in correct libc",
-						Size:             1175,
-						InstalledSize:    4096,
-						PullChecksum:     "Q1p78yvTLG094tHE1+dToJGbmYzQE=",
-						GitCommitOfAport: "97b1c2842faa3bfa30f5811ffbf16d5ff9f1a479",
-						PullDependencies: "musl-utils",
-						Files:            []pkg.ApkFileRecord{},
+			Name:         "libc-utils",
+			Version:      "0.7.2-r0",
+			Licenses:     []string{"BSD"},
+			Type:         pkg.ApkPkg,
+			PURL:         "pkg:alpine/libc-utils@0.7.2-r0?arch=x86_64&upstream=libc-dev&distro=alpine-3.12",
+			Locations:    fixtureLocationSet,
+			MetadataType: pkg.ApkMetadataType,
+			Metadata: pkg.ApkMetadata{
+				Package:          "libc-utils",
+				OriginPackage:    "libc-dev",
+				Maintainer:       "Natanael Copa <ncopa@alpinelinux.org>",
+				Version:          "0.7.2-r0",
+				License:          "BSD",
+				Architecture:     "x86_64",
+				URL:              "http://alpinelinux.org",
+				Description:      "Meta package to pull in correct libc",
+				Size:             1175,
+				InstalledSize:    4096,
+				PullChecksum:     "Q1p78yvTLG094tHE1+dToJGbmYzQE=",
+				GitCommitOfAport: "97b1c2842faa3bfa30f5811ffbf16d5ff9f1a479",
+				PullDependencies: "musl-utils",
+				Files:            []pkg.ApkFileRecord{},
+			},
+		},
+		{
+			Name:         "musl-utils",
+			Version:      "1.1.24-r2",
+			Licenses:     []string{"MIT", "BSD", "GPL2+"},
+			Type:         pkg.ApkPkg,
+			PURL:         "pkg:alpine/musl-utils@1.1.24-r2?arch=x86_64&upstream=musl&distro=alpine-3.12",
+			Locations:    fixtureLocationSet,
+			MetadataType: pkg.ApkMetadataType,
+			Metadata: pkg.ApkMetadata{
+				Package:          "musl-utils",
+				OriginPackage:    "musl",
+				Version:          "1.1.24-r2",
+				Description:      "the musl c library (libc) implementation",
+				Maintainer:       "Timo Teräs <timo.teras@iki.fi>",
+				License:          "MIT BSD GPL2+",
+				Architecture:     "x86_64",
+				URL:              "https://musl.libc.org/",
+				Size:             37944,
+				InstalledSize:    151552,
+				PullDependencies: "scanelf so:libc.musl-x86_64.so.1",
+				PullChecksum:     "Q1bTtF5526tETKfL+lnigzIDvm+2o=",
+				GitCommitOfAport: "4024cc3b29ad4c65544ad068b8f59172b5494306",
+				Files: []pkg.ApkFileRecord{
+					{
+						Path: "/sbin",
 					},
-				},
-				{
-					Name:         "musl-utils",
-					Version:      "1.1.24-r2",
-					Licenses:     []string{"MIT", "BSD", "GPL2+"},
-					Type:         pkg.ApkPkg,
-					PURL:         "pkg:alpine/musl-utils@1.1.24-r2?arch=x86_64&upstream=musl&distro=alpine",
-					MetadataType: pkg.ApkMetadataType,
-					Metadata: pkg.ApkMetadata{
-						Package:          "musl-utils",
-						OriginPackage:    "musl",
-						Version:          "1.1.24-r2",
-						Description:      "the musl c library (libc) implementation",
-						Maintainer:       "Timo Teräs <timo.teras@iki.fi>",
-						License:          "MIT BSD GPL2+",
-						Architecture:     "x86_64",
-						URL:              "https://musl.libc.org/",
-						Size:             37944,
-						InstalledSize:    151552,
-						PullDependencies: "scanelf so:libc.musl-x86_64.so.1",
-						PullChecksum:     "Q1bTtF5526tETKfL+lnigzIDvm+2o=",
-						GitCommitOfAport: "4024cc3b29ad4c65544ad068b8f59172b5494306",
-						Files: []pkg.ApkFileRecord{
-							{
-								Path: "/sbin",
-							},
-							{
-								Path:        "/sbin/ldconfig",
-								OwnerUID:    "0",
-								OwnerGID:    "0",
-								Permissions: "755",
-								Digest: &file.Digest{
-									Algorithm: "'Q1'+base64(sha1)",
-									Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
-								},
-							},
-							{
-								Path: "/usr",
-							},
-							{
-								Path: "/usr/bin",
-							},
-							{
-								Path:        "/usr/bin/iconv",
-								OwnerUID:    "0",
-								OwnerGID:    "0",
-								Permissions: "755",
-								Digest: &file.Digest{
-									Algorithm: "'Q1'+base64(sha1)",
-									Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
-								},
-							},
-							{
-								Path:        "/usr/bin/ldd",
-								OwnerUID:    "0",
-								OwnerGID:    "0",
-								Permissions: "755",
-								Digest: &file.Digest{
-									Algorithm: "'Q1'+base64(sha1)",
-									Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
-								},
-							},
-							{
-								Path:        "/usr/bin/getconf",
-								OwnerUID:    "0",
-								OwnerGID:    "0",
-								Permissions: "755",
-								Digest: &file.Digest{
-									Algorithm: "'Q1'+base64(sha1)",
-									Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
-								},
-							},
-							{
-								Path:        "/usr/bin/getent",
-								OwnerUID:    "0",
-								OwnerGID:    "0",
-								Permissions: "755",
-								Digest: &file.Digest{
-									Algorithm: "'Q1'+base64(sha1)",
-									Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
-								},
-							},
+					{
+						Path:        "/sbin/ldconfig",
+						OwnerUID:    "0",
+						OwnerGID:    "0",
+						Permissions: "755",
+						Digest: &file.Digest{
+							Algorithm: "'Q1'+base64(sha1)",
+							Value:     "Q1Kja2+POZKxEkUOZqwSjC6kmaED4=",
+						},
+					},
+					{
+						Path: "/usr",
+					},
+					{
+						Path: "/usr/bin",
+					},
+					{
+						Path:        "/usr/bin/iconv",
+						OwnerUID:    "0",
+						OwnerGID:    "0",
+						Permissions: "755",
+						Digest: &file.Digest{
+							Algorithm: "'Q1'+base64(sha1)",
+							Value:     "Q1CVmFbdY+Hv6/jAHl1gec2Kbx1EY=",
+						},
+					},
+					{
+						Path:        "/usr/bin/ldd",
+						OwnerUID:    "0",
+						OwnerGID:    "0",
+						Permissions: "755",
+						Digest: &file.Digest{
+							Algorithm: "'Q1'+base64(sha1)",
+							Value:     "Q1yFAhGggmL7ERgbIA7KQxyTzf3ks=",
+						},
+					},
+					{
+						Path:        "/usr/bin/getconf",
+						OwnerUID:    "0",
+						OwnerGID:    "0",
+						Permissions: "755",
+						Digest: &file.Digest{
+							Algorithm: "'Q1'+base64(sha1)",
+							Value:     "Q1dAdYK8M/INibRQF5B3Rw7cmNDDA=",
+						},
+					},
+					{
+						Path:        "/usr/bin/getent",
+						OwnerUID:    "0",
+						OwnerGID:    "0",
+						Permissions: "755",
+						Digest: &file.Digest{
+							Algorithm: "'Q1'+base64(sha1)",
+							Value:     "Q1eR2Dz/WylabgbWMTkd2+hGmEya4=",
 						},
 					},
 				},
@@ -759,37 +746,16 @@ func TestMultiplePackages(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.fixture, func(t *testing.T) {
-			f, err := os.Open(test.fixture)
-			require.NoError(t, err)
-			t.Cleanup(func() { f.Close() })
+	// TODO: relationships are not under test
+	var expectedRelationships []artifact.Relationship
 
-			// TODO: no relationships are under test yet
-			pkgs, _, err := parseApkDB(nil, &generic.Environment{
-				LinuxRelease: &linux.Release{
-					ID: "alpine",
-				},
-			}, source.LocationReadCloser{
-				Location:   source.NewLocation(f.Name()),
-				ReadCloser: f,
-			})
-			require.NoError(t, err)
+	env := generic.Environment{LinuxRelease: &linux.Release{
+		ID:        "alpine",
+		VersionID: "3.12",
+	}}
 
-			if len(pkgs) != 2 {
-				t.Fatalf("unexpected number of entries: %d", len(pkgs))
-			}
+	pkgtest.TestGenericParserWithEnv(t, fixture, parseApkDB, &env, expected, expectedRelationships)
 
-			for idx, entry := range pkgs {
-				if diff := deep.Equal(entry, test.expected[idx]); diff != nil {
-					for _, d := range diff {
-						t.Errorf("diff: %+v", d)
-					}
-				}
-			}
-
-		})
-	}
 }
 
 func Test_processChecksum(t *testing.T) {

--- a/syft/pkg/cataloger/cpp/parse_conanfile_test.go
+++ b/syft/pkg/cataloger/cpp/parse_conanfile_test.go
@@ -1,22 +1,23 @@
 package cpp
 
 import (
-	"os"
 	"testing"
 
-	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
 	"github.com/anchore/syft/syft/source"
 )
 
 func TestParseConanfile(t *testing.T) {
+	fixture := "test-fixtures/conanfile.txt"
+	fixtureLocationSet := source.NewLocationSet(source.NewLocation(fixture))
 	expected := []pkg.Package{
 		{
 			Name:         "catch2",
 			Version:      "2.13.8",
 			PURL:         "pkg:conan/catch2@2.13.8",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -28,6 +29,7 @@ func TestParseConanfile(t *testing.T) {
 			Name:         "docopt.cpp",
 			Version:      "0.6.3",
 			PURL:         "pkg:conan/docopt.cpp@0.6.3",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -39,6 +41,7 @@ func TestParseConanfile(t *testing.T) {
 			Name:         "fmt",
 			Version:      "8.1.1",
 			PURL:         "pkg:conan/fmt@8.1.1",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -50,6 +53,7 @@ func TestParseConanfile(t *testing.T) {
 			Name:         "spdlog",
 			Version:      "1.9.2",
 			PURL:         "pkg:conan/spdlog@1.9.2",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -61,6 +65,7 @@ func TestParseConanfile(t *testing.T) {
 			Name:         "sdl",
 			Version:      "2.0.20",
 			PURL:         "pkg:conan/sdl@2.0.20",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -72,6 +77,7 @@ func TestParseConanfile(t *testing.T) {
 			Name:         "fltk",
 			Version:      "1.3.8",
 			PURL:         "pkg:conan/fltk@1.3.8",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -81,18 +87,8 @@ func TestParseConanfile(t *testing.T) {
 		},
 	}
 
-	fixture, err := os.Open("test-fixtures/conanfile.txt")
-	require.NoError(t, err)
+	// TODO: relationships are not under test
+	var expectedRelationships []artifact.Relationship
 
-	// TODO: no relationships are under test yet
-	actual, _, err := parseConanfile(nil, nil, source.LocationReadCloser{
-		Location:   source.NewLocation(fixture.Name()),
-		ReadCloser: fixture,
-	})
-	require.NoError(t, err)
-
-	differences := deep.Equal(expected, actual)
-	if differences != nil {
-		t.Errorf("returned package list differed from expectation: %+v", differences)
-	}
+	pkgtest.TestGenericParser(t, fixture, parseConanfile, expected, expectedRelationships)
 }

--- a/syft/pkg/cataloger/cpp/parse_conanlock_test.go
+++ b/syft/pkg/cataloger/cpp/parse_conanlock_test.go
@@ -1,22 +1,22 @@
 package cpp
 
 import (
-	"os"
 	"testing"
 
-	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
 	"github.com/anchore/syft/syft/source"
 )
 
 func TestParseConanlock(t *testing.T) {
+	fixture := "test-fixtures/conan.lock"
 	expected := []pkg.Package{
 		{
 			Name:         "zlib",
 			Version:      "1.2.12",
 			PURL:         "pkg:conan/zlib@1.2.12",
+			Locations:    source.NewLocationSet(source.NewLocation(fixture)),
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanLockMetadataType,
@@ -32,18 +32,8 @@ func TestParseConanlock(t *testing.T) {
 		},
 	}
 
-	fixture, err := os.Open("test-fixtures/conan.lock")
-	require.NoError(t, err)
+	// TODO: relationships are not under test
+	var expectedRelationships []artifact.Relationship
 
-	// TODO: no relationships are under test yet
-	actual, _, err := parseConanlock(nil, nil, source.LocationReadCloser{
-		Location:   source.NewLocation(fixture.Name()),
-		ReadCloser: fixture,
-	})
-	require.NoError(t, err)
-
-	differences := deep.Equal(expected, actual)
-	if differences != nil {
-		t.Errorf("returned package list differed from expectation: %+v", differences)
-	}
+	pkgtest.TestGenericParser(t, fixture, parseConanlock, expected, expectedRelationships)
 }

--- a/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
@@ -1,22 +1,23 @@
 package dart
 
 import (
-	"os"
 	"testing"
 
-	"github.com/go-test/deep"
-	"github.com/stretchr/testify/require"
-
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
 	"github.com/anchore/syft/syft/source"
 )
 
 func TestParsePubspecLock(t *testing.T) {
+	fixture := "test-fixtures/pubspec.lock"
+	fixtureLocationSet := source.NewLocationSet(source.NewLocation(fixture))
 	expected := []pkg.Package{
 		{
 			Name:         "ale",
 			Version:      "3.3.0",
 			PURL:         "pkg:pub/ale@3.3.0?hosted_url=pub.hosted.org",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -30,6 +31,7 @@ func TestParsePubspecLock(t *testing.T) {
 			Name:         "analyzer",
 			Version:      "0.40.7",
 			PURL:         "pkg:pub/analyzer@0.40.7",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -42,6 +44,7 @@ func TestParsePubspecLock(t *testing.T) {
 			Name:         "ansicolor",
 			Version:      "1.1.1",
 			PURL:         "pkg:pub/ansicolor@1.1.1",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -54,6 +57,7 @@ func TestParsePubspecLock(t *testing.T) {
 			Name:         "archive",
 			Version:      "2.0.13",
 			PURL:         "pkg:pub/archive@2.0.13",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -66,6 +70,7 @@ func TestParsePubspecLock(t *testing.T) {
 			Name:         "args",
 			Version:      "1.6.0",
 			PURL:         "pkg:pub/args@1.6.0",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -78,6 +83,7 @@ func TestParsePubspecLock(t *testing.T) {
 			Name:         "key_binder",
 			Version:      "1.11.20",
 			PURL:         "pkg:pub/key_binder@1.11.20?vcs_url=git%40github.com:Workiva/key_binder.git%403f7b3a6350e73c7dcac45301c0e18fbd42af02f7",
+			Locations:    fixtureLocationSet,
 			Language:     pkg.Dart,
 			Type:         pkg.DartPubPkg,
 			MetadataType: pkg.DartPubMetadataType,
@@ -89,18 +95,8 @@ func TestParsePubspecLock(t *testing.T) {
 		},
 	}
 
-	fixture, err := os.Open("test-fixtures/pubspec.lock")
-	require.NoError(t, err)
+	// TODO: relationships are not under test
+	var expectedRelationships []artifact.Relationship
 
-	// TODO: no relationships are under test yet
-	actual, _, err := parsePubspecLock(nil, nil, source.LocationReadCloser{
-		Location:   source.NewLocation(fixture.Name()),
-		ReadCloser: fixture,
-	})
-	require.NoError(t, err)
-
-	differences := deep.Equal(expected, actual)
-	if differences != nil {
-		t.Errorf("returned package list differed from expectation: %+v", differences)
-	}
+	pkgtest.TestGenericParser(t, fixture, parsePubspecLock, expected, expectedRelationships)
 }

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -14,10 +14,12 @@ import (
 )
 
 func TestGenericParser(t *testing.T, fixturePath string, parser generic.Parser, expectedPkgs []pkg.Package, expectedRelationships []artifact.Relationship) {
+	t.Helper()
 	TestGenericParserWithEnv(t, fixturePath, parser, nil, expectedPkgs, expectedRelationships)
 }
 
 func TestGenericParserWithEnv(t *testing.T, fixturePath string, parser generic.Parser, env *generic.Environment, expectedPkgs []pkg.Package, expectedRelationships []artifact.Relationship) {
+	t.Helper()
 	fixture, err := os.Open(fixturePath)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This is a follow up to #1286 to use the new `internal/pkgtest` utils for testing. For consistency I'm also updating `deep` comparison references with `cmp` equivalents. 

_Note: this can't be merged until it is rebased with main_