### PR TITLE
Optimise resolver

### DIFF
--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -156,7 +156,10 @@ func execWorker(app *config.Application, sourceInput source.Input, format sbom.F
 	go func() {
 		defer close(errs)
 
-		src, cleanup, err := source.NewFromRegistry(sourceInput, app.Registry.ToOptions(), app.Exclusions)
+		// TODO: check if filter is realy required
+		filter := func(path string) bool { return true }
+
+		src, cleanup, err := source.NewFromRegistry(sourceInput, app.Registry.ToOptions(), filter, app.Exclusions)
 		if cleanup != nil {
 			defer cleanup()
 		}

--- a/cmd/syft/cli/options/packages.go
+++ b/cmd/syft/cli/options/packages.go
@@ -22,6 +22,7 @@ type PackagesOptions struct {
 	Exclude            []string
 	Catalogers         []string
 	Name               string
+	Include            []string
 }
 
 var _ Interface = (*PackagesOptions)(nil)
@@ -50,6 +51,9 @@ func (o *PackagesOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
 
 	cmd.Flags().StringVarP(&o.Name, "name", "", "",
 		"set the name of the target being analyzed")
+
+	cmd.Flags().StringArrayVarP(&o.Include, "include", "", nil,
+		"include extra paths to be scanned using a glob expression")
 
 	return bindPackageConfigOptions(cmd.Flags(), v)
 }
@@ -86,6 +90,10 @@ func bindPackageConfigOptions(flags *pflag.FlagSet, v *viper.Viper) error {
 	}
 
 	if err := v.BindPFlag("platform", flags.Lookup("platform")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("include", flags.Lookup("include")); err != nil {
 		return err
 	}
 

--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -66,7 +66,7 @@ func execWorker(app *config.Application, si source.Input, writer sbom.Writer) <-
 	go func() {
 		defer close(errs)
 
-		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions)
+		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Catalogers)
 		if cleanup != nil {
 			defer cleanup()
 		}

--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -66,7 +66,7 @@ func execWorker(app *config.Application, si source.Input, writer sbom.Writer) <-
 	go func() {
 		defer close(errs)
 
-		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Catalogers)
+		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Inclusions, app.Catalogers)
 		if cleanup != nil {
 			defer cleanup()
 		}

--- a/cmd/syft/cli/poweruser/poweruser.go
+++ b/cmd/syft/cli/poweruser/poweruser.go
@@ -80,7 +80,7 @@ func execWorker(app *config.Application, si source.Input, writer sbom.Writer) <-
 			return
 		}
 
-		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions)
+		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Catalogers)
 		if err != nil {
 			errs <- err
 			return

--- a/cmd/syft/cli/poweruser/poweruser.go
+++ b/cmd/syft/cli/poweruser/poweruser.go
@@ -80,7 +80,7 @@ func execWorker(app *config.Application, si source.Input, writer sbom.Writer) <-
 			return
 		}
 
-		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Catalogers)
+		src, cleanup, err := source.New(si, app.Registry.ToOptions(), app.Exclusions, app.Inclusions, app.Catalogers)
 		if err != nil {
 			errs <- err
 			return

--- a/cmd/syft/main.go
+++ b/cmd/syft/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"log"
+	"os"
+	"runtime"
+	"runtime/pprof"
 
 	"github.com/anchore/syft/cmd/syft/cli"
 )
@@ -14,5 +17,14 @@ func main() {
 
 	if err := cli.Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)
