### PR TITLE
Add java virtualpath to metadata

### DIFF
--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -353,7 +353,7 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 		}
 		return pkg.JavaMetadataType, pkg.JavaMetadata{
 			ArchiveDigests: digests,
-			VirtualPath: p.PackageSourceInfo,
+			VirtualPath:    p.PackageSourceInfo,
 		}
 	case pkg.GoModulePkg:
 		var h1Digest string

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -355,7 +355,6 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 			ArchiveDigests: digests,
 			VirtualPath: p.PackageSourceInfo
 		}
-		
 	case pkg.GoModulePkg:
 		var h1Digest string
 		for _, value := range p.PackageChecksums {

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -355,6 +355,7 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 			ArchiveDigests: digests,
 			VirtualPath: p.PackageSourceInfo
 		}
+		
 	case pkg.GoModulePkg:
 		var h1Digest string
 		for _, value := range p.PackageChecksums {

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -353,7 +353,7 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 		}
 		return pkg.JavaMetadataType, pkg.JavaMetadata{
 			ArchiveDigests: digests,
-			VirtualPath: p.PackageSourceInfo
+			VirtualPath: p.PackageSourceInfo,
 		}
 	case pkg.GoModulePkg:
 		var h1Digest string

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -353,6 +353,7 @@ func extractMetadata(p *spdx.Package2_2, info pkgInfo) (pkg.MetadataType, interf
 		}
 		return pkg.JavaMetadataType, pkg.JavaMetadata{
 			ArchiveDigests: digests,
+			VirtualPath: p.PackageSourceInfo
 		}
 	case pkg.GoModulePkg:
 		var h1Digest string

--- a/syft/formats/spdx22json/decoder_test.go
+++ b/syft/formats/spdx22json/decoder_test.go
@@ -83,7 +83,10 @@ func TestSPDXJSONDecoder(t *testing.T) {
 						switch p.Type {
 						case pkg.JavaPkg:
 							if p.Metadata.(pkg.JavaMetadata).VirtualPath != "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar" {
-								assert.NoError(t, fmt.Errorf("Unable to find jar VirtualPath: %s for package: %s", pkgName, p.Metadata.(pkg.JavaMetadata).VirtualPath))
+								assert.NoError(t, fmt.Errorf("Mismatch in jar for package: %s. "+
+									"Expected `acquired package info from installed java archive: "+ 
+									"/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar` and "+
+									"received VirtualPath: %s ", pkgName, p.Metadata.(pkg.JavaMetadata).VirtualPath))
 							}
 						}					
 					}

--- a/syft/formats/spdx22json/decoder_test.go
+++ b/syft/formats/spdx22json/decoder_test.go
@@ -84,11 +84,11 @@ func TestSPDXJSONDecoder(t *testing.T) {
 						case pkg.JavaPkg:
 							if p.Metadata.(pkg.JavaMetadata).VirtualPath != "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar" {
 								assert.NoError(t, fmt.Errorf("Mismatch in jar for package: %s. "+
-									"Expected `acquired package info from installed java archive: "+ 
+									"Expected `acquired package info from installed java archive: "+
 									"/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar` and "+
 									"received VirtualPath: %s ", pkgName, p.Metadata.(pkg.JavaMetadata).VirtualPath))
 							}
-						}					
+						}
 					}
 					assert.NoError(t, fmt.Errorf("Unable to find package: %s", pkgName))
 				}

--- a/syft/formats/spdx22json/decoder_test.go
+++ b/syft/formats/spdx22json/decoder_test.go
@@ -83,10 +83,7 @@ func TestSPDXJSONDecoder(t *testing.T) {
 						switch p.Type {
 						case pkg.JavaPkg:
 							if p.Metadata.(pkg.JavaMetadata).VirtualPath != "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar" {
-								assert.NoError(t, fmt.Errorf("Mismatch in jar for package: %s. "+
-									"Expected `acquired package info from installed java archive: "+
-									"/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar` and "+
-									"received VirtualPath: %s ", pkgName, p.Metadata.(pkg.JavaMetadata).VirtualPath))
+								assert.Equal(t, "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar", p.Metadata.(pkg.JavaMetadata).VirtualPath)
 							}
 						}
 					}

