### PR TITLE
fix: additional excessive go binary warnings

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -85,12 +85,12 @@ func makeGoMainPackage(mod *debug.BuildInfo, arch string, location source.Locati
 // 2) reading file headers from binaries compiled by < go1.18
 func getArchs(readers []io.ReaderAt, builds []*debug.BuildInfo) []string {
 	if len(readers) != len(builds) {
-		log.Warnf("golang cataloger: bin parsing: number of builds and readers doesn't match")
+		log.Trace("golang cataloger: bin parsing: number of builds and readers doesn't match")
 		return nil
 	}
 
 	if len(readers) == 0 || len(builds) == 0 {
-		log.Warnf("golang cataloger: bin parsing: %d readers and %d build info items", len(readers), len(builds))
+		log.Tracef("golang cataloger: bin parsing: %d readers and %d build info items", len(readers), len(builds))
 		return nil
 	}
 
@@ -107,7 +107,7 @@ func getArchs(readers []io.ReaderAt, builds []*debug.BuildInfo) []string {
 	for i, r := range readers {
 		a, err := getGOARCHFromBin(r)
 		if err != nil {
-			log.Warnf("golang cataloger: bin parsing: getting arch from binary: %v", err)
+			log.Tracef("golang cataloger: bin parsing: getting arch from binary: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
:arrow_up: Follow-up to https://github.com/anchore/syft/pull/1424.
:bug: Fixes https://github.com/anchore/syft/issues/1403.

The original fix b125ea83baa30dc981e82f4ddd384602f778f090 didn't catch all the excessive warnings, it seems like getArches can also be called on binaries that aren't necessarily go binaries, so the messages from this should also be Trace instead of Warn