### PR TITLE
feat: set cosign attest predicate type based on Syft output type

### DIFF
--- a/cmd/syft/cli/attest/attest.go
+++ b/cmd/syft/cli/attest/attest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
@@ -130,7 +131,21 @@ func execWorker(app *config.Application, si source.Input, writer sbom.Writer) <-
 				return
 			}
 
-			args := []string{"attest", si.UserInput, "--predicate", f.Name()}
+			// Select Cosign predicate type based on defined output type
+			// As orientation, check: https://github.com/sigstore/cosign/blob/main/pkg/cosign/attestation/attestation.go
+			var predicateType string
+			switch strings.ToLower(o) {
+			case "cyclonedx-json":
+				predicateType = "cyclonedx"
+			case "spdx-tag-value":
+				predicateType = "spdx"
+			case "spdx-json":
+				predicateType = "spdxjson"
+			default:
+				predicateType = "custom"
+			}
+
+			args := []string{"attest", si.UserInput, "--predicate", f.Name(), "--type", predicateType}
 			if app.Attest.Key != "" {
 				args = append(args, "--key", app.Attest.Key)
 			}


### PR DESCRIPTION
In #1533, I wanted to remove the hardcoded "custom" predicate type passed to Cosign. This seemed to fix some of the issues I was seeing, though to be honest at this point I don't know exactly why 😅 

However, what I did not anticipate is that there's still no way to manually set a predicate type. Generally, I think it makes sense to set the predicate type on the type we are passing as predicate to Cosign.

Thus, here my attempt at this. 

Please mind, this is untested so far. Wanted to get general feedback on this first (or if someone can quickly test this and verify the attestation, that'd be cool).

Also, if someone can tell me how I can properly reference the output type in the switch statement rather than just using string comparison based on the user input here without major refactoring, I'd be happy to hear about that :)


