### PR TITLE
source: when base is set, responsePath should be absolute

### DIFF
--- a/syft/source/directory_resolver.go
+++ b/syft/source/directory_resolver.go
@@ -330,12 +330,19 @@ func (r directoryResolver) responsePath(path string) string {
 		path = posixToWindows(path)
 	}
 
-	// always return references relative to the request path (not absolute path)
+	// clean references to the request path (either the root, or the base if set)
 	if filepath.IsAbs(path) {
-		// we need to account for the cwd relative to the running process and the given root for the directory resolver
-		prefix := filepath.Clean(filepath.Join(r.currentWd, r.currentWdRelativeToRoot))
-		return strings.TrimPrefix(path, prefix+string(filepath.Separator))
+		var prefix string
+		if r.base != "" {
+			prefix = r.base
+		} else {
+			// we need to account for the cwd relative to the running process and the given root for the directory resolver
+			prefix = filepath.Clean(filepath.Join(r.currentWd, r.currentWdRelativeToRoot))
+			prefix += string(filepath.Separator)
+		}
+		path = strings.TrimPrefix(path, prefix)
 	}
+
 	return path
 }
 

--- a/syft/source/directory_resolver_test.go
+++ b/syft/source/directory_resolver_test.go
@@ -898,7 +898,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./base",
 			expected: []string{
-				"base",
+				"/base",
 			},
 		},
 		{
@@ -906,7 +906,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./foo",
 			expected: []string{
-				"base",
+				"/base",
 			},
 		},
 		{
@@ -914,7 +914,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./bar",
 			expected: []string{
-				"base",
+				"/base",
 			},
 		},
 		{
@@ -922,7 +922,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./baz",
 			expected: []string{
-				"base",
+				"/base",
 			},
 		},
 		{
@@ -930,7 +930,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./sub/link",
 			expected: []string{
-				"sub/item",
+				"/sub/item",
 			},
 		},
 		{
@@ -938,7 +938,7 @@ func TestDirectoryResolver_FilesByPath_baseRoot(t *testing.T) {
 			root:  "./test-fixtures/symlinks-base/",
 			input: "./chain",
 			expected: []string{
-				"base",
+				"/base",
 			},
 		},
 	}


### PR DESCRIPTION
:arrow_up: Follow up to #1485 

When base is set, it should appear identically to when we scan the root filesystem - and as a result, the path should begin with the path separator.

E.g. when scanning the root `./target/` with the same base, `target/bin/busybox` should appear in the output as `/bin/busybox`, not as previously as `bin/busybox`.

Signed-off-by: Justin Chadwell <me@jedevc.com>