### PR TITLE
Add alpine type to purl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7
+	github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/facebookincubator/nvdtools v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,6 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7 h1:kDrYkTSM9uIxaX/P9s0F4nKYNM+hnSgLJdLpqvsaQ/g=
-github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501 h1:AV7qjwMcM4r8wFhJq3jLRztew3ywIyPTRapl2T1s9o8=
 github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1 h1:DXUAm/H9chRTEzMfkFyduBIcCiJyFXhCmv3zH3C0HGs=

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7 h1:kDrYkTSM9uIxaX/P9s0F4nKYNM+hnSgLJdLpqvsaQ/g=
 github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
+github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501 h1:AV7qjwMcM4r8wFhJq3jLRztew3ywIyPTRapl2T1s9o8=
+github.com/anchore/packageurl-go v0.1.1-0.20230104203445-02e0a6721501/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1 h1:DXUAm/H9chRTEzMfkFyduBIcCiJyFXhCmv3zH3C0HGs=
 github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/syft/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder_test.go
@@ -92,7 +92,7 @@ func Test_decode(t *testing.T) {
 							},
 						},
 						CPE:        "cpe:2.3:*:another:package:2:*:*:*:*:*:*:*",
-						PackageURL: "pkg:alpine/alpine-baselayout@3.2.0-r16?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.14.2",
+						PackageURL: "pkg:apk/alpine/alpine-baselayout@3.2.0-r16?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.14.2",
 						Properties: &[]cyclonedx.Property{
 
 							{
@@ -193,7 +193,7 @@ func Test_decode(t *testing.T) {
 				{
 					pkg:  "package-2",
 					ver:  "2.0.2",
-					purl: "pkg:alpine/alpine-baselayout@3.2.0-r16?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.14.2",
+					purl: "pkg:apk/alpine/alpine-baselayout@3.2.0-r16?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.14.2",
 				},
 			},
 		},

--- a/syft/formats/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model_test.go
@@ -46,7 +46,7 @@ func TestToSyftModel(t *testing.T) {
 					},
 					{
 						Category: "PACKAGE-MANAGER",
-						Locator:  "pkg:alpine/pkg-1@5.4.3?arch=x86_64&upstream=p1-origin&distro=alpine-3.10.9",
+						Locator:  "pkg:apk/alpine/pkg-1@5.4.3?arch=x86_64&upstream=p1-origin&distro=alpine-3.10.9",
 						RefType:  "purl",
 					},
 				},
@@ -145,7 +145,7 @@ func Test_extractMetadata(t *testing.T) {
 				PackageExternalReferences: []*spdx.PackageExternalReference{
 					{
 						Category: "PACKAGE-MANAGER",
-						Locator:  "pkg:alpine/pkg-2@7.3.1?arch=x86_64&upstream=apk-origin@9.1.3&distro=alpine-3.10.9",
+						Locator:  "pkg:apk/alpine/pkg-2@7.3.1?arch=x86_64&upstream=apk-origin@9.1.3&distro=alpine-3.10.9",
 						RefType:  "purl",
 					},
 				},

--- a/syft/formats/spdxjson/test-fixtures/spdx/alpine-3.10.syft.spdx.json
+++ b/syft/formats/spdxjson/test-fixtures/spdx/alpine-3.10.syft.spdx.json
@@ -27,7 +27,7 @@
     },
     {
      "referenceCategory": "PACKAGE_MANAGER",
-     "referenceLocator": "pkg:alpine/busybox@1.30.1-r5?arch=x86_64&distro=alpine-3.10.9",
+     "referenceLocator": "pkg:apk/alpine/busybox@1.30.1-r5?arch=x86_64&distro=alpine-3.10.9",
      "referenceType": "purl"
     }
    ],
@@ -51,7 +51,7 @@
     },
     {
      "referenceCategory": "PACKAGE_MANAGER",
-     "referenceLocator": "pkg:alpine/libssl1.1@1.1.1k-r0?arch=x86_64&distro=alpine-3.10.9",
+     "referenceLocator": "pkg:apk/alpine/libssl1.1@1.1.1k-r0?arch=x86_64&distro=alpine-3.10.9",
      "referenceType": "purl"
     }
    ],
