### PR TITLE
chore: add unit test for wolfi os release identification

### DIFF
--- a/syft/linux/identify_release_test.go
+++ b/syft/linux/identify_release_test.go
@@ -321,6 +321,16 @@ func TestIdentifyRelease(t *testing.T) {
 				CPEName:      "cpe:/o:almalinux:almalinux:8.4:GA",
 			},
 		},
+		{
+			fixture: "test-fixtures/os/wolfi",
+			release: &Release{
+				PrettyName: "Wolfi",
+				Name:       "Wolfi",
+				ID:         "wolfi",
+				VersionID:  "20220914",
+				HomeURL:    "https://wolfi.dev",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/linux/test-fixtures/os/wolfi/etc/os-release
+++ b/syft/linux/test-fixtures/os/wolfi/etc/os-release
@@ -1,0 +1,5 @@
+ID=wolfi
+NAME="Wolfi"
+PRETTY_NAME="Wolfi"
+VERSION_ID="20220914"
+HOME_URL="https://wolfi.dev"


### PR DESCRIPTION
Adds a release identification unit test for [Wolfi OS](https://github.com/wolfi-dev/)