### PR TITLE
fix: sanitize SPDX LicenseRefs

### DIFF
--- a/syft/formats/common/spdxhelpers/license.go
+++ b/syft/formats/common/spdxhelpers/license.go
@@ -24,6 +24,12 @@ func License(p pkg.Package) string {
 	// take all licenses and assume an AND expression; for information about license expressions see https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/
 	parsedLicenses := parseLicenses(p.Licenses)
 
+	for i, v := range parsedLicenses {
+		if strings.HasPrefix(v, spdxlicense.LicenseRefPrefix) {
+			parsedLicenses[i] = SanitizeElementID(v)
+		}
+	}
+
 	if len(parsedLicenses) == 0 {
 		return NOASSERTION
 	}

--- a/syft/formats/common/spdxhelpers/license_test.go
+++ b/syft/formats/common/spdxhelpers/license_test.go
@@ -65,6 +65,17 @@ func Test_License(t *testing.T) {
 			},
 			expected: "GPL-2.0-only",
 		},
+		{
+			name: "includes valid LicenseRef-",
+			input: pkg.Package{
+				Licenses: []string{
+					"one thing first",
+					"two things/#$^second",
+					"MIT",
+				},
+			},
+			expected: "LicenseRef-one-thing-first AND LicenseRef-two-things----second AND MIT",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -514,8 +514,8 @@ func toFileTypes(metadata *source.FileMetadata) (ty []string) {
 
 func toOtherLicenses(catalog *pkg.Catalog) []*spdx.OtherLicense {
 	licenses := map[string]bool{}
-	for _, pkg := range catalog.Sorted() {
-		for _, license := range parseLicenses(pkg.Licenses) {
+	for _, p := range catalog.Sorted() {
+		for _, license := range parseLicenses(p.Licenses) {
 			if strings.HasPrefix(license, spdxlicense.LicenseRefPrefix) {
 				licenses[license] = true
 			}
@@ -526,7 +526,7 @@ func toOtherLicenses(catalog *pkg.Catalog) []*spdx.OtherLicense {
 		// separate the actual ID from the prefix
 		name := strings.TrimPrefix(license, spdxlicense.LicenseRefPrefix)
 		result = append(result, &spdx.OtherLicense{
-			LicenseIdentifier: license,
+			LicenseIdentifier: SanitizeElementID(license),
 			LicenseName:       name,
 			ExtractedText:     NONE, // we probably should have some extracted text here, but this is good enough for now
 		})


### PR DESCRIPTION
Some SPDX LicenseRefs may be output incorrectly with invalid characters or whitespace, this PR sanitizes licenseRefs to adhere to the spec.

Fixes: #1651 