### PR TITLE
 Refactor the Generic Cataloger re-uses filesystem indexing

### DIFF
--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -32,6 +32,7 @@ func globToRegexPattern(glob string) string {
 	rPattern = strings.ReplaceAll(rPattern, "}", ")")
 	rPattern = strings.ReplaceAll(rPattern, ",", "|")
 	rPattern = strings.ReplaceAll(rPattern, rDir, "(.*/)*")
+	rPattern += "$"
 	return rPattern
 }
 

--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -168,5 +168,4 @@ func (c *Cataloger) parseRequest(resolver source.FileResolver, location source.L
 	}
 
 	return discoveredPackages, discoveredRelationships, nil
-
 }

--- a/syft/pkg/cataloger/rpm/parse_rpm_db_test.go
+++ b/syft/pkg/cataloger/rpm/parse_rpm_db_test.go
@@ -70,6 +70,11 @@ func (r *rpmdbTestFileResolverMock) FilesByMIMEType(...string) ([]source.Locatio
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (r *rpmdbTestFileResolverMock) HasMimeTypeAtLocation(mimeType string, location source.Location) bool {
+	panic(fmt.Errorf("not implemented"))
+	return false
+}
+
 func TestParseRpmDB(t *testing.T) {
 	tests := []struct {
 		fixture     string

--- a/syft/source/all_layers_resolver.go
+++ b/syft/source/all_layers_resolver.go
@@ -221,6 +221,34 @@ func (r *allLayersResolver) FilesByMIMEType(types ...string) ([]Location, error)
 	return locations, nil
 }
 
+// HasMimeTypeAtLocation indicates if mimetype exist at the location in the underlying source
+func (r *allLayersResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	mimeMatch := false
+
+	for _, layerIdx := range r.layers {
+		layer := r.img.Layers[layerIdx]
+
+		refs, err := layer.FilesByMIMEType([]string{mimeType}...)
+
+		if err != nil {
+			continue
+		}
+
+		for _, ref := range refs {
+			if string(ref.RealPath) == location.RealPath {
+				mimeMatch = true
+				break
+			}
+		}
+
+		if mimeMatch {
+			break
+		}
+	}
+
+	return mimeMatch
+}
+
 func (r *allLayersResolver) AllLocations() <-chan Location {
 	results := make(chan Location)
 	go func() {

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -319,6 +319,22 @@ func (r *directoryResolver) HasPath(userPath string) bool {
 	return r.fileTree.HasPath(file.Path(requestPath))
 }
 
+// HasMimeTypeAtLocation indicates if mimetype exist at the location in the underlying source
+func (r *directoryResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	mimeMatch := false
+
+	if refs, ok := r.refsByMIMEType[mimeType]; ok {
+		for _, ref := range refs {
+			if r.responsePath(string(ref.RealPath)) == location.RealPath {
+				mimeMatch = true
+				break
+			}
+		}
+	}
+
+	return mimeMatch
+}
+
 // Stringer to represent a directory path data source
 func (r directoryResolver) String() string {
 	return fmt.Sprintf("dir:%s", r.path)

--- a/syft/source/excluding_file_resolver.go
+++ b/syft/source/excluding_file_resolver.go
@@ -59,6 +59,23 @@ func (r *excludingResolver) FilesByMIMEType(types ...string) ([]Location, error)
 	return filterLocations(locations, err, r.excludeFn)
 }
 
+func (r *excludingResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	mimeMatch := r.delegate.HasMimeTypeAtLocation(mimeType, location)
+
+	if !mimeMatch {
+		return false
+	}
+
+	// check if location is to be excluded
+	locationMatch := locationMatches(&location, r.excludeFn)
+
+	if locationMatch {
+		return mimeMatch
+	}
+
+	return false
+}
+
 func (r *excludingResolver) RelativeFileByPath(location Location, path string) *Location {
 	l := r.delegate.RelativeFileByPath(location, path)
 	if l != nil && locationMatches(l, r.excludeFn) {

--- a/syft/source/excluding_file_resolver_test.go
+++ b/syft/source/excluding_file_resolver_test.go
@@ -176,6 +176,10 @@ func (r *mockResolver) FilesByMIMEType(_ ...string) ([]Location, error) {
 	return r.getLocations()
 }
 
+func (r *mockResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	return true
+}
+
 func (r *mockResolver) RelativeFileByPath(_ Location, path string) *Location {
 	return &Location{
 		Coordinates: Coordinates{

--- a/syft/source/file_resolver.go
+++ b/syft/source/file_resolver.go
@@ -34,6 +34,8 @@ type FilePathResolver interface {
 	// RelativeFileByPath fetches a single file at the given path relative to the layer squash of the given reference.
 	// This is helpful when attempting to find a file that is in the same layer or lower as another file.
 	RelativeFileByPath(_ Location, path string) *Location
+	// HasMimeTypeAtLocation indicates if mimetype exist at the location in the underlying source
+	HasMimeTypeAtLocation(mimeType string, location Location) bool
 }
 
 type FileLocationResolver interface {

--- a/syft/source/image_squash_resolver.go
+++ b/syft/source/image_squash_resolver.go
@@ -189,6 +189,25 @@ func (r *imageSquashResolver) FilesByMIMEType(types ...string) ([]Location, erro
 	return locations, nil
 }
 
+func (r *imageSquashResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	mimeMatch := false
+
+	refs, err := r.img.FilesByMIMETypeFromSquash([]string{mimeType}...)
+
+	if err != nil {
+		return false
+	}
+
+	for _, ref := range refs {
+		if string(ref.RealPath) == location.RealPath {
+			mimeMatch = true
+			break
+		}
+	}
+
+	return mimeMatch
+}
+
 func (r *imageSquashResolver) FileMetadataByLocation(location Location) (FileMetadata, error) {
 	return fileMetadataByLocation(r.img, location)
 }

--- a/syft/source/location.go
+++ b/syft/source/location.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
@@ -121,4 +122,13 @@ func (l Location) Equals(other Location) bool {
 	return l.RealPath == other.RealPath &&
 		l.VirtualPath == other.VirtualPath &&
 		l.FileSystemID == other.FileSystemID
+}
+
+func (l Location) MatchesRePattern(re *regexp.Regexp) bool {
+	match := re.MatchString(l.RealPath)
+	// if !match {
+	// 	panic(fmt.Sprintf("re <%s>: %s", re, l.RealPath))
+	// }
+
+	return match
 }

--- a/syft/source/mock_resolver.go
+++ b/syft/source/mock_resolver.go
@@ -160,3 +160,18 @@ func (r MockResolver) FilesByMIMEType(types ...string) ([]Location, error) {
 	}
 	return locations, nil
 }
+
+func (r MockResolver) HasMimeTypeAtLocation(mimeType string, location Location) bool {
+	mimeMatch := false
+
+	if locations, ok := r.mimeTypeIndex[mimeType]; ok {
+		for _, loc := range locations {
+			if loc.RealPath == location.RealPath {
+				mimeMatch = true
+				break
+			}
+		}
+	}
+
+	return mimeMatch
+}


### PR DESCRIPTION
### Perfomance enhancement

There have been issues raised which indicate that the catalogging process is slow (e.g. https://github.com/anchore/syft/pull/1355 , https://github.com/anchore/syft/issues/1446 , https://github.com/anchore/syft/issues/1353 )

A large part of this is due to glob pattern searches.

More precisly, each catagolger has a collection of defined glob patterns, many of which are against the entire file system `**/*` to search.. 

Now that syft supports multiple catalogers with multiple glob patterns, this can cause significant os time bound restrictions on the perfomance, the entire file system is searched again and again, once per glob..

This glob pattern search does not reuse the initial filesystem indexing that syft does. This PR refactors the cataloger such that the indexing can be reused. 

Note the generic cataloger support globs, paths, and mime-types. This PR reuses the index for all three of the types. The globs are addressed using a naive mapping of glob->regex.

Benchmark against this [project](https://gist.github.com/Mikcl/3c171b074c65a77288788f4fb86cef0c) vs the current main branch:

```
8.86s user 2.34s system 90% cpu 12.421 total
17.16s user 2.14s system 117% cpu 16.455 total
```

Setting the parallism=4 brings this PR's Results down even further:

```
9.20s user 2.52s system 131% cpu 8.888 total
15.97s user 1.59s system 178% cpu 9.830 total
```

We can see that this PR is almost as effective (slightly more) as increasing the parallelism, which is expected given that everything now is in-memory rather that os system bound.