@@ -100,7 +100,7 @@
     },
     {
      "referenceCategory": "PACKAGE_MANAGER",
-     "referenceLocator": "pkg:alpine/ssl_client@1.30.1-r5?arch=x86_64&upstream=busybox&distro=alpine-3.10.9",
+     "referenceLocator": "pkg:apk/alpine/ssl_client@1.30.1-r5?arch=x86_64&upstream=busybox&distro=alpine-3.10.9",
      "referenceType": "purl"
     }
    ],

--- a/syft/formats/spdxtagvalue/test-fixtures/tag-value.spdx
+++ b/syft/formats/spdxtagvalue/test-fixtures/tag-value.spdx
@@ -21,7 +21,7 @@ PackageLicenseDeclared: GPL-2.0-only
 PackageCopyrightText: NOASSERTION
 PackageDescription: Size optimized toolbox of many common UNIX utilities
 ExternalRef: SECURITY cpe23Type cpe:2.3:a:busybox:busybox:1.31.1-r19:*:*:*:*:*:*:*
-ExternalRef: PACKAGE-MANAGER purl pkg:alpine/busybox@1.31.1-r19?arch=x86_64&upstream=busybox&distro=alpine-3.12.5
+ExternalRef: PACKAGE-MANAGER purl pkg:apk/alpine/busybox@1.31.1-r19?arch=x86_64&upstream=busybox&distro=alpine-3.12.5
 
 ##### Package: my-app
 

--- a/syft/formats/test-fixtures/alpine-syft.json
+++ b/syft/formats/test-fixtures/alpine-syft.json
@@ -24,7 +24,7 @@
     "cpe:2.3:a:alpine:alpine-baselayout:3.2.0-r16:*:*:*:*:*:*:*",
     "cpe:2.3:a:alpine:alpine_baselayout:3.2.0-r16:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/alpine-baselayout@3.2.0-r16?arch=x86_64",
+   "purl": "pkg:apk/alpine/alpine-baselayout@3.2.0-r16?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "alpine-baselayout",
@@ -504,7 +504,7 @@
     "cpe:2.3:a:alpine:alpine-keys:2.3-r1:*:*:*:*:*:*:*",
     "cpe:2.3:a:alpine:alpine_keys:2.3-r1:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/alpine-keys@2.3-r1?arch=x86_64",
+   "purl": "pkg:apk/alpine/alpine-keys@2.3-r1?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "alpine-keys",
@@ -790,7 +790,7 @@
     "cpe:2.3:a:apk:apk-tools:2.12.7-r0:*:*:*:*:*:*:*",
     "cpe:2.3:a:apk:apk_tools:2.12.7-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/apk-tools@2.12.7-r0?arch=x86_64",
