### PR TITLE
Refactor spdx tooling test to reduce intermittent failures

### DIFF
--- a/test/cli/test-fixtures/image-java-spdx-tools/Makefile
+++ b/test/cli/test-fixtures/image-java-spdx-tools/Makefile
@@ -1,8 +1,10 @@
 all: build validate
 
+IMAGE := "spdx-java-tools:latest"
+
 .PHONY: build
 build:
 	docker build -t spdx-java-tools:latest .
 
 validate:
-	docker run --rm -v ${FILE}:/home/build/${BASE} spdx-java-tools:latest Verify ${BASE}
+	docker run --rm -v $(DIR):/home/build/ $(IMAGE) Verify /home/build/$(BASE)


### PR DESCRIPTION
We've seen several failures of the SPDX tooling test, but haven't been able to determine exactly why:

<img width="1074" alt="Screenshot 2023-04-03 at 1 33 24 PM" src="https://user-images.githubusercontent.com/590471/229594286-5b8e3bc7-21dd-4a46-972b-ae3002c37d15.png">

I have a couple educated guesses and made some targeted refactors, but have no conclusive evidence if this will fix the underlying issue (seems to only happen in CI every once in a while).

I've also made a couple of improvements:
- uses the existing test fixture facilities, as to leverage any preloaded CI cache without requiring a re build of the image.
- uses a temp dir per test Run() call instead of sharing directories.
- passes the explicit file for syft to write to and passes this file path to the verification tool