### PR TITLE
Output only valid CPEs for CycloneDX OS components

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/format.go
+++ b/syft/formats/common/cyclonedxhelpers/format.go
@@ -92,11 +92,20 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 			Name:        distro.ID,
 			Version:     distro.VersionID,
 			// TODO should we add a PURL?
-			CPE:                distro.CPEName,
+			CPE:                formatCPE(distro.CPEName),
 			ExternalReferences: eRefs,
 			Properties:         properties,
 		},
 	}
+}
+
+func formatCPE(cpeString string) string {
+	cpe, err := pkg.NewCPE(cpeString)
+	if err != nil {
+		log.Debugf("skipping invalid CPE: %s", cpeString)
+		return ""
+	}
+	return pkg.CPEString(cpe)
 }
 
 // NewBomDescriptor returns a new BomDescriptor tailored for the current time and "syft" tool details.

--- a/syft/formats/common/cyclonedxhelpers/format_test.go
+++ b/syft/formats/common/cyclonedxhelpers/format_test.go
@@ -1,0 +1,33 @@
+package cyclonedxhelpers
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_formatCPE(t *testing.T) {
+	tests := []struct {
+		cpe      string
+		expected string
+	}{
+		{
+			cpe:      "cpe:2.3:o:amazon:amazon_linux:2",
+			expected: "cpe:2.3:o:amazon:amazon_linux:2:*:*:*:*:*:*:*",
+		},
+		{
+			cpe:      "cpe:/o:opensuse:leap:15.2",
+			expected: "cpe:2.3:o:opensuse:leap:15.2:*:*:*:*:*:*:*",
+		},
+		{
+			cpe:      "invalid-cpe",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.cpe, func(t *testing.T) {
+			out := formatCPE(test.cpe)
+			assert.Equal(t, test.expected, out)
+		})
+	}
+}

--- a/syft/formats/common/cyclonedxhelpers/format_test.go
+++ b/syft/formats/common/cyclonedxhelpers/format_test.go
@@ -1,8 +1,9 @@
 package cyclonedxhelpers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_formatCPE(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue where invalid CPEs may be output in the CycloneDX OS component.

Fixes: #1337 