### PR TITLE
fix: further improvements to CPE generation for apk packages

### DIFF
--- a/syft/pkg/cataloger/common/cpe/apk.go
+++ b/syft/pkg/cataloger/common/cpe/apk.go
@@ -10,7 +10,10 @@ var (
 	pythonPrefixes   = []string{"py-", "py2-", "py3-"}
 	rubyPrefixes     = []string{"ruby-"}
 	urlPrefixVendors = map[string][]string{
-		"https://www.gnu.org/": []string{"gnu"},
+		"https://www.gnu.org/":         {"gnu"},
+		"https://developer.gnome.org/": {"gnome"},
+		"https://www.ruby-lang.org/":   {"ruby-lang"},
+		"https://llvm.org/":            {"llvm"},
 	}
 )
 

--- a/syft/pkg/cataloger/common/cpe/apk.go
+++ b/syft/pkg/cataloger/common/cpe/apk.go
@@ -146,6 +146,40 @@ func rubyCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 	return products
 }
 
+func candidateVendorsFromUpstream(m pkg.ApkMetadata) fieldCandidateSet {
+	vendors := newFieldCandidateSet()
+	upstream := m.Upstream()
+	if upstream != "" {
+		vendors.add(fieldCandidate{
+			value:                       upstream,
+			disallowSubSelections:       true,
+			disallowDelimiterVariations: true,
+		})
+
+		vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, pkg.ApkPkg, upstream, upstream)...)
+		vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, pkg.ApkPkg, upstream)...)
+	}
+
+	return vendors
+}
+
+func candidateProductsFromUpstream(m pkg.ApkMetadata) fieldCandidateSet {
+	products := newFieldCandidateSet()
+	upstream := m.Upstream()
+	if upstream != "" {
+		products.add(fieldCandidate{
+			value:                       upstream,
+			disallowSubSelections:       true,
+			disallowDelimiterVariations: true,
+		})
+
+		products.addValue(findAdditionalProducts(defaultCandidateAdditions, pkg.ApkPkg, upstream)...)
+		products.removeByValue(findProductsToRemove(defaultCandidateRemovals, pkg.ApkPkg, upstream)...)
+	}
+
+	return products
+}
+
 func candidateVendorsForAPK(p pkg.Package) fieldCandidateSet {
 	metadata, ok := p.Metadata.(pkg.ApkMetadata)
 	if !ok {
@@ -155,6 +189,7 @@ func candidateVendorsForAPK(p pkg.Package) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
 	vendors.union(pythonCandidateVendorsFromAPK(metadata))
 	vendors.union(rubyCandidateVendorsFromAPK(metadata))
+	vendors.union(candidateVendorsFromUpstream(metadata))
 
 	return vendors
 }
@@ -168,6 +203,7 @@ func candidateProductsForAPK(p pkg.Package) fieldCandidateSet {
 	products := newFieldCandidateSet()
 	products.union(pythonCandidateProductsFromAPK(metadata))
 	products.union(rubyCandidateProductsFromAPK(metadata))
+	products.union(candidateProductsFromUpstream(metadata))
 
 	return products
 }

--- a/syft/pkg/cataloger/common/cpe/apk.go
+++ b/syft/pkg/cataloger/common/cpe/apk.go
@@ -7,14 +7,8 @@ import (
 )
 
 var (
-	pythonPrefixes   = []string{"py-", "py2-", "py3-"}
-	rubyPrefixes     = []string{"ruby-"}
-	urlPrefixVendors = map[string][]string{
-		"https://www.gnu.org/":         {"gnu"},
-		"https://developer.gnome.org/": {"gnome"},
-		"https://www.ruby-lang.org/":   {"ruby-lang"},
-		"https://llvm.org/":            {"llvm"},
-	}
+	pythonPrefixes = []string{"py-", "py2-", "py3-"}
+	rubyPrefixes   = []string{"ruby-"}
 )
 
 func pythonCandidateVendorsFromName(v string) fieldCandidateSet {
@@ -186,24 +180,6 @@ func candidateProductsFromAPKUpstream(m pkg.ApkMetadata) fieldCandidateSet {
 	return products
 }
 
-func candidateVendorsFromAPKProjectURL(m pkg.ApkMetadata) fieldCandidateSet {
-	vendors := newFieldCandidateSet()
-
-	for urlPrefix, additionalVendors := range urlPrefixVendors {
-		if strings.HasPrefix(m.URL, urlPrefix) {
-			for _, v := range additionalVendors {
-				vendors.add(fieldCandidate{
-					value:                       v,
-					disallowSubSelections:       true,
-					disallowDelimiterVariations: true,
-				})
-			}
-		}
-	}
-
-	return vendors
-}
-
 func candidateVendorsForAPK(p pkg.Package) fieldCandidateSet {
 	metadata, ok := p.Metadata.(pkg.ApkMetadata)
 	if !ok {
@@ -214,7 +190,7 @@ func candidateVendorsForAPK(p pkg.Package) fieldCandidateSet {
 	vendors.union(pythonCandidateVendorsFromAPK(metadata))
 	vendors.union(rubyCandidateVendorsFromAPK(metadata))
 	vendors.union(candidateVendorsFromAPKUpstream(metadata))
-	vendors.union(candidateVendorsFromAPKProjectURL(metadata))
+	vendors.union(candidateVendorsFromURL(metadata.URL))
 
 	return vendors
 }

--- a/syft/pkg/cataloger/common/cpe/apk.go
+++ b/syft/pkg/cataloger/common/cpe/apk.go
@@ -13,21 +13,12 @@ var (
 
 func pythonCandidateVendorsFromName(v string) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
-	vendors.add(fieldCandidate{
-		value:                       v,
-		disallowSubSelections:       true,
-		disallowDelimiterVariations: true,
-	})
-
+	vendors.addValue(v)
 	vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, pkg.PythonPkg, v, v)...)
 	vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, pkg.PythonPkg, v)...)
 
 	for _, av := range additionalVendorsForPython(v) {
-		vendors.add(fieldCandidate{
-			value:                       av,
-			disallowSubSelections:       true,
-			disallowDelimiterVariations: true,
-		})
+		vendors.addValue(av)
 		vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, pkg.PythonPkg, av, av)...)
 		vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, pkg.PythonPkg, av)...)
 	}
