### PR TITLE
fix: guard for locations < 1 in alpmdb parse

### DIFF
--- a/syft/pkg/cataloger/alpm/parse_alpm_db.go
+++ b/syft/pkg/cataloger/alpm/parse_alpm_db.go
@@ -42,10 +42,12 @@ func parseAlpmDB(resolver source.FileResolver, env *generic.Environment, reader 
 	if err != nil {
 		return nil, nil, err
 	}
+
 	pkgFiles, err := parseMtree(r)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	// The replace the files found the the pacman database with the files from the mtree These contain more metadata and
 	// thus more useful.
 	metadata.Files = pkgFiles
@@ -105,6 +107,10 @@ func getFileReader(path string, resolver source.FileResolver) (io.Reader, error)
 	locs, err := resolver.FilesByPath(path)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(locs) == 0 {
+		return nil, fmt.Errorf("could not find file: %s", path)
 	}
 	// TODO: Should we maybe check if we found the file
 	dbContentReader, err := resolver.FileContentsByLocation(locs[0])


### PR DESCRIPTION
## Summary 

Attempts to address #1094 - syft would continue to try and resolve file contents when no locations were found for `FilesByPath` causing a panic when trying to access position 0 of an empty slice.

Error message just before panic on windows:
```
DEBUG directory resolver unable to evaluate symlink for 
path="C:\msys64\var\lib\pacman\local\libp11-kit-0.24.1-4\mtree" : 
CreateFile C:\C:: The filename, directory name, or volume label syntax is incorrect.
```

This fix removes the possibility of panic by checking the locations found before `FilesBypath` is called.

It does not address the fact that `C:\msys64\var\lib\pacman\local\libp11-kit-0.24.1-4\mtree` is a valid path that should be able to be parsed. 

Also note: this error will eventually surface to:
https://github.com/anchore/syft/blob/b290a445ca65cd4f29b197fb5f2d14970239df89/syft/pkg/cataloger/catalog.go#L54-L58

This is an error condition for syft and will result in the program status code 1.

A follow-up PR will be made that can address the correct parsing of the above `mtree` file on windows. 

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>