### PR TITLE
refactor: move apk upstream logic to apk metadata

### DIFF
--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -126,18 +126,18 @@ func (m ApkMetadata) Upstream() string {
 		return m.OriginPackage
 	}
 
-	for _, p := range prefixes {
-		if strings.HasPrefix(m.Package, p) {
-			return strings.TrimPrefix(m.Package, p)
-		}
-	}
-
 	groups := internal.MatchNamedCaptureGroups(upstreamPattern, m.Package)
 
 	upstream, ok := groups["upstream"]
-	if ok {
-		return upstream
+	if !ok {
+		upstream = m.Package
 	}
 
-	return m.Package
+	for _, p := range prefixes {
+		if strings.HasPrefix(upstream, p) {
+			return strings.TrimPrefix(upstream, p)
+		}
+	}
+
+	return upstream
 }

--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -4,18 +4,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/scylladb/go-set/strset"
 
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/syft/file"
 )
 
 const ApkDBGlob = "**/lib/apk/db/installed"
 
-var _ FileOwner = (*ApkMetadata)(nil)
+var (
+	_               FileOwner = (*ApkMetadata)(nil)
+	prefixes                  = []string{"py-", "py2-", "py3-", "ruby-"}
+	upstreamPattern           = regexp.MustCompile(`^(?P<upstream>[\w-]+?)\-?\d[\d\.]*$`)
+)
 
 // ApkMetadata represents all captured data for a Alpine DB package entry.
 // See the following sources for more information:
@@ -113,4 +119,25 @@ func (m ApkMetadata) OwnedFiles() (result []string) {
 	result = s.List()
 	sort.Strings(result)
 	return result
+}
+
+func (m ApkMetadata) Upstream() string {
+	if m.OriginPackage != "" && m.OriginPackage != m.Package {
+		return m.OriginPackage
+	}
+
+	for _, p := range prefixes {
+		if strings.HasPrefix(m.Package, p) {
+			return strings.TrimPrefix(m.Package, p)
+		}
+	}
+
+	groups := internal.MatchNamedCaptureGroups(upstreamPattern, m.Package)
+
+	upstream, ok := groups["upstream"]
+	if ok {
+		return upstream
+	}
+
+	return m.Package
 }

--- a/syft/pkg/apk_metadata.go
+++ b/syft/pkg/apk_metadata.go
@@ -20,7 +20,7 @@ const ApkDBGlob = "**/lib/apk/db/installed"
 var (
 	_               FileOwner = (*ApkMetadata)(nil)
 	prefixes                  = []string{"py-", "py2-", "py3-", "ruby-"}
-	upstreamPattern           = regexp.MustCompile(`^(?P<upstream>[\w-]+?)\-?\d[\d\.]*$`)
+	upstreamPattern           = regexp.MustCompile(`^(?P<upstream>[a-zA-Z][\w-]*?)\-?\d[\d\.]*$`)
 )
 
 // ApkMetadata represents all captured data for a Alpine DB package entry.

--- a/syft/pkg/apk_metadata_test.go
+++ b/syft/pkg/apk_metadata_test.go
@@ -303,6 +303,20 @@ func TestApkMetadata_Upstream(t *testing.T) {
 			},
 			expected: "123456",
 		},
+		{
+			name: "ruby-3.6 upstream ruby",
+			metadata: ApkMetadata{
+				Package: "ruby-3.6",
+			},
+			expected: "ruby",
+		},
+		{
+			name: "ruby3.6 upstream ruby",
+			metadata: ApkMetadata{
+				Package: "ruby3.6",
+			},
+			expected: "ruby",
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/apk_metadata_test.go
+++ b/syft/pkg/apk_metadata_test.go
@@ -282,6 +282,27 @@ func TestApkMetadata_Upstream(t *testing.T) {
 			},
 			expected: "abc101-a12345",
 		},
+		{
+			name: "package starting with single digit",
+			metadata: ApkMetadata{
+				Package: "3proxy",
+			},
+			expected: "3proxy",
+		},
+		{
+			name: "package starting with multiple digits",
+			metadata: ApkMetadata{
+				Package: "356proxy",
+			},
+			expected: "356proxy",
+		},
+		{
+			name: "package composed of only digits",
+			metadata: ApkMetadata{
+				Package: "123456",
+			},
+			expected: "123456",
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/apkdb/package_test.go
+++ b/syft/pkg/cataloger/apkdb/package_test.go
@@ -208,6 +208,34 @@ func Test_PackageURL(t *testing.T) {
 			},
 			expected: "pkg:apk/alpine/abc101.191.23456@101.191.23456?arch=a&upstream=abc&distro=alpine-3.4.6",
 		},
+		{
+			name: "abc101-12345-1045 upstream abc101-12345",
+			metadata: pkg.ApkMetadata{
+				Package:       "abc101-12345-1045",
+				Version:       "101.191.23456",
+				Architecture:  "a",
+				OriginPackage: "abc101-12345-1045",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/abc101-12345-1045@101.191.23456?arch=a&upstream=abc101-12345&distro=alpine-3.4.6",
+		},
+		{
+			name: "abc101-a12345-1045 upstream abc101-a12345",
+			metadata: pkg.ApkMetadata{
+				Package:       "abc101-a12345-1045",
+				Version:       "101.191.23456",
+				Architecture:  "a",
+				OriginPackage: "abc101-a12345-1045",
+			},
+			distro: linux.Release{
+				ID:        "alpine",
+				VersionID: "3.4.6",
+			},
+			expected: "pkg:apk/alpine/abc101-a12345-1045@101.191.23456?arch=a&upstream=abc101-a12345&distro=alpine-3.4.6",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Export the logic for parsing upstream APK package names so it can be accessed from apk metadata objects directly.

This also tightens the upstream regex pattern as several edge cases were being missed.