### PR TITLE
Fix parsing of apk databases with large entries

### DIFF
--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -264,7 +264,7 @@ func parseListValue(value string) []string {
 		return items
 	}
 
-	return []string{}
+	return nil
 }
 
 func nilFieldsToEmptySlice(p *pkg.ApkMetadata) {


### PR DESCRIPTION
This PR is a suggested solution to #1354. An alternative implementation could have been to increase the scanner buffer size even further, but the chosen implementation avoids the need to find a perfect buffer size since whole entries no longer need to fit within the buffer. Consequently, it also removes the custom configuration applied to the scanner.

This PR also updates existing tests that were testing `parseApkDBEntry` to test `parseApkDB` instead, since `parseApkDBEntry` no longer exists in the suggested implementation.

**Caveat:** The test fixture used to demonstrate the failure and prove the fix is `syft/pkg/cataloger/apkdb/test-fixtures/very-large-entries`. This is the APK installed DB taken from the image where the failure was first noticed. **This file is large (~4.6 MB)!** Let me know if you think it makes sense to approach this test in a different way.

Closes #1354 