### PR TITLE
fix: return unicode version only letter/num

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
@@ -48,7 +49,9 @@ func parseRequirementsTxt(_ source.FileResolver, _ *generic.Environment, reader 
 			continue
 		}
 		name := strings.TrimSpace(parts[0])
-		version := strings.TrimSpace(parts[1])
+		version := strings.TrimFunc(parts[1], func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		})
 		packages = append(packages, newPackageForIndex(name, version, reader.Location))
 	}
 

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -37,6 +37,14 @@ func TestParseRequirementsTxt(t *testing.T) {
 			Language:  pkg.Python,
 			Type:      pkg.PythonPkg,
 		},
+		{
+			Name:      "argh",
+			Version:   "0.26.2",
+			PURL:      "pkg:pypi/argh@0.26.2",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+		},
 	}
 
 	var expectedRelationships []artifact.Relationship

--- a/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
+++ b/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
@@ -10,3 +10,6 @@ coverage != 3.5 # Version Exclusion. Anything except version 3.5
 numpyNew; sys_platform == 'win32'
 numpy >= 3.4.1; sys_platform == 'win32'
 Mopidy-Dirble ~= 1.1 # Compatible release. Same as >= 1.1, == 1.*
+argh==0.26.2 \
+  --hash=sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3 \
+  --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65


### PR DESCRIPTION
## Summary
Closes #1360 - Trim space fails to cut the end of a string given a blocking `\`

This fix updates the string parser function to only return strings with valid Unicode letter/number.

cc @robcresswell 

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>