@@ -37,6 +28,7 @@ func pythonCandidateVendorsFromName(v string) fieldCandidateSet {
 
 func pythonCandidateVendorsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
+	upstream := m.Upstream()
 
 	for _, p := range pythonPrefixes {
 		if strings.HasPrefix(m.Package, p) {
@@ -44,8 +36,8 @@ func pythonCandidateVendorsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 			vendors.union(pythonCandidateVendorsFromName(t))
 		}
 
-		if m.OriginPackage != m.Package && strings.HasPrefix(m.OriginPackage, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.OriginPackage, p))
+		if upstream != m.Package && strings.HasPrefix(upstream, p) {
+			t := strings.ToLower(strings.TrimPrefix(upstream, p))
 			vendors.union(pythonCandidateVendorsFromName(t))
 		}
 	}
@@ -55,12 +47,7 @@ func pythonCandidateVendorsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 
 func pythonCandidateProductsFromName(p string) fieldCandidateSet {
 	products := newFieldCandidateSet()
-	products.add(fieldCandidate{
-		value:                       p,
-		disallowSubSelections:       true,
-		disallowDelimiterVariations: true,
-	})
-
+	products.addValue(p)
 	products.addValue(findAdditionalProducts(defaultCandidateAdditions, pkg.PythonPkg, p)...)
 	products.removeByValue(findProductsToRemove(defaultCandidateRemovals, pkg.PythonPkg, p)...)
 	return products
@@ -68,6 +55,7 @@ func pythonCandidateProductsFromName(p string) fieldCandidateSet {
 
 func pythonCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 	products := newFieldCandidateSet()
+	upstream := m.Upstream()
 
 	for _, p := range pythonPrefixes {
 		if strings.HasPrefix(m.Package, p) {
@@ -75,8 +63,8 @@ func pythonCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 			products.union(pythonCandidateProductsFromName(t))
 		}
 
-		if m.OriginPackage != m.Package && strings.HasPrefix(m.OriginPackage, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.OriginPackage, p))
+		if upstream != m.Package && strings.HasPrefix(upstream, p) {
+			t := strings.ToLower(strings.TrimPrefix(upstream, p))
 			products.union(pythonCandidateProductsFromName(t))
 		}
 	}
@@ -86,12 +74,7 @@ func pythonCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 
 func rubyCandidateVendorsFromName(v string) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
-	vendors.add(fieldCandidate{
-		value:                       v,
-		disallowSubSelections:       true,
-		disallowDelimiterVariations: true,
-	})
-
+	vendors.addValue(v)
 	vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, pkg.GemPkg, v, v)...)
 	vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, pkg.GemPkg, v)...)
 	return vendors
