### PR TITLE
fix: improve CPE generation for curl APK

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -180,6 +180,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		// Alpine packages
 		{
 			pkg.ApkPkg,
+			candidateKey{PkgName: "curl"},
+			candidateAddition{AdditionalVendors: []string{"haxx"}},
+		},
+		{
+			pkg.ApkPkg,
 			candidateKey{PkgName: "python3"},
 			candidateAddition{AdditionalProducts: []string{"python"}, AdditionalVendors: []string{"python", "python_software_foundation"}},
 		},


### PR DESCRIPTION
The correct CPE for curl is `cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*`