### PR TITLE
Improve pnpm support

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
@@ -3,6 +3,7 @@ package javascript
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -16,7 +17,8 @@ import (
 var _ generic.Parser = parsePnpmLock
 
 type pnpmLockYaml struct {
-	Dependencies map[string]string `json:"dependencies"`
+	Dependencies map[string]string      `json:"dependencies"`
+	Packages     map[string]interface{} `json:"packages"`
 }
 
 func parsePnpmLock(resolver source.FileResolver, _ *generic.Environment, reader source.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
@@ -33,6 +35,19 @@ func parsePnpmLock(resolver source.FileResolver, _ *generic.Environment, reader 
 	}
 
 	for name, version := range lockFile.Dependencies {
+		pkgs = append(pkgs, newPnpmPackage(resolver, reader.Location, name, version))
+	}
+
+	// parse packages from packages section of pnpm-lock.yaml
+	for nameVersion := range lockFile.Packages {
+		nameVersionSplit := strings.Split(strings.TrimPrefix(nameVersion, "/"), "/")
+
+		// last element in split array is version
+		version := nameVersionSplit[len(nameVersionSplit)-1]
+
+		// construct name from all array items other than last item (version)
+		name := strings.Join(nameVersionSplit[:len(nameVersionSplit)-1], "/")
+
 		pkgs = append(pkgs, newPnpmPackage(resolver, reader.Location, name, version))
 	}
 

--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
@@ -40,6 +40,14 @@ func TestParsePnpmLock(t *testing.T) {
 			Language:  pkg.JavaScript,
 			Type:      pkg.NpmPkg,
 		},
+		{
+			Name:      "@bcoe/v8-coverage",
+			Version:   "0.2.3",
+			PURL:      "pkg:npm/%40bcoe/v8-coverage@0.2.3",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+		},
 	}
 
 	pkgtest.TestFileParser(t, fixture, parsePnpmLock, expectedPkgs, expectedRelationships)


### PR DESCRIPTION
Improve pnpm support

- Parse packages section from pnpm-lock.yaml to get transitive dependencies.
- Should add support for getting dependencies from pnpm-lock.yaml files that use workspaces.
  - This is due to the fact all dependencies should get listed under the packages section.

Closes #1535