### PR TITLE
fix: cyclonedx component type for binaries

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/component.go
+++ b/syft/formats/common/cyclonedxhelpers/component.go
@@ -27,8 +27,13 @@ func encodeComponent(p pkg.Package) cyclonedx.Component {
 		properties = &props
 	}
 
+	componentType := cyclonedx.ComponentTypeLibrary
+	if p.Type == pkg.BinaryPkg {
+		componentType = cyclonedx.ComponentTypeApplication
+	}
+
 	return cyclonedx.Component{
-		Type:               cyclonedx.ComponentTypeLibrary,
+		Type:               componentType,
 		Name:               p.Name,
 		Group:              encodeGroup(p),
 		Version:            p.Version,

--- a/syft/formats/common/cyclonedxhelpers/component_test.go
+++ b/syft/formats/common/cyclonedxhelpers/component_test.go
@@ -144,6 +144,60 @@ func Test_encodeComponentProperties(t *testing.T) {
 	}
 }
 
+func Test_encodeCompomentType(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  pkg.Package
+		want cyclonedx.Component
+	}{
+		{
+			name: "non-binary package",
+			pkg: pkg.Package{
+				Name:    "pkg1",
+				Version: "1.9.2",
+				Type:    pkg.GoModulePkg,
+			},
+			want: cyclonedx.Component{
+				Name:    "pkg1",
+				Version: "1.9.2",
+				Type:    cyclonedx.ComponentTypeLibrary,
+				Properties: &[]cyclonedx.Property{
+					{
+						Name:  "syft:package:type",
+						Value: "go-module",
+					},
+				},
+			},
+		},
+		{
+			name: "non-binary package",
+			pkg: pkg.Package{
+				Name:    "pkg1",
+				Version: "3.1.2",
+				Type:    pkg.BinaryPkg,
+			},
+			want: cyclonedx.Component{
+				Name:    "pkg1",
+				Version: "3.1.2",
+				Type:    cyclonedx.ComponentTypeApplication,
+				Properties: &[]cyclonedx.Property{
+					{
+						Name:  "syft:package:type",
+						Value: "binary",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.pkg.ID()
+			p := encodeComponent(tt.pkg)
+			assert.Equal(t, tt.want, p)
+		})
+	}
+}
+
 func Test_deriveBomRef(t *testing.T) {
 	pkgWithPurl := pkg.Package{
 		Name:    "django",


### PR DESCRIPTION
Adds some logic to output `binary` packages as CycloneDX `application` type.

Fixes #1402 