### PR TITLE
chore: fix test busybox image sha

### DIFF
--- a/syft/source/test-fixtures/image-symlinks/Dockerfile
+++ b/syft/source/test-fixtures/image-symlinks/Dockerfile
@@ -1,5 +1,5 @@
 # LAYER 0:
-FROM busybox:latest
+FROM busybox:1.34.0
 
 # LAYER 1:
 ADD file-1.txt .


### PR DESCRIPTION
Fixes some failing tests due to a busybox image update: uses pinned tag instead of `:latest`.