--- a/syft/formats/spdx22json/decoder_test.go
+++ b/syft/formats/spdx22json/decoder_test.go
@@ -24,7 +24,7 @@ func TestSPDXJSONDecoder(t *testing.T) {
 		},
 		{
 			path:          "alpine-3.10.vendor.spdx.json",
-			packages:      []string{"alpine", "busybox", "ssl_client"},
+			packages:      []string{"alpine", "busybox", "ssl_client", "nashorn"},
 			relationships: []string{},
 		},
 		{
@@ -80,6 +80,12 @@ func TestSPDXJSONDecoder(t *testing.T) {
 						if p.Name == pkgName {
 							continue packages
 						}
+						switch p.Type {
+						case pkg.JavaPkg:
+							if p.Metadata.(pkg.JavaMetadata).VirtualPath != "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar" {
+								assert.NoError(t, fmt.Errorf("Unable to find jar VirtualPath: %s for package: %s", pkgName, p.Metadata.(pkg.JavaMetadata).VirtualPath))
+							}
+						}					
 					}
 					assert.NoError(t, fmt.Errorf("Unable to find package: %s", pkgName))
 				}

--- a/syft/formats/spdx22json/test-fixtures/spdx/alpine-3.10.vendor.spdx.json
+++ b/syft/formats/spdx22json/test-fixtures/spdx/alpine-3.10.vendor.spdx.json
@@ -19,35 +19,7 @@
       "SPDXID": "SPDXRef-3d8071c3d70438ff",
       "name": "nashorn",
       "licenseConcluded": "NONE",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "9e42986307c8341ff4c244668822615b5a909138"
-        }
-      ],
       "downloadLocation": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:oracle-corporation:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
-          "referenceType": "cpe23Type"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:oracle_corporation:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
-          "referenceType": "cpe23Type"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceLocator": "cpe:2.3:a:nashorn:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
-          "referenceType": "cpe23Type"
-        },
-        {
-          "referenceCategory": "PACKAGE_MANAGER",
-          "referenceLocator": "pkg:maven/nashorn/nashorn@1.8.0_312-8u312-b07~18.04-b07",
-          "referenceType": "purl"
-        }
-      ],
       "filesAnalyzed": true,
       "licenseDeclared": "NONE",
       "sourceInfo": "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar",

--- a/syft/formats/spdx22json/test-fixtures/spdx/alpine-3.10.vendor.spdx.json
+++ b/syft/formats/spdx22json/test-fixtures/spdx/alpine-3.10.vendor.spdx.json
@@ -16,6 +16,44 @@
   ],
   "packages": [
     {
+      "SPDXID": "SPDXRef-3d8071c3d70438ff",
+      "name": "nashorn",
+      "licenseConcluded": "NONE",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9e42986307c8341ff4c244668822615b5a909138"
+        }
+      ],
+      "downloadLocation": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:oracle-corporation:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:oracle_corporation:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:nashorn:nashorn:1.8.0_312-8u312-b07\\~18.04-b07:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
+        },
+        {
+          "referenceCategory": "PACKAGE_MANAGER",
+          "referenceLocator": "pkg:maven/nashorn/nashorn@1.8.0_312-8u312-b07~18.04-b07",
+          "referenceType": "purl"
+        }
+      ],
+      "filesAnalyzed": true,
+      "licenseDeclared": "NONE",
+      "sourceInfo": "acquired package info from installed java archive: /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext/nashorn.jar",
+      "versionInfo": "1.8.0_312-8u312-b07~18.04-b07"
+    },
+    {
       "name": "alpine",
       "SPDXID": "SPDXRef-alpine-3.10",
       "versionInfo": "3.10",


### PR DESCRIPTION
When the components come from an spdx-json file, the source_path contains valuable info that just gets thrown away when its converted to the syft sbom format. Keep that info, very useful for debugging.