### PR TITLE
chore: update goreleaser brew token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,7 @@ jobs:
           QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BREW_TOKEN: ${{ secrets.ANCHORE_GIT_READ_TOKEN }}
 
       - uses: anchore/sbom-action@v0
         continue-on-error: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,6 +86,7 @@ brews:
   - tap:
       owner: anchore
       name: homebrew-syft
+      token: "{{.Env.GITHUB_BREW_TOKEN}}"
     ids:
       - darwin-archives
       - linux-archives


### PR DESCRIPTION
This PR _should_ correct the brew publishing failure in the new workflow.