### PR TITLE
feat: add httpd classifier

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -18,6 +18,19 @@ func TestClassifierCataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 		expected   pkg.Package
 	}{
 		{
+			name:       "positive-httpd-2.4.54",
+			fixtureDir: "test-fixtures/classifiers/positive/httpd-2.4.54",
+			expected: pkg.Package{
+				Name:      "httpd",
+				Version:   "2.4.54",
+				Type:      "binary",
+				PURL:      "pkg:generic/httpd@2.4.54",
+				Locations: singleLocation("httpd"),
+				Metadata: pkg.BinaryMetadata{
+					Classifier: "httpd-binary",
+				},
+			},
+		}, {
 			name:       "positive-php-cli-8.2.1",
 			fixtureDir: "test-fixtures/classifiers/positive/php-cli-8.2.1",
 			expected: pkg.Package{

--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -132,4 +132,13 @@ var defaultClassifiers = []classifier{
 		PURL:    mustPURL("pkg:generic/php@version"),
 		CPEs:    singleCPE("cpe:2.3:a:php:php:*:*:*:*:*:*:*:*"),
 	},
+	{
+		Class:    "httpd-binary",
+		FileGlob: "**/httpd",
+		EvidenceMatcher: fileContentsVersionMatcher(
+			`(?m)Apache\/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+		Package: "httpd",
+		PURL:    mustPURL("pkg:generic/httpd@version"),
+		CPEs:    singleCPE("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"),
+	},
 }

--- a/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/httpd-2.4.54/httpd
+++ b/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/httpd-2.4.54/httpd
@@ -1,0 +1,18 @@
+<Directory "
+mailto:
+Apache/2.4.54
+ Server at <a href="
+<address>
+--
+</a> Port 
+ Server at 
+Apache/2.4.54 (Unix)
+ap_logio_add_bytes_out
+ap_ident_lookup
+--
+access_compat_ap_satisfies
+Apache
+Apache/2.4
+Apache/2
+<VirtualHost
+<Limit

--- a/test/integration/package_deduplication_test.go
+++ b/test/integration/package_deduplication_test.go
@@ -22,13 +22,13 @@ func TestPackageDeduplication(t *testing.T) {
 	}{
 		{
 			scope:        source.AllLayersScope,
-			packageCount: 173, // without deduplication this would be 618
+			packageCount: 174, // without deduplication this would be 618
 			instanceCount: map[string]int{
 				"basesystem": 1,
 				"wget":       1,
 				"curl":       2, // upgraded in the image
 				"vsftpd":     1,
-				"httpd":      1,
+				"httpd":      2, // rpm, binary
 			},
 			locationCount: map[string]int{
 				"basesystem-10.0-7.el7.centos": 4,
@@ -37,17 +37,18 @@ func TestPackageDeduplication(t *testing.T) {
 				"wget-1.14-18.el7_6.1":         3,
 				"vsftpd-3.0.2-29.el7_9":        2,
 				"httpd-2.4.6-97.el7.centos.5":  1,
+				"httpd-2.4.6":                  1, // binary
 			},
 		},
 		{
 			scope:        source.SquashedScope,
-			packageCount: 171,
+			packageCount: 172,
 			instanceCount: map[string]int{
 				"basesystem": 1,
 				"wget":       1,
 				"curl":       1, // upgraded, but the most recent
 				"vsftpd":     1,
-				"httpd":      1,
+				"httpd":      2, // rpm, binary
 			},
 			locationCount: map[string]int{
 				"basesystem-10.0-7.el7.centos": 1,
@@ -55,6 +56,7 @@ func TestPackageDeduplication(t *testing.T) {
 				"wget-1.14-18.el7_6.1":         1,
 				"vsftpd-3.0.2-29.el7_9":        1,
 				"httpd-2.4.6-97.el7.centos.5":  1,
+				"httpd-2.4.6":                  1, // binary
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a binary cataloger for httpd

- As it will be detected as package, I did not add file name - apache2 (ubuntu OS package)
- To pass `make integration`, I updated package_deduplication_test.go. But sorry, this may not be proper.

fixes #1440