### PR TITLE
fix: only generate PURL on empty string

### DIFF
--- a/syft/pkg/cataloger/catalog.go
+++ b/syft/pkg/cataloger/catalog.go
@@ -70,7 +70,9 @@ func Catalog(resolver source.FileResolver, release *linux.Release, catalogers ..
 			p.CPEs = append(p.CPEs, cpe.Generate(p)...)
 
 			// generate PURL (note: this is excluded from package ID, so is safe to mutate)
-			p.PURL = pkg.URL(p, release)
+			if p.PURL == "" {
+				p.PURL = pkg.URL(p, release)
+			}
 
 			// if we were not able to identify the language we have an opportunity
 			// to try and get this value from the PURL. Worst case we assert that

--- a/syft/pkg/cataloger/catalog.go
+++ b/syft/pkg/cataloger/catalog.go
@@ -45,9 +45,7 @@ func newMonitor() (*progress.Manual, *progress.Manual) {
 func Catalog(resolver source.FileResolver, release *linux.Release, catalogers ...pkg.Cataloger) (*pkg.Catalog, []artifact.Relationship, error) {
 	catalog := pkg.NewCatalog()
 	var allRelationships []artifact.Relationship
-
 	filesProcessed, packagesDiscovered := newMonitor()
-
 	// perform analysis, accumulating errors for each failed analysis
 	var errs error
 	for _, c := range catalogers {
@@ -88,7 +86,6 @@ func Catalog(resolver source.FileResolver, release *linux.Release, catalogers ..
 			} else {
 				allRelationships = append(allRelationships, owningRelationships...)
 			}
-			// add to catalog
 			catalog.Add(p)
 		}
 


### PR DESCRIPTION
## Summary
Purl Generation has changed a bit between v0.59.x and v0.60.x

A good example of this can be demonstrated by the following values for alpine:
```
PRE v0.60.x
pkg:alpine/busybox@1.31.1-r19?arch=x86_64&upstream=busybox&distro=alpine-3.12.5

Included in v0.60.x
pkg:alpine/busybox@1.31.1-r19
```

There are two places within syft that can generate two different values for PURL given a certain package type:

Let’s look at the above alpine case:
Here is the first section where a PURL can be set:
https://github.com/anchore/syft/blob/e0acfa98c7ba1e34a0acdbc4b1af69328c310531/syft/pkg/cataloger/apkdb/package.go#L29-L57

This can be found when the "apkdb-cataloger" is running and parsing the apk DB.

Syft gets a second pass at PURL generation here in catalog.go for all packages
https://github.com/anchore/syft/blob/e0acfa98c7ba1e34a0acdbc4b1af69328c310531/syft/pkg/cataloger/catalog.go#L67-L91

The function that gets a crack at each package post the catalogers running is `func URL` from the `package pkg`
https://github.com/anchore/syft/blob/e0acfa98c7ba1e34a0acdbc4b1af69328c310531/syft/pkg/url.go#L28-L60

Previously alpine packages were gated behind the `urlIdentifier interface`
I believe moving to the generic cataloger removed this method PackageURL from certain package metadata types causing this check to no longer short circuit PURL generation:
```
	if p.Metadata != nil {
		if i, ok := p.Metadata.(urlIdentifier); ok {
			return i.PackageURL(release)
		}
	} 
```

There is a pretty simple hack to fix this where we only do a PURL generation in `catalog.go` if one has not already been set `if p.PURL="" {try again} `, but I wanted to run it by everyone to talk about since we had a stricter check on the interface earlier vs just covering for a blank string.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>