### PR TITLE
fix: ruby classifier

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -686,6 +686,23 @@ func Test_Cataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			name:       "positive-ruby-2.6.10",
+			fixtureDir: "test-fixtures/classifiers/dynamic/ruby-library-2.6.10",
+			expected: pkg.Package{
+				Name:      "ruby",
+				Version:   "2.6.10p210",
+				Type:      "binary",
+				PURL:      "pkg:generic/ruby@2.6.10p210",
+				Locations: locations("ruby", "libruby.so.2.6.10"),
+				Metadata: pkg.BinaryMetadata{
+					Matches: []pkg.ClassifierMatch{
+						match("ruby-binary", "ruby"),
+						match("ruby-binary", "libruby.so.2.6.10"),
+					},
+				},
+			},
+		},
+		{
 			name:       "positive-ruby-1.9.3p551",
 			fixtureDir: "test-fixtures/classifiers/positive/ruby-1.9.3p551",
 			expected: pkg.Package{

--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -283,4 +283,4 @@ var libpythonMatcher = fileNameTemplateVersionMatcher(
 var rubyMatcher = fileContentsVersionMatcher(
 	// ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-linux]
 	// ruby 2.7.7p221 (2022-11-24 revision 168ec2b1e5) [x86_64-linux]
-	`(?m)ruby (?P<version>[0-9]\.[0-9]\.[0-9](p[0-9]+)?) `)
+	`(?m)ruby (?P<version>[0-9]+\.[0-9]+\.[0-9]+(p[0-9]+)?) `)

--- a/syft/pkg/cataloger/binary/test-fixtures/Makefile
+++ b/syft/pkg/cataloger/binary/test-fixtures/Makefile
@@ -6,6 +6,7 @@ all: \
 	classifiers/dynamic/python-binary-3.4-alpine \
 	classifiers/dynamic/ruby-library-3.2.1 \
 	classifiers/dynamic/ruby-library-2.7.7 \
+	classifiers/dynamic/ruby-library-2.6.10 \
 	classifiers/dynamic/argocd-2.5.11 \
 	classifiers/dynamic/argocd-2.6.4 \
 	classifiers/dynamic/helm-3.11.1 \
@@ -73,6 +74,18 @@ classifiers/dynamic/ruby-library-2.7.7:
 	./get-image-file.sh $($@_image) \
 		/usr/local/lib/libruby.so.2.7 \
 		$@/libruby.so.2.7
+
+classifiers/dynamic/ruby-library-2.6.10:
+	$(eval $@_image := "ruby:2.6.10@sha256:771a810704167e55da8a19970c5dfa6eb795dfee32547adffa29ea72703f7243")
+	./get-image-file.sh $($@_image) \
+		/usr/local/bin/ruby \
+		$@/ruby
+	./get-image-file.sh $($@_image) \
+		/usr/local/lib/libruby.so.2.6.10 \
+		$@/libruby.so.2.6.10
+	./get-image-file.sh $($@_image) \
+		/usr/local/lib/libruby.so.2.6 \
+		$@/libruby.so.2.6
 
 classifiers/dynamic/argocd-2.5.11:
 	$(eval $@_image := "argoproj/argocd:v2.5.11@sha256:d1062935b3256ec69422843ebcb50debb54fd389436961586000c8ce6ee7f249")


### PR DESCRIPTION
This PR fixes binary cataloger for ruby

- Support Double-digit version like 2.6.10

Fixes #1677 