### PR TITLE
Rename sbom.PackageCatalog to sbom.Packages

### DIFF
--- a/cmd/syft/cli/eventloop/tasks.go
+++ b/cmd/syft/cli/eventloop/tasks.go
@@ -47,7 +47,7 @@ func generateCatalogPackagesTask(app *config.Application) (Task, error) {
 	task := func(results *sbom.Artifacts, src *source.Source) ([]artifact.Relationship, error) {
 		packageCatalog, relationships, theDistro, err := syft.CatalogPackages(src, app.ToCatalogerConfig())
 
-		results.PackageCatalog = packageCatalog
+		results.Packages = packageCatalog
 		results.LinuxDistribution = theDistro
 
 		return relationships, err

--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -54,7 +54,7 @@ func ToSyftModel(bom *cyclonedx.BOM) (*sbom.SBOM, error) {
 
 	s := &sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkg.NewCollection(),
+			Packages:          pkg.NewCollection(),
 			LinuxDistribution: linuxReleaseFromComponents(*bom.Components),
 		},
 		Source:     extractComponents(bom.Metadata),
@@ -95,7 +95,7 @@ func collectPackages(component *cyclonedx.Component, s *sbom.SBOM, idMap map[str
 		}
 		// TODO there must be a better way than needing to call this manually:
 		p.SetID()
-		s.Artifacts.PackageCatalog.Add(*p)
+		s.Artifacts.Packages.Add(*p)
 	}
 
 	if component.Components != nil {

--- a/syft/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder_test.go
@@ -210,7 +210,7 @@ func Test_decode(t *testing.T) {
 					assert.Equal(t, e.ver, sbom.Artifacts.LinuxDistribution.VersionID)
 				}
 				if e.pkg != "" {
-					for p := range sbom.Artifacts.PackageCatalog.Enumerate() {
+					for p := range sbom.Artifacts.Packages.Enumerate() {
 						if e.pkg != p.Name {
 							continue
 						}
@@ -238,7 +238,7 @@ func Test_decode(t *testing.T) {
 						if e.relation != "" {
 							foundRelation := false
 							for _, r := range sbom.Relationships {
-								p := sbom.Artifacts.PackageCatalog.Package(r.To.ID())
+								p := sbom.Artifacts.Packages.Package(r.To.ID())
 								if e.relation == p.Name {
 									foundRelation = true
 									break

--- a/syft/formats/common/cyclonedxhelpers/format.go
+++ b/syft/formats/common/cyclonedxhelpers/format.go
@@ -25,7 +25,7 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 	cdxBOM.SerialNumber = uuid.New().URN()
 	cdxBOM.Metadata = toBomDescriptor(internal.ApplicationName, s.Descriptor.Version, s.Source)
 
-	packages := s.Artifacts.PackageCatalog.Sorted()
+	packages := s.Artifacts.Packages.Sorted()
 	components := make([]cyclonedx.Component, len(packages))
 	for i, p := range packages {
 		components[i] = encodeComponent(p)

--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -123,10 +123,10 @@ func ToFormatModel(s sbom.SBOM) *spdx.Document {
 			// Cardinality: optional, one
 			CreatorComment: "",
 		},
-		Packages:      toPackages(s.Artifacts.PackageCatalog, s),
+		Packages:      toPackages(s.Artifacts.Packages, s),
 		Files:         toFiles(s),
 		Relationships: relationships,
-		OtherLicenses: toOtherLicenses(s.Artifacts.PackageCatalog),
+		OtherLicenses: toOtherLicenses(s.Artifacts.Packages),
 	}
 }
 

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -33,7 +33,7 @@ func ToSyftModel(doc *spdx.Document) (*sbom.SBOM, error) {
 	s := &sbom.SBOM{
 		Source: src,
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkg.NewCollection(),
+			Packages:          pkg.NewCollection(),
 			FileMetadata:      map[source.Coordinates]source.FileMetadata{},
 			FileDigests:       map[source.Coordinates][]file.Digest{},
 			LinuxDistribution: findLinuxReleaseByPURL(doc),
@@ -110,7 +110,7 @@ func collectSyftPackages(s *sbom.SBOM, spdxIDMap map[string]interface{}, doc *sp
 	for _, p := range doc.Packages {
 		syftPkg := toSyftPackage(p)
 		spdxIDMap[string(p.PackageSPDXIdentifier)] = syftPkg
-		s.Artifacts.PackageCatalog.Add(*syftPkg)
+		s.Artifacts.Packages.Add(*syftPkg)
 	}
 }
 

--- a/syft/formats/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model_test.go
@@ -91,7 +91,7 @@ func TestToSyftModel(t *testing.T) {
 
 	assert.NotNil(t, sbom)
 
-	pkgs := sbom.Artifacts.PackageCatalog.Sorted()
+	pkgs := sbom.Artifacts.Packages.Sorted()
 
 	assert.Len(t, pkgs, 2)
 

--- a/syft/formats/cyclonedxjson/decoder_test.go
+++ b/syft/formats/cyclonedxjson/decoder_test.go
@@ -57,7 +57,7 @@ func Test_decodeJSON(t *testing.T) {
 				split = strings.SplitN(pkg, ":", 2)
 				name = split[0]
 				version = split[1]
-				for p := range bom.Artifacts.PackageCatalog.Enumerate() {
+				for p := range bom.Artifacts.Packages.Enumerate() {
 					if p.Name == name {
 						assert.Equal(t, version, p.Version)
 						continue pkgs

--- a/syft/formats/cyclonedxxml/decoder_test.go
+++ b/syft/formats/cyclonedxxml/decoder_test.go
@@ -57,7 +57,7 @@ func Test_decodeXML(t *testing.T) {
 				split = strings.SplitN(pkg, ":", 2)
 				name = split[0]
 				version = split[1]
-				for p := range bom.Artifacts.PackageCatalog.Enumerate() {
+				for p := range bom.Artifacts.Packages.Enumerate() {
 					if p.Name == name {
 						assert.Equal(t, version, p.Version)
 						continue pkgs

--- a/syft/formats/github/encoder.go
+++ b/syft/formats/github/encoder.go
@@ -107,7 +107,7 @@ func toPath(s source.Metadata, p pkg.Package) string {
 func toGithubManifests(s *sbom.SBOM) Manifests {
 	manifests := map[string]*Manifest{}
 
-	for _, p := range s.Artifacts.PackageCatalog.Sorted() {
+	for _, p := range s.Artifacts.Packages.Sorted() {
 		path := toPath(s.Source, p)
 		manifest, ok := manifests[path]
 		if !ok {

--- a/syft/formats/github/encoder_test.go
+++ b/syft/formats/github/encoder_test.go
@@ -28,7 +28,7 @@ func Test_toGithubModel(t *testing.T) {
 				VersionID: "18.04",
 				IDLike:    []string{"debian"},
 			},
-			PackageCatalog: pkg.NewCollection(),
+			Packages: pkg.NewCollection(),
 		},
 	}
 	for _, p := range []pkg.Package{
@@ -71,7 +71,7 @@ func Test_toGithubModel(t *testing.T) {
 			nil,
 			"",
 		).ToString()
-		s.Artifacts.PackageCatalog.Add(p)
+		s.Artifacts.Packages.Add(p)
 	}
 
 	actual := toGithubModel(&s)

--- a/syft/formats/internal/testutils/utils.go
+++ b/syft/formats/internal/testutils/utils.go
@@ -119,7 +119,7 @@ func ImageInput(t testing.TB, testImage string, options ...ImageOption) sbom.SBO
 
 	return sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog: catalog,
+			Packages: catalog,
 			LinuxDistribution: &linux.Release{
 				PrettyName: "debian",
 				Name:       "debian",
@@ -200,7 +200,7 @@ func DirectoryInput(t testing.TB) sbom.SBOM {
 
 	return sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog: catalog,
+			Packages: catalog,
 			LinuxDistribution: &linux.Release{
 				PrettyName: "debian",
 				Name:       "debian",
@@ -231,7 +231,7 @@ func DirectoryInputWithAuthorField(t testing.TB) sbom.SBOM {
 
 	return sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog: catalog,
+			Packages: catalog,
 			LinuxDistribution: &linux.Release{
 				PrettyName: "debian",
 				Name:       "debian",
@@ -359,7 +359,7 @@ func newDirectoryCatalogWithAuthorField() *pkg.Collection {
 
 //nolint:gosec
 func AddSampleFileRelationships(s *sbom.SBOM) {
-	catalog := s.Artifacts.PackageCatalog.Sorted()
+	catalog := s.Artifacts.Packages.Sorted()
 	s.Artifacts.FileMetadata = map[source.Coordinates]source.FileMetadata{}
 
 	files := []string{"/f1", "/f2", "/d1/f3", "/d2/f4", "/z1/f5", "/a1/f6"}

--- a/syft/formats/spdxjson/decoder_test.go
+++ b/syft/formats/spdxjson/decoder_test.go
@@ -73,11 +73,11 @@ func TestSPDXJSONDecoder(t *testing.T) {
 			}
 
 			if test.packages != nil {
-				assert.Equal(t, sbom.Artifacts.PackageCatalog.PackageCount(), len(test.packages))
+				assert.Equal(t, sbom.Artifacts.Packages.PackageCount(), len(test.packages))
 
 			packages:
 				for _, pkgName := range test.packages {
-					for _, p := range sbom.Artifacts.PackageCatalog.Sorted() {
+					for _, p := range sbom.Artifacts.Packages.Sorted() {
 						if p.Name == pkgName {
 							continue packages
 						}

--- a/syft/formats/spdxtagvalue/encoder_test.go
+++ b/syft/formats/spdxtagvalue/encoder_test.go
@@ -49,7 +49,7 @@ func TestSPDXJSONSPDXIDs(t *testing.T) {
 		Format(),
 		sbom.SBOM{
 			Artifacts: sbom.Artifacts{
-				PackageCatalog: pkg.NewCollection(pkgs...),
+				Packages: pkg.NewCollection(pkgs...),
 			},
 			Relationships: nil,
 			Source: source.Metadata{

--- a/syft/formats/syftjson/decoder_test.go
+++ b/syft/formats/syftjson/decoder_test.go
@@ -29,8 +29,8 @@ func TestEncodeDecodeCycle(t *testing.T) {
 		t.Errorf("metadata difference: %+v", d)
 	}
 
-	actualPackages := actualSBOM.Artifacts.PackageCatalog.Sorted()
-	for idx, p := range originalSBOM.Artifacts.PackageCatalog.Sorted() {
+	actualPackages := actualSBOM.Artifacts.Packages.Sorted()
+	for idx, p := range originalSBOM.Artifacts.Packages.Sorted() {
 		if !assert.Equal(t, p.Name, actualPackages[idx].Name) {
 			t.Errorf("different package at idx=%d: %s vs %s", idx, p.Name, actualPackages[idx].Name)
 			continue

--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -100,7 +100,7 @@ func TestEncodeFullJSONDocument(t *testing.T) {
 
 	s := sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog: catalog,
+			Packages: catalog,
 			FileMetadata: map[source.Coordinates]source.FileMetadata{
 				source.NewLocation("/a/place").Coordinates: {
 					Mode:    0775,

--- a/syft/formats/syftjson/to_format_model.go
+++ b/syft/formats/syftjson/to_format_model.go
@@ -26,7 +26,7 @@ func ToFormatModel(s sbom.SBOM) model.Document {
 	}
 
 	return model.Document{
-		Artifacts:             toPackageModels(s.Artifacts.PackageCatalog),
+		Artifacts:             toPackageModels(s.Artifacts.Packages),
 		ArtifactRelationships: toRelationshipModel(s.Relationships),
 		Files:                 toFile(s),
 		Secrets:               toSecrets(s.Artifacts.Secrets),

--- a/syft/formats/syftjson/to_syft_model.go
+++ b/syft/formats/syftjson/to_syft_model.go
@@ -28,7 +28,7 @@ func toSyftModel(doc model.Document) (*sbom.SBOM, error) {
 
 	return &sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    catalog,
+			Packages:          catalog,
 			FileMetadata:      fileArtifacts.FileMetadata,
 			FileDigests:       fileArtifacts.FileDigests,
 			LinuxDistribution: toSyftLinuxRelease(doc.Distro),

--- a/syft/formats/syftjson/to_syft_model_test.go
+++ b/syft/formats/syftjson/to_syft_model_test.go
@@ -119,11 +119,11 @@ func Test_idsHaveChanged(t *testing.T) {
 
 	r := s.Relationships[0]
 
-	from := s.Artifacts.PackageCatalog.Package(r.From.ID())
+	from := s.Artifacts.Packages.Package(r.From.ID())
 	assert.NotNil(t, from)
 	assert.Equal(t, "pkg-1", from.Name)
 
-	to := s.Artifacts.PackageCatalog.Package(r.To.ID())
+	to := s.Artifacts.Packages.Package(r.To.ID())
 	assert.NotNil(t, to)
 	assert.Equal(t, "pkg-2", to.Name)
 }

--- a/syft/formats/table/encoder.go
+++ b/syft/formats/table/encoder.go
@@ -15,7 +15,7 @@ func encoder(output io.Writer, s sbom.SBOM) error {
 	var rows [][]string
 
 	columns := []string{"Name", "Version", "Type"}
-	for _, p := range s.Artifacts.PackageCatalog.Sorted() {
+	for _, p := range s.Artifacts.Packages.Sorted() {
 		row := []string{
 			p.Name,
 			p.Version,

--- a/syft/formats/text/encoder.go
+++ b/syft/formats/text/encoder.go
@@ -34,7 +34,7 @@ func encoder(output io.Writer, s sbom.SBOM) error {
 
 	// populate artifacts...
 	rows := 0
-	for _, p := range s.Artifacts.PackageCatalog.Sorted() {
+	for _, p := range s.Artifacts.Packages.Sorted() {
 		fmt.Fprintf(w, "[%s]\n", p.Name)
 		fmt.Fprintln(w, " Version:\t", p.Version)
 		fmt.Fprintln(w, " Type:\t", string(p.Type))

--- a/syft/pkg/cataloger/sbom/cataloger.go
+++ b/syft/pkg/cataloger/sbom/cataloger.go
@@ -42,7 +42,7 @@ func parseSBOM(_ source.FileResolver, _ *generic.Environment, reader source.Loca
 
 	var pkgs []pkg.Package
 	var relationships []artifact.Relationship
-	for _, p := range s.Artifacts.PackageCatalog.Sorted() {
+	for _, p := range s.Artifacts.Packages.Sorted() {
 		// replace all locations on the package with the location of the SBOM file.
 		// Why not keep the original list of locations? Since the "locations" field is meant to capture
 		// where there is evidence of this file, and the catalogers have not run against any file other than,

--- a/syft/sbom/sbom.go
+++ b/syft/sbom/sbom.go
@@ -20,7 +20,7 @@ type SBOM struct {
 }
 
 type Artifacts struct {
-	PackageCatalog    *pkg.Collection
+	Packages          *pkg.Collection
 	FileMetadata      map[source.Coordinates]source.FileMetadata
 	FileDigests       map[source.Coordinates][]file.Digest
 	FileContents      map[source.Coordinates]string

--- a/test/integration/all_layers_squashed_comparison_test.go
+++ b/test/integration/all_layers_squashed_comparison_test.go
@@ -11,8 +11,8 @@ func Test_AllLayersIncludesSquashed(t *testing.T) {
 	allLayers, _ := catalogFixtureImage(t, "image-suse-all-layers", source.AllLayersScope, nil)
 	squashed, _ := catalogFixtureImage(t, "image-suse-all-layers", source.SquashedScope, nil)
 
-	lenAllLayers := len(allLayers.Artifacts.PackageCatalog.Sorted())
-	lenSquashed := len(squashed.Artifacts.PackageCatalog.Sorted())
+	lenAllLayers := len(allLayers.Artifacts.Packages.Sorted())
+	lenSquashed := len(squashed.Artifacts.Packages.Sorted())
 
 	if lenAllLayers < lenSquashed {
 		t.Errorf("squashed has more packages than all-layers: %d > %d", lenSquashed, lenAllLayers)

--- a/test/integration/catalog_packages_test.go
+++ b/test/integration/catalog_packages_test.go
@@ -100,7 +100,7 @@ func TestPkgCoverageImage(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			pkgCount := 0
 
-			for a := range sbom.Artifacts.PackageCatalog.Enumerate(c.pkgType) {
+			for a := range sbom.Artifacts.Packages.Enumerate(c.pkgType) {
 				if a.Language.String() != "" {
 					observedLanguages.Add(a.Language.String())
 				}
@@ -127,7 +127,7 @@ func TestPkgCoverageImage(t *testing.T) {
 
 			if pkgCount != len(c.pkgInfo)+c.duplicates {
 				t.Logf("Discovered packages of type %+v", c.pkgType)
-				for a := range sbom.Artifacts.PackageCatalog.Enumerate(c.pkgType) {
+				for a := range sbom.Artifacts.Packages.Enumerate(c.pkgType) {
 					t.Log("   ", a)
 				}
 				t.Fatalf("unexpected package count: %d!=%d", pkgCount, len(c.pkgInfo))
@@ -176,7 +176,7 @@ func TestPkgCoverageDirectory(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actualPkgCount := 0
 
-			for actualPkg := range sbom.Artifacts.PackageCatalog.Enumerate(test.pkgType) {
+			for actualPkg := range sbom.Artifacts.Packages.Enumerate(test.pkgType) {
 				observedLanguages.Add(actualPkg.Language.String())
 				observedPkgs.Add(string(actualPkg.Type))
 
@@ -207,7 +207,7 @@ func TestPkgCoverageDirectory(t *testing.T) {
 			}
 
 			if actualPkgCount != len(test.pkgInfo)+test.duplicates {
-				for actualPkg := range sbom.Artifacts.PackageCatalog.Enumerate(test.pkgType) {
+				for actualPkg := range sbom.Artifacts.Packages.Enumerate(test.pkgType) {
 					t.Log("   ", actualPkg)
 				}
 				t.Fatalf("unexpected package count: %d!=%d", actualPkgCount, len(test.pkgInfo))
@@ -246,7 +246,7 @@ func TestPkgCoverageCatalogerConfiguration(t *testing.T) {
 	definedLanguages := internal.NewStringSet()
 	definedLanguages.Add("rust")
 
-	for actualPkg := range sbom.Artifacts.PackageCatalog.Enumerate() {
+	for actualPkg := range sbom.Artifacts.Packages.Enumerate() {
 		observedLanguages.Add(actualPkg.Language.String())
 	}
 
@@ -270,7 +270,7 @@ func TestPkgCoverageImage_HasEvidence(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			for a := range sbom.Artifacts.PackageCatalog.Enumerate(c.pkgType) {
+			for a := range sbom.Artifacts.Packages.Enumerate(c.pkgType) {
 				assert.NotEmpty(t, a.Locations.ToSlice(), "package %q has no locations (type=%q)", a.Name, a.Type)
 				for _, l := range a.Locations.ToSlice() {
 					if _, exists := l.Annotations[pkg.EvidenceAnnotationKey]; !exists {
@@ -300,7 +300,7 @@ func TestPkgCoverageDirectory_HasEvidence(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 
-			for a := range sbom.Artifacts.PackageCatalog.Enumerate(c.pkgType) {
+			for a := range sbom.Artifacts.Packages.Enumerate(c.pkgType) {
 				assert.NotEmpty(t, a.Locations.ToSlice(), "package %q has no locations (type=%q)", a.Name, a.Type)
 				for _, l := range a.Locations.ToSlice() {
 					if _, exists := l.Annotations[pkg.EvidenceAnnotationKey]; !exists {

--- a/test/integration/mariner_distroless_test.go
+++ b/test/integration/mariner_distroless_test.go
@@ -12,7 +12,7 @@ func TestMarinerDistroless(t *testing.T) {
 
 	expectedPkgs := 12
 	actualPkgs := 0
-	for range sbom.Artifacts.PackageCatalog.Enumerate(pkg.RpmPkg) {
+	for range sbom.Artifacts.Packages.Enumerate(pkg.RpmPkg) {
 		actualPkgs += 1
 	}
 

--- a/test/integration/node_packages_test.go
+++ b/test/integration/node_packages_test.go
@@ -14,7 +14,7 @@ func TestNpmPackageLockDirectory(t *testing.T) {
 
 	foundPackages := internal.NewStringSet()
 
-	for actualPkg := range sbom.Artifacts.PackageCatalog.Enumerate(pkg.NpmPkg) {
+	for actualPkg := range sbom.Artifacts.Packages.Enumerate(pkg.NpmPkg) {
 		for _, actualLocation := range actualPkg.Locations.ToSlice() {
 			if strings.Contains(actualLocation.RealPath, "node_modules") {
 				t.Errorf("found packages from package-lock.json in node_modules: %s", actualLocation)
@@ -36,7 +36,7 @@ func TestYarnPackageLockDirectory(t *testing.T) {
 	foundPackages := internal.NewStringSet()
 	expectedPackages := internal.NewStringSet("async@0.9.2", "async@3.2.3", "merge-objects@1.0.5", "should-type@1.3.0", "@4lolo/resize-observer-polyfill@1.5.2")
 
-	for actualPkg := range sbom.Artifacts.PackageCatalog.Enumerate(pkg.NpmPkg) {
+	for actualPkg := range sbom.Artifacts.Packages.Enumerate(pkg.NpmPkg) {
 		for _, actualLocation := range actualPkg.Locations.ToSlice() {
 			if strings.Contains(actualLocation.RealPath, "node_modules") {
 				t.Errorf("found packages from yarn.lock in node_modules: %s", actualLocation)

--- a/test/integration/package_deduplication_test.go
+++ b/test/integration/package_deduplication_test.go
@@ -65,15 +65,15 @@ func TestPackageDeduplication(t *testing.T) {
 		t.Run(string(tt.scope), func(t *testing.T) {
 			sbom, _ := catalogFixtureImage(t, "image-vertical-package-dups", tt.scope, nil)
 
-			for _, p := range sbom.Artifacts.PackageCatalog.Sorted() {
+			for _, p := range sbom.Artifacts.Packages.Sorted() {
 				if p.Type == pkg.BinaryPkg {
 					assert.NotEmpty(t, p.Name)
 				}
 			}
 
-			assert.Equal(t, tt.packageCount, sbom.Artifacts.PackageCatalog.PackageCount())
+			assert.Equal(t, tt.packageCount, sbom.Artifacts.Packages.PackageCount())
 			for name, expectedInstanceCount := range tt.instanceCount {
-				pkgs := sbom.Artifacts.PackageCatalog.PackagesByName(name)
+				pkgs := sbom.Artifacts.Packages.PackagesByName(name)
 
 				// with multiple packages with the same name, something is wrong (or this is the wrong fixture)
 				require.Len(t, pkgs, expectedInstanceCount)

--- a/test/integration/regression_apk_scanner_buffer_size_test.go
+++ b/test/integration/regression_apk_scanner_buffer_size_test.go
@@ -14,7 +14,7 @@ func TestRegression212ApkBufferSize(t *testing.T) {
 
 	expectedPkgs := 58
 	actualPkgs := 0
-	for range sbom.Artifacts.PackageCatalog.Enumerate(pkg.ApkPkg) {
+	for range sbom.Artifacts.Packages.Enumerate(pkg.ApkPkg) {
 		actualPkgs += 1
 	}
 

--- a/test/integration/regression_go_bin_scanner_arch_test.go
+++ b/test/integration/regression_go_bin_scanner_arch_test.go
@@ -20,7 +20,7 @@ func TestRegressionGoArchDiscovery(t *testing.T) {
 
 	var actualELF, actualWIN, actualMACOS int
 
-	for p := range sbom.Artifacts.PackageCatalog.Enumerate(pkg.GoModulePkg) {
+	for p := range sbom.Artifacts.Packages.Enumerate(pkg.GoModulePkg) {
 		for _, l := range p.Locations.ToSlice() {
 			switch {
 			case strings.Contains(l.RealPath, "elf"):

--- a/test/integration/rust_audit_binary_test.go
+++ b/test/integration/rust_audit_binary_test.go
@@ -12,7 +12,7 @@ func TestRustAudit(t *testing.T) {
 
 	expectedPkgs := 2
 	actualPkgs := 0
-	for range sbom.Artifacts.PackageCatalog.Enumerate(pkg.RustPkg) {
+	for range sbom.Artifacts.Packages.Enumerate(pkg.RustPkg) {
 		actualPkgs += 1
 	}
 

--- a/test/integration/sbom_cataloger_test.go
+++ b/test/integration/sbom_cataloger_test.go
@@ -17,7 +17,7 @@ func TestSbomCataloger(t *testing.T) {
 	expectedGoModCatalogerPkgs := 2
 	actualSbomPkgs := 0
 	actualGoModPkgs := 0
-	for pkg := range sbom.Artifacts.PackageCatalog.Enumerate(pkg.GoModulePkg) {
+	for pkg := range sbom.Artifacts.Packages.Enumerate(pkg.GoModulePkg) {
 		if pkg.FoundBy == "go-mod-file-cataloger" {
 			actualGoModPkgs += 1
 		} else if pkg.FoundBy == "sbom-cataloger" {

--- a/test/integration/sqlite_rpmdb_test.go
+++ b/test/integration/sqlite_rpmdb_test.go
@@ -16,7 +16,7 @@ func TestSqliteRpm(t *testing.T) {
 
 	expectedPkgs := 139
 	actualPkgs := 0
-	for range sbom.Artifacts.PackageCatalog.Enumerate(pkg.RpmPkg) {
+	for range sbom.Artifacts.Packages.Enumerate(pkg.RpmPkg) {
 		actualPkgs += 1
 	}
 

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -33,7 +33,7 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 
 	return sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkgCatalog,
+			Packages:          pkgCatalog,
 			LinuxDistribution: actualDistro,
 		},
 		Relationships: relationships,
@@ -68,7 +68,7 @@ func catalogDirectory(t *testing.T, dir string) (sbom.SBOM, *source.Source) {
 
 	return sbom.SBOM{
 		Artifacts: sbom.Artifacts{
-			PackageCatalog:    pkgCatalog,
+			Packages:          pkgCatalog,
 			LinuxDistribution: actualDistro,
 		},
 		Relationships: relationships,


### PR DESCRIPTION
Follow up to #1764 by renaming the `sbom.PackageCatalog` to `sbom.Packages` (related to the #558 work).