### PR TITLE
fix: Update node binary package name

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -66,6 +66,18 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			name:       "positive-node",
+			fixtureDir: "test-fixtures/classifiers/positive",
+			expected: pkg.Package{
+				Name:      "node",
+				Version:   "19.2.1",
+				Locations: singleLocation("node"),
+				Metadata: pkg.BinaryMetadata{
+					Classifier: "nodejs-binary",
+				},
+			},
+		},
+		{
 			name:       "positive-go-hint",
 			fixtureDir: "test-fixtures/classifiers/positive",
 			expected: pkg.Package{

--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -38,7 +38,7 @@ var defaultClassifiers = []classifier{
 		FileGlob: "**/node",
 		EvidenceMatcher: fileContentsVersionMatcher(
 			`(?m)node\.js\/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
-		Package:  "node.js",
+		Package:  "node",
 		Language: pkg.JavaScript,
 		PURL:     mustPURL("pkg:generic/node@version"),
 		CPEs:     singleCPE("cpe:2.3:a:nodejs:node.js:*:*:*:*:*:*:*:*"),

--- a/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/node
+++ b/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/node
@@ -1,0 +1,2 @@
+# this should match node 19.2.1
+node.js/v19.2.1


### PR DESCRIPTION
The node binary cataloger erroneously change the name of the node binary package to `node.js`. This corrects it to just `node`.
