### PR TITLE
chore: fix flaky license sorting

### DIFF
--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/spdx/tools-golang/spdx"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
@@ -521,8 +523,12 @@ func toOtherLicenses(catalog *pkg.Catalog) []*spdx.OtherLicense {
 			}
 		}
 	}
+
 	var result []*spdx.OtherLicense
-	for license := range licenses {
+
+	sorted := maps.Keys(licenses)
+	slices.Sort(sorted)
+	for _, license := range sorted {
 		// separate the actual ID from the prefix
 		name := strings.TrimPrefix(license, spdxlicense.LicenseRefPrefix)
 		result = append(result, &spdx.OtherLicense{

--- a/syft/formats/common/spdxhelpers/to_format_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_format_model_test.go
@@ -473,13 +473,13 @@ func Test_OtherLicenses(t *testing.T) {
 			},
 			expected: []*spdx.OtherLicense{
 				{
-					LicenseIdentifier: "LicenseRef-un-known",
-					LicenseName:       "un known",
+					LicenseIdentifier: "LicenseRef-not-known--s",
+					LicenseName:       "not known %s",
 					ExtractedText:     NONE,
 				},
 				{
-					LicenseIdentifier: "LicenseRef-not-known--s",
-					LicenseName:       "not known %s",
+					LicenseIdentifier: "LicenseRef-un-known",
+					LicenseName:       "un known",
 					ExtractedText:     NONE,
 				},
 			},


### PR DESCRIPTION
This PR fixes an issue where SPDX other licenses are not sorted consistently, causing flaky test failures.