@@ -99,16 +82,19 @@ func rubyCandidateVendorsFromName(v string) fieldCandidateSet {
 
 func rubyCandidateVendorsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
+	upstream := m.Upstream()
 
-	for _, p := range rubyPrefixes {
-		if strings.HasPrefix(m.Package, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.Package, p))
-			vendors.union(rubyCandidateVendorsFromName(t))
-		}
+	if upstream != "ruby" {
+		for _, p := range rubyPrefixes {
+			if strings.HasPrefix(m.Package, p) {
+				t := strings.ToLower(strings.TrimPrefix(m.Package, p))
+				vendors.union(rubyCandidateVendorsFromName(t))
+			}
 
-		if m.OriginPackage != m.Package && strings.HasPrefix(m.OriginPackage, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.OriginPackage, p))
-			vendors.union(rubyCandidateVendorsFromName(t))
+			if upstream != "" && upstream != m.Package && strings.HasPrefix(upstream, p) {
+				t := strings.ToLower(strings.TrimPrefix(upstream, p))
+				vendors.union(rubyCandidateVendorsFromName(t))
+			}
 		}
 	}
 
@@ -117,12 +103,7 @@ func rubyCandidateVendorsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 
 func rubyCandidateProductsFromName(p string) fieldCandidateSet {
 	products := newFieldCandidateSet()
-	products.add(fieldCandidate{
-		value:                       p,
-		disallowSubSelections:       true,
-		disallowDelimiterVariations: true,
-	})
-
+	products.addValue(p)
 	products.addValue(findAdditionalProducts(defaultCandidateAdditions, pkg.GemPkg, p)...)
 	products.removeByValue(findProductsToRemove(defaultCandidateRemovals, pkg.GemPkg, p)...)
 	return products
@@ -130,16 +111,19 @@ func rubyCandidateProductsFromName(p string) fieldCandidateSet {
 
 func rubyCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 	products := newFieldCandidateSet()
+	upstream := m.Upstream()
 
-	for _, p := range rubyPrefixes {
-		if strings.HasPrefix(m.Package, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.Package, p))
-			products.union(rubyCandidateProductsFromName(t))
-		}
+	if upstream != "ruby" {
+		for _, p := range rubyPrefixes {
+			if strings.HasPrefix(m.Package, p) {
+				t := strings.ToLower(strings.TrimPrefix(m.Package, p))
+				products.union(rubyCandidateProductsFromName(t))
+			}
 
-		if m.OriginPackage != m.Package && strings.HasPrefix(m.OriginPackage, p) {
-			t := strings.ToLower(strings.TrimPrefix(m.OriginPackage, p))
-			products.union(rubyCandidateProductsFromName(t))
+			if upstream != "" && upstream != m.Package && strings.HasPrefix(upstream, p) {
+				t := strings.ToLower(strings.TrimPrefix(upstream, p))
+				products.union(rubyCandidateProductsFromName(t))
+			}
 		}
 	}
 
@@ -149,13 +133,8 @@ func rubyCandidateProductsFromAPK(m pkg.ApkMetadata) fieldCandidateSet {
 func candidateVendorsFromAPKUpstream(m pkg.ApkMetadata) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
 	upstream := m.Upstream()
-	if upstream != "" {
-		vendors.add(fieldCandidate{
-			value:                       upstream,
-			disallowSubSelections:       true,
-			disallowDelimiterVariations: true,
-		})
-
+	if upstream != "" && upstream != m.Package {
+		vendors.addValue(upstream)
 		vendors.addValue(findAdditionalVendors(defaultCandidateAdditions, pkg.ApkPkg, upstream, upstream)...)
 		vendors.removeByValue(findVendorsToRemove(defaultCandidateRemovals, pkg.ApkPkg, upstream)...)
 	}
@@ -167,12 +146,7 @@ func candidateProductsFromAPKUpstream(m pkg.ApkMetadata) fieldCandidateSet {
 	products := newFieldCandidateSet()
 	upstream := m.Upstream()
 	if upstream != "" {
-		products.add(fieldCandidate{
-			value:                       upstream,
-			disallowSubSelections:       true,
-			disallowDelimiterVariations: true,
-		})
-
+		products.addValue(upstream)
 		products.addValue(findAdditionalProducts(defaultCandidateAdditions, pkg.ApkPkg, upstream)...)
 		products.removeByValue(findProductsToRemove(defaultCandidateRemovals, pkg.ApkPkg, upstream)...)
 	}
@@ -192,6 +166,11 @@ func candidateVendorsForAPK(p pkg.Package) fieldCandidateSet {
 	vendors.union(candidateVendorsFromAPKUpstream(metadata))
 	vendors.union(candidateVendorsFromURL(metadata.URL))
 
+	for v := range vendors {
+		v.disallowDelimiterVariations = true
+		v.disallowSubSelections = true
+	}
+
 	return vendors
 }
 
@@ -205,6 +184,11 @@ func candidateProductsForAPK(p pkg.Package) fieldCandidateSet {
 	products.union(pythonCandidateProductsFromAPK(metadata))
 	products.union(rubyCandidateProductsFromAPK(metadata))
 	products.union(candidateProductsFromAPKUpstream(metadata))
+
+	for p := range products {
+		p.disallowDelimiterVariations = true
+		p.disallowSubSelections = true
+	}
 
 	return products
 }

--- a/syft/pkg/cataloger/common/cpe/apk_test.go
+++ b/syft/pkg/cataloger/common/cpe/apk_test.go
@@ -24,13 +24,14 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 			expected: []string{"python-cryptography_project", "cryptography", "cryptographyproject", "cryptography_project"},
 		},
 		{
-			name: "py2-pypdf OriginPackage",
+			name: "py2-pypdf with explicit different origin",
 			pkg: pkg.Package{
 				Metadata: pkg.ApkMetadata{
-					OriginPackage: "py2-pypdf",
+					Package:       "py2-pypdf",
+					OriginPackage: "abcdefg",
 				},
 			},
-			expected: []string{"pypdf", "pypdfproject", "pypdf_project"},
+			expected: []string{"pypdf", "pypdfproject", "pypdf_project", "abcdefg"},
 		},
 		{
 			name: "ruby-armadillo Package",
@@ -48,7 +49,7 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 					Package: "python-3.6",
 				},
 			},
-			expected: []string{"python-3.6", "python"},
+			expected: []string{"python", "python_software_foundation"},
 		},
 		{
 			name: "ruby-3.6",
@@ -58,7 +59,7 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 					URL:     "https://www.ruby-lang.org/",
 				},
 			},
-			expected: []string{"ruby-3.6", "ruby", "ruby-lang"},
+			expected: []string{"ruby", "ruby-lang"},
 		},
 		{
 			name: "make",
@@ -68,12 +69,12 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 					URL:     "https://www.gnu.org/software/make",
 				},
 			},
