### PR TITLE
fix: update cache.fingerprint file to java-builds dir

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -36,8 +36,8 @@ jobs:
       - name: Restore Java test-fixture cache
         uses: actions/cache@v3
         with:
-          path: syft/pkg/cataloger/java/test-fixtures/java-builds/packages
-          key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/pkg/cataloger/java/test-fixtures/java-builds/packages.fingerprint' ) }}
+          path: syft/pkg/cataloger/java/test-fixtures/java-builds
+          key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/pkg/cataloger/java/test-fixtures/java-builds/cache.fingerprint' ) }}
 
       - name: Restore RPM test-fixture cache
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ fingerprints:
 
 	# for JAVA BUILD test fixtures
 	cd syft/pkg/cataloger/java/test-fixtures/java-builds && \
-		make packages.fingerprint
+		make cache.fingerprint
 
 	# for GO BINARY test fixtures
 	cd syft/pkg/cataloger/golang/test-fixtures/archs && \

--- a/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
@@ -72,7 +72,7 @@ $(PKGSDIR)/gcc-amd64-darwin-exec-debug:
 	./build-example-macho-binary.sh $(PKGSDIR)
 
 # we need a way to determine if CI should bust the test cache based on the source material
-$(PKGSDIR).fingerprint: clean-examples
-	mkdir -p $(PKGSDIR)
-	find example-* build-* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee $(PKGSDIR).fingerprint
-	sha256sum $(PKGSDIR).fingerprint
+.PHONY: cache.fingerprint
+cache.fingerprint:
+	find example-* build-* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
+	sha256sum cache.fingerprint


### PR DESCRIPTION
### Summary

The `validations` workflow was looking under the `packages` directory for a fingerprint file that was not being created correctly. This caused tests to fail on PR that used the older cache after this update was made:

- https://github.com/anchore/syft/pull/1719/files#diff-1c5a22dae4b51bc7d60c3ec55409b0afe7ce708568c66a5d36854856d2b859e6

This PR syncs the `Makefile` for `java-build` fixtures with patterns that exist already in the codebase. It also links these changes into the main Makefile so that CI can correctly validate when the cache needs to be busted.