### PR TITLE
chore: update github token permissions for goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,7 @@ jobs:
     needs: [quality-gate]
     runs-on: ubuntu-20.04
     permissions:
+      contents: write
       packages: write
     steps:
       - uses: actions/setup-go@v2


### PR DESCRIPTION
This PR updates the release workflow token permissions for goreleaser to be able to publish.