### PR TITLE
Fix panic in APK version specifier handling 

### DIFF
--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -321,9 +321,6 @@ func discoverPackageDependencies(pkgs []pkg.Package) (relationships []artifact.R
 		}
 		lookup[p.Name] = append(lookup[p.Name], p)
 		for _, provides := range apkg.Provides {
-			if provides == "" {
-				continue
-			}
 			k := stripVersionSpecifier(provides)
 			lookup[k] = append(lookup[k], p)
 		}

--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -364,7 +364,7 @@ func stripVersionSpecifier(s string) string {
 	// examples:
 	// musl>=1                 --> musl
 	// cmd:scanelf=1.3.4-r0    --> cmd:scanelf
-	
+
 	items := splitAny(s, "<>=")
 	if len(items) == 0 {
 		return s

--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -364,5 +364,11 @@ func stripVersionSpecifier(s string) string {
 	// examples:
 	// musl>=1                 --> musl
 	// cmd:scanelf=1.3.4-r0    --> cmd:scanelf
-	return splitAny(s, "<>=")[0]
+	
+	items := splitAny(s, "<>=")
+	if len(items) == 0 {
+		return s
+	}
+
+	return items[0]
 }

--- a/syft/pkg/cataloger/apkdb/parse_apk_db.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db.go
@@ -321,6 +321,9 @@ func discoverPackageDependencies(pkgs []pkg.Package) (relationships []artifact.R
 		}
 		lookup[p.Name] = append(lookup[p.Name], p)
 		for _, provides := range apkg.Provides {
+			if provides == "" {
+				continue
+			}
 			k := stripVersionSpecifier(provides)
 			lookup[k] = append(lookup[k], p)
 		}

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -912,6 +912,27 @@ func Test_discoverPackageDependencies(t *testing.T) {
 			},
 		},
 		{
+			name: "strip version specifiers with empty provides value",
+			genFn: func() ([]pkg.Package, []artifact.Relationship) {
+				a := pkg.Package{
+					Name: "package-a",
+					Metadata: pkg.ApkMetadata{
+						Dependencies: []string{"so:libc.musl-x86_64.so.1"},
+					},
+				}
+				a.SetID()
+				b := pkg.Package{
+					Name: "package-b",
+					Metadata: pkg.ApkMetadata{
+						Provides: []string{""},
+					},
+				}
+				b.SetID()
+
+				return []pkg.Package{a, b}, nil
+			},
+		},
+		{
 			name: "depends on package name",
 			genFn: func() ([]pkg.Package, []artifact.Relationship) {
 				a := pkg.Package{

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -1147,3 +1147,42 @@ func newLocationReadCloser(t *testing.T, path string) source.LocationReadCloser 
 
 	return source.NewLocationReadCloser(source.NewLocation(path), f)
 }
+
+func Test_stripVersionSpecifier(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "empty expression",
+			version: "",
+			want:    "",
+		},
+		{
+			name:    "no expression",
+			version: "cmd:foo",
+			want:    "cmd:foo",
+		},
+		{
+			name:    "=",
+			version: "cmd:scanelf=1.3.4-r0",
+			want:    "cmd:scanelf",
+		},
+		{
+			name:    ">=",
+			version: "cmd:scanelf>=1.3.4-r0",
+			want:    "cmd:scanelf",
+		},
+		{
+			name:    "<",
+			version: "cmd:scanelf<1.3.4-r0",
+			want:    "cmd:scanelf",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripVersionSpecifier(tt.version))
+		})
+	}
+}


### PR DESCRIPTION
A bug was introduced in https://github.com/anchore/syft/pull/1063 where Syft would panic if a package listed in the installed DB doesn't "provide" anything.

This PR ~reworks the logic so that Syft allows for empty "provides" values~ (edit: no longer part of this PR, see https://github.com/anchore/syft/pull/1494#issuecomment-1398096945). It also adjusts the `stripVersionSpecifier` helper function to remove the possibility of panicking (index out of range).