### PR TITLE
fix: determine upstream for apk version streams

### DIFF
--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -1,9 +1,11 @@
 package apkdb
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
@@ -39,6 +41,14 @@ func generateUpstream(m pkg.ApkMetadata) string {
 		if strings.HasPrefix(m.Package, p) {
 			return strings.TrimPrefix(m.Package, p)
 		}
+	}
+
+	pattern := regexp.MustCompile(`(?P<upstream>\w+?)\-?\d[\d\.]*`)
+	groups := internal.MatchNamedCaptureGroups(pattern, m.Package)
+
+	upstream, ok := groups["upstream"]
+	if ok {
+		return upstream
 	}
 
 	return m.Package

--- a/syft/pkg/cataloger/apkdb/package_test.go
+++ b/syft/pkg/cataloger/apkdb/package_test.go
@@ -124,6 +124,90 @@ func Test_PackageURL(t *testing.T) {
 			},
 			expected: "pkg:apk/alpine/py3-non-existant@v?arch=a&upstream=abcdefg&distro=alpine-3.4.6",
 		},
+		{
+			name: "postgesql-15 upstream postgresql",
+			metadata: pkg.ApkMetadata{
+				Package:       "postgresql-15",
+				Version:       "15.0",
+				Architecture:  "a",
+				OriginPackage: "postgresql-15",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/postgresql-15@15.0?arch=a&upstream=postgresql&distro=alpine-3.4.6",
+		},
+		{
+			name: "postgesql15 upstream postgresql",
+			metadata: pkg.ApkMetadata{
+				Package:       "postgresql15",
+				Version:       "15.0",
+				Architecture:  "a",
+				OriginPackage: "postgresql15",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/postgresql15@15.0?arch=a&upstream=postgresql&distro=alpine-3.4.6",
+		},
+		{
+			name: "go-1.19 upstream go",
+			metadata: pkg.ApkMetadata{
+				Package:       "go-1.19",
+				Version:       "1.19",
+				Architecture:  "a",
+				OriginPackage: "go-1.19",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/go-1.19@1.19?arch=a&upstream=go&distro=alpine-3.4.6",
+		},
+		{
+			name: "go1.19 upstream go",
+			metadata: pkg.ApkMetadata{
+				Package:       "go1.19",
+				Version:       "1.19",
+				Architecture:  "a",
+				OriginPackage: "go1.19",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/go1.19@1.19?arch=a&upstream=go&distro=alpine-3.4.6",
+		},
+		{
+			name: "abc-101.191.23456 upstream abc",
+			metadata: pkg.ApkMetadata{
+				Package:       "abc-101.191.23456",
+				Version:       "101.191.23456",
+				Architecture:  "a",
+				OriginPackage: "abc-101.191.23456",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/abc-101.191.23456@101.191.23456?arch=a&upstream=abc&distro=alpine-3.4.6",
+		},
+		{
+			name: "abc101.191.23456 upstream abc",
+			metadata: pkg.ApkMetadata{
+				Package:       "abc101.191.23456",
+				Version:       "101.191.23456",
+				Architecture:  "a",
+				OriginPackage: "abc101.191.23456",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/abc101.191.23456@101.191.23456?arch=a&upstream=abc&distro=alpine-3.4.6",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Determines better upstream package name for version-stream apk packages:

Examples:

- postgresql-13 -> postgresql
- postgresql15 -> postgresql
- go-1.19 -> go
- perl100.55 -> perl