### PR TITLE
chore: add debug logging for decode errors

### DIFF
--- a/syft/formats/formats.go
+++ b/syft/formats/formats.go
@@ -2,10 +2,12 @@ package formats
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/formats/cyclonedxjson"
 	"github.com/anchore/syft/syft/formats/cyclonedxxml"
 	"github.com/anchore/syft/syft/formats/github"
@@ -35,6 +37,9 @@ func Formats() []sbom.Format {
 func Identify(by []byte) sbom.Format {
 	for _, f := range Formats() {
 		if err := f.Validate(bytes.NewReader(by)); err != nil {
+			if !errors.Is(err, sbom.ErrValidationNotSupported) {
+				log.Debugf("format %s returned err: %+v", f.ID(), err)
+			}
 			continue
 		}
 		return f

--- a/syft/formats/spdxtagvalue/decoder.go
+++ b/syft/formats/spdxtagvalue/decoder.go
@@ -13,7 +13,7 @@ import (
 func decoder(reader io.Reader) (*sbom.SBOM, error) {
 	doc, err := tvloader.Load2_3(reader)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode spdx-json: %w", err)
+		return nil, fmt.Errorf("unable to decode spdx-tag-value: %w", err)
 	}
 
 	return spdxhelpers.ToSyftModel(doc)


### PR DESCRIPTION
This PR adds debug logging for decode errors. If a file fails to decode, at least a user is now able to run `syft -vv` to see why all the formats failed, like this:

```
[0000] DEBUG format syft-6-json returned err: unable to decode: invalid character 'S' looking for beginning of value
[0000] DEBUG format cyclonedx-1-xml returned err: EOF
[0000] DEBUG format cyclonedx-1-json returned err: invalid character 'S' looking for beginning of value
[0000] DEBUG format spdx-2-tag-value returned err: unable to decode spdx-tag-value: got unknown checksum type sha256
[0000] DEBUG format spdx-2-json returned err: unable to decode spdx-json: invalid character 'S' looking for beginning of value
2022/11/19 09:34:55 error during command execution: failed to decode SBOM: unable to identify format
```

Provides a stop-gap solution for: #1351 