+	}
+	f, err := os.Create("mem.pprof")
+	if err != nil {
+		log.Fatal("could not create memory profile: ", err)
+	}
+	defer f.Close() // error handling omitted for example
+	runtime.GC()    // get up-to-date statistics
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		log.Fatal("could not write memory profile: ", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anchore/syft
 
 go 1.18
 
-replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866
+replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1-0.20221222100750-41a1ac565cce

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anchore/syft
 
 go 1.18
 
-replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455
+replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1-0.20221222100750-41a1ac565cce

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anchore/syft
 
 go 1.18
 
-replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c
+replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230111090613-ee0c9713629f
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1-0.20221222100750-41a1ac565cce

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/anchore/syft
 
 go 1.18
 
+replace github.com/anchore/stereoscope => github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866
+
 require (
 	github.com/CycloneDX/cyclonedx-go v0.7.1-0.20221222100750-41a1ac565cce
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455 h1:A3MXG9IjxfMndKPyo3ob1HsUpzR5iqv5o3uzdZl8gdA=
-github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
+github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c h1:5P0idiTZvWGyN4PWpQ3lw/qH/v90jKqbQnxXTlQ+qV0=
+github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c h1:5P0idiTZvWGyN4PWpQ3lw/qH/v90jKqbQnxXTlQ+qV0=
-github.com/deepfence/stereoscope v0.0.0-20230110115547-51c5d8a68f6c/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
+github.com/deepfence/stereoscope v0.0.0-20230111090613-ee0c9713629f h1:UaK8dpMBhFWiPMF9WPNZyQCFlWBM7lksfC55+o+BZw0=
+github.com/deepfence/stereoscope v0.0.0-20230111090613-ee0c9713629f/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866 h1:rZduS3HEj/bLi9bBmzrftK97M+/jiGqGDjI8kZ9p+hQ=
-github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
+github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455 h1:A3MXG9IjxfMndKPyo3ob1HsUpzR5iqv5o3uzdZl8gdA=
+github.com/deepfence/stereoscope v0.0.0-20230109141257-dda4cc976455/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=

--- a/go.sum
+++ b/go.sum
@@ -280,8 +280,6 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7 h1:kDrYkTSM9uIxaX/P9s0F4nKYNM+hnSgLJdLpqvsaQ/g=
 github.com/anchore/packageurl-go v0.1.1-0.20220428202044-a072fa3cb6d7/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
-github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1 h1:DXUAm/H9chRTEzMfkFyduBIcCiJyFXhCmv3zH3C0HGs=
-github.com/anchore/stereoscope v0.0.0-20221208011002-c5ff155d72f1/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/andybalholm/brotli v1.0.2/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
@@ -631,6 +629,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866 h1:rZduS3HEj/bLi9bBmzrftK97M+/jiGqGDjI8kZ9p+hQ=
+github.com/deepfence/stereoscope v0.0.0-20230106144952-6942641b3866/go.mod h1:/zjVnu2Jdl7xQCUtASegzeEg+IHKrM7SyMqdao3e+Nc=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -56,6 +56,7 @@ type Application struct {
 	Attest             attest             `yaml:"attest" json:"attest" mapstructure:"attest"`
 	Platform           string             `yaml:"platform" json:"platform" mapstructure:"platform"`
 	Name               string             `yaml:"name" json:"name" mapstructure:"name"`
+	Inclusions         []string           `yaml:"include" json:"include" mapstructure:"include"`
 }
 
 func (cfg Application) ToCatalogerConfig() cataloger.Config {

--- a/syft/source/all_layers_resolver_test.go
+++ b/syft/source/all_layers_resolver_test.go
@@ -88,7 +88,7 @@ func TestAllLayersResolver_FilesByPath(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newAllLayersResolver(img, nil)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -206,7 +206,7 @@ func TestAllLayersResolver_FilesByGlob(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newAllLayersResolver(img, nil)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -261,7 +261,7 @@ func Test_imageAllLayersResolver_FilesByMIMEType(t *testing.T) {
 		t.Run(test.fixtureName, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", test.fixtureName)
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newAllLayersResolver(img, nil)
 			assert.NoError(t, err)
 
 			locations, err := resolver.FilesByMIMEType(test.mimeType)
@@ -278,7 +278,7 @@ func Test_imageAllLayersResolver_FilesByMIMEType(t *testing.T) {
 func Test_imageAllLayersResolver_hasFilesystemIDInLocation(t *testing.T) {
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-duplicate-path")
 
-	resolver, err := newAllLayersResolver(img)
+	resolver, err := newAllLayersResolver(img, nil)
 	assert.NoError(t, err)
 
 	locations, err := resolver.FilesByMIMEType("text/plain")
@@ -338,7 +338,7 @@ func TestAllLayersImageResolver_FilesContents(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newAllLayersResolver(img, nil)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.fixture)
@@ -528,7 +528,7 @@ func Test_imageAllLayersResolver_resolvesLinks(t *testing.T) {
 
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newAllLayersResolver(img, nil)
 			assert.NoError(t, err)
 
 			actualLocations := test.runner(resolver)

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/bmatcuk/doublestar/v4"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
 
@@ -121,11 +120,8 @@ func (r *directoryResolver) indexTree(root string, stager *progress.Stage) ([]st
 		func(path string, info os.FileInfo, err error) error {
 			stager.Current = path
 
-			if r.globPatterns != nil {
-				// skip path if does not match any glob patterns
-				if !r.AnyGlobMatches(path) {
-					return nil
-				}
+			if !AnyGlobMatches(r.globPatterns, path) {
+				return nil
 			}
 
 			newRoot, err := r.indexPath(path, info, err)
@@ -140,17 +136,6 @@ func (r *directoryResolver) indexTree(root string, stager *progress.Stage) ([]st
 
 			return nil
 		})
-}
-
-func (r *directoryResolver) AnyGlobMatches(path string) bool {
-	for _, g := range *r.globPatterns {
-		if match, err := doublestar.PathMatch(g, path); err != nil {
-			continue
-		} else if match {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *directoryResolver) indexPath(path string, info os.FileInfo, err error) (string, error) {

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -57,7 +57,7 @@ func TestDirectoryResolver_FilesByPath_relativeRoot(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver(c.relativeRoot)
+			resolver, err := newDirectoryResolver(c.relativeRoot, nil)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(c.input)
@@ -111,7 +111,7 @@ func TestDirectoryResolver_FilesByPath_absoluteRoot(t *testing.T) {
 			absRoot, err := filepath.Abs(c.relativeRoot)
 			require.NoError(t, err)
 
-			resolver, err := newDirectoryResolver(absRoot)
+			resolver, err := newDirectoryResolver(absRoot, nil)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(c.input)
@@ -172,7 +172,7 @@ func TestDirectoryResolver_FilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver(c.root)
+			resolver, err := newDirectoryResolver(c.root, nil)
 			assert.NoError(t, err)
 
 			hasPath := resolver.HasPath(c.input)
@@ -220,7 +220,7 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver("./test-fixtures")
+			resolver, err := newDirectoryResolver("./test-fixtures", nil)
 			assert.NoError(t, err)
 			refs, err := resolver.FilesByPath(c.input...)
 			assert.NoError(t, err)
@@ -233,7 +233,7 @@ func TestDirectoryResolver_MultipleFilesByPath(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver("./test-fixtures", nil)
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/file*")
 	assert.NoError(t, err)
@@ -242,7 +242,7 @@ func TestDirectoryResolver_FilesByGlobMultiple(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/image-symlinks")
+	resolver, err := newDirectoryResolver("./test-fixtures/image-symlinks", nil)
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/*.txt")
 	assert.NoError(t, err)
@@ -250,7 +250,7 @@ func TestDirectoryResolver_FilesByGlobRecursive(t *testing.T) {
 }
 
 func TestDirectoryResolver_FilesByGlobSingle(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures")
+	resolver, err := newDirectoryResolver("./test-fixtures", nil)
 	assert.NoError(t, err)
 	refs, err := resolver.FilesByGlob("**/image-symlinks/*1.txt")
 	assert.NoError(t, err)
@@ -277,7 +277,7 @@ func TestDirectoryResolver_FilesByPath_ResolvesSymlinks(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple")
+			resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple", nil)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.fixture)
@@ -300,7 +300,7 @@ func TestDirectoryResolver_FilesByPath_ResolvesSymlinks(t *testing.T) {
 
 func TestDirectoryResolverDoesNotIgnoreRelativeSystemPaths(t *testing.T) {
 	// let's make certain that "dev/place" is not ignored, since it is not "/dev/place"
-	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	resolver, err := newDirectoryResolver("test-fixtures/system_paths/target", nil)
 	assert.NoError(t, err)
 	// ensure the correct filter function is wired up by default
 	expectedFn := reflect.ValueOf(isUnallowableFileType)
@@ -431,7 +431,7 @@ func Test_isUnallowableFileType(t *testing.T) {
 
 func Test_directoryResolver_index(t *testing.T) {
 	// note: this test is testing the effects from newDirectoryResolver, indexTree, and addPathToIndex
-	r, err := newDirectoryResolver("test-fixtures/system_paths/target")
+	r, err := newDirectoryResolver("test-fixtures/system_paths/target", nil)
 	if err != nil {
 		t.Fatalf("unable to get indexed dir resolver: %+v", err)
 	}
@@ -608,7 +608,7 @@ func Test_directoryResolver_FilesByMIMEType(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.fixturePath, func(t *testing.T) {
-			resolver, err := newDirectoryResolver(test.fixturePath)
+			resolver, err := newDirectoryResolver(test.fixturePath, nil)
 			assert.NoError(t, err)
 			locations, err := resolver.FilesByMIMEType(test.mimeType)
 			assert.NoError(t, err)
@@ -621,7 +621,7 @@ func Test_directoryResolver_FilesByMIMEType(t *testing.T) {
 }
 
 func Test_IndexingNestedSymLinks(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple")
+	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple", nil)
 	require.NoError(t, err)
 
 	// check that we can get the real path
@@ -674,7 +674,7 @@ func Test_IndexingNestedSymLinks_ignoredIndexes(t *testing.T) {
 		return strings.HasSuffix(path, string(filepath.Separator)+"readme")
 	}
 
-	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple", filterFn)
+	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-simple", nil, filterFn)
 	require.NoError(t, err)
 
 	// the path to the real file is PRUNED from the index, so we should NOT expect a location returned
@@ -694,7 +694,7 @@ func Test_IndexingNestedSymLinks_ignoredIndexes(t *testing.T) {
 }
 
 func Test_IndexingNestedSymLinksOutsideOfRoot(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-multiple-roots/root")
+	resolver, err := newDirectoryResolver("./test-fixtures/symlinks-multiple-roots/root", nil)
 	require.NoError(t, err)
 
 	// check that we can get the real path
@@ -712,7 +712,7 @@ func Test_IndexingNestedSymLinksOutsideOfRoot(t *testing.T) {
 }
 
 func Test_RootViaSymlink(t *testing.T) {
-	resolver, err := newDirectoryResolver("./test-fixtures/symlinked-root/nested/link-root")
+	resolver, err := newDirectoryResolver("./test-fixtures/symlinked-root/nested/link-root", nil)
 	require.NoError(t, err)
 
 	locations, err := resolver.FilesByPath("./file1.txt")
@@ -753,7 +753,7 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			r, err := newDirectoryResolver(".")
+			r, err := newDirectoryResolver(".", nil)
 			require.NoError(t, err)
 
 			actual, err := r.FileContentsByLocation(test.location)
@@ -819,7 +819,7 @@ func Test_isUnixSystemRuntimePath(t *testing.T) {
 
 func Test_SymlinkLoopWithGlobsShouldResolve(t *testing.T) {
 	test := func(t *testing.T) {
-		resolver, err := newDirectoryResolver("./test-fixtures/symlinks-loop")
+		resolver, err := newDirectoryResolver("./test-fixtures/symlinks-loop", nil)
 		require.NoError(t, err)
 
 		locations, err := resolver.FilesByGlob("**/file.target")
@@ -853,7 +853,7 @@ func Test_IncludeRootPathInIndex(t *testing.T) {
 		return path != "/"
 	}
 
-	resolver, err := newDirectoryResolver("/", filterFn)
+	resolver, err := newDirectoryResolver("/", nil, filterFn)
 	require.NoError(t, err)
 
 	exists, ref, err := resolver.fileTree.File(file.Path("/"))
@@ -870,7 +870,7 @@ func TestDirectoryResolver_indexPath(t *testing.T) {
 	tempFile, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 
-	resolver, err := newDirectoryResolver(tempFile.Name())
+	resolver, err := newDirectoryResolver(tempFile.Name(), nil)
 	require.NoError(t, err)
 
 	t.Run("filtering path with nil os.FileInfo", func(t *testing.T) {

--- a/syft/source/image_squash_resolver_test.go
+++ b/syft/source/image_squash_resolver_test.go
@@ -69,7 +69,7 @@ func TestImageSquashResolver_FilesByPath(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newImageSquashResolver(img)
+			resolver, err := newImageSquashResolver(img, nil)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -185,7 +185,7 @@ func TestImageSquashResolver_FilesByGlob(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newImageSquashResolver(img)
+			resolver, err := newImageSquashResolver(img, nil)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -249,7 +249,7 @@ func Test_imageSquashResolver_FilesByMIMEType(t *testing.T) {
 		t.Run(test.fixtureName, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", test.fixtureName)
 
-			resolver, err := newImageSquashResolver(img)
+			resolver, err := newImageSquashResolver(img, nil)
 			assert.NoError(t, err)
 
 			locations, err := resolver.FilesByMIMEType(test.mimeType)
@@ -266,7 +266,7 @@ func Test_imageSquashResolver_FilesByMIMEType(t *testing.T) {
 func Test_imageSquashResolver_hasFilesystemIDInLocation(t *testing.T) {
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-duplicate-path")
 
-	resolver, err := newImageSquashResolver(img)
+	resolver, err := newImageSquashResolver(img, nil)
 	assert.NoError(t, err)
 
 	locations, err := resolver.FilesByMIMEType("text/plain")
@@ -324,7 +324,7 @@ func TestSquashImageResolver_FilesContents(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newImageSquashResolver(img)
+			resolver, err := newImageSquashResolver(img, nil)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.fixture)
@@ -475,7 +475,7 @@ func Test_imageSquashResolver_resolvesLinks(t *testing.T) {
 
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newImageSquashResolver(img)
+			resolver, err := newImageSquashResolver(img, nil)
 			assert.NoError(t, err)
 
 			actualLocations := test.runner(resolver)

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -167,13 +167,16 @@ func NewFromRegistry(in Input, registryOptions *image.RegistryOptions, filter im
 }
 
 // New produces a Source based on userInput like dir: or image:tag
-func New(in Input, registryOptions *image.RegistryOptions, exclusions []string, catalogers []string) (*Source, func(), error) {
+func New(in Input, registryOptions *image.RegistryOptions, exclusions []string, inclusions []string, catalogers []string) (*Source, func(), error) {
 	var err error
 	fs := afero.NewOsFs()
 	var source *Source
 	cleanupFn := func() {}
 
 	patterns := []string{}
+	if len(inclusions) > 0 {
+		patterns = append(patterns, inclusions...)
+	}
 	if len(catalogers) > 0 {
 		for _, c := range catalogers {
 			for k := range catalogerGlobPatterns {

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -206,6 +206,7 @@ func New(in Input, registryOptions *image.RegistryOptions, exclusions []string, 
 
 	if err == nil {
 		source.Exclusions = exclusions
+		source.GlobFilter = filter
 	}
 
 	return source, cleanupFn, err

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -26,8 +26,9 @@ import (
 
 var (
 	binarySearchPaths = []string{
-		"/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin",
-		"/usr/lib64", "/usr/lib", "/usr/share", "/usr/local/lib64", "/usr/local/lib",
+		"/usr/lib/jvm/**", "/usr/share/java/**",
+		"/usr/local/sbin/*", "/usr/local/bin/*", "/usr/sbin/*", "/usr/bin/*", "/sbin/*", "/bin/*",
+		"/usr/lib64/*", "/usr/lib/*", "/usr/share/*", "/usr/local/lib64/*", "/usr/local/lib/*",
 	}
 	catalogerGlobPatterns = map[string][]string{
 		"alpmdb-cataloger":        {"**/var/lib/pacman/local/**/desc"},

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -531,7 +531,7 @@ func TestDirectoryExclusions(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			sourceInput, err := ParseInput("dir:"+test.input, "", false)
 			require.NoError(t, err)
-			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil)
+			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil, nil)
 			defer fn()
 
 			if test.err {
@@ -625,7 +625,7 @@ func TestImageExclusions(t *testing.T) {
 			archiveLocation := imagetest.PrepareFixtureImage(t, "docker-archive", test.input)
 			sourceInput, err := ParseInput(archiveLocation, "", false)
 			require.NoError(t, err)
-			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil)
+			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil, nil)
 			defer fn()
 
 			if err != nil {

--- a/syft/source/source_test.go
+++ b/syft/source/source_test.go
@@ -531,7 +531,7 @@ func TestDirectoryExclusions(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			sourceInput, err := ParseInput("dir:"+test.input, "", false)
 			require.NoError(t, err)
-			src, fn, err := New(*sourceInput, registryOpts, test.exclusions)
+			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil)
 			defer fn()
 
 			if test.err {
@@ -625,7 +625,7 @@ func TestImageExclusions(t *testing.T) {
 			archiveLocation := imagetest.PrepareFixtureImage(t, "docker-archive", test.input)
 			sourceInput, err := ParseInput(archiveLocation, "", false)
 			require.NoError(t, err)
-			src, fn, err := New(*sourceInput, registryOpts, test.exclusions)
+			src, fn, err := New(*sourceInput, registryOpts, test.exclusions, nil)
 			defer fn()
 
 			if err != nil {

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -26,7 +26,7 @@ func BenchmarkImagePackageCatalogers(b *testing.B) {
 		userInput := "docker-archive:" + tarPath
 		sourceInput, err := source.ParseInput(userInput, "", false)
 		require.NoError(b, err)
-		theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
+		theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil, nil)
 		b.Cleanup(cleanupSource)
 		if err != nil {
 			b.Fatalf("unable to get source: %+v", err)

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -26,7 +26,7 @@ func BenchmarkImagePackageCatalogers(b *testing.B) {
 		userInput := "docker-archive:" + tarPath
 		sourceInput, err := source.ParseInput(userInput, "", false)
 		require.NoError(b, err)
-		theSource, cleanupSource, err := source.New(*sourceInput, nil, nil)
+		theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
 		b.Cleanup(cleanupSource)
 		if err != nil {
 			b.Fatalf("unable to get source: %+v", err)

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -18,7 +18,7 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 	userInput := "docker-archive:" + tarPath
 	sourceInput, err := source.ParseInput(userInput, "", false)
 	require.NoError(t, err)
-	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
+	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil, nil)
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
 
@@ -54,7 +54,7 @@ func catalogDirectory(t *testing.T, dir string) (sbom.SBOM, *source.Source) {
 	userInput := "dir:" + dir
 	sourceInput, err := source.ParseInput(userInput, "", false)
 	require.NoError(t, err)
-	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
+	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil, nil)
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
 

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -18,7 +18,7 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 	userInput := "docker-archive:" + tarPath
 	sourceInput, err := source.ParseInput(userInput, "", false)
 	require.NoError(t, err)
-	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil)
+	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
 
@@ -54,7 +54,7 @@ func catalogDirectory(t *testing.T, dir string) (sbom.SBOM, *source.Source) {
 	userInput := "dir:" + dir
 	sourceInput, err := source.ParseInput(userInput, "", false)
 	require.NoError(t, err)
-	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil)
+	theSource, cleanupSource, err := source.New(*sourceInput, nil, nil, nil)
 	t.Cleanup(cleanupSource)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes: https://github.com/anchore/syft/issues/1446

Depends On PR: https://github.com/anchore/stereoscope/pull/151

when dpkdb-cataloger is selected syft indexes whole filesystem even when cataloger is looking for files in `**/var/lib/dpkg/{status,status.d/**}`, to fix this this PR adds path filter function which indexes files from paths required by catalogers when provided

improvements while confluentinc/cp-kafka image when all catalogers are enabled 
syft memory usage: ~350MB
syft memory usage with this PR: ~125MB

with only java catalogers enabled
syft memory usage: ~290MB
syft memory usage with this PR: ~80MB


