### PR TITLE
feat: add catalog delete

### DIFF
--- a/syft/pkg/catalog.go
+++ b/syft/pkg/catalog.go
@@ -26,6 +26,15 @@ loopNewIDs:
 	}
 }
 
+func (s *orderedIDSet) delete(id artifact.ID) {
+	for i, existingID := range s.slice {
+		if existingID == id {
+			s.slice = append(s.slice[:i], s.slice[i+1:]...)
+			return
+		}
+	}
+}
+
 // Catalog represents a collection of Packages.
 type Catalog struct {
 	byID      map[artifact.ID]Package
@@ -92,30 +101,32 @@ func (c *Catalog) Packages(ids []artifact.ID) (result []Package) {
 	return result
 }
 
-// Add a package to the Catalog.
-func (c *Catalog) Add(p Package) {
+// Add n packages to the catalog.
+func (c *Catalog) Add(pkgs ...Package) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	id := p.ID()
-	if id == "" {
-		log.Warnf("found package with empty ID while adding to the catalog: %+v", p)
-		p.SetID()
-		id = p.ID()
-	}
-
-	if existing, exists := c.byID[id]; exists {
-		// there is already a package with this fingerprint merge the existing record with the new one
-		if err := existing.merge(p); err != nil {
-			log.Warnf("failed to merge packages: %+v", err)
-		} else {
-			c.byID[id] = existing
-			c.addPathsToIndex(p)
+	for _, p := range pkgs {
+		id := p.ID()
+		if id == "" {
+			log.Warnf("found package with empty ID while adding to the catalog: %+v", p)
+			p.SetID()
+			id = p.ID()
 		}
-		return
-	}
 
-	c.addToIndex(p)
+		if existing, exists := c.byID[id]; exists {
+			// there is already a package with this fingerprint merge the existing record with the new one
+			if err := existing.merge(p); err != nil {
+				log.Warnf("failed to merge packages: %+v", err)
+			} else {
+				c.byID[id] = existing
+				c.addPathsToIndex(p)
+			}
+			return
+		}
+
+		c.addToIndex(p)
+	}
 }
 
 func (c *Catalog) addToIndex(p Package) {
@@ -154,6 +165,55 @@ func (c *Catalog) addPathsToIndex(p Package) {
 func (c *Catalog) addPathToIndex(id artifact.ID, path string) {
 	pathIndex := c.idsByPath[path]
 	pathIndex.add(id)
+	c.idsByPath[path] = pathIndex
+}
+
+func (c *Catalog) Delete(ids ...artifact.ID) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, id := range ids {
+		p, exists := c.byID[id]
+		if !exists {
+			return
+		}
+
+		delete(c.byID, id)
+		c.deleteNameFromIndex(p)
+		c.deleteTypeFromIndex(p)
+		c.deletePathsFromIndex(p)
+	}
+}
+
+func (c *Catalog) deleteNameFromIndex(p Package) {
+	nameIndex := c.idsByName[p.Name]
+	nameIndex.delete(p.id)
+	c.idsByName[p.Name] = nameIndex
+}
+
+func (c *Catalog) deleteTypeFromIndex(p Package) {
+	typeIndex := c.idsByType[p.Type]
+	typeIndex.delete(p.id)
+	c.idsByType[p.Type] = typeIndex
+}
+
+func (c *Catalog) deletePathsFromIndex(p Package) {
+	observedPaths := internal.NewStringSet()
+	for _, l := range p.Locations.ToSlice() {
+		if l.RealPath != "" && !observedPaths.Contains(l.RealPath) {
+			c.deletePathFromIndex(p.id, l.RealPath)
+			observedPaths.Add(l.RealPath)
+		}
+		if l.VirtualPath != "" && l.RealPath != l.VirtualPath && !observedPaths.Contains(l.VirtualPath) {
+			c.deletePathFromIndex(p.id, l.VirtualPath)
+			observedPaths.Add(l.VirtualPath)
+		}
+	}
+}
+
+func (c *Catalog) deletePathFromIndex(id artifact.ID, path string) {
+	pathIndex := c.idsByPath[path]
+	pathIndex.delete(id)
 	c.idsByPath[path] = pathIndex
 }
 

--- a/syft/pkg/catalog_test.go
+++ b/syft/pkg/catalog_test.go
@@ -16,6 +16,31 @@ type expectedIndexes struct {
 	byPath map[string]*strset.Set
 }
 
+func TestCatalogDeleteRemovesPackages(t *testing.T) {
+	c := NewCatalog()
+	pkg1 := Package{
+		id:   artifact.ID("pkg1"),
+		Name: "pkg1",
+		Type: RpmPkg,
+	}
+	pkg2 := Package{
+		id:   artifact.ID("pkg2"),
+		Name: "pkg2",
+		Type: RpmPkg,
+	}
+	pkg3 := Package{
+		id:   artifact.ID("pkg3"),
+		Name: "pkg3",
+		Type: RpmPkg,
+	}
+	c.Add(pkg1, pkg2, pkg3)
+
+	c.Delete(pkg1.ID(), pkg2.ID())
+
+	assert.Equal(t, 1, c.PackageCount())
+	assert.Equal(t, []Package{pkg3}, c.Sorted())
+}
+
 func TestCatalogAddPopulatesIndex(t *testing.T) {
 
 	var pkgs = []Package{


### PR DESCRIPTION
## Summary

Allows consumers of syft as a library to delete packages from the catalog based on their own filter or gating mechanisms.

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>