### PR TITLE
chore: add more detail on SPDX file IDs

### DIFF
--- a/syft/formats/common/spdxhelpers/to_format_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_format_model_test.go
@@ -2,6 +2,7 @@ package spdxhelpers
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/spdx/tools-golang/spdx"
@@ -498,6 +499,46 @@ func Test_OtherLicenses(t *testing.T) {
 			otherLicenses := toOtherLicenses(catalog)
 			require.Len(t, otherLicenses, len(test.expected))
 			require.Equal(t, test.expected, otherLicenses)
+		})
+	}
+}
+
+func Test_toSPDXID(t *testing.T) {
+	tests := []struct {
+		name     string
+		it       artifact.Identifiable
+		expected string
+	}{
+		{
+			name: "short filename",
+			it: source.Coordinates{
+				RealPath: "/short/path/file.txt",
+			},
+			expected: "File-short-path-file.txt",
+		},
+		{
+			name: "long filename",
+			it: source.Coordinates{
+				RealPath: "/some/long/path/with/a/lot/of-text/that-contains-a/file.txt",
+			},
+			expected: "File-...a-lot-of-text-that-contains-a-file.txt",
+		},
+		{
+			name: "package",
+			it: pkg.Package{
+				Type: pkg.NpmPkg,
+				Name: "some-package",
+			},
+			expected: "Package-npm-some-package",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := string(toSPDXID(test.it))
+			// trim the hash
+			got = regexp.MustCompile(`-[a-z0-9]*$`).ReplaceAllString(got, "")
+			require.Equal(t, test.expected, got)
 		})
 	}
 }

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONDirectoryEncoder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONDirectoryEncoder.golden
@@ -3,14 +3,14 @@
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "/some/path",
- "documentNamespace": "https://anchore.com/syft/dir/some/path-1fe34646-a616-48c7-974b-3d1e27d406e3",
+ "documentNamespace": "https://anchore.com/syft/dir/some/path-4029b5ec-6d70-4c0c-aedf-b61c8f5ea93c",
  "creationInfo": {
-  "licenseListVersion": "3.19",
+  "licenseListVersion": "3.20",
   "creators": [
    "Organization: Anchore, Inc",
    "Tool: syft-v0.42.0-bogus"
   ],
-  "created": "2023-01-20T21:41:03Z"
+  "created": "2023-05-02T18:24:17Z"
  },
  "packages": [
   {

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
@@ -3,14 +3,14 @@
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "user-image-input",
- "documentNamespace": "https://anchore.com/syft/image/user-image-input-33759ac3-6006-4f2c-bdc4-f40b9287a7f0",
+ "documentNamespace": "https://anchore.com/syft/image/user-image-input-6b0c6ff8-0f5f-4d95-8c1b-eb966d400804",
  "creationInfo": {
-  "licenseListVersion": "3.19",
+  "licenseListVersion": "3.20",
   "creators": [
    "Organization: Anchore, Inc",
    "Tool: syft-v0.42.0-bogus"
   ],
-  "created": "2023-01-20T21:41:03Z"
+  "created": "2023-05-02T18:24:18Z"
  },
  "packages": [
   {

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -3,14 +3,14 @@
  "dataLicense": "CC0-1.0",
  "SPDXID": "SPDXRef-DOCUMENT",
  "name": "user-image-input",
- "documentNamespace": "https://anchore.com/syft/image/user-image-input-ce98f51f-b483-4e93-9a15-5a8a16d35de6",
+ "documentNamespace": "https://anchore.com/syft/image/user-image-input-ec2f9b25-22ca-46b8-b7f4-484994fe126c",
  "creationInfo": {
-  "licenseListVersion": "3.19",
+  "licenseListVersion": "3.20",
   "creators": [
    "Organization: Anchore, Inc",
    "Tool: syft-v0.42.0-bogus"
   ],
-  "created": "2023-01-20T21:41:03Z"
+  "created": "2023-05-02T18:24:18Z"
  },
  "packages": [
   {
@@ -61,7 +61,7 @@
  "files": [
   {
    "fileName": "/a1/f6",
-   "SPDXID": "SPDXRef-9c2f7510199b17f6",
+   "SPDXID": "SPDXRef-File-a1-f6-9c2f7510199b17f6",
    "fileTypes": [
     "OTHER"
    ],
@@ -76,7 +76,7 @@
   },
   {
    "fileName": "/d1/f3",
-   "SPDXID": "SPDXRef-c6f5b29dca12661f",
+   "SPDXID": "SPDXRef-File-d1-f3-c6f5b29dca12661f",
    "fileTypes": [
     "OTHER"
    ],
@@ -91,7 +91,7 @@
   },
   {
    "fileName": "/d2/f4",
-   "SPDXID": "SPDXRef-c641caa71518099f",
+   "SPDXID": "SPDXRef-File-d2-f4-c641caa71518099f",
    "fileTypes": [
     "OTHER"
    ],
@@ -106,7 +106,7 @@
   },
   {
    "fileName": "/f1",
-   "SPDXID": "SPDXRef-5265a4dde3edbf7c",
+   "SPDXID": "SPDXRef-File-f1-5265a4dde3edbf7c",
    "fileTypes": [
     "OTHER"
    ],
@@ -121,7 +121,7 @@
   },
   {
    "fileName": "/f2",
-   "SPDXID": "SPDXRef-f9e49132a4b96ccd",
+   "SPDXID": "SPDXRef-File-f2-f9e49132a4b96ccd",
    "fileTypes": [
     "OTHER"
    ],
@@ -136,7 +136,7 @@
   },
   {
    "fileName": "/z1/f5",
-   "SPDXID": "SPDXRef-839d99ee67d9d174",
+   "SPDXID": "SPDXRef-File-z1-f5-839d99ee67d9d174",
    "fileTypes": [
     "OTHER"
    ],
@@ -153,32 +153,32 @@
  "relationships": [
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-5265a4dde3edbf7c",
+   "relatedSpdxElement": "SPDXRef-File-f1-5265a4dde3edbf7c",
    "relationshipType": "CONTAINS"
   },
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-839d99ee67d9d174",
+   "relatedSpdxElement": "SPDXRef-File-z1-f5-839d99ee67d9d174",
    "relationshipType": "CONTAINS"
   },
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-9c2f7510199b17f6",
+   "relatedSpdxElement": "SPDXRef-File-a1-f6-9c2f7510199b17f6",
    "relationshipType": "CONTAINS"
   },
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-c641caa71518099f",
+   "relatedSpdxElement": "SPDXRef-File-d2-f4-c641caa71518099f",
    "relationshipType": "CONTAINS"
   },
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-c6f5b29dca12661f",
+   "relatedSpdxElement": "SPDXRef-File-d1-f3-c6f5b29dca12661f",
    "relationshipType": "CONTAINS"
   },
   {
    "spdxElementId": "SPDXRef-Package-python-package-1-66ba429119b8bec6",
-   "relatedSpdxElement": "SPDXRef-f9e49132a4b96ccd",
+   "relatedSpdxElement": "SPDXRef-File-f2-f9e49132a4b96ccd",
    "relationshipType": "CONTAINS"
   },
   {

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXJSONSPDXIDs.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXJSONSPDXIDs.golden
@@ -2,11 +2,11 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: foobar/baz
-DocumentNamespace: https://anchore.com/syft/dir/foobar/baz-478e410d-7fad-472c-b4e9-a4068ef28160
-LicenseListVersion: 3.19
+DocumentNamespace: https://anchore.com/syft/dir/foobar/baz-9c1f31fb-7c72-40a6-8c81-3a08590000a2
+LicenseListVersion: 3.20
 Creator: Organization: Anchore, Inc
 Creator: Tool: syft-v0.42.0-bogus
-Created: 2022-12-21T03:39:05Z
+Created: 2023-05-02T18:24:33Z
 
 ##### Package: @at-sign
 

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -2,46 +2,46 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: user-image-input
-DocumentNamespace: https://anchore.com/syft/image/user-image-input-73433e8c-364f-42b6-b5b7-9a4da8799868
-LicenseListVersion: 3.19
+DocumentNamespace: https://anchore.com/syft/image/user-image-input-5be37b11-b99a-47ff-8725-3984e323d129
+LicenseListVersion: 3.20
 Creator: Organization: Anchore, Inc
 Creator: Tool: syft-v0.42.0-bogus
-Created: 2022-12-21T03:39:05Z
+Created: 2023-05-02T18:24:33Z
 
 ##### Unpackaged files
 
-FileName: /f1
-SPDXID: SPDXRef-5265a4dde3edbf7c
-FileType: OTHER
-FileChecksum: SHA1: 0000000000000000000000000000000000000000
-LicenseConcluded: NOASSERTION
-
-FileName: /z1/f5
-SPDXID: SPDXRef-839d99ee67d9d174
-FileType: OTHER
-FileChecksum: SHA1: 0000000000000000000000000000000000000000
-LicenseConcluded: NOASSERTION
-
 FileName: /a1/f6
-SPDXID: SPDXRef-9c2f7510199b17f6
-FileType: OTHER
-FileChecksum: SHA1: 0000000000000000000000000000000000000000
-LicenseConcluded: NOASSERTION
-
-FileName: /d2/f4
-SPDXID: SPDXRef-c641caa71518099f
+SPDXID: SPDXRef-File-a1-f6-9c2f7510199b17f6
 FileType: OTHER
 FileChecksum: SHA1: 0000000000000000000000000000000000000000
 LicenseConcluded: NOASSERTION
 
 FileName: /d1/f3
-SPDXID: SPDXRef-c6f5b29dca12661f
+SPDXID: SPDXRef-File-d1-f3-c6f5b29dca12661f
+FileType: OTHER
+FileChecksum: SHA1: 0000000000000000000000000000000000000000
+LicenseConcluded: NOASSERTION
+
+FileName: /d2/f4
+SPDXID: SPDXRef-File-d2-f4-c641caa71518099f
+FileType: OTHER
+FileChecksum: SHA1: 0000000000000000000000000000000000000000
+LicenseConcluded: NOASSERTION
+
+FileName: /f1
+SPDXID: SPDXRef-File-f1-5265a4dde3edbf7c
 FileType: OTHER
 FileChecksum: SHA1: 0000000000000000000000000000000000000000
 LicenseConcluded: NOASSERTION
 
 FileName: /f2
-SPDXID: SPDXRef-f9e49132a4b96ccd
+SPDXID: SPDXRef-File-f2-f9e49132a4b96ccd
+FileType: OTHER
+FileChecksum: SHA1: 0000000000000000000000000000000000000000
+LicenseConcluded: NOASSERTION
+
+FileName: /z1/f5
+SPDXID: SPDXRef-File-z1-f5-839d99ee67d9d174
 FileType: OTHER
 FileChecksum: SHA1: 0000000000000000000000000000000000000000
 LicenseConcluded: NOASSERTION
@@ -76,11 +76,11 @@ ExternalRef: PACKAGE-MANAGER purl a-purl-1
 
 ##### Relationships
 
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-5265a4dde3edbf7c
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-839d99ee67d9d174
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-9c2f7510199b17f6
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-c641caa71518099f
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-c6f5b29dca12661f
-Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-f9e49132a4b96ccd
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-f1-5265a4dde3edbf7c
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-z1-f5-839d99ee67d9d174
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-a1-f6-9c2f7510199b17f6
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-d2-f4-c641caa71518099f
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-d1-f3-c6f5b29dca12661f
+Relationship: SPDXRef-Package-python-package-1-66ba429119b8bec6 CONTAINS SPDXRef-File-f2-f9e49132a4b96ccd
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-DOCUMENT
 

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueDirectoryEncoder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueDirectoryEncoder.golden
@@ -2,11 +2,11 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: /some/path
-DocumentNamespace: https://anchore.com/syft/dir/some/path-1d303762-46d2-47b5-9c81-defa91387275
-LicenseListVersion: 3.19
+DocumentNamespace: https://anchore.com/syft/dir/some/path-0f346656-6d10-4dec-b549-a256468cbd35
+LicenseListVersion: 3.20
 Creator: Organization: Anchore, Inc
 Creator: Tool: syft-v0.42.0-bogus
-Created: 2022-12-21T03:39:05Z
+Created: 2023-05-02T18:24:33Z
 
 ##### Package: package-2
 

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
@@ -2,11 +2,11 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: user-image-input
-DocumentNamespace: https://anchore.com/syft/image/user-image-input-559af225-63af-4bc0-94fb-bce94913bcfa
-LicenseListVersion: 3.19
+DocumentNamespace: https://anchore.com/syft/image/user-image-input-4ce1e7c7-642f-4428-bb44-1b48b8edf74d
+LicenseListVersion: 3.20
 Creator: Organization: Anchore, Inc
 Creator: Tool: syft-v0.42.0-bogus
-Created: 2022-12-21T03:39:05Z
+Created: 2023-05-02T18:24:33Z
 
 ##### Package: package-2
 


### PR DESCRIPTION
This PR adjusts how Syft outputs SPDX IDs for files to include some information about the file name in the ID (up to 40 characters). This helps with SPDX Tag Value stability, as the `spdx/tools-golang` library is re-sorting files based on the SPDX ID. The sorting is an issue because layer hashes contribute to the file hashes themselves, so rebuilding a container and re-scanning results in significantly different ordering of the files without this change. This also helps to make relationships more clear when just looking at the SPDX relationship elements, these now include `File-<some-path>`, e.g.:

```
Relationship: SPDXRef-Package-apk-scanelf-e903138d19e85b80 OTHER SPDXRef-File-lib-apk-db-installed-3f4e74b9e4beb504
```