### PR TITLE
Add ALPM Metadata to CYCLONEDX and SPDX output formats

### DIFF
--- a/syft/pkg/alpm_metadata.go
+++ b/syft/pkg/alpm_metadata.go
@@ -14,19 +14,19 @@ var _ FileOwner = (*AlpmMetadata)(nil)
 const AlpmDBGlob = "**/var/lib/pacman/local/**/desc"
 
 type AlpmMetadata struct {
-	BasePackage  string           `mapstructure:"base" json:"basepackage"`
-	Package      string           `mapstructure:"name" json:"package"`
-	Version      string           `mapstructure:"version" json:"version"`
-	Description  string           `mapstructure:"desc" json:"description"`
-	Architecture string           `mapstructure:"arch" json:"architecture"`
+	BasePackage  string           `mapstructure:"base" json:"basepackage" cyclonedx:"basepackage"`
+	Package      string           `mapstructure:"name" json:"package" cyclonedx:"package"`
+	Version      string           `mapstructure:"version" json:"version" cyclonedx:"version"`
+	Description  string           `mapstructure:"desc" json:"description" cyclonedx:"description"`
+	Architecture string           `mapstructure:"arch" json:"architecture" cyclonedx:"architecture"`
 	Size         int              `mapstructure:"size" json:"size" cyclonedx:"size"`
-	Packager     string           `mapstructure:"packager" json:"packager"`
-	License      string           `mapstructure:"license" json:"license"`
-	URL          string           `mapstructure:"url" json:"url"`
-	Validation   string           `mapstructure:"validation" json:"validation"`
-	Reason       int              `mapstructure:"reason" json:"reason"`
-	Files        []AlpmFileRecord `mapstructure:"files" json:"files"`
-	Backup       []AlpmFileRecord `mapstructure:"backup" json:"backup"`
+	Packager     string           `mapstructure:"packager" json:"packager" cyclonedx:"packager"`
+	License      string           `mapstructure:"license" json:"license" cyclonedx:"license"`
+	URL          string           `mapstructure:"url" json:"url" cyclonedx:"url"`
+	Validation   string           `mapstructure:"validation" json:"validation" cyclonedx:"validation"`
+	Reason       int              `mapstructure:"reason" json:"reason" cyclonedx:"reason"`
+	Files        []AlpmFileRecord `mapstructure:"files" json:"files" cyclonedx:"files"`
+	Backup       []AlpmFileRecord `mapstructure:"backup" json:"backup" cyclonedx:"backup"`
 }
 
 type AlpmFileRecord struct {


### PR DESCRIPTION
Add ALPM Metadata to CYCLONEDX and SPDX output formats

Closes #1037

As mentioned in #1037 by @kzantow  it seemed most items may not map to SPDX. I am also unfamiliar with SPDX but didn't seem to find fields that mapped properly to the items needed.