### PR TITLE
Add workaround for macos github actions cache issue

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -154,6 +154,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # TODO: remove this when actions/cache + mac runner is fixed
+      # see https://github.com/actions/cache/issues/1110
+      - name: Downgrade zstd on macOS
+        run: |
+          brew uninstall --ignore-dependencies zstd
+          git -C "$(brew --repo homebrew/core)" checkout d3f04bd Formula/zstd.rb
+          brew install zstd
+
       - name: Download snapshot build
         uses: actions/cache/restore@v3
         with:


### PR DESCRIPTION
A temporary workaround to account for failing acceptance tests due to a false cache miss on mac runners in CI. See https://github.com/actions/cache/issues/1110 for more details.