### PR TITLE
Always set the package ID for java packages

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -133,12 +133,14 @@ func (j *archiveParser) parse() ([]pkg.Package, []artifact.Relationship, error) 
 	// add pURLs to all packages found
 	// note: since package information may change after initial creation when parsing multiple locations within the
 	// jar, we wait until the conclusion of the parsing process before synthesizing pURLs.
-	for i, p := range pkgs {
+	for i := range pkgs {
+		p := &pkgs[i]
 		if m, ok := p.Metadata.(pkg.JavaMetadata); ok {
-			pkgs[i].PURL = packageURL(p.Name, p.Version, m)
+			p.PURL = packageURL(p.Name, p.Version, m)
 		} else {
 			log.WithFields("package", p.String()).Warn("unable to extract java metadata to generate purl")
 		}
+		p.SetID()
 	}
 
 	return pkgs, relationships, nil

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -277,6 +277,10 @@ func TestParseJar(t *testing.T) {
 			}
 
 			for _, a := range actual {
+				if a.ID() == "" {
+					t.Fatalf("empty package ID: %+v", a)
+				}
+
 				e, ok := test.expected[a.Name]
 				if !ok {
 					t.Errorf("entry not found: %s", a.Name)


### PR DESCRIPTION
Today there are several instances of package IDs not being set by the time they reach the package catalog. This isn't good since it's the package catalogers role to do this. This PR adjusts the java package cataloger to call `SetID()` on all packages before returning the results (since the packages may be mutated after creation, this is the safest option).