-			expected: []string{"make", "gnu"},
+			expected: []string{"gnu"},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.expected, candidateVendorsForAPK(test.pkg).values(), "different vendors")
+			assert.ElementsMatch(t, test.expected, candidateVendorsForAPK(test.pkg).uniqueValues(), "different vendors")
 		})
 	}
 }
@@ -94,13 +95,14 @@ func Test_candidateProductsForAPK(t *testing.T) {
 			expected: []string{"cryptography", "python-cryptography"},
 		},
 		{
-			name: "py2-pypdf OriginPackage",
+			name: "py2-pypdf with explicit different origin",
 			pkg: pkg.Package{
 				Metadata: pkg.ApkMetadata{
-					OriginPackage: "py2-pypdf",
+					Package:       "py2-pypdf",
+					OriginPackage: "abcdefg",
 				},
 			},
-			expected: []string{"pypdf"},
+			expected: []string{"pypdf", "abcdefg"},
 		},
 		{
 			name: "ruby-armadillo Package",
@@ -111,10 +113,39 @@ func Test_candidateProductsForAPK(t *testing.T) {
 			},
 			expected: []string{"armadillo"},
 		},
+		{
+			name: "python-3.6",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "python-3.6",
+				},
+			},
+			expected: []string{"python"},
+		},
+		{
+			name: "ruby-3.6",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "ruby-3.6",
+					URL:     "https://www.ruby-lang.org/",
+				},
+			},
+			expected: []string{"ruby"},
+		},
+		{
+			name: "make",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "make",
+					URL:     "https://www.gnu.org/software/make",
+				},
+			},
+			expected: []string{"make"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.expected, candidateProductsForAPK(test.pkg).values(), "different products")
+			assert.ElementsMatch(t, test.expected, candidateProductsForAPK(test.pkg).uniqueValues(), "different products")
 		})
 	}
 }

