### PR TITLE
chore: update test redactor ordering

### DIFF
--- a/syft/formats/internal/testutils/utils.go
+++ b/syft/formats/internal/testutils/utils.go
@@ -47,13 +47,14 @@ func AssertEncoderAgainstGoldenImageSnapshot(t *testing.T, format sbom.Format, s
 
 	err := format.Encode(&buffer, sbom)
 	assert.NoError(t, err)
-	actual := redact(buffer.Bytes(), redactors...)
+	actual := buffer.Bytes()
 
 	// replace the expected snapshot contents with the current encoder contents
 	if updateSnapshot {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
+	actual = redact(actual, redactors...)
 	expected := redact(testutils.GetGoldenFileContents(t), redactors...)
 
 	if json {
@@ -71,13 +72,14 @@ func AssertEncoderAgainstGoldenSnapshot(t *testing.T, format sbom.Format, sbom s
 
 	err := format.Encode(&buffer, sbom)
 	assert.NoError(t, err)
-	actual := redact(buffer.Bytes(), redactors...)
+	actual := buffer.Bytes()
 
 	// replace the expected snapshot contents with the current encoder contents
 	if updateSnapshot {
 		testutils.UpdateGoldenFileContents(t, actual)
 	}
 
+	actual = redact(actual, redactors...)
 	expected := redact(testutils.GetGoldenFileContents(t), redactors...)
 
 	if json {


### PR DESCRIPTION
This reverts format testing to the previous behavior to where golden files are written not redacted.