### PR TITLE
fix: issue when matching format versions

### DIFF
--- a/syft/formats/formats.go
+++ b/syft/formats/formats.go
@@ -85,14 +85,9 @@ func versionMatches(version string, match string) bool {
 		return true
 	}
 
-	dots := strings.Count(match, ".")
-	if dots == 0 {
-		match += ".*"
-	}
 	match = strings.ReplaceAll(match, ".", "\\.")
 	match = strings.ReplaceAll(match, "*", ".*")
-	match = strings.ReplaceAll(match, "\\..*", "(\\..*)*")
-	match = fmt.Sprintf("^%s$", match)
+	match = fmt.Sprintf("^%s(\\..*)*$", match)
 	matcher, err := regexp.Compile(match)
 	if err != nil {
 		return false

--- a/syft/formats/formats_test.go
+++ b/syft/formats/formats_test.go
@@ -228,9 +228,58 @@ func Test_versionMatches(t *testing.T) {
 			matches: true,
 		},
 		{
+			name:    "wildcard-version matches minor",
+			version: "7.1.3",
+			match:   "7.*",
+			matches: true,
+		},
+		{
+			name:    "wildcard-version matches patch",
+			version: "7.4.8",
+			match:   "7.4.*",
+			matches: true,
+		},
+		{
+			name:    "sub-version matches major",
+			version: "7.19.11",
+			match:   "7",
+			matches: true,
+		},
+		{
+			name:    "sub-version matches minor",
+			version: "7.55.2",
+			match:   "7.55",
+			matches: true,
+		},
+		{
+			name:    "sub-version matches patch",
+			version: "7.32.6",
+			match:   "7.32.6",
+			matches: true,
+		},
+		// negative tests
+		{
 			name:    "different number does not match",
 			version: "3",
 			match:   "4",
+			matches: false,
+		},
+		{
+			name:    "sub-version doesn't match major",
+			version: "7.2.5",
+			match:   "8.2.5",
+			matches: false,
+		},
+		{
+			name:    "sub-version doesn't match minor",
+			version: "7.2.9",
+			match:   "7.1",
+			matches: false,
+		},
+		{
+			name:    "sub-version doesn't match patch",
+			version: "7.32.6",
+			match:   "7.32.5",
 			matches: false,
 		},
 	}


### PR DESCRIPTION
While working on PR #1583 I noticed there was an edge-case matching minor versions, for example if Syft JSON format has version `7.0.0`, requesting `json@7.0` would not match.