--- a/syft/pkg/cataloger/common/cpe/apk_test.go
+++ b/syft/pkg/cataloger/common/cpe/apk_test.go
@@ -41,6 +41,15 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 			},
 			expected: []string{"armadillo"},
 		},
+		{
+			name: "python-3.6",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "python-3.6",
+				},
+			},
+			expected: []string{"python-3.6, python"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/pkg/cataloger/common/cpe/apk_test.go
+++ b/syft/pkg/cataloger/common/cpe/apk_test.go
@@ -48,7 +48,27 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 					Package: "python-3.6",
 				},
 			},
-			expected: []string{"python-3.6, python"},
+			expected: []string{"python-3.6", "python"},
+		},
+		{
+			name: "ruby-3.6",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "ruby-3.6",
+					URL:     "https://www.ruby-lang.org/",
+				},
+			},
+			expected: []string{"ruby-3.6", "ruby", "ruby-lang"},
+		},
+		{
+			name: "make",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkMetadata{
+					Package: "make",
+					URL:     "https://www.gnu.org/software/make",
+				},
+			},
+			expected: []string{"make", "gnu"},
 		},
 	}
 	for _, test := range tests {

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -243,6 +243,12 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "bash"},
 			candidateAddition{AdditionalVendors: []string{"gnu"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "alsa-lib"},
+			candidateAddition{AdditionalVendors: []string{"alsa-project"}},
+		},
+		//
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -253,6 +253,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "alsa"},
 			candidateAddition{AdditionalVendors: []string{"alsa-project"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "make"},
+			candidateAddition{AdditionalVendors: []string{"gnu"}},
+		},
 		//
 		// Binary packages
 		{

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -238,6 +238,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "glib"},
 			candidateAddition{AdditionalVendors: []string{"gnome"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "bash"},
+			candidateAddition{AdditionalVendors: []string{"gnu"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -203,6 +203,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "nodejs-current"},
 			candidateAddition{AdditionalProducts: []string{"node.js"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "go"},
+			candidateAddition{AdditionalVendors: []string{"golang"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -223,6 +223,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "clang"},
 			candidateAddition{AdditionalVendors: []string{"llvm"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "openjdk"},
+			candidateAddition{AdditionalVendors: []string{"oracle"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -213,6 +213,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "ruby"},
 			candidateAddition{AdditionalVendors: []string{"ruby-lang"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "bazel"},
+			candidateAddition{AdditionalVendors: []string{"google"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -248,6 +248,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "alsa-lib"},
 			candidateAddition{AdditionalVendors: []string{"alsa-project"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "alsa"},
+			candidateAddition{AdditionalVendors: []string{"alsa-project"}},
+		},
 		//
 		// Binary packages
 		{

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -258,6 +258,21 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "make"},
 			candidateAddition{AdditionalVendors: []string{"gnu"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "git"},
+			candidateAddition{AdditionalVendors: []string{"git-scm"}},
+		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "bind"},
+			candidateAddition{AdditionalVendors: []string{"isc"}},
+		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "libxpm"},
+			candidateAddition{AdditionalVendors: []string{"libxpm_project"}},
+		},
 		//
 		// Binary packages
 		{

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -218,6 +218,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "bazel"},
 			candidateAddition{AdditionalVendors: []string{"google"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "clang"},
+			candidateAddition{AdditionalVendors: []string{"llvm"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -208,6 +208,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "go"},
 			candidateAddition{AdditionalVendors: []string{"golang"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "ruby"},
+			candidateAddition{AdditionalVendors: []string{"ruby-lang"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -233,6 +233,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "glibc"},
 			candidateAddition{AdditionalVendors: []string{"gnu"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "glib"},
+			candidateAddition{AdditionalVendors: []string{"gnome"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -228,6 +228,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "openjdk"},
 			candidateAddition{AdditionalVendors: []string{"oracle"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "glibc"},
+			candidateAddition{AdditionalVendors: []string{"gnu"}},
+		},
 		// Binary packages
 		{
 			pkg.BinaryPkg,

--- a/syft/pkg/cataloger/common/cpe/vendors_from_url.go
+++ b/syft/pkg/cataloger/common/cpe/vendors_from_url.go
@@ -1,0 +1,32 @@
+package cpe
+
+import (
+	"strings"
+)
+
+var (
+	urlPrefixVendors = map[string][]string{
+		"https://www.gnu.org/":         {"gnu"},
+		"https://developer.gnome.org/": {"gnome"},
+		"https://www.ruby-lang.org/":   {"ruby-lang"},
+		"https://llvm.org/":            {"llvm"},
+	}
+)
+
+func candidateVendorsFromURL(url string) fieldCandidateSet {
+	vendors := newFieldCandidateSet()
+
+	for urlPrefix, additionalVendors := range urlPrefixVendors {
+		if strings.HasPrefix(url, urlPrefix) {
+			for _, v := range additionalVendors {
+				vendors.add(fieldCandidate{
+					value:                       v,
+					disallowSubSelections:       true,
+					disallowDelimiterVariations: true,
+				})
+			}
+		}
+	}
+
+	return vendors
+}

--- a/syft/pkg/cataloger/common/cpe/vendors_from_url.go
+++ b/syft/pkg/cataloger/common/cpe/vendors_from_url.go
@@ -10,6 +10,7 @@ var (
 		"https://developer.gnome.org/": {"gnome"},
 		"https://www.ruby-lang.org/":   {"ruby-lang"},
 		"https://llvm.org/":            {"llvm"},
+		"https://www.isc.org/":         {"isc"},
 	}
 )
 


### PR DESCRIPTION
Adds many known CPE vendor candidates to APK CPE generation as well as using known project URL prefixes from APK metadata to generate known vendor candidates.  Eventually we might be able to remove some of the overrides in `candidate_by_packages_type.go` and rely on the URL logic; however, [currently apks installed from Wolfi don't include any URL info](https://github.com/wolfi-dev/os/discussions/652), so we will retain them for now.