### PR TITLE
Unmarshal Syft JSON with missing metadata

### DIFF
--- a/syft/formats/common/property_encoder.go
+++ b/syft/formats/common/property_encoder.go
@@ -364,7 +364,7 @@ func decode(vals map[string]string, value reflect.Value, prefix string, fn Field
 
 func PtrToStruct(ptr interface{}) interface{} {
 	v := reflect.ValueOf(ptr)
-	if v.IsZero() {
+	if v.IsZero() && v.Type().Kind() != reflect.Struct {
 		return nil
 	}
 	switch v.Type().Kind() {

--- a/syft/formats/syftjson/model/package.go
+++ b/syft/formats/syftjson/model/package.go
@@ -78,8 +78,10 @@ func unpackMetadata(p *Package, unpacker packageMetadataUnpacker) error {
 	typ, ok := pkg.MetadataTypeByName[p.MetadataType]
 	if ok {
 		val := reflect.New(typ).Interface()
-		if err := json.Unmarshal(unpacker.Metadata, val); err != nil {
-			return err
+		if len(unpacker.Metadata) > 0 {
+			if err := json.Unmarshal(unpacker.Metadata, val); err != nil {
+				return err
+			}
 		}
 		p.Metadata = reflect.ValueOf(val).Elem().Interface()
 		return nil

--- a/syft/formats/syftjson/model/package_test.go
+++ b/syft/formats/syftjson/model/package_test.go
@@ -212,6 +212,37 @@ func Test_unpackMetadata(t *testing.T) {
 				"thing": "thing-1",
 			},
 		},
+		{
+			name: "can handle package with metadata type but missing metadata",
+			packageData: []byte(`{
+				"metadataType": "GolangBinMetadata"
+			}`),
+			metadataType: pkg.GolangBinMetadataType,
+			wantMetadata: pkg.GolangBinMetadata{},
+		},
+		{
+			name: "can handle package with unknonwn metadata type and missing metadata",
+			packageData: []byte(`{
+				"metadataType": "BadMetadata"
+			}`),
+			wantErr:      require.Error,
+			metadataType: "BadMetadata",
+			wantMetadata: nil,
+		},
+		{
+			name: "can handle package with unknonwn metadata type and metadata",
+			packageData: []byte(`{
+				"metadataType": "BadMetadata",
+				"metadata": {
+					"random": "thing"
+				}
+			}`),
+			wantErr:      require.Error,
+			metadataType: "BadMetadata",
+			wantMetadata: map[string]interface{}{
+				"random": "thing",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR corrects an issue where a Syft JSON with a known `metadataType` but missing `metadata` would fail.

Fixes: #1334 