### PR TITLE
Fix kernel cataloger test fixtures

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -34,32 +34,34 @@ jobs:
         uses: ./.github/actions/bootstrap
 
       - name: Restore Java test-fixture cache
-        id: unit-java-cache
         uses: actions/cache@v3
         with:
           path: syft/pkg/cataloger/java/test-fixtures/java-builds/packages
           key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/pkg/cataloger/java/test-fixtures/java-builds/packages.fingerprint' ) }}
 
       - name: Restore RPM test-fixture cache
-        id: unit-rpm-cache
         uses: actions/cache@v3
         with:
           path: syft/pkg/cataloger/rpm/test-fixtures/rpms
           key: ${{ runner.os }}-unit-rpm-cache-${{ hashFiles( 'syft/pkg/cataloger/rpm/test-fixtures/rpms.fingerprint' ) }}
 
       - name: Restore go binary test-fixture cache
-        id: unit-go-binary-cache
         uses: actions/cache@v3
         with:
           path: syft/pkg/cataloger/golang/test-fixtures/archs/binaries
           key: ${{ runner.os }}-unit-go-binaries-cache-${{ hashFiles( 'syft/pkg/cataloger/golang/test-fixtures/archs/binaries.fingerprint' ) }}
 
       - name: Restore binary cataloger test-fixture cache
-        id: unit-binary-cataloger-cache
         uses: actions/cache@v3
         with:
           path: syft/pkg/cataloger/binary/test-fixtures/classifiers/dynamic
           key: ${{ runner.os }}-unit-binary-cataloger-cache-${{ hashFiles( 'syft/pkg/cataloger/binary/test-fixtures/cache.fingerprint' ) }}
+
+      - name: Restore Kernel test-fixture cache
+        uses: actions/cache@v3
+        with:
+          path: syft/pkg/cataloger/kernel/test-fixtures/cache
+          key: ${{ runner.os }}-unit-kernel-cache-${{ hashFiles( 'syft/pkg/cataloger/kernel/test-fixtures/cache.fingerprint' ) }}
 
       - name: Run unit tests
         run: make unit

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,10 @@ fingerprints:
 	cd syft/pkg/cataloger/rpm/test-fixtures && \
 		make rpms.fingerprint
 
+	# for Kernel test fixtures
+	cd syft/pkg/cataloger/kernel/test-fixtures && \
+		make cache.fingerprint
+
 	# for INSTALL integration test fixtures
 	cd test/install && \
 		make cache.fingerprint

