### PR TITLE
chore: update deprecated set-output calls

### DIFF
--- a/.github/workflows/benchmark-testing.yaml
+++ b/.github/workflows/benchmark-testing.yaml
@@ -33,7 +33,7 @@ jobs:
           OUTPUT="${OUTPUT//'%'/'%25'}"   # URL encode all '%' characters
           OUTPUT="${OUTPUT//$'\n'/'%0A'}" # URL encode all '\n' characters
           OUTPUT="${OUTPUT//$'\r'/'%0D'}" # URL encode all '\r' characters
-          echo "::set-output name=result::$OUTPUT"
+          echo "result=$OUTPUT" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/update-stereoscope-release.yml
+++ b/.github/workflows/update-stereoscope-release.yml
@@ -29,7 +29,7 @@ jobs:
           go mod tidy
 
           # export the version for use with create-pull-request
-          echo "::set-output name=LATEST_VERSION::$LATEST_VERSION"
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
         id: latest-version
 
       - uses: tibdex/github-app-token@v1


### PR DESCRIPTION
Update deprecated `::set-output` calls