### PR TITLE
Normalize alpm md5 refs

### DIFF
--- a/syft/pkg/cataloger/alpm/parse_alpm_db.go
+++ b/syft/pkg/cataloger/alpm/parse_alpm_db.go
@@ -218,7 +218,7 @@ func parseMtree(r io.Reader) ([]pkg.AlpmFileRecord, error) {
 				})
 			case "md5digest":
 				entry.Digests = append(entry.Digests, file.Digest{
-					Algorithm: "md5digest",
+					Algorithm: "md5",
 					Value:     kv.Value(),
 				})
 			default:

--- a/syft/pkg/cataloger/alpm/parse_alpm_db_test.go
+++ b/syft/pkg/cataloger/alpm/parse_alpm_db_test.go
@@ -141,7 +141,7 @@ func TestMtreeParse(t *testing.T) {
 					Time: parseTime("2022-04-10T14:59:52+02:00"),
 					Digests: []file.Digest{
 						{
-							Algorithm: "md5digest",
+							Algorithm: "md5",
 							Value:     "81c39827e38c759d7e847f05db62c233",
 						},
 						{


### PR DESCRIPTION
Small fix to normalize the `md5digest` references to simply `md5` like with other catalogers that raise up digests with algorithm references.