### PR TITLE
npm: package-lock license decoding to accept string or array

### DIFF
--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -78,8 +78,8 @@ func newPackageLockV1Package(resolver source.FileResolver, location source.Locat
 func newPackageLockV2Package(resolver source.FileResolver, location source.Location, name string, u lockPackage) pkg.Package {
 	var licenses []string
 
-	if u.License != "" {
-		licenses = append(licenses, u.License)
+	if u.License != nil {
+		licenses = u.License
 	}
 
 	return finalizeLockPkg(

--- a/syft/pkg/cataloger/javascript/parse_package_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock_test.go
@@ -297,3 +297,44 @@ func TestParsePackageLockAlias(t *testing.T) {
 		pkgtest.TestFileParser(t, packageLock, parsePackageLock, expected, expectedRelationships)
 	}
 }
+
+func TestParsePackageLockLicenseWithArray(t *testing.T) {
+	fixture := "test-fixtures/pkg-lock/array-license-package-lock.json"
+	var expectedRelationships []artifact.Relationship
+	expectedPkgs := []pkg.Package{
+		{
+			Name:         "tmp",
+			Version:      "1.0.0",
+			Licenses:     []string{"ISC"},
+			Language:     pkg.JavaScript,
+			Type:         pkg.NpmPkg,
+			PURL:         "pkg:npm/tmp@1.0.0",
+			MetadataType: "NpmPackageLockJsonMetadata",
+			Metadata:     pkg.NpmPackageLockJSONMetadata{},
+		},
+		{
+			Name:         "pause-stream",
+			Version:      "0.0.11",
+			Licenses:     []string{"MIT", "Apache2"},
+			Language:     pkg.JavaScript,
+			Type:         pkg.NpmPkg,
+			PURL:         "pkg:npm/pause-stream@0.0.11",
+			MetadataType: "NpmPackageLockJsonMetadata",
+			Metadata:     pkg.NpmPackageLockJSONMetadata{},
+		},
+		{
+			Name:         "through",
+			Version:      "2.3.8",
+			Licenses:     []string{"MIT"},
+			Language:     pkg.JavaScript,
+			Type:         pkg.NpmPkg,
+			PURL:         "pkg:npm/through@2.3.8",
+			MetadataType: "NpmPackageLockJsonMetadata",
+			Metadata:     pkg.NpmPackageLockJSONMetadata{},
+		},
+	}
+	for i := range expectedPkgs {
+		expectedPkgs[i].Locations.Add(source.NewLocation(fixture))
+	}
+	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-lock/array-license-package-lock.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-lock/array-license-package-lock.json
@@ -1,0 +1,41 @@
+{
+    "name": "tmp",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "name": "tmp",
+        "version": "1.0.0",
+        "license": "ISC",
+        "dependencies": {
+          "pause-stream": "0.0.11"
+        }
+      },
+      "node_modules/pause-stream": {
+        "version": "0.0.11",
+        "license": [
+            "MIT",
+            "Apache2"
+        ],
+        "dependencies": {
+          "through": "~2.3"
+        }
+      },
+      "node_modules/through": {
+        "version": "2.3.8",
+        "license": "MIT"
+      }
+    },
+    "dependencies": {
+      "pause-stream": {
+        "version": "0.0.11",
+        "requires": {
+          "through": "~2.3"
+        }
+      },
+      "through": {
+        "version": "2.3.8"
+      }
+    }
+  }


### PR DESCRIPTION
Fixes https://github.com/anchore/syft/issues/1479


Introduces new decoding behaviour for the `license` field in `package-lock.json` packages. To accept a string and array as the datatype. 

Previously: only a string was an expected value. This would mean the decoding step would fail in the event of an array being present, and all the remaining dependencies in the package-lock.json would not be cataloged.

This PR:
1. Accepts either a string or an array.
2. If its neither string or array and unable to parse the license field. Sets license to nil and does not error to allow us to capture the remaining package dependencies (at the expense of perhaps an unexpected license field not being captured).


- Have created the new  `packageLockLicense` type with overriden `UnMarshallJSON` behaviour to create this change.
- Added test cases from an example `package-lock.json`
