### PR TITLE
Decode binary and unknown metadata

### DIFF
--- a/syft/formats/syftjson/model/package.go
+++ b/syft/formats/syftjson/model/package.go
@@ -94,5 +94,9 @@ func unpackMetadata(p *Package, unpacker packageMetadataUnpacker) error {
 		p.Metadata = val
 	}
 
-	return errUnknownMetadataType
+	if p.MetadataType != "" {
+		return errUnknownMetadataType
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR fixes an issue where Syft is not decoding binary metadata properly or retaining future metadata types without updating to the corresponding Syft release.