### PR TITLE
fix: duplicate file in tar archive causes read to fail

### DIFF
--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -301,6 +301,12 @@ func fileAnalysisPath(path string) (string, func()) {
 	// unarchived.
 	envelopedUnarchiver, err := archiver.ByExtension(path)
 	if unarchiver, ok := envelopedUnarchiver.(archiver.Unarchiver); err == nil && ok {
+		if tar, ok := unarchiver.(*archiver.Tar); ok {
+			// when tar files are extracted, if there are multiple entries at the same
+			// location, the last entry wins
+			// NOTE: this currently does not display any messages if an overwrite happens
+			tar.OverwriteExisting = true
+		}
 		unarchivedPath, tmpCleanup, err := unarchiveToTmp(path, unarchiver)
 		if err != nil {
 			log.Warnf("file could not be unarchived: %+v", err)

--- a/syft/source/test-fixtures/path-detected-2/.vimrc
+++ b/syft/source/test-fixtures/path-detected-2/.vimrc
@@ -1,0 +1,1 @@
+Another .vimrc file


### PR DESCRIPTION
When extracting `.tar` files, it's possible to have multiple entries with the same path. Using standard `tar` tools, the end result is the last file at a location is the one that remains after unarchiving. This PR adjusts Syft's unarchiving behavior of tar. files to match.

NOTE: prior to this change, Syft would print a `WARN` message when a duplicate path was encountered, it would also stop processing the archive further. This change allows unarchiving to continue but Syft is unable to get any information about duplicate files and no longer prints a warning.

Fixes #1400 