### PR TITLE
fix: decoding null apk metadata pullDependencies

### DIFF
--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -87,6 +87,8 @@ func (a *spaceDelimitedStringSlice) UnmarshalJSON(data []byte) error {
 		}
 		*a = s
 		return nil
+	case nil:
+		return nil
 	default:
 		return fmt.Errorf("invalid type for string array: %T", obj)
 	}

--- a/syft/pkg/apk_metadata_test.go
+++ b/syft/pkg/apk_metadata_test.go
@@ -98,6 +98,15 @@ func TestApkMetadata_UnmarshalJSON(t *testing.T) {
 				Files:         []ApkFileRecord{{Path: "/usr"}},
 			},
 		},
+		{
+			name: "null pullDependencies",
+			input: `{
+"pullDependencies": null
+}`,
+			want: ApkMetadata{
+				Dependencies: nil,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
If APK Metadata JSON contains a `"pullDependencies": null`, this will cause Syft to fail to parse the entire SBOM with an error `invalid type for string array: <nil>`. This PR corrects the issue.
