### PR TITLE
Rename pkg.Catalog to pkg.Collection

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -54,7 +54,7 @@ func ToSyftModel(bom *cyclonedx.BOM) (*sbom.SBOM, error) {
 
 	s := &sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkg.NewCatalog(),
+			PackageCatalog:    pkg.NewCollection(),
 			LinuxDistribution: linuxReleaseFromComponents(*bom.Components),
 		},
 		Source:     extractComponents(bom.Metadata),

--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -141,10 +141,10 @@ func toSPDXID(identifiable artifact.Identifiable) spdx.ElementID {
 	return spdx.ElementID(id)
 }
 
-// packages populates all Package Information from the package Catalog (see https://spdx.github.io/spdx-spec/3-package-information/)
+// packages populates all Package Information from the package Collection (see https://spdx.github.io/spdx-spec/3-package-information/)
 //
 //nolint:funlen
-func toPackages(catalog *pkg.Catalog, sbom sbom.SBOM) (results []*spdx.Package) {
+func toPackages(catalog *pkg.Collection, sbom sbom.SBOM) (results []*spdx.Package) {
 	for _, p := range catalog.Sorted() {
 		// name should be guaranteed to be unique, but semantically useful and stable
 		id := toSPDXID(p)
@@ -516,7 +516,7 @@ func toFileTypes(metadata *source.FileMetadata) (ty []string) {
 	return ty
 }
 
-func toOtherLicenses(catalog *pkg.Catalog) []*spdx.OtherLicense {
+func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 	licenses := map[string]bool{}
 	for _, p := range catalog.Sorted() {
 		for _, license := range parseLicenses(p.Licenses) {

--- a/syft/formats/common/spdxhelpers/to_format_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_format_model_test.go
@@ -421,7 +421,7 @@ func Test_H1Digest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			catalog := pkg.NewCatalog(test.pkg)
+			catalog := pkg.NewCollection(test.pkg)
 			pkgs := toPackages(catalog, s)
 			require.Len(t, pkgs, 1)
 			for _, p := range pkgs {
@@ -494,7 +494,7 @@ func Test_OtherLicenses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			catalog := pkg.NewCatalog(test.pkg)
+			catalog := pkg.NewCollection(test.pkg)
 			otherLicenses := toOtherLicenses(catalog)
 			require.Len(t, otherLicenses, len(test.expected))
 			require.Equal(t, test.expected, otherLicenses)

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -33,7 +33,7 @@ func ToSyftModel(doc *spdx.Document) (*sbom.SBOM, error) {
 	s := &sbom.SBOM{
 		Source: src,
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkg.NewCatalog(),
+			PackageCatalog:    pkg.NewCollection(),
 			FileMetadata:      map[source.Coordinates]source.FileMetadata{},
 			FileDigests:       map[source.Coordinates][]file.Digest{},
 			LinuxDistribution: findLinuxReleaseByPURL(doc),

--- a/syft/formats/github/encoder_test.go
+++ b/syft/formats/github/encoder_test.go
@@ -28,7 +28,7 @@ func Test_toGithubModel(t *testing.T) {
 				VersionID: "18.04",
 				IDLike:    []string{"debian"},
 			},
-			PackageCatalog: pkg.NewCatalog(),
+			PackageCatalog: pkg.NewCollection(),
 		},
 	}
 	for _, p := range []pkg.Package{

--- a/syft/formats/internal/testutils/utils.go
+++ b/syft/formats/internal/testutils/utils.go
@@ -93,7 +93,7 @@ func AssertEncoderAgainstGoldenSnapshot(t *testing.T, format sbom.Format, sbom s
 
 func ImageInput(t testing.TB, testImage string, options ...ImageOption) sbom.SBOM {
 	t.Helper()
-	catalog := pkg.NewCatalog()
+	catalog := pkg.NewCollection()
 	var cfg imageCfg
 	var img *image.Image
 	for _, opt := range options {
@@ -145,7 +145,7 @@ func carriageRedactor(s []byte) []byte {
 	return []byte(msg)
 }
 
-func populateImageCatalog(catalog *pkg.Catalog, img *image.Image) {
+func populateImageCatalog(catalog *pkg.Collection, img *image.Image) {
 	_, ref1, _ := img.SquashedTree().File("/somefile-1.txt", filetree.FollowBasenameLinks)
 	_, ref2, _ := img.SquashedTree().File("/somefile-2.txt", filetree.FollowBasenameLinks)
 
@@ -252,8 +252,8 @@ func DirectoryInputWithAuthorField(t testing.TB) sbom.SBOM {
 	}
 }
 
-func newDirectoryCatalog() *pkg.Catalog {
-	catalog := pkg.NewCatalog()
+func newDirectoryCatalog() *pkg.Collection {
+	catalog := pkg.NewCollection()
 
 	// populate catalog with test data
 	catalog.Add(pkg.Package{
@@ -303,8 +303,8 @@ func newDirectoryCatalog() *pkg.Catalog {
 	return catalog
 }
 
-func newDirectoryCatalogWithAuthorField() *pkg.Catalog {
-	catalog := pkg.NewCatalog()
+func newDirectoryCatalogWithAuthorField() *pkg.Collection {
+	catalog := pkg.NewCollection()
 
 	// populate catalog with test data
 	catalog.Add(pkg.Package{

--- a/syft/formats/spdxtagvalue/encoder_test.go
+++ b/syft/formats/spdxtagvalue/encoder_test.go
@@ -49,7 +49,7 @@ func TestSPDXJSONSPDXIDs(t *testing.T) {
 		Format(),
 		sbom.SBOM{
 			Artifacts: sbom.Artifacts{
-				PackageCatalog: pkg.NewCatalog(pkgs...),
+				PackageCatalog: pkg.NewCollection(pkgs...),
 			},
 			Relationships: nil,
 			Source: source.Metadata{

--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -47,7 +47,7 @@ func schemaVersionRedactor(s []byte) []byte {
 }
 
 func TestEncodeFullJSONDocument(t *testing.T) {
-	catalog := pkg.NewCatalog()
+	catalog := pkg.NewCollection()
 
 	p1 := pkg.Package{
 		Name:    "package-1",

--- a/syft/formats/syftjson/to_format_model.go
+++ b/syft/formats/syftjson/to_format_model.go
@@ -173,7 +173,7 @@ func toFileType(ty stereoscopeFile.Type) string {
 	}
 }
 
-func toPackageModels(catalog *pkg.Catalog) []model.Package {
+func toPackageModels(catalog *pkg.Collection) []model.Package {
 	artifacts := make([]model.Package, 0)
 	if catalog == nil {
 		return artifacts

--- a/syft/formats/syftjson/to_syft_model.go
+++ b/syft/formats/syftjson/to_syft_model.go
@@ -131,7 +131,7 @@ func toSyftLinuxRelease(d model.LinuxRelease) *linux.Release {
 	}
 }
 
-func toSyftRelationships(doc *model.Document, catalog *pkg.Catalog, relationships []model.Relationship, idAliases map[string]string) []artifact.Relationship {
+func toSyftRelationships(doc *model.Document, catalog *pkg.Collection, relationships []model.Relationship, idAliases map[string]string) []artifact.Relationship {
 	idMap := make(map[string]interface{})
 
 	for _, p := range catalog.Sorted() {
@@ -256,8 +256,8 @@ func toSyftSourceData(s model.Source) *source.Metadata {
 	return nil
 }
 
-func toSyftCatalog(pkgs []model.Package, idAliases map[string]string) *pkg.Catalog {
-	catalog := pkg.NewCatalog()
+func toSyftCatalog(pkgs []model.Package, idAliases map[string]string) *pkg.Collection {
+	catalog := pkg.NewCollection()
 	for _, p := range pkgs {
 		catalog.Add(toSyftPackage(p, idAliases))
 	}

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -34,7 +34,7 @@ import (
 // CatalogPackages takes an inventory of packages from the given image from a particular perspective
 // (e.g. squashed source, all-layers source). Returns the discovered  set of packages, the identified Linux
 // distribution, and the source object used to wrap the data source.
-func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Catalog, []artifact.Relationship, *linux.Release, error) {
+func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Collection, []artifact.Relationship, *linux.Release, error) {
 	resolver, err := src.FileResolver(cfg.Search.Scope)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to determine resolver while cataloging packages: %w", err)
@@ -76,7 +76,7 @@ func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Catalog, []
 	return catalog, relationships, release, err
 }
 
-func newSourceRelationshipsFromCatalog(src *source.Source, c *pkg.Catalog) []artifact.Relationship {
+func newSourceRelationshipsFromCatalog(src *source.Source, c *pkg.Collection) []artifact.Relationship {
 	relationships := make([]artifact.Relationship, 0) // Should we pre-allocate this by giving catalog a Len() method?
 	for p := range c.Enumerate() {
 		relationships = append(relationships, artifact.Relationship{

--- a/syft/pkg/catalog_test.go
+++ b/syft/pkg/catalog_test.go
@@ -145,7 +145,7 @@ func TestCatalogDeleteRemovesPackages(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewCatalog()
+			c := NewCollection()
 			for _, p := range test.pkgs {
 				c.Add(p)
 			}
@@ -212,13 +212,13 @@ func TestCatalogAddPopulatesIndex(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewCatalog(pkgs...)
+			c := NewCollection(pkgs...)
 			assertIndexes(t, c, test.expectedIndexes)
 		})
 	}
 }
 
-func assertIndexes(t *testing.T, c *Catalog, expectedIndexes expectedIndexes) {
+func assertIndexes(t *testing.T, c *Collection, expectedIndexes expectedIndexes) {
 	// assert path index
 	assert.Len(t, c.idsByPath, len(expectedIndexes.byPath), "unexpected path index length")
 	for path, expectedIds := range expectedIndexes.byPath {
@@ -306,7 +306,7 @@ func TestCatalog_PathIndexDeduplicatesRealVsVirtualPaths(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			for _, path := range test.paths {
-				actualPackages := NewCatalog(test.pkgs...).PackagesByPath(path)
+				actualPackages := NewCollection(test.pkgs...).PackagesByPath(path)
 				require.Len(t, actualPackages, 1)
 			}
 		})
@@ -373,7 +373,7 @@ func TestCatalog_MergeRecords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual := NewCatalog(tt.pkgs...).PackagesByPath("/b/path")
+			actual := NewCollection(tt.pkgs...).PackagesByPath("/b/path")
 			require.Len(t, actual, 1)
 			assert.Equal(t, tt.expectedLocations, actual[0].Locations.ToSlice())
 			require.Len(t, actual[0].CPEs, tt.expectedCPECount)
@@ -382,7 +382,7 @@ func TestCatalog_MergeRecords(t *testing.T) {
 }
 
 func TestCatalog_EnumerateNilCatalog(t *testing.T) {
-	var c *Catalog
+	var c *Collection
 	assert.Empty(t, c.Enumerate())
 }
 

--- a/syft/pkg/cataloger/catalog.go
+++ b/syft/pkg/cataloger/catalog.go
@@ -105,8 +105,8 @@ func runCataloger(cataloger pkg.Cataloger, resolver source.FileResolver) (catalo
 // request.
 //
 //nolint:funlen
-func Catalog(resolver source.FileResolver, _ *linux.Release, parallelism int, catalogers ...pkg.Cataloger) (*pkg.Catalog, []artifact.Relationship, error) {
-	catalog := pkg.NewCatalog()
+func Catalog(resolver source.FileResolver, _ *linux.Release, parallelism int, catalogers ...pkg.Cataloger) (*pkg.Collection, []artifact.Relationship, error) {
+	catalog := pkg.NewCollection()
 	var allRelationships []artifact.Relationship
 
 	filesProcessed, packagesDiscovered := newMonitor()

--- a/syft/pkg/deprecated.go
+++ b/syft/pkg/deprecated.go
@@ -1,0 +1,9 @@
+package pkg
+
+// Deprecated: use Collection instead
+type Catalog = Collection
+
+// Deprecated: use NewCollection() instead
+func NewCatalog(pkgs ...Package) *Catalog {
+	return NewCollection(pkgs...)
+}

--- a/syft/pkg/relationships.go
+++ b/syft/pkg/relationships.go
@@ -2,7 +2,7 @@ package pkg
 
 import "github.com/anchore/syft/syft/artifact"
 
-func NewRelationships(catalog *Catalog) []artifact.Relationship {
+func NewRelationships(catalog *Collection) []artifact.Relationship {
 	rels := RelationshipsByFileOwnership(catalog)
 	rels = append(rels, RelationshipsEvidentBy(catalog)...)
 	return rels

--- a/syft/pkg/relationships_by_file_ownership.go
+++ b/syft/pkg/relationships_by_file_ownership.go
@@ -31,7 +31,7 @@ type ownershipByFilesMetadata struct {
 
 // RelationshipsByFileOwnership creates a package-to-package relationship based on discovering which packages have
 // evidence locations that overlap with ownership claim from another package's package manager metadata.
-func RelationshipsByFileOwnership(catalog *Catalog) []artifact.Relationship {
+func RelationshipsByFileOwnership(catalog *Collection) []artifact.Relationship {
 	var relationships = findOwnershipByFilesRelationships(catalog)
 
 	var edges []artifact.Relationship
@@ -55,7 +55,7 @@ func RelationshipsByFileOwnership(catalog *Catalog) []artifact.Relationship {
 
 // findOwnershipByFilesRelationships find overlaps in file ownership with a file that defines another package. Specifically, a .Location.Path of
 // a package is found to be owned by another (from the owner's .Metadata.Files[]).
-func findOwnershipByFilesRelationships(catalog *Catalog) map[artifact.ID]map[artifact.ID]*strset.Set {
+func findOwnershipByFilesRelationships(catalog *Collection) map[artifact.ID]map[artifact.ID]*strset.Set {
 	var relationships = make(map[artifact.ID]map[artifact.ID]*strset.Set)
 
 	if catalog == nil {

--- a/syft/pkg/relationships_by_file_ownership_test.go
+++ b/syft/pkg/relationships_by_file_ownership_test.go
@@ -139,7 +139,7 @@ func TestOwnershipByFilesRelationship(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			pkgs, expectedRelations := test.setup(t)
-			c := NewCatalog(pkgs...)
+			c := NewCollection(pkgs...)
 			relationships := RelationshipsByFileOwnership(c)
 
 			assert.Len(t, relationships, len(expectedRelations))

--- a/syft/pkg/relationships_evident_by.go
+++ b/syft/pkg/relationships_evident_by.go
@@ -4,7 +4,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 )
 
-func RelationshipsEvidentBy(catalog *Catalog) []artifact.Relationship {
+func RelationshipsEvidentBy(catalog *Collection) []artifact.Relationship {
 	var edges []artifact.Relationship
 	for _, p := range catalog.Sorted() {
 		for _, l := range p.Locations.ToSlice() {

--- a/syft/pkg/relationships_evident_by_test.go
+++ b/syft/pkg/relationships_evident_by_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRelationshipsEvidentBy(t *testing.T) {
 
-	c := NewCatalog()
+	c := NewCollection()
 
 	coordA := source.Coordinates{
 		RealPath:     "/somewhere/real",
@@ -53,7 +53,7 @@ func TestRelationshipsEvidentBy(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		catalog *Catalog
+		catalog *Collection
 		want    []artifact.Relationship
 	}{
 		{

--- a/syft/sbom/sbom.go
+++ b/syft/sbom/sbom.go
@@ -20,7 +20,7 @@ type SBOM struct {
 }
 
 type Artifacts struct {
-	PackageCatalog    *pkg.Catalog
+	PackageCatalog    *pkg.Collection
 	FileMetadata      map[source.Coordinates]source.FileMetadata
 	FileDigests       map[source.Coordinates][]file.Digest
 	FileContents      map[source.Coordinates]string

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -22,7 +22,7 @@ func BenchmarkImagePackageCatalogers(b *testing.B) {
 	imagetest.GetFixtureImage(b, "docker-archive", fixtureImageName)
 	tarPath := imagetest.GetFixtureImageTarPath(b, fixtureImageName)
 
-	var pc *pkg.Catalog
+	var pc *pkg.Collection
 	for _, c := range cataloger.ImageCatalogers(cataloger.DefaultConfig()) {
 		// in case of future alteration where state is persisted, assume no dependency is safe to reuse
 		userInput := "docker-archive:" + tarPath


### PR DESCRIPTION
As part of the work under #558  (from https://github.com/anchore/syft/issues/558#issuecomment-1081846913) renames the pkg.Catalog to pkg.Collection. The existing pkg.Catalog type and constructor is still in the codebase as a type alias and deprecation notice. The type aliases will be removed in syft 1.0.