### PR TITLE
Add support for java "nar" files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For commercial support options with Syft or Grype, please [contact Anchore](http
 - Erlang (rebar3)
 - Go (go.mod, Go binaries)
 - Haskell (cabal, stack)
-- Java (jar, ear, war, par, sar, native-image)
+- Java (jar, ear, war, par, sar, nar, native-image)
 - JavaScript (npm, yarn)
 - Jenkins Plugins (jpi, hpi)
 - Nix (outputs in /nix/store)

--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -108,7 +108,7 @@ func (a archiveFilename) extension() string {
 
 func (a archiveFilename) pkgType() pkg.Type {
 	switch strings.ToLower(a.extension()) {
-	case "jar", "war", "ear", "lpkg", "par", "sar":
+	case "jar", "war", "ear", "lpkg", "par", "sar", "nar":
 		return pkg.JavaPkg
 	case "jpi", "hpi":
 		return pkg.JenkinsPluginPkg

--- a/syft/pkg/cataloger/java/archive_filename_test.go
+++ b/syft/pkg/cataloger/java/archive_filename_test.go
@@ -80,6 +80,13 @@ func TestExtractInfoFromJavaArchiveFilename(t *testing.T) {
 			ty:        pkg.JavaPkg,
 		},
 		{
+			filename:  "pkg-extra-field-maven-4.3.2-rc1.nar",
+			version:   "4.3.2-rc1",
+			extension: "nar",
+			name:      "pkg-extra-field-maven",
+			ty:        pkg.JavaPkg,
+		},
+		{
 			filename:  "/some/path/pkg-extra-field-maven-4.3.2-rc1.jpi",
 			version:   "4.3.2-rc1",
 			extension: "jpi",

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -24,6 +24,7 @@ var archiveFormatGlobs = []string{
 	"**/*.ear",
 	"**/*.par",
 	"**/*.sar",
+	"**/*.nar",
 	"**/*.jpi",
 	"**/*.hpi",
 	"**/*.lpkg", // Zip-compressed package used to deploy applications

--- a/syft/pkg/cataloger/java/cataloger_test.go
+++ b/syft/pkg/cataloger/java/cataloger_test.go
@@ -21,6 +21,7 @@ func Test_ArchiveCataloger_Globs(t *testing.T) {
 				"java-archives/example.ear",
 				"java-archives/example.par",
 				"java-archives/example.sar",
+				"java-archives/example.nar",
 				"java-archives/example.jpi",
 				"java-archives/example.hpi",
 				"java-archives/example.lpkg",

--- a/syft/pkg/cataloger/java/test-fixtures/glob-paths/java-archives/example.nar
+++ b/syft/pkg/cataloger/java/test-fixtures/glob-paths/java-archives/example.nar
@@ -1,0 +1,1 @@
+example archive


### PR DESCRIPTION
Add support for nar files.

- Update README.md to show that nar is now supported.
- Created a java-archives/example.nar so that the tests wouldn't break.
- Add nar glob and as an option for pkgType.

Closes #1701