### PR TITLE
Fix installed versions in Dockerfile used in make integration

### DIFF
--- a/test/integration/test-fixtures/image-vertical-package-dups/Dockerfile
+++ b/test/integration/test-fixtures/image-vertical-package-dups/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7.9.2009
 # modifying the RPM DB multiple times will result in duplicate packages when using all-layers (if there was no de-dup logic)
 # curl is tricky, it already exists in the image and is being upgraded
-RUN yum install -y wget curl
-RUN yum install -y vsftpd
-RUN yum install -y httpd
+RUN yum install -y wget-1.14-18.el7_6.1 curl-7.29.0-59.el7_9.1
+RUN yum install -y vsftpd-3.0.2-29.el7_9
+RUN yum install -y httpd-2.4.6-97.el7.centos.5


### PR DESCRIPTION
To stable test

- Fix installed versions in Dockerfile used in `make intedration`
- In this time, installed httpd version will be changed
  - As-Is : `2.4.6-98.el7.centos.6` (latest version)
  - To-Be : `2.4.6-97.el7.centos.5`

related : https://github.com/anchore/syft/pull/1536