### PR TITLE
fix: remove author contributing to javascript CPEs

### DIFF
--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -129,7 +129,6 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
-				"cpe:2.3:a:jon:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:bob:name:3.2:*:*:*:*:*:*:*",
 			},
 		},

--- a/syft/pkg/cataloger/common/cpe/javascript.go
+++ b/syft/pkg/cataloger/common/cpe/javascript.go
@@ -13,13 +13,6 @@ func candidateVendorsForJavascript(p pkg.Package) fieldCandidateSet {
 		return nil
 	}
 
-	if metadata.Author != "" {
-		vendors.add(fieldCandidate{
-			value:                 normalizePersonName(stripEmailSuffix(metadata.Author)),
-			disallowSubSelections: true,
-		})
-	}
-
 	if metadata.URL != "" {
 		vendors.union(candidateVendorsFromURL(metadata.URL))
 	}


### PR DESCRIPTION
Syft was generating CPEs for javascript packages and including author information, but these were just splitting by `@`, assuming the author may have been an email address. However, the author is the form `Name <email> (url)`, e.g. `George Costanza <george@costanza.net> (https://costanza.net)`, which could result in a CPE similar to:

```
cpe:2.3:a:george-costanza-<george:package:6.14.6:*:*:*:*:*:*:*
```

This PR simply removes using the author, as there were not any identified cases that this was useful.