### PR TITLE
read relative etc/apk/repositories for alpine version when no OS provided

### DIFF
--- a/syft/pkg/cataloger/apkdb/cataloger_test.go
+++ b/syft/pkg/cataloger/apkdb/cataloger_test.go
@@ -24,6 +24,7 @@ func TestCataloger_Globs(t *testing.T) {
 			pkgtest.NewCatalogTester().
 				FromDirectory(t, test.fixture).
 				ExpectsResolverContentQueries(test.expected).
+				IgnoreUnfulfilledPathResponses("etc/apk/repositories").
 				TestCataloger(t, NewApkdbCataloger())
 		})
 	}


### PR DESCRIPTION
fixes #1572 

Sort of

The way apkdb works now, if it cannot find an `/etc/os-release` (or similar files on a fixed list), and if the ID is not `"alpine"`, it still reports on the package, but no purl is provided.

This has several problems.

* not everything will have an `etc/os-release`. This especially runs true when you are looking at a filesystem with multiple containers, or perhaps you have modified the `os-release` because your OS isn't alpine, but the packages in the embedded container are.
* there are multiple potential sources for packages; `os-release` is not necessarily the best place to find out where it came from.
* packages can come from multiple parallel locations, i.e. `/etc/apk/repositories` can have alpinelinux.org but also other places
* the version used for the packages might entirely be different from the version of the OS

This tries to address some of it. It does so very cautiously. If it cannot find an `/etc/os-release`, i.e. `linux.Release` is nil, then then it tries to read the `etc/apk/repositories` relative to where it found `lib/apk/db/installed` (so if it is embedded deep in the filesystem, it still can find it). If it finds `alpinelinux.org` in there, it sets it up as if running on alpine, and takes the version from there.

It is an improvement over the current design, but could be improved further.

* it should _prefer_ `etc/apk/repositories` over `os-release`; this uses it only if release still is nil
* it should read multiple options from `repositories`, but that will have to wait, since there is no way to correlate those with a particular package in `installed`

This is a real if imperfect improvement over the current state.

apk team is looking at improving this chain-of-custody, including providing a purl in the `installed` file. Things will get much easier then. See [this issue](https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10875). Until then, this can help.