### PR TITLE
fix: excessive go binary warnings

### DIFF
--- a/syft/pkg/cataloger/golang/scan_binary.go
+++ b/syft/pkg/cataloger/golang/scan_binary.go
@@ -24,7 +24,7 @@ func scanFile(reader unionreader.UnionReader, filename string) ([]*debug.BuildIn
 	for _, r := range readers {
 		bi, err := getBuildInfo(r)
 		if err != nil {
-			log.WithFields("file", filename, "error", err).Warn("unable to read golang buildinfo")
+			log.WithFields("file", filename, "error", err).Trace("unable to read golang buildinfo")
 			continue
 		}
 		if bi == nil {


### PR DESCRIPTION
This PR fixes excessive Go binary parse errors, e.g.:

```
[0000]  INFO syft version: 0.62.3
[0011]  INFO identified distro: Red Hat Enterprise Linux 8.7 (Ootpa)
[0011]  INFO cataloging image
[0017]  WARN unable to read golang buildinfo error=not a Go executable file=/usr/bin/bash
[0017]  WARN golang cataloger: bin parsing: number of builds and readers doesn't match
[0017]  WARN unable to read golang buildinfo error=not a Go executable file=/usr/bin/brotli
[0017]  WARN golang cataloger: bin parsing: number of builds and readers doesn't match
[0017]  WARN unable to read golang buildinfo error=not a Go executable file=/usr/bin/busctl
[0017]  WARN golang cataloger: bin parsing: number of builds and readers doesn't match
<snip ... another 2000 lines of the same 2 warnings for various files>
```

Fixes #1403 