### PR TITLE
fix: update graalvm cataloger to fix panic

### DIFF
--- a/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
+++ b/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
@@ -237,6 +237,8 @@ func newPE(filename string, r io.ReaderAt) (nativeImage, error) {
 		exportSymbolsDataDirectory = h.DataDirectory[0]
 	case *pe.OptionalHeader64:
 		exportSymbolsDataDirectory = h.DataDirectory[0]
+	default:
+		return nil, fmt.Errorf("unable to get exportSymbolsDataDirectory from binary: %s", filename)
 	}
 	// If we have no exported symbols it is not a Native Image
 	if exportSymbolsDataDirectory.Size == 0 {

--- a/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
+++ b/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
@@ -231,8 +231,13 @@ func newPE(filename string, r io.ReaderAt) (nativeImage, error) {
 	if err != nil {
 		return fileError(filename, err)
 	}
-	optionalHeader := bi.OptionalHeader.(*pe.OptionalHeader64)
-	exportSymbolsDataDirectory := optionalHeader.DataDirectory[0]
+	var exportSymbolsDataDirectory pe.DataDirectory
+	switch h := bi.OptionalHeader.(type) {
+	case *pe.OptionalHeader32:
+		exportSymbolsDataDirectory = h.DataDirectory[0]
+	case *pe.OptionalHeader64:
+		exportSymbolsDataDirectory = h.DataDirectory[0]
+	}
 	// If we have no exported symbols it is not a Native Image
 	if exportSymbolsDataDirectory.Size == 0 {
 		return fileError(filename, errors.New(nativeImageMissingExportedDataDirectoryError))


### PR DESCRIPTION
This PR corrects a panic in the graalvm cataloger due to differences in 32/64-bit binaries.

Fixes #1453