### PR TITLE
Parallel package catalog processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,9 @@ file-metadata:
   # SYFT_FILE_METADATA_DIGESTS env var
   digests: ["sha256"]
 
+# maximum number of workers used to process the list of package catalogers in parallel
+parallelism: 1
+
 # cataloging secrets is exposed through the power-user subcommand
 secrets:
   cataloger:

--- a/cmd/syft/cli/options/packages.go
+++ b/cmd/syft/cli/options/packages.go
@@ -22,6 +22,7 @@ type PackagesOptions struct {
 	Exclude            []string
 	Catalogers         []string
 	Name               string
+	Parallelism        int
 }
 
 var _ Interface = (*PackagesOptions)(nil)
@@ -50,6 +51,14 @@ func (o *PackagesOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
 
 	cmd.Flags().StringVarP(&o.Name, "name", "", "",
 		"set the name of the target being analyzed")
+
+	cmd.Flags().IntVarP(&o.Parallelism, "parallelism", "", 1,
+		"number of workers to use to process the catalogers in parallel")
+
+	// Lets not expose this as a cli option
+	if err := cmd.Flags().MarkHidden("parallelism"); err != nil {
+		return err
+	}
 
 	return bindPackageConfigOptions(cmd.Flags(), v)
 }
@@ -86,6 +95,10 @@ func bindPackageConfigOptions(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	if err := v.BindPFlag("platform", flags.Lookup("platform")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("parallelism", flags.Lookup("parallelism")); err != nil {
 		return err
 	}
 

--- a/cmd/syft/cli/options/packages.go
+++ b/cmd/syft/cli/options/packages.go
@@ -22,7 +22,6 @@ type PackagesOptions struct {
 	Exclude            []string
 	Catalogers         []string
 	Name               string
-	Parallelism        int
 }
 
 var _ Interface = (*PackagesOptions)(nil)
@@ -51,14 +50,6 @@ func (o *PackagesOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
 
 	cmd.Flags().StringVarP(&o.Name, "name", "", "",
 		"set the name of the target being analyzed")
-
-	cmd.Flags().IntVarP(&o.Parallelism, "parallelism", "", 1,
-		"number of workers to use to process the catalogers in parallel")
-
-	// Lets not expose this as a cli option
-	if err := cmd.Flags().MarkHidden("parallelism"); err != nil {
-		return err
-	}
 
 	return bindPackageConfigOptions(cmd.Flags(), v)
 }
@@ -95,10 +86,6 @@ func bindPackageConfigOptions(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	if err := v.BindPFlag("platform", flags.Lookup("platform")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("parallelism", flags.Lookup("parallelism")); err != nil {
 		return err
 	}
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -56,6 +56,7 @@ type Application struct {
 	Attest             attest             `yaml:"attest" json:"attest" mapstructure:"attest"`
 	Platform           string             `yaml:"platform" json:"platform" mapstructure:"platform"`
 	Name               string             `yaml:"name" json:"name" mapstructure:"name"`
+	Parallelism        int                `yaml:"parallelism" json:"parallelism" mapstructure:"parallelism"` // --parallelism the number of catalog workers to run in parallel
 }
 
 func (cfg Application) ToCatalogerConfig() cataloger.Config {
@@ -65,7 +66,8 @@ func (cfg Application) ToCatalogerConfig() cataloger.Config {
 			IncludeUnindexedArchives: cfg.Package.SearchUnindexedArchives,
 			Scope:                    cfg.Package.Cataloger.ScopeOpt,
 		},
-		Catalogers: cfg.Catalogers,
+		Catalogers:  cfg.Catalogers,
+		Parallelism: cfg.Parallelism,
 	}
 }
 

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -56,7 +56,7 @@ type Application struct {
 	Attest             attest             `yaml:"attest" json:"attest" mapstructure:"attest"`
 	Platform           string             `yaml:"platform" json:"platform" mapstructure:"platform"`
 	Name               string             `yaml:"name" json:"name" mapstructure:"name"`
-	Parallelism        int                `yaml:"parallelism" json:"parallelism" mapstructure:"parallelism"` // --parallelism the number of catalog workers to run in parallel
+	Parallelism        int                `yaml:"parallelism" json:"parallelism" mapstructure:"parallelism"` // the number of catalog workers to run in parallel
 }
 
 func (cfg Application) ToCatalogerConfig() cataloger.Config {
@@ -184,6 +184,7 @@ func loadDefaultValues(v *viper.Viper) {
 	v.SetDefault("quiet", false)
 	v.SetDefault("check-for-app-update", true)
 	v.SetDefault("catalogers", nil)
+	v.SetDefault("parallelism", 1)
 
 	// for each field in the configuration struct, see if the field implements the defaultValueLoader interface and invoke it if it does
 	value := reflect.ValueOf(Application{})

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -69,7 +69,7 @@ func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Catalog, []
 		}
 	}
 
-	catalog, relationships, err := cataloger.Catalog(resolver, release, catalogers...)
+	catalog, relationships, err := cataloger.Catalog(resolver, release, cfg.Parallelism, catalogers...)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/syft/pkg/cataloger/config.go
+++ b/syft/pkg/cataloger/config.go
@@ -5,13 +5,15 @@ import (
 )
 
 type Config struct {
-	Search     SearchConfig
-	Catalogers []string
+	Search      SearchConfig
+	Catalogers  []string
+	Parallelism int
 }
 
 func DefaultConfig() Config {
 	return Config{
-		Search: DefaultSearchConfig(),
+		Search:      DefaultSearchConfig(),
+		Parallelism: 1,
 	}
 }
 

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -206,7 +206,10 @@ func TestPackagesCmdFlags(t *testing.T) {
 		},
 		{
 			name: "override-default-parallelism",
-			args: []string{"packages", "-vvv", "-o", "json", "--parallelism", "2", coverageImage},
+			args: []string{"packages", "-vvv", "-o", "json", coverageImage},
+			env: map[string]string{
+				"SYFT_PARALLELISM": "2",
+			},
 			assertions: []traitAssertion{
 				// the application config in the log matches that of what we expect to have been configured.
 				assertInOutput("parallelism: 2"),

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -213,7 +213,7 @@ func TestPackagesCmdFlags(t *testing.T) {
 			assertions: []traitAssertion{
 				// the application config in the log matches that of what we expect to have been configured.
 				assertInOutput("parallelism: 2"),
-				assertInOutput("Using parallelism=2 for catalogs"),
+				assertInOutput("parallelism=2"),
 				assertPackageCount(34),
 				assertSuccessfulReturnCode,
 			},
@@ -224,7 +224,7 @@ func TestPackagesCmdFlags(t *testing.T) {
 			assertions: []traitAssertion{
 				// the application config in the log matches that of what we expect to have been configured.
 				assertInOutput("parallelism: 1"),
-				assertInOutput("Using parallelism=1 for catalogs"),
+				assertInOutput("parallelism=1"),
 				assertPackageCount(34),
 				assertSuccessfulReturnCode,
 			},

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -204,6 +204,28 @@ func TestPackagesCmdFlags(t *testing.T) {
 				assertSuccessfulReturnCode,
 			},
 		},
+		{
+			name: "override-default-parallelism",
+			args: []string{"packages", "-vvv", "-o", "json", "--parallelism", "2", coverageImage},
+			assertions: []traitAssertion{
+				// the application config in the log matches that of what we expect to have been configured.
+				assertInOutput("parallelism: 2"),
+				assertInOutput("Using parallelism=2 for catalogs"),
+				assertPackageCount(34),
+				assertSuccessfulReturnCode,
+			},
+		},
+		{
+			name: "default-parallelism",
+			args: []string{"packages", "-vvv", "-o", "json", coverageImage},
+			assertions: []traitAssertion{
+				// the application config in the log matches that of what we expect to have been configured.
+				assertInOutput("parallelism: 1"),
+				assertInOutput("Using parallelism=1 for catalogs"),
+				assertPackageCount(34),
+				assertSuccessfulReturnCode,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -41,7 +41,7 @@ func BenchmarkImagePackageCatalogers(b *testing.B) {
 
 		b.Run(c.Name(), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				pc, _, err = cataloger.Catalog(resolver, theDistro, c)
+				pc, _, err = cataloger.Catalog(resolver, theDistro, 1, c)
 				if err != nil {
 					b.Fatalf("failure during benchmark: %+v", err)
 				}


### PR DESCRIPTION
Closes #1353 

This introduces a new option `SYFT_PARALLELISM=N` environement variable and syft config file value. Which will use at most `N` workers to process the package catalogers in parallel. The default will be 1.


- uses the `sync` library to create a wait group, waiting for all package catalogers to finish before proceeding.
- effectively has no real change in behaviour to users calling `syft` today, as the default is to create one worker.

----

## example performance benchmark comparision

> Open to recommendations on performance benchmarking but early results on laptop seem promising:

[Created](https://gist.github.com/Mikcl/3c171b074c65a77288788f4fb86cef0c) an exmple directory with `venv` and `node_modules`


```
➜  syft git:(mikcl/concurrent-catalog) SYFT_PARALLELISM=1 time go run cmd/syft/main.go packages  --file ../dump  /path/to/project
[indexing truncated]
 ✔ Indexed /Users/mikcl/Documents/junk/benchmark-concurrent
 ✔ Cataloged packages      [758 packages]

go run cmd/syft/main.go packages --file ../dump   13.29s user 1.75s system 114% cpu 13.179 total
➜  syft git:(mikcl/concurrent-catalog) SYFT_PARALLELISM=4 time  go run cmd/syft/main.go packages   --file ../dump  /path/to/project
[indexing truncated]
 ✔ Indexed /Users/mikcl/Documents/junk/benchmark-concurrent
 ✔ Cataloged packages      [758 packages]
go run cmd/syft/main.go packages --file ../dump   14.16s user 1.94s system 174% cpu 9.235 total
```

1 worker: `13.29s user 1.75s system 114% cpu 13.179 total`
4 workers: `14.16s user 1.94s system 174% cpu 9.235 total`

> uname -a
Darwin Kernel Version 21.6.0: [date redacted]; root:xnu-8020.141.5~2/RELEASE_ARM64_T8101 arm64


For larger file systems and cpu's with more cores, this may be useful :) 