### PR TITLE
Fix AssertEncoderAgainstGoldenSnapshot calls to conditionally update

### DIFF
--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -20,8 +20,8 @@ func TestDirectoryEncoder(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		testutils.DirectoryInput(t),
-		true,
 		*updateJson,
+		true,
 	)
 }
 
@@ -31,8 +31,8 @@ func TestImageEncoder(t *testing.T) {
 		Format(),
 		testutils.ImageInput(t, testImage, testutils.FromSnapshot()),
 		testImage,
-		true,
 		*updateJson,
+		true,
 	)
 }
 

--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -40,7 +40,7 @@ func TestImageEncoder(t *testing.T) {
 }
 
 func schemaVersionRedactor(s []byte) []byte {
-	pattern := regexp.MustCompile(`(?m),?\s*"schema":\s*\{[^}]*}`)
+	pattern := regexp.MustCompile(`,?\s*"schema":\s*\{[^}]*}`)
 	out := pattern.ReplaceAll(s, []byte(""))
 	return out
 }

--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -2,6 +2,7 @@ package syftjson
 
 import (
 	"flag"
+	"regexp"
 	"testing"
 
 	"github.com/anchore/syft/syft/artifact"
@@ -22,6 +23,7 @@ func TestDirectoryEncoder(t *testing.T) {
 		testutils.DirectoryInput(t),
 		*updateJson,
 		true,
+		schemaVersionRedactor,
 	)
 }
 
@@ -33,7 +35,14 @@ func TestImageEncoder(t *testing.T) {
 		testImage,
 		*updateJson,
 		true,
+		schemaVersionRedactor,
 	)
+}
+
+func schemaVersionRedactor(s []byte) []byte {
+	pattern := regexp.MustCompile(`(?m),?\s*"schema":\s*\{[^}]*}`)
+	out := pattern.ReplaceAll(s, []byte(""))
+	return out
 }
 
 func TestEncodeFullJSONDocument(t *testing.T) {

--- a/syft/formats/table/encoder_test.go
+++ b/syft/formats/table/encoder_test.go
@@ -15,8 +15,8 @@ func TestTableEncoder(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		testutils.DirectoryInput(t),
-		false,
 		*updateTableGoldenFiles,
+		false,
 	)
 }
 


### PR DESCRIPTION
Fixes calls to AssertEncoderAgainstGoldenSnapshot to not hardcode the `updateSnapshot` parameter and to instead use the conditional CLI flag when running tests.