### PR TITLE
Add purls for binary classifiers

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -23,6 +23,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "python",
 				Version:   "3.7.4a-vZ9",
+				PURL:      "pkg:generic/python@3.7.4a-vZ9",
 				Locations: singleLocation("libpython3.7.so"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "python-binary-lib",
@@ -35,6 +36,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "python",
 				Version:   "3.6.3a-vZ9",
+				PURL:      "pkg:generic/python@3.6.3a-vZ9",
 				Locations: singleLocation("python3.6"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "python-binary",
@@ -47,6 +49,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "python",
 				Version:   "3.9-aZ5",
+				PURL:      "pkg:generic/python@3.9-aZ5",
 				Locations: singleLocation("patchlevel.h"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "cpython-source",
@@ -59,6 +62,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "go",
 				Version:   "1.14",
+				PURL:      "pkg:generic/go@1.14",
 				Locations: singleLocation("go"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "go-binary",
@@ -71,6 +75,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "node",
 				Version:   "19.2.1",
+				PURL:      "pkg:generic/node@19.2.1",
 				Locations: singleLocation("node"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "nodejs-binary",
@@ -83,6 +88,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			expected: pkg.Package{
 				Name:      "go",
 				Version:   "1.15",
+				PURL:      "pkg:generic/go@1.15",
 				Locations: singleLocation("VERSION"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier: "go-binary-hint",
@@ -109,6 +115,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Name:      "java",
 				Version:   "1.8.0_352-b08",
 				Type:      "binary",
+				PURL:      "pkg:generic/java@1.8.0_352-b08",
 				Locations: singleLocation("java"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier:  "java-binary-openjdk",
@@ -123,6 +130,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Name:      "java",
 				Version:   "11.0.17+8-LTS",
 				Type:      "binary",
+				PURL:      "pkg:generic/java@11.0.17+8-LTS",
 				Locations: singleLocation("java"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier:  "java-binary-openjdk",
@@ -137,6 +145,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Name:      "java",
 				Version:   "19.0.1+10-21",
 				Type:      "binary",
+				PURL:      "pkg:generic/java@19.0.1+10-21",
 				Locations: singleLocation("java"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier:  "java-binary-oracle",
@@ -151,6 +160,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Name:      "java",
 				Version:   "19.0.1+10-21",
 				Type:      "binary",
+				PURL:      "pkg:generic/java@19.0.1+10-21",
 				Locations: singleLocation("java"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier:  "java-binary-oracle",
@@ -165,6 +175,7 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Name:      "java",
 				Version:   "1.8.0-foreman_2022_09_22_15_30-b00",
 				Type:      "binary",
+				PURL:      "pkg:generic/java@1.8.0-foreman_2022_09_22_15_30-b00",
 				Locations: singleLocation("java"),
 				Metadata: pkg.BinaryMetadata{
 					Classifier:  "java-binary-ibm",
@@ -277,6 +288,7 @@ func assertPackagesAreEqual(t *testing.T, expected pkg.Package, p pkg.Package) {
 	meta2 := p.Metadata.(pkg.BinaryMetadata)
 	if expected.Name != p.Name ||
 		expected.Version != p.Version ||
+		expected.PURL != p.PURL ||
 		meta1.Classifier != meta2.Classifier {
 		assert.Failf(t, "packages not equal", "%v != %v", expected, p)
 	}

--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -10,6 +10,7 @@ var defaultClassifiers = []classifier{
 			`(.*/|^)python(?P<version>[0-9]+\.[0-9]+)$`,
 			`(?m)(?P<version>{{ .version }}\.[0-9]+[-_a-zA-Z0-9]*)`),
 		Package: "python",
+		PURL:    mustPURL("pkg:generic/python@version"),
 	},
 	{
 		Class:    "python-binary-lib",
@@ -18,6 +19,7 @@ var defaultClassifiers = []classifier{
 			`(.*/|^)libpython(?P<version>[0-9]+\.[0-9]+).so.*$`,
 			`(?m)(?P<version>{{ .version }}\.[0-9]+[-_a-zA-Z0-9]*)`),
 		Package: "python",
+		PURL:    mustPURL("pkg:generic/python@version"),
 	},
 	{
 		Class:    "cpython-source",
@@ -25,6 +27,7 @@ var defaultClassifiers = []classifier{
 		EvidenceMatcher: fileContentsVersionMatcher(
 			`(?m)#define\s+PY_VERSION\s+"?(?P<version>[0-9\.\-_a-zA-Z]+)"?`),
 		Package: "python",
+		PURL:    mustPURL("pkg:generic/python@version"),
 	},
 	{
 		Class:    "go-binary",
@@ -32,6 +35,7 @@ var defaultClassifiers = []classifier{
 		EvidenceMatcher: fileContentsVersionMatcher(
 			`(?m)go(?P<version>[0-9]+\.[0-9]+(\.[0-9]+|beta[0-9]+|alpha[0-9]+|rc[0-9]+)?)\x00`),
 		Package: "go",
+		PURL:    mustPURL("pkg:generic/go@version"),
 		CPEs:    singleCPE("cpe:2.3:a:golang:go:*:*:*:*:*:*:*:*"),
 	},
 	{
@@ -42,6 +46,7 @@ var defaultClassifiers = []classifier{
 			// [NUL]openjdk[NUL]java[NUL]1.8[NUL]1.8.0_352-b08[NUL]
 			`(?m)\x00openjdk\x00java\x00(?P<release>[0-9]+[.0-9]*)\x00(?P<version>[0-9]+[^\x00]+)\x00`),
 		Package: "java",
+		PURL:    mustPURL("pkg:generic/java@version"),
 		// TODO the updates might need to be part of the CPE, like: 1.8.0:update152
 		CPEs: singleCPE("cpe:2.3:a:oracle:openjdk:*:*:*:*:*:*:*:*"),
 	},
@@ -52,6 +57,7 @@ var defaultClassifiers = []classifier{
 			// [NUL]java[NUL]1.8[NUL][NUL][NUL][NUL]1.8.0-foreman_2022_09_22_15_30-b00[NUL]
 			`(?m)\x00java\x00(?P<release>[0-9]+[.0-9]+)\x00{4}(?P<version>[0-9]+[-._a-zA-Z0-9]+)\x00`),
 		Package: "java",
+		PURL:    mustPURL("pkg:generic/java@version"),
 		CPEs:    singleCPE("cpe:2.3:a:ibm:java:*:*:*:*:*:*:*:*"),
 	},
 	{
@@ -61,6 +67,7 @@ var defaultClassifiers = []classifier{
 			// [NUL]19.0.1+10-21[NUL]
 			`(?m)\x00(?P<version>[0-9]+[.0-9]+[+][-0-9]+)\x00`),
 		Package: "java",
+		PURL:    mustPURL("pkg:generic/java@version"),
 		CPEs:    singleCPE("cpe:2.3:a:oracle:jre:*:*:*:*:*:*:*:*"),
 	},
 	{
@@ -79,6 +86,7 @@ var defaultClassifiers = []classifier{
 		EvidenceMatcher: fileContentsVersionMatcher(
 			`(?m)go(?P<version>[0-9]+\.[0-9]+(\.[0-9]+|beta[0-9]+|alpha[0-9]+|rc[0-9]+)?)`),
 		Package: "go",
+		PURL:    mustPURL("pkg:generic/go@version"),
 	},
 	{
 		Class:    "busybox-binary",


### PR DESCRIPTION
I noticed that purls were empty for binary matched packages

```
  {
      "id": "42128c6f2809fa6c",
      "name": "go",
      "version": "1.19.4",
      "type": "binary",
      "foundBy": "binary-cataloger",
      ...
      "purl": "",
      ...
  },
```

And after 

```
  {
     "id": "42128c6f2809fa6c",
     "name": "go",
     "version": "1.19.4",
     "type": "binary",
     "foundBy": "binary-cataloger",
     ...
     "purl": "pkg:generic/go@1.19.4",
     ...
  },
```

Reference: [purl-spec generic type](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#generic)

cc: @kzantow  

