### PR TITLE
Enable SBOM conversions from STDIN

### DIFF
--- a/cmd/syft/cli/convert.go
+++ b/cmd/syft/cli/convert.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	convertExample = `  {{.appName}} {{.command}} img.syft.json -o spdx-json                      convert a syft SBOM to spdx-json, output goes to stdout in table format, by default
-  {{.appName}} {{.command}} img.syft.json -o cyclonedx-json=img.cdx.json    convert a syft SBOM to CycloneDX, output goes to a file named img.cdx.json
+	convertExample = `  {{.appName}} {{.command}} img.syft.json -o spdx-json                      convert a syft SBOM to spdx-json, output goes to stdout
+  {{.appName}} {{.command}} img.syft.json -o cyclonedx-json=img.cdx.json    convert a syft SBOM to CycloneDX, output is written to the file "img.cdx.json""
+  {{.appName}} {{.command}} - -o spdx-json                                  convert an SBOM from STDIN to spdx-json
 `
 )
 

--- a/test/cli/all_formats_convertible_test.go
+++ b/test/cli/all_formats_convertible_test.go
@@ -10,14 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConvertCmdFlags(t *testing.T) {
+func TestAllFormatsConvertable(t *testing.T) {
 	assertions := []traitAssertion{
-		func(tb testing.TB, stdout, _ string, _ int) {
-			tb.Helper()
-			if len(stdout) < 1000 {
-				tb.Errorf("there may not be any report output (len=%d)", len(stdout))
-			}
-		},
+		assertStdoutLengthGreaterThan(1000),
 		assertSuccessfulReturnCode,
 	}
 

--- a/test/cli/convert_cmd_test.go
+++ b/test/cli/convert_cmd_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestConvertCmd(t *testing.T) {
+	assertions := []traitAssertion{
+		assertInOutput("PackageName: musl-utils"),
+		assertSuccessfulReturnCode,
+	}
+
+	tests := []struct {
+		from string
+		to   string
+	}{
+		{from: "syft-json", to: "spdx-tag-value"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("from %s to %s", test.from, test.to), func(t *testing.T) {
+			sbomArgs := []string{"dir:./test-fixtures/image-pkg-coverage", "-o", test.from}
+			cmd, stdout, stderr := runSyft(t, nil, sbomArgs...)
+			if cmd.ProcessState.ExitCode() != 0 {
+				t.Log("STDOUT:\n", stdout)
+				t.Log("STDERR:\n", stderr)
+				t.Log("COMMAND:", strings.Join(cmd.Args, " "))
+				t.Fatalf("failure executing syft creating an sbom")
+				return
+			}
+
+			convertArgs := []string{"convert", "-", "-o", test.to}
+			cmd = getSyftCommand(t, convertArgs...)
+
+			cmd.Stdin = strings.NewReader(stdout)
+			stdout, stderr = runCommandObj(t, cmd, nil, false)
+
+			for _, traitFn := range assertions {
+				traitFn(t, stdout, stderr, cmd.ProcessState.ExitCode())
+			}
+			if t.Failed() {
+				t.Log("STDOUT:\n", stdout)
+				t.Log("STDERR:\n", stderr)
+				t.Log("COMMAND:", strings.Join(cmd.Args, " "))
+			}
+		})
+	}
+}


### PR DESCRIPTION
A small addition to the `convert` command to allow for taking SBOMs from stdin:
```
cat my.sbom | syft convert - -o spdx-json
```