### PR TITLE
fix: missing APK node vulnerabilities

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -138,6 +138,17 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "python"},
 			candidateAddition{AdditionalVendors: []string{"python_software_foundation"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "nodejs"},
+			candidateAddition{AdditionalProducts: []string{"node.js"}},
+		},
+		// Binary packages
+		{
+			pkg.BinaryPkg,
+			candidateKey{PkgName: "node"},
+			candidateAddition{AdditionalProducts: []string{"nodejs", "node.js"}},
+		},
 	})
 
 var defaultCandidateRemovals = buildCandidateRemovalLookup(


### PR DESCRIPTION
This PR adjusts some node identifications to properly pick up APK vulnerabilities.

Fixes https://github.com/anchore/grype/issues/1043