### PR TITLE
fix: only cache java packages and not source content

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Restore Java test-fixture cache
         uses: actions/cache@v3
         with:
-          path: syft/pkg/cataloger/java/test-fixtures/java-builds
+          path: syft/pkg/cataloger/java/test-fixtures/java-builds/packages
           key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/pkg/cataloger/java/test-fixtures/java-builds/cache.fingerprint' ) }}
 
       - name: Restore RPM test-fixture cache

--- a/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
@@ -74,5 +74,5 @@ $(PKGSDIR)/gcc-amd64-darwin-exec-debug:
 # we need a way to determine if CI should bust the test cache based on the source material
 .PHONY: cache.fingerprint
 cache.fingerprint:
-	find example* build* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
+	find example* build* gradle* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
 	sha256sum cache.fingerprint

--- a/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/java-builds/Makefile
@@ -74,5 +74,5 @@ $(PKGSDIR)/gcc-amd64-darwin-exec-debug:
 # we need a way to determine if CI should bust the test cache based on the source material
 .PHONY: cache.fingerprint
 cache.fingerprint:
-	find example-* build-* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
+	find example* build* Makefile -type f -exec sha256sum {} \; | sort | tee /dev/stderr | tee cache.fingerprint
 	sha256sum cache.fingerprint


### PR DESCRIPTION
## Summary
Revert changes from https://github.com/anchore/syft/pull/1748.

We only want to cache the final package test fixtures builds.

We do want to calculate based on a few more files being changed so those have been added for the CI check by `find build*` rather than `build-`