### PR TITLE
fix: update Makefile to remove old signing arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,13 +279,8 @@ snapshot-with-signing: ## Build snapshot release binaries and packages (with dum
 	echo "dist: $(SNAPSHOTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml
 
-	rm -f .github/scripts/apple-signing/log/*.txt
-
 	# build release snapshots
-	bash -c "$(SNAPSHOT_CMD) --config $(TEMPDIR)/goreleaser.yaml || (cat .github/scripts/apple-signing/log/*.txt && false)"
-
-	# remove the keychain with the trusted self-signed cert automatically
-	.github/scripts/apple-signing/cleanup.sh
+	bash -c "$(SNAPSHOT_CMD) --config $(TEMPDIR)/goreleaser.yaml"
 
 snapshot-docker-assets: # Build snapshot images of docker images that will be published on release
 	$(call title,Building snapshot docker release assets)
@@ -362,17 +357,12 @@ release: clean-dist CHANGELOG.md
 	echo "dist: $(DISTDIR)" > $(TEMPDIR)/goreleaser.yaml
 	cat .goreleaser.yaml >> $(TEMPDIR)/goreleaser.yaml
 
-	rm -f .github/scripts/apple-signing/log/*.txt
-
 	# note: notarization cannot be done in parallel, thus --parallelism 1
 	bash -c "\
 		$(RELEASE_CMD) \
 			--config $(TEMPDIR)/goreleaser.yaml \
 			--parallelism 1 \
-			--release-notes <(cat CHANGELOG.md)\
-				 || (cat .github/scripts/apple-signing/log/*.txt && false)"
-
-	cat .github/scripts/apple-signing/log/*.txt
+			--release-notes <(cat CHANGELOG.md)
 
 	# TODO: turn this into a post-release hook
 	# upload the version file that supports the application version update check (excluding pre-releases)

--- a/syft/pkg/binary_metadata.go
+++ b/syft/pkg/binary_metadata.go
@@ -1,7 +1,7 @@
 package pkg
 
 type BinaryMetadata struct {
-	Classifier  string
-	RealPath    string
-	VirtualPath string
+	Classifier  string `mapstructure:"Classifier" json:"classifier"`
+	RealPath    string `mapstructure:"RealPath" json:"realPath"`
+	VirtualPath string `mapstructure:"VirtualPath" json:"virtualPath"`
 }


### PR DESCRIPTION
### Summary

Our old apple signing architecture was still present in some of the Makefile release scripts.

This PR allows the CI flow to not block on the presence of log files that no longer exist.

Users should be able to run `make make snapshot-with-signing` with status code 0 and the build artifacts located in `snaoshot`

For more context on the error and the lines removed to fix this error see this build log:
https://github.com/anchore/syft/actions/runs/3363098999/jobs/5576370179

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>