### PR TITLE
Defer closing the opened file when using FileScheme

### DIFF
--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -385,6 +385,7 @@ func (s *Source) SetID() {
 	case FileScheme:
 		// attempt to use the digest of the contents of the file as the ID
 		file, err := os.Open(s.Metadata.Path)
+		defer file.Close()
 		if err != nil {
 			d = digest.FromString(s.Metadata.Path).String()
 			break


### PR DESCRIPTION
On another project - https://github.com/defenseunicorns/zarf , I kept receiving the following error on our Windows build:

```
The process cannot access the file because it is being used by another process.
 ```
 
This error was thrown attempting to remove files that had been referenced by `source.NewFromFile`.

I believe the root cause is the dangling file reference in `SetID`. Linux/Mac are able to overcome this and can still remove the file, but Windows cannot.