### PR TITLE
fix: remove cabal.project.freeze panic on last pkg

### DIFF
--- a/syft/pkg/cataloger/haskell/parse_cabal_freeze.go
+++ b/syft/pkg/cataloger/haskell/parse_cabal_freeze.go
@@ -34,6 +34,14 @@ func parseCabalFreeze(_ source.FileResolver, _ *generic.Environment, reader sour
 
 		line = strings.TrimSpace(line)
 		startPkgEncoding, endPkgEncoding := strings.Index(line, "any.")+4, strings.Index(line, ",")
+		// case where comma not found for last package in constraint list
+		if endPkgEncoding == -1 {
+			endPkgEncoding = len(line)
+		}
+		if startPkgEncoding >= endPkgEncoding || startPkgEncoding < 0 {
+			continue
+		}
+
 		line = line[startPkgEncoding:endPkgEncoding]
 		fields := strings.Split(line, " ==")
 

--- a/syft/pkg/cataloger/haskell/test-fixtures/cabal.project.freeze
+++ b/syft/pkg/cataloger/haskell/test-fixtures/cabal.project.freeze
@@ -12,6 +12,6 @@ constraints: any.Cabal ==3.2.1.0,
              any.RSA ==2.4.1,
              any.SHA ==1.6.4.4,
              void -safe,
-             any.Spock ==0.14.0.0,
-             
+             any.Spock ==0.14.0.0
+
 index-state: hackage.haskell.org 2022-07-07T01:01:53Z


### PR DESCRIPTION
## Summary
Fixes #1362 

cabal.project.freeze does not generate trailing comma for final packages under `constraints`

This would lead to a `-1` value for `endPkgEncoding` causing a panic when attempting to parse portions of the package `line`

This PR adds protections to set endPkgEncoding to the end of the `line` if -1 is encountered, while also adding a guard against other potential incorrect line parsing states

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>