### PR TITLE
chore: update deprecated release flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TEMP_DIR := ./.tmp
 # Command templates #################################
 LINT_CMD := $(TEMP_DIR)/golangci-lint run --tests=false
 GOIMPORTS_CMD := $(TEMP_DIR)/gosimports -local github.com/anchore
-RELEASE_CMD := $(TEMP_DIR)/goreleaser release --rm-dist
+RELEASE_CMD := $(TEMP_DIR)/goreleaser release --clean
 SNAPSHOT_CMD := $(RELEASE_CMD) --skip-publish --skip-sign --snapshot
 CHRONICLE_CMD = $(TEMP_DIR)/chronicle
 GLOW_CMD = $(TEMP_DIR)/glow


### PR DESCRIPTION
A recent release of go-releaser deprecated the `--rm-dist` flag - this pr upgrades the release command to use the new `--clean` flag