### PR TITLE
feat: retain go package info when no module declared

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -51,7 +51,6 @@ func parseGoBinary(_ source.FileResolver, _ *generic.Environment, reader source.
 	internal.CloseAndLogError(reader.ReadCloser, reader.RealPath)
 
 	for i, mod := range mods {
-		log.Info(mod.Path)
 		pkgs = append(pkgs, buildGoPkgInfo(reader.Location, mod, archs[i])...)
 	}
 	return pkgs, nil, nil

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -243,6 +243,48 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			},
 		},
 		{
+			name: "parse a mod with path but no main module",
+			arch: archDetails,
+			mod: &debug.BuildInfo{
+				GoVersion: goCompiledVersion,
+				Settings: []debug.BuildSetting{
+					{Key: "GOARCH", Value: archDetails},
+					{Key: "GOOS", Value: "darwin"},
+					{Key: "GOAMD64", Value: "v1"},
+				},
+				Path: "github.com/a/b/c",
+			},
+			expected: []pkg.Package{
+				{
+					Name:     "github.com/a/b/c",
+					Version:  "(devel)",
+					PURL:     "pkg:golang/github.com/a/b/c@(devel)",
+					Language: pkg.Go,
+					Type:     pkg.GoModulePkg,
+					Locations: source.NewLocationSet(
+						source.Location{
+							Coordinates: source.Coordinates{
+								RealPath:     "/a-path",
+								FileSystemID: "layer-id",
+							},
+						},
+					),
+					MetadataType: pkg.GolangBinMetadataType,
+					Metadata: pkg.GolangBinMetadata{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						H1Digest:          "",
+						BuildSettings: map[string]string{
+							"GOAMD64": "v1",
+							"GOARCH":  "amd64",
+							"GOOS":    "darwin",
+						},
+						MainModule: "github.com/a/b/c",
+					},
+				},
+			},
+		},
+		{
 			name: "parse a mod without packages",
 			arch: archDetails,
 			mod: &debug.BuildInfo{


### PR DESCRIPTION
If there is at least a path declared, construct a main module from that and retain all of the other information we can, build flags, etc rather than dropping them entirely from the sbom