### PR TITLE
Push noisy log statements to trace-level

### DIFF
--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -28,7 +28,8 @@ func (c *Cataloger) WithParserByGlobs(parser Parser, globs ...string) *Cataloger
 		func(resolver source.FileResolver, env Environment) []request {
 			var requests []request
 			for _, g := range globs {
-				// TODO: add more trace logging here
+				log.WithFields("glob", g).Trace("searching for paths matching glob")
+
 				matches, err := resolver.FilesByGlob(g)
 				if err != nil {
 					log.Warnf("unable to process glob=%q: %+v", g, err)
@@ -47,7 +48,8 @@ func (c *Cataloger) WithParserByMimeTypes(parser Parser, types ...string) *Catal
 		func(resolver source.FileResolver, env Environment) []request {
 			var requests []request
 			for _, t := range types {
-				// TODO: add more trace logging here
+				log.WithFields("mimetype", t).Trace("searching for paths matching mimetype")
+
 				matches, err := resolver.FilesByMIMEType(t)
 				if err != nil {
 					log.Warnf("unable to process mimetype=%q: %+v", t, err)
@@ -65,11 +67,12 @@ func (c *Cataloger) WithParserByPath(parser Parser, paths ...string) *Cataloger 
 	c.processor = append(c.processor,
 		func(resolver source.FileResolver, env Environment) []request {
 			var requests []request
-			for _, g := range paths {
-				// TODO: add more trace logging here
-				matches, err := resolver.FilesByPath(g)
+			for _, p := range paths {
+				log.WithFields("path", p).Trace("searching for path")
+
+				matches, err := resolver.FilesByPath(p)
 				if err != nil {
-					log.Warnf("unable to process path=%q: %+v", g, err)
+					log.Warnf("unable to process path=%q: %+v", p, err)
 					continue
 				}
 				requests = append(requests, makeRequests(parser, matches)...)

--- a/syft/pkg/cataloger/golang/scan_binary.go
+++ b/syft/pkg/cataloger/golang/scan_binary.go
@@ -53,7 +53,8 @@ func getBuildInfo(r io.ReaderAt) (bi *debug.BuildInfo, err error) {
 	if err != nil {
 		if err.Error() == "not a Go executable" {
 			// since the cataloger can only select executables and not distinguish if they are a go-compiled
-			// binary, we should not show warnings/logs in this case.
+			// binary, we should not show warnings/logs in this case. For this reason we nil-out err here.
+			err = nil
 			return
 		}
 		// in this case we could not read the or parse the file, but not explicitly because it is not a

--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -338,7 +338,7 @@ func (r directoryResolver) FilesByPath(userPaths ...string) ([]Location, error) 
 		// we should be resolving symlinks and preserving this information as a VirtualPath to the real file
 		evaluatedPath, err := filepath.EvalSymlinks(userStrPath)
 		if err != nil {
-			log.Debugf("directory resolver unable to evaluate symlink for path=%q : %+v", userPath, err)
+			log.Tracef("unable to evaluate symlink for path=%q : %+v", userPath, err)
 			continue
 		}
 


### PR DESCRIPTION
There are a few log statements that are expected to continually show what appears to be possible issues even though there is nothing wrong. These statements are useful when trying to troubleshoot issues, however, are fairly verbose even for the `debug` log level:
```
[0000] DEBUG checking if a new version of syft is available
[0000]  INFO new version of syft is available: 0.66.2 (current version is 0.66.0)
[0000] DEBUG image: source=DockerDaemon location=alpine:latest from-lib=stereoscope
[0000] DEBUG image metadata: digest=sha256:042a816809aac8d0f7d7cacac7965782ee2ecac3f21bcf9f24b1de1a7387b769 mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[alpine:latest] from-lib=stereoscope
[0000] DEBUG layer metadata: index=0 digest=sha256:8e012198eea15b2554b07014081c85fec4967a1b9cc4b65bd9a4bce3ae1c0c88 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip from-lib=stereoscope
[0000]  INFO identified distro: Alpine Linux v3.17
[0000]  INFO cataloging image
[0000] DEBUG cataloging packages catalogers=15 parallelism=1
[0000] DEBUG discovered 0 packages cataloger=alpmdb-cataloger
[0000] DEBUG discovered 0 packages cataloger=ruby-gemspec-cataloger
[0000] DEBUG discovered 0 packages cataloger=python-package-cataloger
[0000] DEBUG discovered 0 packages cataloger=php-composer-installed-cataloger
[0000] DEBUG discovered 0 packages cataloger=javascript-package-cataloger
[0000] DEBUG discovered 0 packages cataloger=dpkgdb-cataloger
[0000] DEBUG discovered 0 packages cataloger=rpm-db-cataloger
[0000] DEBUG discovered 0 packages cataloger=java-cataloger
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /bin/busybox: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/bin/busybox"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/bin/busybox"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /lib/ld-musl-x86_64.so.1: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/ld-musl-x86_64.so.1"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/ld-musl-x86_64.so.1"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /lib/libapk.so.3.12.0: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libapk.so.3.12.0"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libapk.so.3.12.0"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /lib/libcrypto.so.3: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libcrypto.so.3"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libcrypto.so.3"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /lib/libssl.so.3: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libssl.so.3"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libssl.so.3"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /lib/libz.so.1.2.13: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libz.so.1.2.13"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/lib/libz.so.1.2.13"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /sbin/apk: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/sbin/apk"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/sbin/apk"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: one or more symbols are missing from the native image executable
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/bin/getconf: one or more symbols are missing from the native image executable.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/getconf"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/getconf"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: one or more symbols are missing from the native image executable
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/bin/getent: one or more symbols are missing from the native image executable.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/getent"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/getent"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: one or more symbols are missing from the native image executable
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/bin/iconv: one or more symbols are missing from the native image executable.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/iconv"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/iconv"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/bin/scanelf: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/scanelf"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/scanelf"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/bin/ssl_client: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/ssl_client"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/bin/ssl_client"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/lib/engines-3/afalg.so: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/afalg.so"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/afalg.so"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/lib/engines-3/capi.so: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/capi.so"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/capi.so"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/lib/engines-3/loader_attic.so: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/loader_attic.so"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/loader_attic.so"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/lib/engines-3/padlock.so: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/padlock.so"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/engines-3/padlock.so"): unrecognized PE machine: 0x457f.
[0000] DEBUG native-image cataloger: no symbols found.
[0000] DEBUG native-image cataloger: error extracting SBOM from /usr/lib/ossl-modules/legacy.so: no symbol section.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/ossl-modules/legacy.so"): invalid magic number in record at byte 0x0.
[0000] DEBUG native-image cataloger: unable to read executable (file="/usr/lib/ossl-modules/legacy.so"): unrecognized PE machine: 0x457f.
[0000] DEBUG discovered 0 packages cataloger=graalvm-native-image-cataloger
[0000] DEBUG discovered 15 packages cataloger=apkdb-cataloger
[0000] DEBUG found path duplicate of /lib/ld-musl-x86_64.so.1
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
[0000] DEBUG found path duplicate of /etc/ssl/certs/ca-certificates.crt
[0000] DEBUG found path duplicate of /etc/ssl/certs/ca-certificates.crt
[0000] DEBUG found path duplicate of /etc/ssl/misc/tsget.pl
[0000] DEBUG found path duplicate of /lib/libcrypto.so.3
[0000] DEBUG found path duplicate of /lib/libssl.so.3
[0000] DEBUG found path duplicate of /lib/libz.so.1.2.13
[0000] DEBUG discovered 0 packages cataloger=go-module-binary-cataloger
[0000] DEBUG discovered 0 packages cataloger=dotnet-deps-cataloger
[0000] DEBUG discovered 0 packages cataloger=portage-cataloger
[0000] DEBUG discovered 0 packages cataloger=sbom-cataloger
[0000] DEBUG discovered 1 packages cataloger=binary-cataloger
<report>
```

This PR pushes many of these statements to trace level, or removes them entirely:
```
[0000] DEBUG checking if a new version of syft is available
[0000] DEBUG no new syft update available
[0000] DEBUG image: source=DockerDaemon location=alpine:latest from-lib=stereoscope
[0000] DEBUG image metadata: digest=sha256:042a816809aac8d0f7d7cacac7965782ee2ecac3f21bcf9f24b1de1a7387b769 mediaType=application/vnd.docker.distribution.manifest.v2+json tags=[alpine:latest] from-lib=stereoscope
[0000] DEBUG layer metadata: index=0 digest=sha256:8e012198eea15b2554b07014081c85fec4967a1b9cc4b65bd9a4bce3ae1c0c88 mediaType=application/vnd.docker.image.rootfs.diff.tar.gzip from-lib=stereoscope
[0000]  INFO identified distro: Alpine Linux v3.17
[0000]  INFO cataloging image
[0000] DEBUG cataloging packages catalogers=15 parallelism=1
[0000] DEBUG discovered 0 packages cataloger=alpmdb-cataloger
[0000] DEBUG discovered 0 packages cataloger=ruby-gemspec-cataloger
[0000] DEBUG discovered 0 packages cataloger=python-package-cataloger
[0000] DEBUG discovered 0 packages cataloger=php-composer-installed-cataloger
[0000] DEBUG discovered 0 packages cataloger=javascript-package-cataloger
[0000] DEBUG discovered 0 packages cataloger=dpkgdb-cataloger
[0000] DEBUG discovered 0 packages cataloger=rpm-db-cataloger
[0000] DEBUG discovered 0 packages cataloger=java-cataloger
[0000] DEBUG discovered 0 packages cataloger=graalvm-native-image-cataloger
[0000] DEBUG discovered 15 packages cataloger=apkdb-cataloger
[0000] DEBUG found path duplicate of /lib/ld-musl-x86_64.so.1
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616adfeb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5e69ca50.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58cbb476.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616abc23.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-60ac2099.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616db30d.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58e4f17d.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ac3bc.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-61666e3f.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
[0000] DEBUG found path duplicate of /etc/ssl/certs/ca-certificates.crt
[0000] DEBUG found path duplicate of /etc/ssl/certs/ca-certificates.crt
[0000] DEBUG found path duplicate of /etc/ssl/misc/tsget.pl
[0000] DEBUG found path duplicate of /lib/libcrypto.so.3
[0000] DEBUG found path duplicate of /lib/libssl.so.3
[0000] DEBUG found path duplicate of /lib/libz.so.1.2.13
[0000] DEBUG discovered 0 packages cataloger=go-module-binary-cataloger
[0000] DEBUG discovered 0 packages cataloger=dotnet-deps-cataloger
[0000] DEBUG discovered 0 packages cataloger=portage-cataloger
[0000] DEBUG discovered 0 packages cataloger=sbom-cataloger
[0000] DEBUG discovered 1 packages cataloger=binary-cataloger
```

This additionally pushes some of the `nil` checks up to the `nativeImage` object creation instead of around attributes on the  object.