+   "purl": "pkg:apk/alpine/apk-tools@2.12.7-r0?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "apk-tools",
@@ -882,7 +882,7 @@
    "cpes": [
     "cpe:2.3:a:busybox:busybox:1.33.1-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/busybox@1.33.1-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/busybox@1.33.1-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "busybox",
@@ -1059,7 +1059,7 @@
     "cpe:2.3:a:ca:ca-certificates-bundle:20191127-r5:*:*:*:*:*:*:*",
     "cpe:2.3:a:ca:ca_certificates_bundle:20191127-r5:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/ca-certificates-bundle@20191127-r5?arch=x86_64",
+   "purl": "pkg:apk/alpine/ca-certificates-bundle@20191127-r5?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "ca-certificates-bundle",
@@ -1131,7 +1131,7 @@
     "cpe:2.3:a:libc:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
     "cpe:2.3:a:libc:libc_utils:0.7.2-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libc-utils@0.7.2-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libc-utils",
@@ -1169,7 +1169,7 @@
    "cpes": [
     "cpe:2.3:a:libcrypto1.1:libcrypto1.1:1.1.1l-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libcrypto1.1@1.1.1l-r0?arch=x86_64",
+   "purl": "pkg:apk/alpine/libcrypto1.1@1.1.1l-r0?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libcrypto1.1",
@@ -1347,7 +1347,7 @@
    "cpes": [
     "cpe:2.3:a:libretls:libretls:3.3.3p1-r2:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libretls@3.3.3p1-r2?arch=x86_64",
+   "purl": "pkg:apk/alpine/libretls@3.3.3p1-r2?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libretls",
@@ -1412,7 +1412,7 @@
    "cpes": [
     "cpe:2.3:a:libssl1.1:libssl1.1:1.1.1l-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libssl1.1@1.1.1l-r0?arch=x86_64",
+   "purl": "pkg:apk/alpine/libssl1.1@1.1.1l-r0?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libssl1.1",
@@ -1480,7 +1480,7 @@
    "cpes": [
     "cpe:2.3:a:musl:musl:1.2.2-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/musl@1.2.2-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/musl@1.2.2-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "musl",
@@ -1549,7 +1549,7 @@
     "cpe:2.3:a:musl:musl-utils:1.2.2-r3:*:*:*:*:*:*:*",
     "cpe:2.3:a:musl:musl_utils:1.2.2-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/musl-utils@1.2.2-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/musl-utils@1.2.2-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "musl-utils",
@@ -1647,7 +1647,7 @@
    "cpes": [
     "cpe:2.3:a:scanelf:scanelf:1.3.2-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/scanelf@1.3.2-r0?arch=x86_64",
+   "purl": "pkg:apk/alpine/scanelf@1.3.2-r0?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "scanelf",
@@ -1707,7 +1707,7 @@
     "cpe:2.3:a:ssl:ssl-client:1.33.1-r3:*:*:*:*:*:*:*",
     "cpe:2.3:a:ssl:ssl_client:1.33.1-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/ssl_client@1.33.1-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/ssl_client@1.33.1-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "ssl_client",
@@ -1762,7 +1762,7 @@
    "cpes": [
     "cpe:2.3:a:zlib:zlib:1.2.11-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/zlib@1.2.11-r3?arch=x86_64",
+   "purl": "pkg:apk/alpine/zlib@1.2.11-r3?arch=x86_64",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "zlib",

--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -42,10 +42,8 @@ func packageURL(m pkg.ApkMetadata, distro *linux.Release) string {
 	}
 
 	return packageurl.NewPackageURL(
-		// note: this is currently a candidate and not technically within spec
-		// see https://github.com/package-url/purl-spec#other-candidate-types-to-define
+		packageurl.TypeAlpine,
 		"alpine",
-		"",
 		m.Package,
 		m.Version,
 		pkg.PURLQualifiers(

--- a/syft/pkg/cataloger/apkdb/package_test.go
+++ b/syft/pkg/cataloger/apkdb/package_test.go
@@ -43,7 +43,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.4.6",
 			},
-			expected: "pkg:alpine/p@v?arch=a&distro=alpine-3.4.6",
+			expected: "pkg:apk/alpine/p@v?arch=a&distro=alpine-3.4.6",
 		},
 		{
 			name: "missing architecture",
@@ -55,7 +55,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.4.6",
 			},
-			expected: "pkg:alpine/p@v?distro=alpine-3.4.6",
+			expected: "pkg:apk/alpine/p@v?distro=alpine-3.4.6",
 		},
 		// verify #351
 		{
@@ -68,7 +68,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.4.6",
 			},
-			expected: "pkg:alpine/g++@v84?arch=am86&distro=alpine-3.4.6",
+			expected: "pkg:apk/alpine/g++@v84?arch=am86&distro=alpine-3.4.6",
 		},
 		{
 			metadata: pkg.ApkMetadata{
@@ -80,7 +80,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.15.0",
 			},
-			expected: "pkg:alpine/g%20plus%20plus@v84?arch=am86&distro=alpine-3.15.0",
+			expected: "pkg:apk/alpine/g%20plus%20plus@v84?arch=am86&distro=alpine-3.15.0",
 		},
 		{
 			name: "add source information as qualifier",
@@ -94,7 +94,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.4.6",
 			},
-			expected: "pkg:alpine/p@v?arch=a&upstream=origin&distro=alpine-3.4.6",
+			expected: "pkg:apk/alpine/p@v?arch=a&upstream=origin&distro=alpine-3.4.6",
 		},
 	}
 

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -637,7 +637,7 @@ func TestMultiplePackages(t *testing.T) {
 			Version:      "0.7.2-r0",
 			Licenses:     []string{"BSD"},
 			Type:         pkg.ApkPkg,
-			PURL:         "pkg:alpine/libc-utils@0.7.2-r0?arch=x86_64&upstream=libc-dev&distro=alpine-3.12",
+			PURL:         "pkg:apk/alpine/libc-utils@0.7.2-r0?arch=x86_64&upstream=libc-dev&distro=alpine-3.12",
 			Locations:    fixtureLocationSet,
 			MetadataType: pkg.ApkMetadataType,
 			Metadata: pkg.ApkMetadata{
@@ -663,7 +663,7 @@ func TestMultiplePackages(t *testing.T) {
 			Version:      "1.1.24-r2",
 			Licenses:     []string{"MIT", "BSD", "GPL2+"},
 			Type:         pkg.ApkPkg,
-			PURL:         "pkg:alpine/musl-utils@1.1.24-r2?arch=x86_64&upstream=musl&distro=alpine-3.12",
+			PURL:         "pkg:apk/alpine/musl-utils@1.1.24-r2?arch=x86_64&upstream=musl&distro=alpine-3.12",
 			Locations:    fixtureLocationSet,
 			MetadataType: pkg.ApkMetadataType,
 			Metadata: pkg.ApkMetadata{

--- a/syft/pkg/cataloger/sbom/cataloger_test.go
+++ b/syft/pkg/cataloger/sbom/cataloger_test.go
@@ -40,7 +40,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/alpine-baselayout@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/alpine-baselayout@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:alpine-baselayout:alpine-baselayout:3.2.0-r23:*:*:*:*:*:*:*",
 				"cpe:2.3:a:alpine-baselayout:alpine_baselayout:3.2.0-r23:*:*:*:*:*:*:*",
@@ -57,7 +57,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/alpine-baselayout-data@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/alpine-baselayout-data@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:alpine-baselayout-data:alpine-baselayout-data:3.2.0-r23:*:*:*:*:*:*:*",
 				"cpe:2.3:a:alpine-baselayout-data:alpine_baselayout_data:3.2.0-r23:*:*:*:*:*:*:*",
@@ -78,7 +78,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"MIT"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:alpine-keys:alpine-keys:2.4-r1:*:*:*:*:*:*:*",
 				"cpe:2.3:a:alpine-keys:alpine_keys:2.4-r1:*:*:*:*:*:*:*",
@@ -95,7 +95,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/apk-tools@2.12.9-r3?arch=x86_64&upstream=apk-tools&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=x86_64&upstream=apk-tools&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:apk-tools:apk-tools:2.12.9-r3:*:*:*:*:*:*:*",
 				"cpe:2.3:a:apk-tools:apk_tools:2.12.9-r3:*:*:*:*:*:*:*",
@@ -112,7 +112,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/busybox@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/busybox@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:busybox:busybox:1.35.0-r17:*:*:*:*:*:*:*",
 			),
@@ -124,7 +124,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"MPL-2.0", "AND", "MIT"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/ca-certificates-bundle@20220614-r0?arch=x86_64&upstream=ca-certificates&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/ca-certificates-bundle@20220614-r0?arch=x86_64&upstream=ca-certificates&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:ca-certificates-bundle:ca-certificates-bundle:20220614-r0:*:*:*:*:*:*:*",
 				"cpe:2.3:a:ca-certificates-bundle:ca_certificates_bundle:20220614-r0:*:*:*:*:*:*:*",
@@ -145,7 +145,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"BSD-2-Clause", "AND", "BSD-3-Clause"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:libc-utils:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
 				"cpe:2.3:a:libc-utils:libc_utils:0.7.2-r3:*:*:*:*:*:*:*",
@@ -162,7 +162,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"OpenSSL"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/libcrypto1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/libcrypto1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:libcrypto1.1:libcrypto1.1:1.1.1s-r0:*:*:*:*:*:*:*",
 			),
@@ -174,7 +174,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"OpenSSL"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/libssl1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/libssl1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:libssl1.1:libssl1.1:1.1.1s-r0:*:*:*:*:*:*:*",
 			),
@@ -186,7 +186,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"MIT"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/musl@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/musl@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:musl:musl:1.2.3-r1:*:*:*:*:*:*:*",
 			),
@@ -198,7 +198,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"MIT", "BSD", "GPL2+"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/musl-utils@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/musl-utils@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:musl-utils:musl-utils:1.2.3-r1:*:*:*:*:*:*:*",
 				"cpe:2.3:a:musl-utils:musl_utils:1.2.3-r1:*:*:*:*:*:*:*",
@@ -215,7 +215,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:scanelf:scanelf:1.3.4-r0:*:*:*:*:*:*:*",
 			),
@@ -227,7 +227,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"GPL-2.0-only"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:ssl-client:ssl-client:1.35.0-r17:*:*:*:*:*:*:*",
 				"cpe:2.3:a:ssl-client:ssl_client:1.35.0-r17:*:*:*:*:*:*:*",
@@ -244,7 +244,7 @@ func Test_parseSBOM(t *testing.T) {
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
 			Licenses:  []string{"Zlib"},
 			FoundBy:   "sbom-cataloger",
-			PURL:      "pkg:alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
+			PURL:      "pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:zlib:zlib:1.2.12-r3:*:*:*:*:*:*:*",
 			),

--- a/syft/pkg/cataloger/sbom/test-fixtures/alpine/syft-json/sbom.syft.json
+++ b/syft/pkg/cataloger/sbom/test-fixtures/alpine/syft-json/sbom.syft.json
@@ -24,7 +24,7 @@
     "cpe:2.3:a:alpine:alpine-baselayout:3.2.0-r23:*:*:*:*:*:*:*",
     "cpe:2.3:a:alpine:alpine_baselayout:3.2.0-r23:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/alpine-baselayout@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/alpine-baselayout@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "alpine-baselayout",
@@ -411,7 +411,7 @@
     "cpe:2.3:a:alpine:alpine-baselayout-data:3.2.0-r23:*:*:*:*:*:*:*",
     "cpe:2.3:a:alpine:alpine_baselayout_data:3.2.0-r23:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/alpine-baselayout-data@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/alpine-baselayout-data@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "alpine-baselayout-data",
@@ -570,7 +570,7 @@
     "cpe:2.3:a:alpine:alpine-keys:2.4-r1:*:*:*:*:*:*:*",
     "cpe:2.3:a:alpine:alpine_keys:2.4-r1:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "alpine-keys",
@@ -1007,7 +1007,7 @@
     "cpe:2.3:a:apk:apk-tools:2.12.9-r3:*:*:*:*:*:*:*",
     "cpe:2.3:a:apk:apk_tools:2.12.9-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/apk-tools@2.12.9-r3?arch=x86_64&upstream=apk-tools&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=x86_64&upstream=apk-tools&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "apk-tools",
@@ -1110,7 +1110,7 @@
    "cpes": [
     "cpe:2.3:a:busybox:busybox:1.35.0-r17:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/busybox@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/busybox@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "busybox",
@@ -1294,7 +1294,7 @@
     "cpe:2.3:a:ca:ca-certificates-bundle:20220614-r0:*:*:*:*:*:*:*",
     "cpe:2.3:a:ca:ca_certificates_bundle:20220614-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/ca-certificates-bundle@20220614-r0?arch=x86_64&upstream=ca-certificates&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/ca-certificates-bundle@20220614-r0?arch=x86_64&upstream=ca-certificates&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "ca-certificates-bundle",
@@ -1369,7 +1369,7 @@
     "cpe:2.3:a:libc:libc-utils:0.7.2-r3:*:*:*:*:*:*:*",
     "cpe:2.3:a:libc:libc_utils:0.7.2-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libc-utils",
@@ -1410,7 +1410,7 @@
    "cpes": [
     "cpe:2.3:a:libcrypto1.1:libcrypto1.1:1.1.1s-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libcrypto1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/libcrypto1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libcrypto1.1",
@@ -1589,7 +1589,7 @@
    "cpes": [
     "cpe:2.3:a:libssl1.1:libssl1.1:1.1.1s-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/libssl1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/libssl1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "libssl1.1",
@@ -1663,7 +1663,7 @@
    "cpes": [
     "cpe:2.3:a:musl:musl:1.2.3-r1:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/musl@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/musl@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "musl",
@@ -1735,7 +1735,7 @@
     "cpe:2.3:a:musl:musl-utils:1.2.3-r1:*:*:*:*:*:*:*",
     "cpe:2.3:a:musl:musl_utils:1.2.3-r1:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/musl-utils@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/musl-utils@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "musl-utils",
@@ -1843,7 +1843,7 @@
    "cpes": [
     "cpe:2.3:a:scanelf:scanelf:1.3.4-r0:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "scanelf",
@@ -1908,7 +1908,7 @@
     "cpe:2.3:a:ssl:ssl-client:1.35.0-r17:*:*:*:*:*:*:*",
     "cpe:2.3:a:ssl:ssl_client:1.35.0-r17:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "ssl_client",
@@ -1970,7 +1970,7 @@
    "cpes": [
     "cpe:2.3:a:zlib:zlib:1.2.12-r3:*:*:*:*:*:*:*"
    ],
-   "purl": "pkg:alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
+   "purl": "pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
    "metadataType": "ApkMetadata",
    "metadata": {
     "package": "zlib",

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -1,6 +1,8 @@
 package pkg
 
-import "github.com/anchore/packageurl-go"
+import (
+	"github.com/anchore/packageurl-go"
+)
 
 // Type represents a Package Type for or within a language ecosystem (there may be multiple package types within a language ecosystem)
 type Type string
@@ -58,7 +60,7 @@ var AllPkgs = []Type{
 func (t Type) PackageURLType() string {
 	switch t {
 	case ApkPkg:
-		return "alpine"
+		return packageurl.TypeAlpine
 	case AlpmPkg:
 		return "alpm"
 	case GemPkg:
@@ -114,7 +116,7 @@ func TypeByName(name string) Type {
 		return RpmPkg
 	case "alpm":
 		return AlpmPkg
-	case "alpine":
+	case packageurl.TypeAlpine:
 		return ApkPkg
 	case packageurl.TypeMaven:
 		return JavaPkg

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -116,7 +116,7 @@ func TypeByName(name string) Type {
 		return RpmPkg
 	case "alpm":
 		return AlpmPkg
-	case packageurl.TypeAlpine:
+	case packageurl.TypeAlpine, "alpine":
 		return ApkPkg
 	case packageurl.TypeMaven:
 		return JavaPkg

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -19,7 +19,7 @@ func TestTypeFromPURL(t *testing.T) {
 			expected: RpmPkg,
 		},
 		{
-			purl:     "pkg:alpine/util-linux@2.32.1",
+			purl:     "pkg:apk/alpine/util-linux@2.32.1",
 			expected: ApkPkg,
 		},
 		{


### PR DESCRIPTION
apk is now in the purl spec: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#apk

Requires https://github.com/anchore/packageurl-go/pull/9 to be merged, and then I will update deps in this PR.

