### PR TITLE
fix: python CPE generation for alpine

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -127,6 +127,17 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "python-rrdtool"},
 			candidateAddition{AdditionalProducts: []string{"rrdtool"}},
 		},
+		// Alpine packages
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "python3"},
+			candidateAddition{AdditionalProducts: []string{"python"}, AdditionalVendors: []string{"python", "python_software_foundation"}},
+		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "python"},
+			candidateAddition{AdditionalVendors: []string{"python_software_foundation"}},
+		},
 	})
 
 var defaultCandidateRemovals = buildCandidateRemovalLookup(


### PR DESCRIPTION
Accurate CPE generation is important for getting accurate matches for alpine packages since it uses the NVD data to match and the alpine fix feed to deselect matches accordingly.  This ensures we generate expected CPE's for `python3` and `python`. 