### PR TITLE
javascript cataloger: node binary: nil pointer dereference

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_node_binary.go
+++ b/syft/pkg/cataloger/javascript/parse_node_binary.go
@@ -36,7 +36,7 @@ func parseNodeBinary(_ source.FileResolver, _ *generic.Environment, reader sourc
 	// TODO add node specific metadata to the packages to help with vulnerability matching
 	if p != nil {
 		p.Language = pkg.JavaScript
-        p.SetID()
+		p.SetID()
 		return []pkg.Package{*p}, nil, nil
 	}
 	return nil, nil, nil

--- a/syft/pkg/cataloger/javascript/parse_node_binary.go
+++ b/syft/pkg/cataloger/javascript/parse_node_binary.go
@@ -36,8 +36,8 @@ func parseNodeBinary(_ source.FileResolver, _ *generic.Environment, reader sourc
 	// TODO add node specific metadata to the packages to help with vulnerability matching
 	if p != nil {
 		p.Language = pkg.JavaScript
+        p.SetID()
 		return []pkg.Package{*p}, nil, nil
 	}
-	p.SetID()
 	return nil, nil, nil
 }


### PR DESCRIPTION
The JavaScript indexer now contains a node binary indexer, but this triggers a nil pointer dereference in my case:

```
github.com/anchore/syft/syft/pkg.(*Package).SetID(0x0)
        /home/runner/work/syft/syft/syft/pkg/package.go:42 +0x36
github.com/anchore/syft/syft/pkg/cataloger/javascript.parseNodeBinary({0xc000c78760?, 0xc019612710?}, 0x10?, {{{{0xc001909810, 0xd}, {0xc0069602d0, 0x47}}, {0xc001909810, 0xd}, {0xb1b2, ...}}, ...})
        /home/runner/work/syft/syft/syft/pkg/cataloger/javascript/parse_node_binary.go:41 +0x186
github.com/anchore/syft/syft/pkg/cataloger/generic.(*Cataloger).Catalog(0xc01162b6e0, {0x2804a40, 0xc000e800a0})
        /home/runner/work/syft/syft/syft/pkg/cataloger/generic/cataloger.go:127 +0x70e
github.com/anchore/syft/syft/pkg/cataloger.Catalog({0x2804a40?, 0xc000e800a0}, 0x8?, {0xc01163a1a0, 0xd, 0x0?})
        /home/runner/work/syft/syft/syft/pkg/cataloger/catalog.go:56 +0x3d8
github.com/anchore/syft/syft.CatalogPackages(0xc00f976600, {{0x1, 0x0, {0x242b880, 0x8}}, {0x0, 0x0, 0x0}})
        /home/runner/work/syft/syft/syft/lib.go:72 +0x5a5
github.com/anchore/syft/cmd/syft/cli/eventloop.generateCatalogPackagesTask.func1(0xc00fbdb040, 0x40571d?)
        /home/runner/work/syft/syft/cmd/syft/cli/eventloop/tasks.go:49 +0xdc
github.com/anchore/syft/cmd/syft/cli/eventloop.RunTask(0x5894c5?, 0xc000542720?, 0xc00006cfd0?, 0xc011630360, 0xc0001a26c0?)
        /home/runner/work/syft/syft/cmd/syft/cli/eventloop/tasks.go:223 +0x85
created by github.com/anchore/syft/cmd/syft/cli/packages.buildRelationships
        /home/runner/work/syft/syft/cmd/syft/cli/packages/packages.go:121 +0x65
```

If I look at the code, this looks quite normal to me:
```
	// TODO add node specific metadata to the packages to help with vulnerability matching
	if p != nil {
		p.Language = pkg.JavaScript
		return []pkg.Package{*p}, nil, nil
	}
	p.SetID()
```

I reach the `p.SetID()`in my case, but this code is only reachable if `p` is a `nil`, so this error is normal, but should not occur.

I don't know if this is the right fix, maybe something else must be done in this case though.