### PR TITLE
Relax error conditions for catalogers

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -1,6 +1,8 @@
 package binary
 
 import (
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -432,4 +434,50 @@ func assertPackagesAreEqual(t *testing.T, expected pkg.Package, p pkg.Package) {
 		meta1.Classifier != meta2.Classifier {
 		assert.Failf(t, "packages not equal", "%v != %v", expected, p)
 	}
+}
+
+type panicyResolver struct {
+	globCalled bool
+}
+
+func (p panicyResolver) FileContentsByLocation(location source.Location) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p panicyResolver) HasPath(s string) bool {
+	return true
+}
+
+func (p panicyResolver) FilesByPath(paths ...string) ([]source.Location, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p *panicyResolver) FilesByGlob(patterns ...string) ([]source.Location, error) {
+	p.globCalled = true
+	return nil, errors.New("not implemented")
+}
+
+func (p panicyResolver) FilesByMIMEType(types ...string) ([]source.Location, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (p panicyResolver) RelativeFileByPath(_ source.Location, path string) *source.Location {
+	return nil
+}
+
+func (p panicyResolver) AllLocations() <-chan source.Location {
+	return nil
+}
+
+func (p panicyResolver) FileMetadataByLocation(location source.Location) (source.FileMetadata, error) {
+	return source.FileMetadata{}, errors.New("not implemented")
+}
+
+func Test_Cataloger_ResilientToErrors(t *testing.T) {
+	c := NewCataloger()
+
+	resolver := &panicyResolver{}
+	_, _, err := c.Catalog(resolver)
+	assert.NoError(t, err)
+	assert.True(t, resolver.globCalled)
 }

--- a/test/cli/spdx_tooling_validation_test.go
+++ b/test/cli/spdx_tooling_validation_test.go
@@ -36,6 +36,8 @@ func TestSpdxValidationTooling(t *testing.T) {
 				fixturesPath := filepath.Join(cwd, "test-fixtures", "image-java-spdx-tools")
 				buildCmd := exec.Command("make", "build")
 				buildCmd.Dir = fixturesPath
+				buildCmd.Stdout = os.Stdout
+				buildCmd.Stderr = os.Stderr
 				err = buildCmd.Run()
 				require.NoError(t, err)
 			},

--- a/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
+++ b/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/jdk
+FROM openjdk:11
 
 RUN wget https://github.com/spdx/tools-java/releases/download/v1.1.3/tools-java-1.1.3.zip && \
 	unzip tools-java-1.1.3.zip && \


### PR DESCRIPTION
This PR adjusts the binary cataloger to compartmentalize errors to individual classifiers and continue to the next classifier when an error occurs.

This prevents errors from being fatal, such as:
```
[0001] TRACE cataloging complete cataloger=portage-cataloger
[0001] TRACE cataloging started cataloger=sbom-cataloger
[0001] DEBUG discovered 0 packages cataloger=sbom-cataloger
[0001] TRACE cataloging complete cataloger=sbom-cataloger
[0001] TRACE cataloging started cataloger=binary-cataloger
[0001]  WARN error while cataloging cataloger=binary-cataloger
No packages discovered
2023/01/19 13:12:27 error during command execution: 1 error occurred:
	* failed to resolve files by glob (**/python*): cycle during symlink resolution
```