--- a/syft/pkg/cataloger/kernel/cataloger_test.go
+++ b/syft/pkg/cataloger/kernel/cataloger_test.go
@@ -9,25 +9,25 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func Test_JavascriptCataloger(t *testing.T) {
+func Test_KernelCataloger(t *testing.T) {
 	kernelPkg := pkg.Package{
 		Name:    "linux-kernel",
-		Version: "6.2.9-200.fc37.x86_64",
+		Version: "6.0.7-301.fc37.x86_64",
 		FoundBy: "linux-kernel-cataloger",
 		Locations: source.NewLocationSet(
 			source.NewVirtualLocation(
-				"/lib/modules/6.2.9-200.fc37.x86_64/vmlinuz",
-				"/lib/modules/6.2.9-200.fc37.x86_64/vmlinuz",
+				"/lib/modules/6.0.7-301.fc37.x86_64/vmlinuz",
+				"/lib/modules/6.0.7-301.fc37.x86_64/vmlinuz",
 			),
 		),
 		Type:         pkg.LinuxKernelPkg,
-		PURL:         "pkg:generic/linux-kernel@6.2.9-200.fc37.x86_64",
+		PURL:         "pkg:generic/linux-kernel@6.0.7-301.fc37.x86_64",
 		MetadataType: pkg.LinuxKernelMetadataType,
 		Metadata: pkg.LinuxKernelMetadata{
 			Name:            "",
 			Architecture:    "x86",
-			Version:         "6.2.9-200.fc37.x86_64",
-			ExtendedVersion: "6.2.9-200.fc37.x86_64 (mockbuild@bkernel02.iad2.fedoraproject.org) #1 SMP PREEMPT_DYNAMIC Thu Mar 30 22:31:57 UTC 2023",
+			Version:         "6.0.7-301.fc37.x86_64",
+			ExtendedVersion: "6.0.7-301.fc37.x86_64 (mockbuild@bkernel01.iad2.fedoraproject.org) #1 SMP PREEMPT_DYNAMIC Fri Nov 4 18:35:48 UTC 2022",
 			BuildTime:       "",
 			Author:          "",
 			Format:          "bzImage",
@@ -39,29 +39,29 @@ func Test_JavascriptCataloger(t *testing.T) {
 	}
 
 	kernelModulePkg := pkg.Package{
-		Name:    "fsa4480",
+		Name:    "ttynull",
 		Version: "",
 		FoundBy: "linux-kernel-cataloger",
 		Locations: source.NewLocationSet(
-			source.NewVirtualLocation("/lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko",
-				"/lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko",
+			source.NewVirtualLocation("/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
+				"/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
 			),
 		),
 		Licenses: []string{
 			"GPL v2",
 		},
 		Type:         pkg.LinuxKernelModulePkg,
-		PURL:         "pkg:generic/fsa4480",
+		PURL:         "pkg:generic/ttynull",
 		MetadataType: pkg.LinuxKernelModuleMetadataType,
 		Metadata: pkg.LinuxKernelModuleMetadata{
-			Name:          "fsa4480",
+			Name:          "ttynull",
 			Version:       "",
 			SourceVersion: "",
 			License:       "GPL v2",
-			Path:          "/lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko",
-			Description:   "ON Semiconductor FSA4480 driver",
-			KernelVersion: "6.2.9-200.fc37.x86_64",
-			VersionMagic:  "6.2.9-200.fc37.x86_64 SMP preempt mod_unload ",
+			Path:          "/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
+			Description:   "",
+			KernelVersion: "6.0.7-301.fc37.x86_64",
+			VersionMagic:  "6.0.7-301.fc37.x86_64 SMP preempt mod_unload ",
 			Parameters:    map[string]pkg.LinuxKernelModuleParameter{},
 		},
 	}

--- a/syft/pkg/cataloger/kernel/test-fixtures/Makefile
+++ b/syft/pkg/cataloger/kernel/test-fixtures/Makefile
@@ -1,0 +1,7 @@
+all:
+
+# we need a way to determine if CI should bust the test cache based on the source material
+.PHONY: cache.fingerprint
+cache.fingerprint:
+	find Makefile **/Dockerfile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
+	sha256sum cache.fingerprint

--- a/syft/pkg/cataloger/kernel/test-fixtures/image-kernel-and-modules/Dockerfile
+++ b/syft/pkg/cataloger/kernel/test-fixtures/image-kernel-and-modules/Dockerfile
@@ -1,17 +1,19 @@
 FROM fedora:37@sha256:3f987b7657e944cf87a129cc262982d4f80e38bd98f7db313ccaf90ca7069dd2
 
 RUN dnf install 'dnf-command(download)' cpio xz -y
-RUN dnf download kernel-core kernel-modules-core -y
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/Packages/k/kernel-6.0.7-301.fc37.x86_64.rpm
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/Packages/k/kernel-modules-6.0.7-301.fc37.x86_64.rpm
+RUN dnf download kernel-core-6.0.7-301.fc37 kernel-modules-6.0.7-301.fc37 -y
 
 RUN rpm2cpio kernel-core-*.rpm | cpio -t && \
-    rpm2cpio kernel-core-*.rpm | cpio -idmv ./lib/modules/6.2.9-200.fc37.x86_64/vmlinuz
+    rpm2cpio kernel-core-*.rpm | cpio -idmv ./lib/modules/6.0.7-301.fc37.x86_64/vmlinuz
 
-RUN rpm2cpio kernel-modules-core-*.rpm | cpio -t && \
-    rpm2cpio kernel-modules-core-*.rpm | cpio -idmv ./lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko.xz
+RUN rpm2cpio kernel-modules-*.rpm | cpio -t && \
+    rpm2cpio kernel-modules-*.rpm | cpio -idmv ./lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko.xz
 
-RUN unxz /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko.xz
+RUN unxz /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko.xz
 
 FROM scratch
 
-COPY --from=0 /lib/modules/6.2.9-200.fc37.x86_64/vmlinuz /lib/modules/6.2.9-200.fc37.x86_64/vmlinuz
-COPY --from=0 /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko
+COPY --from=0 /lib/modules/6.0.7-301.fc37.x86_64/vmlinuz /lib/modules/6.0.7-301.fc37.x86_64/vmlinuz
+COPY --from=0 /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko

--- a/test/integration/catalog_packages_cases_test.go
+++ b/test/integration/catalog_packages_cases_test.go
@@ -22,7 +22,7 @@ var imageOnlyTestCases = []testCase{
 		name:    "find kernel module packages",
 		pkgType: pkg.LinuxKernelModulePkg,
 		pkgInfo: map[string]string{
-			"fsa4480": "",
+			"ttynull": "",
 		},
 	},
 	{

--- a/test/integration/catalog_packages_cases_test.go
+++ b/test/integration/catalog_packages_cases_test.go
@@ -15,7 +15,7 @@ var imageOnlyTestCases = []testCase{
 		name:    "find kernel packages",
 		pkgType: pkg.LinuxKernelPkg,
 		pkgInfo: map[string]string{
-			"linux-kernel": "6.2.9-200.fc37.x86_64",
+			"linux-kernel": "6.0.7-301.fc37.x86_64",
 		},
 	},
 	{

--- a/test/integration/test-fixtures/image-pkg-coverage/Dockerfile
+++ b/test/integration/test-fixtures/image-pkg-coverage/Dockerfile
@@ -1,20 +1,22 @@
 FROM fedora:37@sha256:3f987b7657e944cf87a129cc262982d4f80e38bd98f7db313ccaf90ca7069dd2
 
 RUN dnf install 'dnf-command(download)' cpio xz -y
-RUN dnf download kernel-core kernel-modules-core -y
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/Packages/k/kernel-6.0.7-301.fc37.x86_64.rpm
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/37/Everything/x86_64/os/Packages/k/kernel-modules-6.0.7-301.fc37.x86_64.rpm
+RUN dnf download kernel-core-6.0.7-301.fc37 kernel-modules-6.0.7-301.fc37 -y
 
 RUN rpm2cpio kernel-core-*.rpm | cpio -t && \
-    rpm2cpio kernel-core-*.rpm | cpio -idmv ./lib/modules/6.2.9-200.fc37.x86_64/vmlinuz
+    rpm2cpio kernel-core-*.rpm | cpio -idmv ./lib/modules/6.0.7-301.fc37.x86_64/vmlinuz
 
-RUN rpm2cpio kernel-modules-core-*.rpm | cpio -t && \
-    rpm2cpio kernel-modules-core-*.rpm | cpio -idmv ./lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko.xz
+RUN rpm2cpio kernel-modules-*.rpm | cpio -t && \
+    rpm2cpio kernel-modules-*.rpm | cpio -idmv ./lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko.xz
 
-RUN unxz /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko.xz
+RUN unxz /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko.xz
 
 FROM scratch
 
-COPY --from=0 /lib/modules/6.2.9-200.fc37.x86_64/vmlinuz /lib/modules/6.2.9-200.fc37.x86_64/vmlinuz
-COPY --from=0 /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko /lib/modules/6.2.9-200.fc37.x86_64/kernel/drivers/usb/typec/mux/fsa4480.ko
+COPY --from=0 /lib/modules/6.0.7-301.fc37.x86_64/vmlinuz /lib/modules/6.0.7-301.fc37.x86_64/vmlinuz
+COPY --from=0 /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko
 
 COPY pkgs/ .
 # we duplicate to show a package count difference between all-layers and squashed scopes


### PR DESCRIPTION
This PR does a few things:
- pins the kernel test fixtures to a specific version that is not in the updates fedora channel (I needed to swap out the module under test since we couldn't pin the module being currently used)
- caches test images in CI between runs