### PR TITLE
fix: reduce logging for bad dpkg lines

### DIFF
--- a/syft/pkg/cataloger/deb/parse_dpkg_db.go
+++ b/syft/pkg/cataloger/deb/parse_dpkg_db.go
@@ -151,7 +151,7 @@ func extractAllFields(reader *bufio.Reader) (map[string]interface{}, error) {
 			var val interface{}
 			key, val, err = handleNewKeyValue(line)
 			if err != nil {
-				log.Warnf("parsing dpkg status: extracting key-value from line: %s err: %v", line, err)
+				log.Debugf("parsing dpkg status: extracting key-value from line: %s err: %v", line, err)
 				continue
 			}
 

--- a/syft/pkg/cataloger/deb/parse_dpkg_db.go
+++ b/syft/pkg/cataloger/deb/parse_dpkg_db.go
@@ -151,7 +151,7 @@ func extractAllFields(reader *bufio.Reader) (map[string]interface{}, error) {
 			var val interface{}
 			key, val, err = handleNewKeyValue(line)
 			if err != nil {
-				log.Debugf("parsing dpkg status: extracting key-value from line: %s err: %v", line, err)
+				log.Tracef("parsing dpkg status: extracting key-value from line: %s err: %v", line, err)
 				continue
 			}
 


### PR DESCRIPTION
When scanning DPKG with invalid lines, we should DEBUG log these vs. WARN.