### PR TITLE
fix: correct apk purls for other distros

### DIFF
--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -28,8 +28,7 @@ func newPackage(d pkg.ApkMetadata, release *linux.Release, locations ...source.L
 
 // packageURL returns the PURL for the specific Alpine package (see https://github.com/package-url/purl-spec)
 func packageURL(m pkg.ApkMetadata, distro *linux.Release) string {
-	if distro == nil || distro.ID != "alpine" {
-		// note: there is no namespace variation (like with debian ID_LIKE for ubuntu ID, for example)
+	if distro == nil {
 		return ""
 	}
 
@@ -44,7 +43,7 @@ func packageURL(m pkg.ApkMetadata, distro *linux.Release) string {
 
 	return packageurl.NewPackageURL(
 		packageurl.TypeAlpine,
-		"alpine",
+		strings.ToLower(distro.ID),
 		m.Package,
 		m.Version,
 		pkg.PURLQualifiers(

--- a/syft/pkg/cataloger/apkdb/package_test.go
+++ b/syft/pkg/cataloger/apkdb/package_test.go
@@ -20,7 +20,7 @@ func Test_PackageURL(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "bad distro",
+			name: "non-alpine distro",
 			metadata: pkg.ApkMetadata{
 				Package:      "p",
 				Version:      "v",
@@ -30,7 +30,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "something else",
 				VersionID: "3.4.6",
 			},
-			expected: "",
+			expected: "pkg:apk/something%20else/p@v?arch=a&distro=something%20else-3.4.6",
 		},
 		{
 			name: "gocase",
@@ -235,6 +235,19 @@ func Test_PackageURL(t *testing.T) {
 				VersionID: "3.4.6",
 			},
 			expected: "pkg:apk/alpine/abc101-a12345-1045@101.191.23456?arch=a&upstream=abc101-a12345&distro=alpine-3.4.6",
+		},
+		{
+			name: "wolfi distro",
+			metadata: pkg.ApkMetadata{
+				Package:      "p",
+				Version:      "v",
+				Architecture: "a",
+			},
+			distro: linux.Release{
+				ID:        "wolfi",
+				VersionID: "20221230",
+			},
+			expected: "pkg:apk/wolfi/p@v?arch=a&distro=wolfi-20221230",
 		},
 	}
 


### PR DESCRIPTION
The apk purl spec allows for vendor-specific namespace.  I noticed in the embedded SBOMs from wolfi that the purls are of the form `pkg:apk/wolfi/curl@7.83.0-r0?arch=x86`, but the current logic in syft actually prevents purl generation entirely if the distro isn't alpine, so this corrects that behaviour.