### PR TITLE
fix: update config struct to not decode password/key

### DIFF
--- a/internal/config/attest.go
+++ b/internal/config/attest.go
@@ -3,6 +3,7 @@ package config
 import "github.com/spf13/viper"
 
 type attest struct {
+	// IMPORTANT: do not show the attestation key/password in any YAML/JSON output (sensitive information)
 	Key      string `yaml:"-" json:"-" mapstructure:"key"`
 	Password string `yaml:"-" json:"-" mapstructure:"password"`
 }

--- a/internal/config/attest.go
+++ b/internal/config/attest.go
@@ -3,8 +3,8 @@ package config
 import "github.com/spf13/viper"
 
 type attest struct {
-	Key      string `yaml:"key" json:"key" mapstructure:"key"`
-	Password string `yaml:"password" json:"password" mapstructure:"password"`
+	Key      string `yaml:"-" json:"-" mapstructure:"key"`
+	Password string `yaml:"-" json:"-" mapstructure:"password"`
 }
 
 func (cfg attest) loadDefaultValues(v *viper.Viper) {

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -229,6 +229,20 @@ func TestPackagesCmdFlags(t *testing.T) {
 				assertSuccessfulReturnCode,
 			},
 		},
+		{
+			name: "password and key not in config output",
+			args: []string{"packages", "-vvv", "-o", "json", coverageImage},
+			env: map[string]string{
+				"SYFT_ATTEST_PASSWORD": "secret_password",
+				"SYFT_ATTEST_KEY":      "secret_key_path",
+			},
+			assertions: []traitAssertion{
+				assertNotInOutput("secret_password"),
+				assertNotInOutput("secret_key_path"),
+				assertPackageCount(34),
+				assertSuccessfulReturnCode,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Affects syft versions >= v0.69.0

Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>