### PR TITLE
Fix decoding package groups from cyclonedx sboms

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/component.go
+++ b/syft/formats/common/cyclonedxhelpers/component.go
@@ -2,6 +2,7 @@ package cyclonedxhelpers
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
 
@@ -27,10 +28,15 @@ func encodeComponent(p pkg.Package) cyclonedx.Component {
 		properties = &props
 	}
 
+	name, group := encodeName(p.Name)
+	if group == "" {
+		group = encodeGroup(p)
+	}
+
 	return cyclonedx.Component{
 		Type:               cyclonedx.ComponentTypeLibrary,
-		Name:               p.Name,
-		Group:              encodeGroup(p),
+		Name:               name,
+		Group:              group,
 		Version:            p.Version,
 		PackageURL:         p.PURL,
 		Licenses:           encodeLicenses(p),
@@ -41,6 +47,13 @@ func encodeComponent(p pkg.Package) cyclonedx.Component {
 		ExternalReferences: encodeExternalReferences(p),
 		Properties:         properties,
 		BOMRef:             deriveBomRef(p),
+	}
+}
+
+func encodeName(name string) (string, string) {
+	if strings.Contains(name, "/") {
+		parts := strings.Split(name, "/")
+		return parts[0], parts[1]
 	}
 }
 

--- a/syft/formats/common/cyclonedxhelpers/component.go
+++ b/syft/formats/common/cyclonedxhelpers/component.go
@@ -70,7 +70,7 @@ func decodeComponent(c *cyclonedx.Component) *pkg.Package {
 	}
 
 	p := &pkg.Package{
-		Name:      c.Name,
+		Name:      decodeName(c.Group, c.Name),
 		Version:   c.Version,
 		Locations: decodeLocations(values),
 		Licenses:  decodeLicenses(c),
@@ -93,6 +93,13 @@ func decodeComponent(c *cyclonedx.Component) *pkg.Package {
 	}
 
 	return p
+}
+
+func decodeName(group string, name string) string {
+	if group != "" {
+		return group + "/" + name
+	}
+	return name
 }
 
 func decodeLocations(vals map[string]string) source.LocationSet {


### PR DESCRIPTION
This PR is work extracted from #1029 specifically relating to comment https://github.com/anchore/syft/pull/1029#issuecomment-1239317225 from @wurstbrot (cc: @patrikbeno). This fixes the decoding of cyclonedx packages to account for information that may be stored in the `group` attribute. However, what work has not been completed yet is considering how that should affect the encoding of a package into the `group` attribute. Without this we cannot pass the encode-decode-encode integration test that attempts to prove stability in our encoding and decoding methods.