### PR TITLE
Fix shell completion by adding missing usage message required by spf13/cobra

### DIFF
--- a/cmd/syft/cli/commands.go
+++ b/cmd/syft/cli/commands.go
@@ -55,6 +55,7 @@ func New() (*cobra.Command, error) {
 
 	// rootCmd is currently an alias for the packages command
 	rootCmd := &cobra.Command{
+		Use:           fmt.Sprintf("%s [SOURCE]", internal.ApplicationName),
 		Short:         packagesCmd.Short,
 		Long:          packagesCmd.Long,
 		Args:          packagesCmd.Args,


### PR DESCRIPTION
Attempts a fix for #962. 

All credit to @cschug - see [this comment](https://github.com/anchore/syft/issues/962#issuecomment-1477771492)

As pointed out in that comment, the spf13/cobra library writes out the shell completion script using a `fmt.Sprintf` [here](https://github.com/spf13/cobra/blob/v1.6.1/bash_completionsV2.go#L37-L365). 

The `%[1]s` in that string seem to be replaced with the first command in the `Use:` field of the `cobra.Command` struct. Currently this field is ***not*** set so the `%[1]s` expand to an empty string resulting in a broken shell completion script. 

Adding the field (following the same method used by grype - [here](https://github.com/anchore/grype/blob/main/cmd/root.go#L63)) gives the `spf13/cobra` library the info it needs to correctly generate the shell completion script.

Testing locally seems to show everything is working OK. The shell completion now works as expected after running `source <(syft completion bash)`

Fixes: #962 