### PR TITLE
Remove more side effects from application config testing

### DIFF
--- a/internal/config/application_test.go
+++ b/internal/config/application_test.go
@@ -6,12 +6,21 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO: set negative case when config.yaml is no longer a valid option
 func TestApplicationConfig(t *testing.T) {
+	// disable homedir package cache for testing
+	originalCacheOpt := homedir.DisableCache
+	homedir.DisableCache = true
+	t.Cleanup(func() {
+		homedir.DisableCache = originalCacheOpt
+	})
+
 	// config is picked up at desired configuration paths
 	// VALID: .syft.yaml, .syft/config.yaml, ~/.syft.yaml, <XDG_CONFIG_HOME>/syft/config.yaml
 	// DEPRECATED: config.yaml is currently supported by
@@ -19,7 +28,7 @@ func TestApplicationConfig(t *testing.T) {
 		name       string
 		setup      func(t *testing.T) string
 		assertions func(t *testing.T, app *Application)
-		Cleanup    func(t *testing.T)
+		cleanup    func()
 	}{
 		{
 			name: "explicit config",
@@ -29,65 +38,46 @@ func TestApplicationConfig(t *testing.T) {
 			assertions: func(t *testing.T, app *Application) {
 				assert.Equal(t, "test-explicit-config", app.File)
 			},
-			Cleanup: func(t *testing.T) {},
 		},
 		{
 			name: "current working directory named config",
 			setup: func(t *testing.T) string {
 				err := os.Chdir("./test-fixtures/config-wd-file") // change application cwd to test-fixtures
-				if err != nil {
-					t.Fatalf("%s failed to change cwd: %+v", t.Name(), err)
-				}
+				require.NoError(t, err)
 				return ""
 			},
 			assertions: func(t *testing.T, app *Application) {
 				assert.Equal(t, "test-wd-named-config", app.File)
 			},
-			Cleanup: func(t *testing.T) {},
 		},
 		{
 			name: "current working directory syft dir config",
 			setup: func(t *testing.T) string {
 				err := os.Chdir("./test-fixtures/config-dir-test") // change application cwd to test-fixtures
-				if err != nil {
-					t.Fatalf("%s failed to change cwd: %+v", t.Name(), err)
-				}
+				require.NoError(t, err)
 				return ""
 			},
 			assertions: func(t *testing.T, app *Application) {
 				assert.Equal(t, "test-dir-config", app.File)
 			},
-			Cleanup: func(t *testing.T) {},
 		},
 		{
 			name: "home directory file config",
 			setup: func(t *testing.T) string {
 				// Because Setenv affects the whole process, it cannot be used in parallel tests or
 				// tests with parallel ancestors: see separate XDG test for consequence of this
-				t.Setenv("HOME", "./test-fixtures/config-home-test")
-				err := os.Link("./test-fixtures/config-home-test/config-file/.syft.yaml", "./test-fixtures/config-home-test/.syft.yaml")
-				if err != nil {
-					t.Fatalf("%s failed to link home config: %+v", t.Name(), err)
-				}
+				t.Setenv("HOME", "./test-fixtures/config-home-test/config-file")
 				return ""
 			},
 			assertions: func(t *testing.T, app *Application) {
 				assert.Equal(t, "test-home-config", app.File)
-			},
-			Cleanup: func(t *testing.T) {
-				err := os.Remove("./test-fixtures/config-home-test/.syft.yaml") //
-				if err != nil {
-					t.Fatalf("%s failed to remove home config link: %+v", t.Name(), err)
-				}
 			},
 		},
 		{
 			name: "XDG file config",
 			setup: func(t *testing.T) string {
 				wd, err := os.Getwd()
-				if err != nil {
-					t.Fatalf("%s: failed to get working directory: %+v", t.Name(), err)
-				}
+				require.NoError(t, err)
 				configDir := path.Join(wd, "./test-fixtures/config-home-test") // set HOME to testdata
 				t.Setenv("XDG_CONFIG_DIRS", configDir)
 				xdg.Reload()
@@ -96,25 +86,31 @@ func TestApplicationConfig(t *testing.T) {
 			assertions: func(t *testing.T, app *Application) {
 				assert.Equal(t, "test-home-XDG-config", app.File)
 			},
-			Cleanup: func(t *testing.T) {},
+			cleanup: func() {
+				require.NoError(t, os.Unsetenv("XDG_CONFIG_DIRS"))
+				xdg.Reload()
+			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer test.Cleanup(t)
-			wd, err := os.Getwd()
-			if err != nil {
-				t.Fatalf("failed to get working directory: %+v", err)
+			if test.cleanup != nil {
+				t.Cleanup(test.cleanup)
 			}
+			wd, err := os.Getwd()
+			require.NoError(t, err)
+
 			defer os.Chdir(wd) // reset working directory after test
 			application := &Application{}
 			viperInstance := viper.New()
 
+			// this will override home in case you are running this test locally and DO have a syft config
+			// in your home directory... now it will be ignored
+			t.Setenv("HOME", "/foo/bar")
+
 			configPath := test.setup(t)
 			err = application.LoadAllValues(viperInstance, configPath)
-			if err != nil {
-				t.Fatalf("failed to load application config: %+v", err)
-			}
+			require.NoError(t, err)
 			test.assertions(t, application)
 		})
 	}


### PR DESCRIPTION
Follow up to #1640 with a few adjustments:
- remove the symlink during testing since this is writing to paths in the repo (which is not ideal)
- uses the t.Cleanup facility for each test instead of `defer` calls
- removes a side effect against the xdg package based on XDG_CONFIG_PATH env var that persists after the test in the xdg package
- the homedir package has its own cache which needs to be disabled during testing (since the definition of HOME changes)
- for users that have a config in the home directory we change `HOME` to always point to a different (bogus) location so that never enters the equation.
- nit: changes `t.Fatal` to `require.NoError` calls instead