### PR TITLE
Add ability to see the first location a package was added

### DIFF
--- a/syft/pkg/package.go
+++ b/syft/pkg/package.go
@@ -59,6 +59,8 @@ func (p *Package) merge(other Package) error {
 		return fmt.Errorf("cannot merge packages with different IDs: %q vs %q", p.id, other.id)
 	}
 
+	log.WithFields("id", p.id, "purl", p.PURL).Trace("merging similar packages")
+
 	if p.PURL != other.PURL {
 		log.Warnf("merging packages have with different pURLs: %q=%q vs %q=%q", p.id, p.PURL, other.id, other.PURL)
 	}

--- a/syft/source/image_all_layers_resolver.go
+++ b/syft/source/image_all_layers_resolver.go
@@ -18,8 +18,8 @@ type imageAllLayersResolver struct {
 	layers []int
 }
 
-// newAllLayersResolver returns a new resolver from the perspective of all image layers for the given image.
-func newAllLayersResolver(img *image.Image) (*imageAllLayersResolver, error) {
+// newImageAllLayersResolver returns a new resolver from the perspective of all image layers for the given image.
+func newImageAllLayersResolver(img *image.Image) (*imageAllLayersResolver, error) {
 	if len(img.Layers) == 0 {
 		return nil, fmt.Errorf("the image does not contain any layers")
 	}
@@ -202,7 +202,7 @@ func (r *imageAllLayersResolver) FileContentsByLocation(location Location) (io.R
 		return nil, fmt.Errorf("cannot read contents of non-file %q", location.ref.RealPath)
 	}
 
-	return r.img.FileContentsByRef(location.ref)
+	return r.img.OpenReference(location.ref)
 }
 
 func (r *imageAllLayersResolver) FilesByMIMEType(types ...string) ([]Location, error) {

--- a/syft/source/image_all_layers_resolver_test.go
+++ b/syft/source/image_all_layers_resolver_test.go
@@ -91,7 +91,7 @@ func TestAllLayersResolver_FilesByPath(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newImageAllLayersResolver(img)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -205,7 +205,7 @@ func TestAllLayersResolver_FilesByGlob(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newImageAllLayersResolver(img)
 			if err != nil {
 				t.Fatalf("could not create resolver: %+v", err)
 			}
@@ -257,7 +257,7 @@ func Test_imageAllLayersResolver_FilesByMIMEType(t *testing.T) {
 		t.Run(test.fixtureName, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", test.fixtureName)
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newImageAllLayersResolver(img)
 			assert.NoError(t, err)
 
 			locations, err := resolver.FilesByMIMEType(test.mimeType)
@@ -274,7 +274,7 @@ func Test_imageAllLayersResolver_FilesByMIMEType(t *testing.T) {
 func Test_imageAllLayersResolver_hasFilesystemIDInLocation(t *testing.T) {
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-duplicate-path")
 
-	resolver, err := newAllLayersResolver(img)
+	resolver, err := newImageAllLayersResolver(img)
 	assert.NoError(t, err)
 
 	locations, err := resolver.FilesByMIMEType("text/plain")
@@ -334,7 +334,7 @@ func TestAllLayersImageResolver_FilesContents(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newImageAllLayersResolver(img)
 			assert.NoError(t, err)
 
 			refs, err := resolver.FilesByPath(test.fixture)
@@ -361,7 +361,7 @@ func TestAllLayersImageResolver_FilesContents_errorOnDirRequest(t *testing.T) {
 
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-	resolver, err := newAllLayersResolver(img)
+	resolver, err := newImageAllLayersResolver(img)
 	assert.NoError(t, err)
 
 	var dirLoc *Location
@@ -675,7 +675,7 @@ func Test_imageAllLayersResolver_resolvesLinks(t *testing.T) {
 
 			img := imagetest.GetFixtureImage(t, "docker-archive", "image-symlinks")
 
-			resolver, err := newAllLayersResolver(img)
+			resolver, err := newImageAllLayersResolver(img)
 			assert.NoError(t, err)
 
 			actual := test.runner(resolver)
@@ -689,7 +689,7 @@ func Test_imageAllLayersResolver_resolvesLinks(t *testing.T) {
 func TestAllLayersResolver_AllLocations(t *testing.T) {
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-files-deleted")
 
-	resolver, err := newAllLayersResolver(img)
+	resolver, err := newImageAllLayersResolver(img)
 	assert.NoError(t, err)
 
 	paths := strset.New()

--- a/syft/source/image_squash_resolver.go
+++ b/syft/source/image_squash_resolver.go
@@ -168,7 +168,7 @@ func (r *imageSquashResolver) FileContentsByLocation(location Location) (io.Read
 		return nil, fmt.Errorf("unable to get file contents for directory: %+v", location)
 	}
 
-	return r.img.FileContentsByRef(location.ref)
+	return r.img.OpenReference(location.ref)
 }
 
 func (r *imageSquashResolver) AllLocations() <-chan Location {

--- a/syft/source/image_squash_with_all_layers_resolver.go
+++ b/syft/source/image_squash_with_all_layers_resolver.go
@@ -1,0 +1,98 @@
+package source
+
+import (
+	"github.com/anchore/stereoscope/pkg/image"
+	"io"
+)
+
+var _ FileResolver = (*imageSquashWithAllLayersResolver)(nil)
+
+// imageSquashWithAllLayersResolver acts like a squash resolver, but additionally returns all paths in earlier layers
+// that have been added/modified (like the all-layers resolver).
+type imageSquashWithAllLayersResolver struct {
+	squashed  *imageSquashResolver
+	allLayers *imageAllLayersResolver
+}
+
+// newImageSquashWithAllLayersResolver returns a new resolver from the perspective of the squashed representation for
+// the given image, but additionally returns all instances of a path that have been added/modified.
+func newImageSquashWithAllLayersResolver(img *image.Image) (*imageSquashWithAllLayersResolver, error) {
+	squashed, err := newImageSquashResolver(img)
+	if err != nil {
+		return nil, err
+	}
+
+	allLayers, err := newImageAllLayersResolver(img)
+	if err != nil {
+		return nil, err
+	}
+
+	return &imageSquashWithAllLayersResolver{
+		squashed:  squashed,
+		allLayers: allLayers,
+	}, nil
+}
+
+func (i imageSquashWithAllLayersResolver) FileContentsByLocation(location Location) (io.ReadCloser, error) {
+	return i.squashed.FileContentsByLocation(location)
+}
+
+func (i imageSquashWithAllLayersResolver) HasPath(s string) bool {
+	return i.squashed.HasPath(s)
+}
+
+func (i imageSquashWithAllLayersResolver) filterLocations(locations []Location, err error) ([]Location, error) {
+	if err != nil {
+		return locations, err
+	}
+	var ret []Location
+	for _, l := range locations {
+		if i.squashed.HasPath(l.RealPath) {
+			// not only should the real path to the file exist, but the way we took to get there should also exist
+			// (e.g. if we are looking for /etc/passwd, but the real path is /etc/passwd -> /etc/passwd-1, then we should
+			// make certain that /etc/passwd-1 exists)
+			if l.VirtualPath != "" && !i.squashed.HasPath(l.VirtualPath) {
+				continue
+			}
+			ret = append(ret, l)
+		}
+	}
+	return ret, nil
+}
+
+func (i imageSquashWithAllLayersResolver) FilesByPath(paths ...string) ([]Location, error) {
+	return i.filterLocations(i.allLayers.FilesByPath(paths...))
+}
+
+func (i imageSquashWithAllLayersResolver) FilesByGlob(patterns ...string) ([]Location, error) {
+	return i.filterLocations(i.allLayers.FilesByGlob(patterns...))
+}
+
+func (i imageSquashWithAllLayersResolver) FilesByMIMEType(types ...string) ([]Location, error) {
+	return i.filterLocations(i.allLayers.FilesByMIMEType(types...))
+}
+
+func (i imageSquashWithAllLayersResolver) RelativeFileByPath(l Location, path string) *Location {
+	if !i.squashed.HasPath(path) {
+		return nil
+	}
+	return i.allLayers.RelativeFileByPath(l, path)
+}
+
+func (i imageSquashWithAllLayersResolver) AllLocations() <-chan Location {
+	var ret = make(chan Location)
+	go func() {
+		defer close(ret)
+		for l := range i.allLayers.AllLocations() {
+			if i.squashed.HasPath(l.RealPath) {
+				ret <- l
+			}
+		}
+	}()
+
+	return ret
+}
+
+func (i imageSquashWithAllLayersResolver) FileMetadataByLocation(location Location) (FileMetadata, error) {
+	return fileMetadataByLocation(i.squashed.img, location)
+}

--- a/syft/source/scope.go
+++ b/syft/source/scope.go
@@ -10,14 +10,17 @@ const (
 	UnknownScope Scope = "UnknownScope"
 	// SquashedScope indicates to only catalog content visible from the squashed filesystem representation (what can be seen only within the container at runtime)
 	SquashedScope Scope = "Squashed"
-	// AllLayersScope indicates to catalog content on all layers, irregardless if it is visible from the container at runtime.
+	// AllLayersScope indicates to catalog content on all layers, regardless if it is visible from the container at runtime.
 	AllLayersScope Scope = "AllLayers"
+	// SquashedWithAllLayersScope indicates to catalog content on all layers, but only include content visible from the squashed filesystem representation.
+	SquashedWithAllLayersScope Scope = "SquashedWithAllLayers"
 )
 
 // AllScopes is a slice containing all possible scope options
 var AllScopes = []Scope{
 	SquashedScope,
 	AllLayersScope,
+	SquashedWithAllLayersScope,
 }
 
 // ParseScope returns a scope as indicated from the given string.
@@ -27,6 +30,8 @@ func ParseScope(userStr string) Scope {
 		return SquashedScope
 	case "all-layers", strings.ToLower(AllLayersScope.String()):
 		return AllLayersScope
+	case "squashed-with-all-layers", strings.ToLower(SquashedWithAllLayersScope.String()):
+		return SquashedWithAllLayersScope
 	}
 	return UnknownScope
 }

--- a/syft/source/source.go
+++ b/syft/source/source.go
@@ -466,7 +466,9 @@ func (s *Source) FileResolver(scope Scope) (FileResolver, error) {
 		case SquashedScope:
 			resolver, err = newImageSquashResolver(s.Image)
 		case AllLayersScope:
-			resolver, err = newAllLayersResolver(s.Image)
+			resolver, err = newImageAllLayersResolver(s.Image)
+		case SquashedWithAllLayersScope:
+			resolver, err = newImageSquashWithAllLayersResolver(s.Image)
 		default:
 			return nil, fmt.Errorf("bad image scope provided: %+v", scope)
 		}


### PR DESCRIPTION
Adds a `squashed-with-all-layers` resolver which acts like the squashed resolver with the additional behavior of returning instances of the path found in all other layers. This, combined with additional changes to denote the layer index directly in locations, allows for someone to be able to know the first location a package was introduced.

For example:
```Dockerfile
# Dockerfile for test:latest
FROM alpine:latest
RUN apk add wget
RUN apk add curl
```

When running syft...
```
$ syft -o json -s squashed-with-all-layers test:latest  -vvv
...
[0000] DEBUG discovered 58 packages cataloger=apkdb-cataloger
[0000] DEBUG found path duplicate of /lib/ld-musl-x86_64.so.1
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-58199dcc.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616ae350.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
[0000] DEBUG found path duplicate of /usr/share/apk/keys/alpine-devel@lists.alpinelinux.org-616a9724.rsa.pub
...
[0000] TRACE merging similar packages id=291d1267b40d636f purl=pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=d9700f02cf26e8b8 purl=pkg:apk/alpine/musl@1.2.3-r4?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=623d53216342d45e purl=pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=256fc96b4a8c4da8 purl=pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&upstream=busybox&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=92b19c7750fb559d purl=pkg:apk/alpine/alpine-baselayout@3.4.0-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=2b5e23d349b556cf purl=pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=b805d823ae624f04 purl=pkg:apk/alpine/ca-certificates-bundle@20220614-r4?arch=x86_64&upstream=ca-certificates&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=d3084c788891fb28 purl=pkg:apk/alpine/libcrypto3@3.0.8-r3?arch=x86_64&upstream=openssl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=2a95f0251fba7a33 purl=pkg:apk/alpine/libssl3@3.0.8-r3?arch=x86_64&upstream=openssl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=b15247aafcd4a647 purl=pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&upstream=busybox&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=94014313cfcd2b71 purl=pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=e5f757b0df1f62bc purl=pkg:apk/alpine/apk-tools@2.12.10-r1?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=e903138d19e85b80 purl=pkg:apk/alpine/scanelf@1.3.5-r1?arch=x86_64&upstream=pax-utils&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=f71ecf5267e6c37b purl=pkg:apk/alpine/musl-utils@1.2.3-r4?arch=x86_64&upstream=musl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=8126b232e2d3c608 purl=pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=291d1267b40d636f purl=pkg:apk/alpine/alpine-baselayout-data@3.4.0-r0?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=d9700f02cf26e8b8 purl=pkg:apk/alpine/musl@1.2.3-r4?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=623d53216342d45e purl=pkg:apk/alpine/busybox@1.35.0-r29?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=256fc96b4a8c4da8 purl=pkg:apk/alpine/busybox-binsh@1.35.0-r29?arch=x86_64&upstream=busybox&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=92b19c7750fb559d purl=pkg:apk/alpine/alpine-baselayout@3.4.0-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=2b5e23d349b556cf purl=pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=b805d823ae624f04 purl=pkg:apk/alpine/ca-certificates-bundle@20220614-r4?arch=x86_64&upstream=ca-certificates&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=d3084c788891fb28 purl=pkg:apk/alpine/libcrypto3@3.0.8-r3?arch=x86_64&upstream=openssl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=2a95f0251fba7a33 purl=pkg:apk/alpine/libssl3@3.0.8-r3?arch=x86_64&upstream=openssl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=b15247aafcd4a647 purl=pkg:apk/alpine/ssl_client@1.35.0-r29?arch=x86_64&upstream=busybox&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=94014313cfcd2b71 purl=pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=e5f757b0df1f62bc purl=pkg:apk/alpine/apk-tools@2.12.10-r1?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=e903138d19e85b80 purl=pkg:apk/alpine/scanelf@1.3.5-r1?arch=x86_64&upstream=pax-utils&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=f71ecf5267e6c37b purl=pkg:apk/alpine/musl-utils@1.2.3-r4?arch=x86_64&upstream=musl&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=8126b232e2d3c608 purl=pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=58d60d9b7d1565f1 purl=pkg:apk/alpine/libunistring@1.1-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=3841a3199a1ee118 purl=pkg:apk/alpine/libidn2@2.3.4-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=e40c4f862e3949e8 purl=pkg:apk/alpine/pcre2@10.42-r0?arch=x86_64&distro=alpine-3.17.3
[0000] TRACE merging similar packages id=971b42d7909ea972 purl=pkg:apk/alpine/wget@1.21.3-r2?arch=x86_64&distro=alpine-3.17.3

# proceeds to output 25 packages, not 58
```

You'll see merged location elements for each package:
```json
{
  "id": "94014313cfcd2b71",
  "name": "zlib",
  "version": "1.2.13-r0",
  "type": "apk",
  "foundBy": "apkdb-cataloger",
  "locations": [
    {
      "path": "/lib/apk/db/installed",
      "layerID": "sha256:0d71e44edab1e63f802dfd59cbf8c128c4f89f2ae3c4edb79475678dcedb5bff"
    },
    {
      "path": "/lib/apk/db/installed",
      "layerID": "sha256:a2ea955c0abfa7fb734e0991ef02fb4e4f35e8090ae76cd6f14dc58d037fa23e"
    },
    {
      "path": "/lib/apk/db/installed",
      "layerID": "sha256:f1417ff83b319fbdae6dd9cd6d8c9c88002dcd75ecf6ec201c8c6894681cf2b5"
    }
  ],
  "licenses": [
    "Zlib"
  ],
  "language": "",
  "cpes": [
    "cpe:2.3:a:zlib:zlib:1.2.13-r0:*:*:*:*:*:*:*"
  ],
  "purl": "pkg:apk/alpine/zlib@1.2.13-r0?arch=x86_64&distro=alpine-3.17.3",
...
```

TODO: 
- [ ] add tests 🧛 🩸 
- [ ] add layer index to location?
- [ ] sort slice from location set not lexically, but by layer order.
- [ ] there are a log of "found path duplicate of <file>" log entries, which hints that there is an issue with relationship creation for these duplicate packages found.

Open question:
- Should we omit packages for certain ecosystems that have been found in previous layers but are known to be the same? E.g. deb/apk/rpm packages are in a single DB, so adding any new package will make the previously installed packages look like they've been installed again, which isn't what's happening here.

Problems:
- This will report packages that get removed and are not logically in the squashed representation (introducing FPs relative to the squashed representation).

Closes #435 