### PR TITLE
License set refactor

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/component.go
+++ b/syft/formats/common/cyclonedxhelpers/component.go
@@ -78,7 +78,7 @@ func decodeComponent(c *cyclonedx.Component) *pkg.Package {
 		Name:      c.Name,
 		Version:   c.Version,
 		Locations: decodeLocations(values),
-		Licenses:  decodeLicenses(c),
+		Licenses:  pkg.NewLicenseSet(decodeLicenses(c)...),
 		CPEs:      decodeCPEs(c),
 		PURL:      c.PackageURL,
 	}

--- a/syft/formats/common/cyclonedxhelpers/decoder_test.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder_test.go
@@ -280,7 +280,7 @@ func Test_missingDataDecode(t *testing.T) {
 		},
 	})
 
-	assert.Len(t, pkg.Licenses, 0)
+	assert.Len(t, pkg.Licenses.ToSlice(), 0)
 }
 
 func Test_missingComponentsDecode(t *testing.T) {

--- a/syft/formats/common/cyclonedxhelpers/external_references_test.go
+++ b/syft/formats/common/cyclonedxhelpers/external_references_test.go
@@ -50,7 +50,7 @@ func Test_encodeExternalReferences(t *testing.T) {
 				Language:     pkg.Rust,
 				Type:         pkg.RustPkg,
 				MetadataType: pkg.RustCargoPackageMetadataType,
-				Licenses:     nil,
+				Licenses:     pkg.NewLicenseSet(),
 				Metadata: pkg.CargoPackageMetadata{
 					Name:     "ansi_term",
 					Version:  "0.12.1",

--- a/syft/formats/common/cyclonedxhelpers/licenses.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses.go
@@ -85,7 +85,7 @@ func separateLicenses(p pkg.Package) (spdx, other cyclonedx.Licenses, expression
 			as a license choice and the invalid expression as a license string.
 
 	*/
-	for _, l := range p.Licenses {
+	for _, l := range p.Licenses.ToSlice() {
 		// singular expression case
 		if value, exists := spdxlicense.ID(l.SPDXExpression); exists {
 			spdxc = append(spdxc, cyclonedx.LicenseChoice{

--- a/syft/formats/common/cyclonedxhelpers/licenses.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses.go
@@ -44,9 +44,9 @@ func encodeLicenses(p pkg.Package) *cyclonedx.Licenses {
 }
 
 func decodeLicenses(c *cyclonedx.Component) []pkg.License {
-	licenses := make([]pkg.License, 0)
+	licenses := pkg.NewLicenseSet()
 	if c == nil || c.Licenses == nil {
-		return licenses
+		return licenses.ToSlice()
 	}
 
 	for _, l := range *c.Licenses {
@@ -56,16 +56,16 @@ func decodeLicenses(c *cyclonedx.Component) []pkg.License {
 		// these fields are mutually exclusive in the spec
 		switch {
 		case l.License.ID != "":
-			licenses = append(licenses, pkg.NewLicenseFromURL(l.License.ID, l.License.URL))
+			licenses.Add(pkg.NewLicenseFromURL(l.License.ID, l.License.URL))
 		case l.License.Name != "":
-			licenses = append(licenses, pkg.NewLicenseFromURL(l.License.Name, l.License.URL))
+			licenses.Add(pkg.NewLicenseFromURL(l.License.Name, l.License.URL))
 		case l.Expression != "":
-			licenses = append(licenses, pkg.NewLicenseFromURL(l.Expression, l.License.URL))
+			licenses.Add(pkg.NewLicenseFromURL(l.Expression, l.License.URL))
 		default:
 		}
 	}
 
-	return licenses
+	return licenses.ToSlice()
 }
 
 func separateLicenses(p pkg.Package) (spdx, other cyclonedx.Licenses, expressions []string) {

--- a/syft/formats/common/cyclonedxhelpers/licenses_test.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses_test.go
@@ -24,9 +24,9 @@ func Test_encodeLicense(t *testing.T) {
 		{
 			name: "no SPDX licenses",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("RandomLicense"),
-				},
+				),
 			},
 			expected: &cyclonedx.Licenses{
 				{
@@ -39,10 +39,10 @@ func Test_encodeLicense(t *testing.T) {
 		{
 			name: "single SPDX ID and Non SPDX ID",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("mit"),
 					pkg.NewLicense("FOOBAR"),
-				},
+				),
 			},
 			expected: &cyclonedx.Licenses{
 				{
@@ -60,9 +60,9 @@ func Test_encodeLicense(t *testing.T) {
 		{
 			name: "with complex SPDX license expression",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("MIT AND GPL-3.0-only"),
-				},
+				),
 			},
 			expected: &cyclonedx.Licenses{
 				{
@@ -73,10 +73,10 @@ func Test_encodeLicense(t *testing.T) {
 		{
 			name: "with multiple complex SPDX license expression",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("MIT AND GPL-3.0-only"),
 					pkg.NewLicense("MIT AND GPL-3.0-only WITH Classpath-exception-2.0"),
-				},
+				),
 			},
 			expected: &cyclonedx.Licenses{
 				{

--- a/syft/formats/common/spdxhelpers/license.go
+++ b/syft/formats/common/spdxhelpers/license.go
@@ -17,15 +17,16 @@ func License(p pkg.Package) (concluded, declared string) {
 	//   (i) the SPDX file creator has attempted to but cannot reach a reasonable objective determination;
 	//   (ii) the SPDX file creator has made no attempt to determine this field; or
 	//   (iii) the SPDX file creator has intentionally provided no information (no meaning should be implied by doing so).
+	licenses := p.Licenses.ToSlice()
 
-	if len(p.Licenses) == 0 {
+	if len(licenses) == 0 {
 		return NOASSERTION, NOASSERTION
 	}
 
 	// take all licenses and assume an AND expression;
 	// for information about license expressions see:
 	// https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/
-	pc, pd := parseLicenses(p.Licenses)
+	pc, pd := parseLicenses(licenses)
 
 	for i, v := range pc {
 		if strings.HasPrefix(v, spdxlicense.LicenseRefPrefix) {

--- a/syft/formats/common/spdxhelpers/license_test.go
+++ b/syft/formats/common/spdxhelpers/license_test.go
@@ -28,7 +28,7 @@ func Test_License(t *testing.T) {
 		{
 			name: "no SPDX licenses",
 			input: pkg.Package{
-				Licenses: []pkg.License{pkg.NewLicense("made-up")},
+				Licenses: pkg.NewLicenseSet(pkg.NewLicense("made-up")),
 			},
 			expected: struct{ concluded, declared string }{
 				concluded: "NOASSERTION",
@@ -38,7 +38,7 @@ func Test_License(t *testing.T) {
 		{
 			name: "with SPDX license",
 			input: pkg.Package{
-				Licenses: []pkg.License{pkg.NewLicense("MIT")},
+				Licenses: pkg.NewLicenseSet(pkg.NewLicense("MIT")),
 			},
 			expected: struct {
 				concluded string
@@ -51,51 +51,51 @@ func Test_License(t *testing.T) {
 		{
 			name: "with SPDX license expression",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("MIT"),
 					pkg.NewLicense("GPL-3.0-only"),
-				},
+				),
 			},
 			expected: struct {
 				concluded string
 				declared  string
 			}{
 				concluded: "NOASSERTION",
-				declared:  "MIT AND GPL-3.0-only",
+				declared:  "GPL-3.0-only AND MIT",
 			},
 		},
 		{
 			name: "includes valid LicenseRef-",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("one thing first"),
 					pkg.NewLicense("two things/#$^second"),
 					pkg.NewLicense("MIT"),
-				},
+				),
 			},
 			expected: struct {
 				concluded string
 				declared  string
 			}{
 				concluded: "NOASSERTION",
-				declared:  "LicenseRef-one-thing-first AND LicenseRef-two-things----second AND MIT",
+				declared:  "MIT AND LicenseRef-one-thing-first AND LicenseRef-two-things----second",
 			},
 		},
 		{
 			name: "join parentheses correctly",
 			input: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("one thing first"),
 					pkg.NewLicense("MIT AND GPL-3.0-only"),
 					pkg.NewLicense("MIT OR APACHE-2.0"),
-				},
+				),
 			},
 			expected: struct {
 				concluded string
 				declared  string
 			}{
 				concluded: "NOASSERTION",
-				declared:  "LicenseRef-one-thing-first AND (MIT AND GPL-3.0-only) AND (MIT OR APACHE-2.0)",
+				declared:  "(MIT AND GPL-3.0-only) AND (MIT OR APACHE-2.0) AND LicenseRef-one-thing-first",
 			},
 		},
 	}

--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -522,7 +522,8 @@ func toFileTypes(metadata *source.FileMetadata) (ty []string) {
 func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 	licenses := map[string]bool{}
 	for _, p := range catalog.Sorted() {
-		declaredLicenses, concludedLicenses := parseLicenses(p.Licenses)
+		packageLicenses := p.Licenses.ToSlice()
+		declaredLicenses, concludedLicenses := parseLicenses(packageLicenses)
 		for _, license := range declaredLicenses {
 			if strings.HasPrefix(license, spdxlicense.LicenseRefPrefix) {
 				licenses[license] = true

--- a/syft/formats/common/spdxhelpers/to_format_model_test.go
+++ b/syft/formats/common/spdxhelpers/to_format_model_test.go
@@ -447,16 +447,16 @@ func Test_OtherLicenses(t *testing.T) {
 		{
 			name: "no licenseRef",
 			pkg: pkg.Package{
-				Licenses: []pkg.License{},
+				Licenses: pkg.NewLicenseSet(),
 			},
 			expected: nil,
 		},
 		{
 			name: "single licenseRef",
 			pkg: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("foobar"),
-				},
+				),
 			},
 			expected: []*spdx.OtherLicense{
 				{
@@ -468,10 +468,10 @@ func Test_OtherLicenses(t *testing.T) {
 		{
 			name: "multiple licenseRef",
 			pkg: pkg.Package{
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicense("internal made up license name"),
 					pkg.NewLicense("new apple license 2.0"),
-				},
+				),
 			},
 			expected: []*spdx.OtherLicense{
 				{

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -280,7 +280,7 @@ func toSyftPackage(p *spdx.Package) *pkg.Package {
 		Type:         info.typ,
 		Name:         p.PackageName,
 		Version:      p.PackageVersion,
-		Licenses:     parseSPDXLicenses(p),
+		Licenses:     pkg.NewLicenseSet(parseSPDXLicenses(p)...),
 		CPEs:         extractCPEs(p),
 		PURL:         info.purl.String(),
 		Language:     info.lang,

--- a/syft/formats/internal/testutils/utils.go
+++ b/syft/formats/internal/testutils/utils.go
@@ -162,9 +162,9 @@ func populateImageCatalog(catalog *pkg.Collection, img *image.Image) {
 		FoundBy:      "the-cataloger-1",
 		Language:     pkg.Python,
 		MetadataType: pkg.PythonPackageMetadataType,
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicense("MIT"),
-		},
+		),
 		Metadata: pkg.PythonPackageMetadata{
 			Name:    "package-1",
 			Version: "1.0.1",
@@ -270,9 +270,9 @@ func newDirectoryCatalog() *pkg.Collection {
 		),
 		Language:     pkg.Python,
 		MetadataType: pkg.PythonPackageMetadataType,
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicense("MIT"),
-		},
+		),
 		Metadata: pkg.PythonPackageMetadata{
 			Name:    "package-1",
 			Version: "1.0.1",
@@ -323,9 +323,9 @@ func newDirectoryCatalogWithAuthorField() *pkg.Collection {
 		),
 		Language:     pkg.Python,
 		MetadataType: pkg.PythonPackageMetadataType,
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicense("MIT"),
-		},
+		),
 		Metadata: pkg.PythonPackageMetadata{
 			Name:    "package-1",
 			Version: "1.0.1",

--- a/syft/formats/syftjson/encoder_test.go
+++ b/syft/formats/syftjson/encoder_test.go
@@ -61,7 +61,7 @@ func TestEncodeFullJSONDocument(t *testing.T) {
 		FoundBy:      "the-cataloger-1",
 		Language:     pkg.Python,
 		MetadataType: pkg.PythonPackageMetadataType,
-		Licenses:     []pkg.License{pkg.NewLicense("MIT")},
+		Licenses:     pkg.NewLicenseSet(pkg.NewLicense("MIT")),
 		Metadata: pkg.PythonPackageMetadata{
 			Name:    "package-1",
 			Version: "1.0.1",

--- a/syft/formats/syftjson/to_format_model.go
+++ b/syft/formats/syftjson/to_format_model.go
@@ -194,8 +194,8 @@ func toPackageModel(p pkg.Package) model.Package {
 	// we want to make sure all catalogers are
 	// initializing the array; this is a good choke point for this check
 	var licenses = make([]pkg.License, 0)
-	if p.Licenses != nil {
-		licenses = p.Licenses
+	if len(p.Licenses.ToSlice()) > 0 {
+		licenses = p.Licenses.ToSlice()
 	}
 
 	return model.Package{

--- a/syft/formats/syftjson/to_syft_model.go
+++ b/syft/formats/syftjson/to_syft_model.go
@@ -276,12 +276,14 @@ func toSyftPackage(p model.Package, idAliases map[string]string) pkg.Package {
 		cpes = append(cpes, value)
 	}
 
+	licenseSet := pkg.NewLicenseSet(p.Licenses...)
+
 	out := pkg.Package{
 		Name:         p.Name,
 		Version:      p.Version,
 		FoundBy:      p.FoundBy,
 		Locations:    source.NewLocationSet(p.Locations...),
-		Licenses:     p.Licenses,
+		Licenses:     licenseSet,
 		Language:     p.Language,
 		Type:         p.Type,
 		CPEs:         cpes,

--- a/syft/pkg/cataloger/alpm/cataloger_test.go
+++ b/syft/pkg/cataloger/alpm/cataloger_test.go
@@ -14,16 +14,17 @@ import (
 
 func TestAlpmCataloger(t *testing.T) {
 	dbLocation := source.NewLocation("var/lib/pacman/local/gmp-6.2.1-2/desc")
+	licenses := []pkg.License{
+		pkg.NewLicenseFromLocation("LGPL3", dbLocation),
+		pkg.NewLicenseFromLocation("GPL", dbLocation),
+	}
 	expectedPkgs := []pkg.Package{
 		{
-			Name:    "gmp",
-			Version: "6.2.1-2",
-			Type:    pkg.AlpmPkg,
-			FoundBy: "alpmdb-cataloger",
-			Licenses: []pkg.License{
-				pkg.NewLicenseFromLocation("LGPL3", dbLocation),
-				pkg.NewLicenseFromLocation("GPL", dbLocation),
-			},
+			Name:         "gmp",
+			Version:      "6.2.1-2",
+			Type:         pkg.AlpmPkg,
+			FoundBy:      "alpmdb-cataloger",
+			Licenses:     pkg.NewLicenseSet(licenses...),
 			Locations:    source.NewLocationSet(dbLocation),
 			CPEs:         nil,
 			PURL:         "",

--- a/syft/pkg/cataloger/alpm/package.go
+++ b/syft/pkg/cataloger/alpm/package.go
@@ -11,12 +11,12 @@ import (
 
 func newPackage(m *parsedData, release *linux.Release, dbLocation source.Location) pkg.Package {
 	licenseCandidates := strings.Split(m.Licenses, "\n")
-
+	licenseList := pkg.NewLicensesFromLocation(dbLocation.WithoutAnnotations(), licenseCandidates...)
 	p := pkg.Package{
 		Name:         m.Package,
 		Version:      m.Version,
 		Locations:    source.NewLocationSet(dbLocation),
-		Licenses:     pkg.NewLicensesFromLocation(dbLocation.WithoutAnnotations(), licenseCandidates...),
+		Licenses:     pkg.NewLicenseSet(licenseList...),
 		Type:         pkg.AlpmPkg,
 		PURL:         packageURL(m, release),
 		MetadataType: pkg.AlpmMetadataType,

--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -10,13 +10,18 @@ import (
 )
 
 func newPackage(d parsedData, release *linux.Release, dbLocation source.Location) pkg.Package {
-	licenseStrings := strings.Split(d.License, " ")
+	licenses := pkg.NewLicenseSet(
+		pkg.NewLicensesFromLocation(
+			dbLocation,
+			strings.Split(d.License, " ")...,
+		)...,
+	)
 
 	p := pkg.Package{
 		Name:         d.Package,
 		Version:      d.Version,
 		Locations:    source.NewLocationSet(dbLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-		Licenses:     pkg.NewLicensesFromLocation(dbLocation, licenseStrings...),
+		Licenses:     licenses,
 		PURL:         packageURL(d.ApkMetadata, release),
 		Type:         pkg.ApkPkg,
 		MetadataType: pkg.ApkMetadataType,

--- a/syft/pkg/cataloger/cpp/parse_conanfile_test.go
+++ b/syft/pkg/cataloger/cpp/parse_conanfile_test.go
@@ -12,12 +12,14 @@ import (
 func TestParseConanfile(t *testing.T) {
 	fixture := "test-fixtures/conanfile.txt"
 	fixtureLocationSet := source.NewLocationSet(source.NewLocation(fixture))
+	fixtureLicenseSet := pkg.NewLicenseSet()
 	expected := []pkg.Package{
 		{
 			Name:         "catch2",
 			Version:      "2.13.8",
 			PURL:         "pkg:conan/catch2@2.13.8",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -30,6 +32,7 @@ func TestParseConanfile(t *testing.T) {
 			Version:      "0.6.3",
 			PURL:         "pkg:conan/docopt.cpp@0.6.3",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -42,6 +45,7 @@ func TestParseConanfile(t *testing.T) {
 			Version:      "8.1.1",
 			PURL:         "pkg:conan/fmt@8.1.1",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -54,6 +58,7 @@ func TestParseConanfile(t *testing.T) {
 			Version:      "1.9.2",
 			PURL:         "pkg:conan/spdlog@1.9.2",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -66,6 +71,7 @@ func TestParseConanfile(t *testing.T) {
 			Version:      "2.0.20",
 			PURL:         "pkg:conan/sdl@2.0.20",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,
@@ -78,6 +84,7 @@ func TestParseConanfile(t *testing.T) {
 			Version:      "1.3.8",
 			PURL:         "pkg:conan/fltk@1.3.8",
 			Locations:    fixtureLocationSet,
+			Licenses:     fixtureLicenseSet,
 			Language:     pkg.CPP,
 			Type:         pkg.ConanPkg,
 			MetadataType: pkg.ConanMetadataType,

--- a/syft/pkg/cataloger/deb/cataloger_test.go
+++ b/syft/pkg/cataloger/deb/cataloger_test.go
@@ -16,11 +16,9 @@ func TestDpkgCataloger(t *testing.T) {
 			Name:    "libpam-runtime",
 			Version: "1.1.8-3.6",
 			FoundBy: "dpkgdb-cataloger",
-			Licenses: []pkg.License{
-				pkg.NewLicenseFromLocation("GPL-1", licenseLocation),
-				pkg.NewLicenseFromLocation("GPL-2", licenseLocation),
-				pkg.NewLicenseFromLocation("LGPL-2.1", licenseLocation),
-			},
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicensesFromLocation(licenseLocation, "GPL-1", "GPL-2", "LGPL-2.1")...,
+			),
 			Locations: source.NewLocationSet(
 				source.NewVirtualLocation("/var/lib/dpkg/status", "/var/lib/dpkg/status"),
 				source.NewVirtualLocation("/var/lib/dpkg/info/libpam-runtime.md5sums", "/var/lib/dpkg/info/libpam-runtime.md5sums"),
@@ -82,7 +80,7 @@ func TestDpkgCataloger(t *testing.T) {
 
 	pkgtest.NewCatalogTester().
 		WithImageResolver(t, "image-dpkg").
-		IgnoreLocationLayer(). // this fixture can be rebuilt, thus the layer ID will change
+		IgnoreLocationLayer().
 		Expects(expected, nil).
 		TestCataloger(t, c)
 }

--- a/syft/pkg/cataloger/deb/package.go
+++ b/syft/pkg/cataloger/deb/package.go
@@ -23,11 +23,10 @@ const (
 
 func newDpkgPackage(d pkg.DpkgMetadata, dbLocation source.Location, resolver source.FileResolver, release *linux.Release) pkg.Package {
 	// TODO: separate pr to license refactor, but explore extracting dpkg-specific license parsing into a separate function
-	licenses := make([]pkg.License, 0)
 	p := pkg.Package{
 		Name:         d.Package,
 		Version:      d.Version,
-		Licenses:     licenses,
+		Licenses:     pkg.NewLicenseSet(),
 		Locations:    source.NewLocationSet(dbLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
 		PURL:         packageURL(d, release),
 		Type:         pkg.DebPkg,

--- a/syft/pkg/cataloger/deb/package.go
+++ b/syft/pkg/cataloger/deb/package.go
@@ -95,10 +95,12 @@ func addLicenses(resolver source.FileResolver, dbLocation source.Location, p *pk
 	if copyrightReader != nil && copyrightLocation != nil {
 		defer internal.CloseAndLogError(copyrightReader, copyrightLocation.VirtualPath)
 		// attach the licenses
-		licenseStrs := parseLicensesFromCopyright(copyrightReader)
-		for _, licenseStr := range licenseStrs {
-			p.Licenses = append(p.Licenses, pkg.NewLicenseFromLocation(licenseStr, copyrightLocation.WithoutAnnotations()))
-		}
+		p.Licenses.Add(
+			pkg.NewLicensesFromLocation(
+				copyrightLocation.WithoutAnnotations(),
+				parseLicensesFromCopyright(copyrightReader)...,
+			)...,
+		)
 		// keep a record of the file where this was discovered
 		p.Locations.Add(*copyrightLocation)
 	}

--- a/syft/pkg/cataloger/deb/parse_dpkg_db_test.go
+++ b/syft/pkg/cataloger/deb/parse_dpkg_db_test.go
@@ -307,7 +307,7 @@ Installed-Size: 10kib
 					Name:         "apt",
 					Type:         "deb",
 					PURL:         "pkg:deb/debian/apt?distro=debian-10",
-					Licenses:     []pkg.License{},
+					Licenses:     pkg.NewLicenseSet(),
 					Locations:    source.NewLocationSet(source.NewLocation("place")),
 					MetadataType: "DpkgMetadata",
 					Metadata: pkg.DpkgMetadata{

--- a/syft/pkg/cataloger/golang/package.go
+++ b/syft/pkg/cataloger/golang/package.go
@@ -24,7 +24,7 @@ func (c *goBinaryCataloger) newGoBinaryPackage(resolver source.FileResolver, dep
 	p := pkg.Package{
 		Name:         dep.Path,
 		Version:      dep.Version,
-		Licenses:     licenses,
+		Licenses:     pkg.NewLicenseSet(licenses...),
 		PURL:         packageURL(dep.Path, dep.Version),
 		Language:     pkg.Go,
 		Type:         pkg.GoModulePkg,

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -497,9 +497,6 @@ func TestBuildGoPkgInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			for i := range test.expected {
 				p := &test.expected[i]
-				if p.Licenses == nil {
-					p.Licenses = []pkg.License{}
-				}
 				p.SetID()
 			}
 			location := source.NewLocationFromCoordinates(

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -50,7 +50,7 @@ func (c *goModCataloger) parseGoModFile(resolver source.FileResolver, _ *generic
 		packages[m.Mod.Path] = pkg.Package{
 			Name:         m.Mod.Path,
 			Version:      m.Mod.Version,
-			Licenses:     licenses,
+			Licenses:     pkg.NewLicenseSet(licenses...),
 			Locations:    source.NewLocationSet(reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
 			PURL:         packageURL(m.Mod.Path, m.Mod.Version),
 			Language:     pkg.Go,
@@ -72,7 +72,7 @@ func (c *goModCataloger) parseGoModFile(resolver source.FileResolver, _ *generic
 		packages[m.New.Path] = pkg.Package{
 			Name:         m.New.Path,
 			Version:      m.New.Version,
-			Licenses:     licenses,
+			Licenses:     pkg.NewLicenseSet(licenses...),
 			Locations:    source.NewLocationSet(reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
 			PURL:         packageURL(m.New.Path, m.New.Version),
 			Language:     pkg.Go,

--- a/syft/pkg/cataloger/golang/parse_go_mod_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod_test.go
@@ -21,6 +21,7 @@ func TestParseGoMod(t *testing.T) {
 					Version:      "v1.3.1",
 					PURL:         "pkg:golang/github.com/bmatcuk/doublestar@v1.3.1",
 					Locations:    source.NewLocationSet(source.NewLocation("test-fixtures/one-package")),
+					Licenses:     pkg.NewLicenseSet(),
 					Language:     pkg.Go,
 					Type:         pkg.GoModulePkg,
 					MetadataType: pkg.GolangModMetadataType,
@@ -37,6 +38,7 @@ func TestParseGoMod(t *testing.T) {
 					Version:      "v0.0.0-20200624184116-66aa578126db",
 					PURL:         "pkg:golang/github.com/anchore/go-testutils@v0.0.0-20200624184116-66aa578126db",
 					Locations:    source.NewLocationSet(source.NewLocation("test-fixtures/many-packages")),
+					Licenses:     pkg.NewLicenseSet(),
 					Language:     pkg.Go,
 					Type:         pkg.GoModulePkg,
 					MetadataType: pkg.GolangModMetadataType,
@@ -88,12 +90,6 @@ func TestParseGoMod(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.fixture, func(t *testing.T) {
-			for i := range test.expected {
-				p := &test.expected[i]
-				if p.Licenses == nil {
-					p.Licenses = []pkg.License{}
-				}
-			}
 			c := goModCataloger{}
 			pkgtest.NewCatalogTester().
 				FromFile(t, test.fixture).
@@ -116,6 +112,7 @@ func Test_GoSumHashes(t *testing.T) {
 					Version:      "v0.6.0",
 					PURL:         "pkg:golang/github.com/CycloneDX/cyclonedx-go@v0.6.0",
 					Locations:    source.NewLocationSet(source.NewLocation("go.mod")),
+					Licenses:     pkg.NewLicenseSet(),
 					FoundBy:      "go-mod-file-cataloger",
 					Language:     pkg.Go,
 					Type:         pkg.GoModulePkg,
@@ -127,6 +124,7 @@ func Test_GoSumHashes(t *testing.T) {
 					Version:      "v0.0.0-20180116102854-5a71ef0e047d",
 					PURL:         "pkg:golang/github.com/acarl005/stripansi@v0.0.0-20180116102854-5a71ef0e047d",
 					Locations:    source.NewLocationSet(source.NewLocation("go.mod")),
+					Licenses:     pkg.NewLicenseSet(),
 					FoundBy:      "go-mod-file-cataloger",
 					Language:     pkg.Go,
 					Type:         pkg.GoModulePkg,
@@ -154,12 +152,6 @@ func Test_GoSumHashes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.fixture, func(t *testing.T) {
-			for i := range test.expected {
-				p := &test.expected[i]
-				if p.Licenses == nil {
-					p.Licenses = []pkg.License{}
-				}
-			}
 			pkgtest.NewCatalogTester().
 				FromDirectory(t, test.fixture).
 				Expects(test.expected, nil).

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -147,6 +147,11 @@ func (p *CatalogTester) IgnoreLocationLayer() *CatalogTester {
 	p.locationComparer = func(x, y source.Location) bool {
 		return cmp.Equal(x.Coordinates.RealPath, y.Coordinates.RealPath) && cmp.Equal(x.VirtualPath, y.VirtualPath)
 	}
+
+	// we need to update the license comparer to use the ignored location layer
+	p.licenseComparer = func(x, y pkg.License) bool {
+		return cmp.Equal(x, y, cmp.Comparer(p.locationComparer))
+	}
 	return p
 }
 

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -64,7 +64,7 @@ func DefaultLocationComparer(x, y source.Location) bool {
 }
 
 func DefaultLicenseComparer(x, y pkg.License) bool {
-	return cmp.Equal(x, y, cmpopts.IgnoreFields(pkg.License{}, "Location"))
+	return cmp.Equal(x, y, cmp.Comparer(DefaultLocationComparer))
 }
 
 func (p *CatalogTester) FromDirectory(t *testing.T, path string) *CatalogTester {

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -334,7 +334,28 @@ func AssertPackagesEqual(t *testing.T, a, b pkg.Package) {
 			},
 		),
 		cmp.Comparer(
+			func(x, y pkg.LicenseSet) bool {
+				xs := x.ToSlice()
+				ys := y.ToSlice()
+
+				if len(xs) != len(ys) {
+					return false
+				}
+				for i, xe := range xs {
+					ye := ys[i]
+					if !DefaultLicenseComparer(xe, ye) {
+						return false
+					}
+				}
+
+				return true
+			},
+		),
+		cmp.Comparer(
 			DefaultLocationComparer,
+		),
+		cmp.Comparer(
+			DefaultLicenseComparer,
 		),
 	}
 

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -64,16 +64,7 @@ func DefaultLocationComparer(x, y source.Location) bool {
 }
 
 func DefaultLicenseComparer(x, y pkg.License) bool {
-	xh, err := x.Hash()
-	if err != nil {
-		return false
-	}
-	yh, err := y.Hash()
-	if err != nil {
-		return false
-	}
-
-	return cmp.Equal(xh, yh)
+	return cmp.Equal(x, y, cmpopts.IgnoreFields(pkg.License{}, "Location"))
 }
 
 func (p *CatalogTester) FromDirectory(t *testing.T, path string) *CatalogTester {

--- a/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
+++ b/syft/pkg/cataloger/internal/pkgtest/test_generic_parser.go
@@ -222,6 +222,7 @@ func (p *CatalogTester) TestCataloger(t *testing.T, cataloger pkg.Cataloger) {
 	}
 }
 
+// nolint:funlen
 func (p *CatalogTester) assertPkgs(t *testing.T, pkgs []pkg.Package, relationships []artifact.Relationship) {
 	t.Helper()
 

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -189,10 +189,12 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		Name:     selectName(manifest, j.fileInfo),
 		Version:  selectVersion(manifest, j.fileInfo),
 		Language: pkg.Java,
-		Licenses: pkg.NewLicensesFromLocation(
-			// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
-			j.location,
-			selectLicenses(manifest)...,
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicensesFromLocation(
+				// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
+				j.location,
+				selectLicenses(manifest)...,
+			)...,
 		),
 		Locations: source.NewLocationSet(
 			j.location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -99,9 +99,9 @@ func TestParseJar(t *testing.T) {
 					Name:    "example-jenkins-plugin",
 					Version: "1.0-SNAPSHOT",
 					PURL:    "pkg:maven/io.jenkins.plugins/example-jenkins-plugin@1.0-SNAPSHOT",
-					Licenses: []pkg.License{
+					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromLocation("MIT License", source.NewLocation("test-fixtures/java-builds/packages/example-jenkins-plugin.hpi")),
-					},
+					),
 					Language:     pkg.Java,
 					Type:         pkg.JenkinsPluginPkg,
 					MetadataType: pkg.JavaMetadataType,

--- a/syft/pkg/cataloger/javascript/cataloger_test.go
+++ b/syft/pkg/cataloger/javascript/cataloger_test.go
@@ -19,9 +19,9 @@ func Test_JavascriptCataloger(t *testing.T) {
 			Locations: locationSet,
 			Language:  pkg.JavaScript,
 			Type:      pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation("package-lock.json")),
-			},
+			),
 			MetadataType: pkg.NpmPackageLockJSONMetadataType,
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz", Integrity: "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw=="},
 		},
@@ -44,9 +44,9 @@ func Test_JavascriptCataloger(t *testing.T) {
 			Locations: locationSet,
 			Language:  pkg.JavaScript,
 			Type:      pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation("package-lock.json")),
-			},
+			),
 			MetadataType: pkg.NpmPackageLockJSONMetadataType,
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/cowsay/-/cowsay-1.4.0.tgz", Integrity: "sha512-rdg5k5PsHFVJheO/pmE3aDg2rUDDTfPJau6yYkZYlHFktUz+UxbE+IgnUAEyyCyv4noL5ltxXD0gZzmHPCy/9g=="},
 		},

--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -19,12 +19,14 @@ func newPackageJSONPackage(u packageJSON, indexLocation source.Location) pkg.Pac
 	}
 
 	p := pkg.Package{
-		Name:         u.Name,
-		Version:      u.Version,
-		PURL:         packageURL(u.Name, u.Version),
-		Locations:    source.NewLocationSet(indexLocation),
-		Language:     pkg.JavaScript,
-		Licenses:     pkg.NewLicensesFromLocation(indexLocation, licenseCandidates...),
+		Name:      u.Name,
+		Version:   u.Version,
+		PURL:      packageURL(u.Name, u.Version),
+		Locations: source.NewLocationSet(indexLocation),
+		Language:  pkg.JavaScript,
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicensesFromLocation(indexLocation, licenseCandidates...)...,
+		),
 		Type:         pkg.NpmPkg,
 		MetadataType: pkg.NpmPackageJSONMetadataType,
 		Metadata: pkg.NpmPackageJSONMetadata{
@@ -80,10 +82,12 @@ func newPackageLockV2Package(resolver source.FileResolver, location source.Locat
 		resolver,
 		location,
 		pkg.Package{
-			Name:         name,
-			Version:      u.Version,
-			Locations:    source.NewLocationSet(location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-			Licenses:     pkg.NewLicensesFromLocation(location, u.License...),
+			Name:      name,
+			Version:   u.Version,
+			Locations: source.NewLocationSet(location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicensesFromLocation(location, u.License...)...,
+			),
 			PURL:         packageURL(name, u.Version),
 			Language:     pkg.JavaScript,
 			Type:         pkg.NpmPkg,
@@ -125,7 +129,7 @@ func newYarnLockPackage(resolver source.FileResolver, location source.Location, 
 
 func finalizeLockPkg(resolver source.FileResolver, location source.Location, p pkg.Package) pkg.Package {
 	licenseCandidate := addLicenses(p.Name, resolver, location)
-	p.Licenses = append(p.Licenses, pkg.NewLicensesFromLocation(location, licenseCandidate...)...)
+	p.Licenses.Add(pkg.NewLicensesFromLocation(location, licenseCandidate...)...)
 	p.SetID()
 	return p
 }

--- a/syft/pkg/cataloger/javascript/parse_package_json_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json_test.go
@@ -23,9 +23,9 @@ func TestParsePackageJSON(t *testing.T) {
 				PURL:     "pkg:npm/npm@6.14.6",
 				Type:     pkg.NpmPkg,
 				Language: pkg.JavaScript,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("Artistic-2.0", source.NewLocation("test-fixtures/pkg-json/package.json")),
-				},
+				),
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
 					Name:        "npm",
@@ -45,9 +45,9 @@ func TestParsePackageJSON(t *testing.T) {
 				PURL:     "pkg:npm/npm@6.14.6",
 				Type:     pkg.NpmPkg,
 				Language: pkg.JavaScript,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("ISC", source.NewLocation("test-fixtures/pkg-json/package-license-object.json")),
-				},
+				),
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
 					Name:        "npm",
@@ -66,10 +66,9 @@ func TestParsePackageJSON(t *testing.T) {
 				Version: "6.14.6",
 				PURL:    "pkg:npm/npm@6.14.6",
 				Type:    pkg.NpmPkg,
-				Licenses: []pkg.License{
-					pkg.NewLicenseFromLocation("MIT", source.NewLocation("test-fixtures/pkg-json/package-license-objects.json")),
-					pkg.NewLicenseFromLocation("Apache-2.0", source.NewLocation("test-fixtures/pkg-json/package-license-objects.json")),
-				},
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicensesFromLocation(source.NewLocation("test-fixtures/pkg-json/package-license-objects.json"), "MIT", "Apache-2.0")...,
+				),
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
@@ -127,9 +126,9 @@ func TestParsePackageJSON(t *testing.T) {
 				Version: "6.14.6",
 				PURL:    "pkg:npm/npm@6.14.6",
 				Type:    pkg.NpmPkg,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("Artistic-2.0", source.NewLocation("test-fixtures/pkg-json/package-nested-author.json")),
-				},
+				),
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
@@ -149,9 +148,9 @@ func TestParsePackageJSON(t *testing.T) {
 				Version: "1.1.1",
 				PURL:    "pkg:npm/function-bind@1.1.1",
 				Type:    pkg.NpmPkg,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("MIT", source.NewLocation("test-fixtures/pkg-json/package-repo-string.json")),
-				},
+				),
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{
@@ -171,9 +170,9 @@ func TestParsePackageJSON(t *testing.T) {
 				Version: "6.14.6",
 				PURL:    "pkg:npm/npm@6.14.6",
 				Type:    pkg.NpmPkg,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("Artistic-2.0", source.NewLocation("test-fixtures/pkg-json/package-private.json")),
-				},
+				),
 				Language:     pkg.JavaScript,
 				MetadataType: pkg.NpmPackageJSONMetadataType,
 				Metadata: pkg.NpmPackageJSONMetadata{

--- a/syft/pkg/cataloger/javascript/parse_package_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock_test.go
@@ -139,9 +139,9 @@ func TestParsePackageLockV2(t *testing.T) {
 			PURL:     "pkg:npm/%40types/prop-types@15.7.5",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz", Integrity: "sha1-XxnSuFqY6VWANvajysyIGUIPBc8="},
 		},
@@ -151,9 +151,9 @@ func TestParsePackageLockV2(t *testing.T) {
 			PURL:     "pkg:npm/%40types/react@18.0.17",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz", Integrity: "sha1-RYPZwyLWfv5LOak10iPtzHBQzPQ="},
 		},
@@ -163,9 +163,9 @@ func TestParsePackageLockV2(t *testing.T) {
 			PURL:     "pkg:npm/%40types/scheduler@0.16.2",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz", Integrity: "sha1-GmL4lSVyPd4kuhsBsJK/XfitTTk="},
 		},
@@ -175,9 +175,9 @@ func TestParsePackageLockV2(t *testing.T) {
 			PURL:     "pkg:npm/csstype@3.1.0",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{Resolved: "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz", Integrity: "sha1-TdysNxjXh8+d8NG30VAzklyPKfI="},
 		},
@@ -286,9 +286,9 @@ func TestParsePackageLockAlias(t *testing.T) {
 		PURL:     "pkg:npm/alias-check@1.0.0",
 		Language: pkg.JavaScript,
 		Type:     pkg.NpmPkg,
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicenseFromLocation("ISC", source.NewLocation(packageLockV2)),
-		},
+		),
 		MetadataType: "NpmPackageLockJsonMetadata",
 		Metadata:     pkg.NpmPackageLockJSONMetadata{},
 	}
@@ -317,9 +317,9 @@ func TestParsePackageLockLicenseWithArray(t *testing.T) {
 			Version:  "1.0.0",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("ISC", source.NewLocation(fixture)),
-			},
+			),
 			PURL:         "pkg:npm/tmp@1.0.0",
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{},
@@ -330,10 +330,9 @@ func TestParsePackageLockLicenseWithArray(t *testing.T) {
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
 
-			Licenses: []pkg.License{
-				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-				pkg.NewLicenseFromLocation("Apache2", source.NewLocation(fixture)),
-			},
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicensesFromLocation(source.NewLocation(fixture), "MIT", "Apache2")...,
+			),
 			PURL:         "pkg:npm/pause-stream@0.0.11",
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{},
@@ -343,9 +342,9 @@ func TestParsePackageLockLicenseWithArray(t *testing.T) {
 			Version:  "2.3.8",
 			Language: pkg.JavaScript,
 			Type:     pkg.NpmPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			PURL:         "pkg:npm/through@2.3.8",
 			MetadataType: "NpmPackageLockJsonMetadata",
 			Metadata:     pkg.NpmPackageLockJSONMetadata{},

--- a/syft/pkg/cataloger/kernel/cataloger_test.go
+++ b/syft/pkg/cataloger/kernel/cataloger_test.go
@@ -47,14 +47,14 @@ func Test_KernelCataloger(t *testing.T) {
 				"/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
 			),
 		),
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicenseFromLocation("GPL v2",
 				source.NewVirtualLocation(
 					"/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
 					"/lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko",
 				),
 			),
-		},
+		),
 		Type:         pkg.LinuxKernelModulePkg,
 		PURL:         "pkg:generic/ttynull",
 		MetadataType: pkg.LinuxKernelModuleMetadataType,

--- a/syft/pkg/cataloger/kernel/package.go
+++ b/syft/pkg/cataloger/kernel/package.go
@@ -28,10 +28,12 @@ func newLinuxKernelPackage(metadata pkg.LinuxKernelMetadata, archiveLocation sou
 
 func newLinuxKernelModulePackage(metadata pkg.LinuxKernelModuleMetadata, kmLocation source.Location) pkg.Package {
 	p := pkg.Package{
-		Name:         metadata.Name,
-		Version:      metadata.Version,
-		Locations:    source.NewLocationSet(kmLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-		Licenses:     pkg.NewLicensesFromLocation(kmLocation, metadata.License),
+		Name:      metadata.Name,
+		Version:   metadata.Version,
+		Locations: source.NewLocationSet(kmLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicensesFromLocation(kmLocation, metadata.License)...,
+		),
 		PURL:         packageURL(metadata.Name, metadata.Version),
 		Type:         pkg.LinuxKernelModulePkg,
 		MetadataType: pkg.LinuxKernelModuleMetadataType,

--- a/syft/pkg/cataloger/php/package.go
+++ b/syft/pkg/cataloger/php/package.go
@@ -9,11 +9,14 @@ import (
 )
 
 func newComposerLockPackage(m parsedData, indexLocation source.Location) pkg.Package {
+	licenses := pkg.NewLicenseSet(
+		pkg.NewLicensesFromLocation(indexLocation, m.License...)...,
+	)
 	p := pkg.Package{
 		Name:         m.Name,
 		Version:      m.Version,
 		Locations:    source.NewLocationSet(indexLocation),
-		Licenses:     pkg.NewLicensesFromLocation(indexLocation, m.License...),
+		Licenses:     licenses,
 		PURL:         packageURL(m),
 		Language:     pkg.PHP,
 		Type:         pkg.PhpComposerPkg,

--- a/syft/pkg/cataloger/php/parse_composer_lock_test.go
+++ b/syft/pkg/cataloger/php/parse_composer_lock_test.go
@@ -19,9 +19,9 @@ func TestParseComposerFileLock(t *testing.T) {
 			Version:   "1.0.2",
 			PURL:      "pkg:composer/adoy/fastcgi-client@1.0.2",
 			Locations: locations,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			Language:     pkg.PHP,
 			Type:         pkg.PhpComposerPkg,
 			MetadataType: pkg.PhpComposerJSONMetadataType,
@@ -60,9 +60,9 @@ func TestParseComposerFileLock(t *testing.T) {
 			Locations: locations,
 			PURL:      "pkg:composer/alcaeus/mongo-php-adapter@1.1.11",
 			Language:  pkg.PHP,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-			},
+			),
 			Type:         pkg.PhpComposerPkg,
 			MetadataType: pkg.PhpComposerJSONMetadataType,
 			Metadata: pkg.PhpComposerJSONMetadata{

--- a/syft/pkg/cataloger/php/parse_installed_json_test.go
+++ b/syft/pkg/cataloger/php/parse_installed_json_test.go
@@ -24,9 +24,9 @@ func TestParseInstalledJsonComposerV1(t *testing.T) {
 			Language:     pkg.PHP,
 			Type:         pkg.PhpComposerPkg,
 			MetadataType: pkg.PhpComposerJSONMetadataType,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicense("MIT"),
-			},
+			),
 			Metadata: pkg.PhpComposerJSONMetadata{
 				Name:    "asm89/stack-cors",
 				Version: "1.3.0",
@@ -73,9 +73,9 @@ func TestParseInstalledJsonComposerV1(t *testing.T) {
 			PURL:     "pkg:composer/behat/mink@v1.8.1",
 			Language: pkg.PHP,
 			Type:     pkg.PhpComposerPkg,
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicense("MIT"),
-			},
+			),
 			MetadataType: pkg.PhpComposerJSONMetadataType,
 			Metadata: pkg.PhpComposerJSONMetadata{
 				Name:    "behat/mink",
@@ -131,12 +131,14 @@ func TestParseInstalledJsonComposerV1(t *testing.T) {
 	for _, fixture := range fixtures {
 		t.Run(fixture, func(t *testing.T) {
 			locations := source.NewLocationSet(source.NewLocation(fixture))
+			loc := source.NewLocation(fixture)
 			for i := range expectedPkgs {
 				expectedPkgs[i].Locations = locations
-				for k := range expectedPkgs[i].Licenses {
-					loc := source.NewLocation(fixture)
-					expectedPkgs[i].Licenses[k].Location = &loc
+				licenses := expectedPkgs[i].Licenses.ToSlice()
+				for k := range licenses {
+					licenses[k].Location = &loc
 				}
+				expectedPkgs[i].Licenses = pkg.NewLicenseSet(licenses...)
 			}
 			pkgtest.TestFileParser(t, fixture, parseInstalledJSON, expectedPkgs, expectedRelationships)
 		})

--- a/syft/pkg/cataloger/portage/cataloger_test.go
+++ b/syft/pkg/cataloger/portage/cataloger_test.go
@@ -23,7 +23,11 @@ func TestPortageCataloger(t *testing.T) {
 				source.NewLocation("var/db/pkg/app-containers/skopeo-1.5.1/SIZE"),
 				expectedLicenseLocation,
 			),
-			Licenses:     pkg.NewLicensesFromLocation(expectedLicenseLocation, "Apache-2.0", "BSD", "BSD-2", "CC-BY-SA-4.0", "ISC", "MIT"),
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicensesFromLocation(
+					expectedLicenseLocation,
+					"Apache-2.0", "BSD", "BSD-2", "CC-BY-SA-4.0", "ISC", "MIT")...,
+			),
 			Type:         pkg.PortagePkg,
 			MetadataType: pkg.PortageMetadataType,
 			Metadata: pkg.PortageMetadata{

--- a/syft/pkg/cataloger/portage/parse_portage_contents.go
+++ b/syft/pkg/cataloger/portage/parse_portage_contents.go
@@ -116,8 +116,13 @@ func addLicenses(resolver source.FileResolver, dbLocation source.Location, p *pk
 		}
 	}
 
-	licenseCandidates := findings.ToSlice()
-	p.Licenses = pkg.NewLicensesFromLocation(*location, licenseCandidates...)
+	p.Licenses = pkg.NewLicenseSet(
+		pkg.NewLicensesFromLocation(
+			*location,
+			findings.ToSlice()...,
+		)...,
+	)
+
 	p.Locations.Add(location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation))
 }
 

--- a/syft/pkg/cataloger/python/cataloger_test.go
+++ b/syft/pkg/cataloger/python/cataloger_test.go
@@ -45,9 +45,9 @@ func Test_PackageCataloger(t *testing.T) {
 				PURL:     "pkg:pypi/requests@2.22.0",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("Apache 2.0", source.NewLocation("test-fixtures/egg-info/PKG-INFO")),
-				},
+				),
 				FoundBy:      "python-package-cataloger",
 				MetadataType: pkg.PythonPackageMetadataType,
 				Metadata: pkg.PythonPackageMetadata{
@@ -83,9 +83,9 @@ func Test_PackageCataloger(t *testing.T) {
 				PURL:     "pkg:pypi/Pygments@2.6.1?vcs_url=git+https://github.com/python-test/test.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("BSD License", source.NewLocation("test-fixtures/dist-info/METADATA")),
-				},
+				),
 				FoundBy:      "python-package-cataloger",
 				MetadataType: pkg.PythonPackageMetadataType,
 				Metadata: pkg.PythonPackageMetadata{
@@ -121,9 +121,9 @@ func Test_PackageCataloger(t *testing.T) {
 				PURL:     "pkg:pypi/Pygments@2.6.1",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("BSD License", source.NewLocation("test-fixtures/malformed-record/dist-info/METADATA")),
-				},
+				),
 				FoundBy:      "python-package-cataloger",
 				MetadataType: pkg.PythonPackageMetadataType,
 				Metadata: pkg.PythonPackageMetadata{
@@ -153,9 +153,9 @@ func Test_PackageCataloger(t *testing.T) {
 				PURL:     "pkg:pypi/Pygments@2.6.1",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("BSD License", source.NewLocation("test-fixtures/partial.dist-info/METADATA")),
-				},
+				),
 				FoundBy:      "python-package-cataloger",
 				MetadataType: pkg.PythonPackageMetadataType,
 				Metadata: pkg.PythonPackageMetadata{
@@ -177,9 +177,9 @@ func Test_PackageCataloger(t *testing.T) {
 				PURL:     "pkg:pypi/requests@2.22.0",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
-				Licenses: []pkg.License{
+				Licenses: pkg.NewLicenseSet(
 					pkg.NewLicenseFromLocation("Apache 2.0", source.NewLocation("test-fixtures/test.egg-info")),
-				},
+				),
 				FoundBy:      "python-package-cataloger",
 				MetadataType: pkg.PythonPackageMetadataType,
 				Metadata: pkg.PythonPackageMetadata{

--- a/syft/pkg/cataloger/python/package.go
+++ b/syft/pkg/cataloger/python/package.go
@@ -59,11 +59,13 @@ func newPackageForRequirementsWithMetadata(name, version string, metadata pkg.Py
 
 func newPackageForPackage(m parsedData, sources ...source.Location) pkg.Package {
 	p := pkg.Package{
-		Name:         m.Name,
-		Version:      m.Version,
-		PURL:         packageURL(m.Name, m.Version, &m.PythonPackageMetadata),
-		Locations:    source.NewLocationSet(sources...),
-		Licenses:     pkg.NewLicensesFromLocation(m.LicenseLocation, m.Licenses),
+		Name:      m.Name,
+		Version:   m.Version,
+		PURL:      packageURL(m.Name, m.Version, &m.PythonPackageMetadata),
+		Locations: source.NewLocationSet(sources...),
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicensesFromLocation(m.LicenseLocation, m.Licenses)...,
+		),
 		Language:     pkg.Python,
 		Type:         pkg.PythonPkg,
 		MetadataType: pkg.PythonPackageMetadataType,

--- a/syft/pkg/cataloger/rpm/package.go
+++ b/syft/pkg/cataloger/rpm/package.go
@@ -17,7 +17,7 @@ func newPackage(dbOrRpmLocation source.Location, pd parsedData, distro *linux.Re
 	p := pkg.Package{
 		Name:         pd.Name,
 		Version:      toELVersion(pd.RpmMetadata),
-		Licenses:     pd.Licenses,
+		Licenses:     pkg.NewLicenseSet(pd.Licenses...),
 		PURL:         packageURL(pd.RpmMetadata, distro),
 		Locations:    source.NewLocationSet(dbOrRpmLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
 		Type:         pkg.RpmPkg,

--- a/syft/pkg/cataloger/rpm/parse_rpm_db_test.go
+++ b/syft/pkg/cataloger/rpm/parse_rpm_db_test.go
@@ -98,9 +98,9 @@ func TestParseRpmDB(t *testing.T) {
 					Locations:    source.NewLocationSet(packagesLocation),
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmMetadataType,
-					Licenses: []pkg.License{
+					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromLocation("MIT", packagesLocation),
-					},
+					),
 					Metadata: pkg.RpmMetadata{
 						Name:      "dive",
 						Epoch:     nil,
@@ -127,9 +127,9 @@ func TestParseRpmDB(t *testing.T) {
 					Locations:    source.NewLocationSet(packagesLocation),
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmMetadataType,
-					Licenses: []pkg.License{
+					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromLocation("MIT", packagesLocation),
-					},
+					),
 					Metadata: pkg.RpmMetadata{
 						Name:      "dive",
 						Epoch:     nil,

--- a/syft/pkg/cataloger/rpm/parse_rpm_test.go
+++ b/syft/pkg/cataloger/rpm/parse_rpm_test.go
@@ -27,9 +27,9 @@ func TestParseRpmFiles(t *testing.T) {
 					FoundBy:      "rpm-file-cataloger",
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmMetadataType,
-					Licenses: []pkg.License{
+					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromLocation("MIT", abcRpmLocation),
-					},
+					),
 					Metadata: pkg.RpmMetadata{
 						Name:      "abc",
 						Epoch:     intRef(0),
@@ -56,9 +56,9 @@ func TestParseRpmFiles(t *testing.T) {
 					FoundBy:      "rpm-file-cataloger",
 					Type:         pkg.RpmPkg,
 					MetadataType: pkg.RpmMetadataType,
-					Licenses: []pkg.License{
+					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromLocation("Public Domain", zorkRpmLocation),
-					},
+					),
 					Metadata: pkg.RpmMetadata{
 						Name:      "zork",
 						Epoch:     intRef(0),

--- a/syft/pkg/cataloger/ruby/package.go
+++ b/syft/pkg/cataloger/ruby/package.go
@@ -23,10 +23,12 @@ func newGemfileLockPackage(name, version string, locations ...source.Location) p
 
 func newGemspecPackage(m gemData, gemSpecLocation source.Location) pkg.Package {
 	p := pkg.Package{
-		Name:         m.Name,
-		Version:      m.Version,
-		Locations:    source.NewLocationSet(gemSpecLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-		Licenses:     pkg.NewLicensesFromLocation(gemSpecLocation, m.Licenses...),
+		Name:      m.Name,
+		Version:   m.Version,
+		Locations: source.NewLocationSet(gemSpecLocation.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicensesFromLocation(gemSpecLocation, m.Licenses...)...,
+		),
 		PURL:         packageURL(m.Name, m.Version),
 		Language:     pkg.Ruby,
 		Type:         pkg.GemPkg,

--- a/syft/pkg/cataloger/ruby/parse_gemspec_test.go
+++ b/syft/pkg/cataloger/ruby/parse_gemspec_test.go
@@ -19,9 +19,9 @@ func TestParseGemspec(t *testing.T) {
 		PURL:      "pkg:gem/bundler@2.1.4",
 		Locations: locations,
 		Type:      pkg.GemPkg,
-		Licenses: []pkg.License{
+		Licenses: pkg.NewLicenseSet(
 			pkg.NewLicenseFromLocation("MIT", source.NewLocation(fixture)),
-		},
+		),
 		Language:     pkg.Ruby,
 		MetadataType: pkg.GemMetadataType,
 		Metadata: pkg.GemMetadata{

--- a/syft/pkg/cataloger/rust/parse_cargo_lock_test.go
+++ b/syft/pkg/cataloger/rust/parse_cargo_lock_test.go
@@ -21,7 +21,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:     "ansi_term",
 				Version:  "0.12.1",
@@ -40,7 +40,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "matches",
 				Version:      "0.1.8",
@@ -57,7 +57,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "memchr",
 				Version:      "2.3.3",
@@ -74,7 +74,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "natord",
 				Version:      "1.0.9",
@@ -91,7 +91,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:     "nom",
 				Version:  "4.2.3",
@@ -111,7 +111,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:     "unicode-bidi",
 				Version:  "0.3.4",
@@ -130,7 +130,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "version_check",
 				Version:      "0.1.5",
@@ -147,7 +147,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:     "winapi",
 				Version:  "0.3.9",
@@ -167,7 +167,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "winapi-i686-pc-windows-gnu",
 				Version:      "0.4.0",
@@ -184,7 +184,7 @@ func TestParseCargoLock(t *testing.T) {
 			Language:     pkg.Rust,
 			Type:         pkg.RustPkg,
 			MetadataType: pkg.RustCargoPackageMetadataType,
-			Licenses:     nil,
+			Licenses:     pkg.NewLicenseSet(),
 			Metadata: pkg.CargoPackageMetadata{
 				Name:         "winapi-x86_64-pc-windows-gnu",
 				Version:      "0.4.0",

--- a/syft/pkg/cataloger/sbom/cataloger_test.go
+++ b/syft/pkg/cataloger/sbom/cataloger_test.go
@@ -38,7 +38,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "3.2.0-r23",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("GPL-2.0-only")},
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/alpine-baselayout@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -55,7 +55,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "3.2.0-r23",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("GPL-2.0-only")},
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/alpine-baselayout-data@3.2.0-r23?arch=x86_64&upstream=alpine-baselayout&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -76,7 +76,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "2.4-r1",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("MIT")},
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("MIT")),
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/alpine-keys@2.4-r1?arch=x86_64&upstream=alpine-keys&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -93,7 +93,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "2.12.9-r3",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("GPL-2.0-only")},
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/apk-tools@2.12.9-r3?arch=x86_64&upstream=apk-tools&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -110,7 +110,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.35.0-r17",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("GPL-2.0-only")},
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/busybox@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -122,10 +122,10 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "20220614-r0",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicense("MPL-2.0"),
 				pkg.NewLicense("MIT"),
-			},
+			),
 			FoundBy: "sbom-cataloger",
 			PURL:    "pkg:apk/alpine/ca-certificates-bundle@20220614-r0?arch=x86_64&upstream=ca-certificates&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -146,10 +146,10 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "0.7.2-r3",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicense("BSD-2-Clause"),
 				pkg.NewLicense("BSD-3-Clause"),
-			},
+			),
 			FoundBy: "sbom-cataloger",
 			PURL:    "pkg:apk/alpine/libc-utils@0.7.2-r3?arch=x86_64&upstream=libc-dev&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -166,7 +166,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.1.1s-r0",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("OpenSSL")}, // SPDX expression is not set
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("OpenSSL")), // SPDX expression is not set
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/libcrypto1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -178,7 +178,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.1.1s-r0",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("OpenSSL")}, // SPDX expression is not set
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("OpenSSL")), // SPDX expression is not set
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/libssl1.1@1.1.1s-r0?arch=x86_64&upstream=openssl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -190,7 +190,7 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.2.3-r1",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses:  []pkg.License{pkg.NewLicense("MIT")}, // SPDX expression is not set
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("MIT")), // SPDX expression is not set
 			FoundBy:   "sbom-cataloger",
 			PURL:      "pkg:apk/alpine/musl@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -202,11 +202,11 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.2.3-r1",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
+			Licenses: pkg.NewLicenseSet(
 				pkg.NewLicense("MIT"),
 				pkg.NewLicense("BSD"),
 				pkg.NewLicense("GPL2+"), // SPDX expression is not set
-			},
+			),
 			FoundBy: "sbom-cataloger",
 			PURL:    "pkg:apk/alpine/musl-utils@1.2.3-r1?arch=x86_64&upstream=musl&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
@@ -223,11 +223,9 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.3.4-r0",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
-				pkg.NewLicense("GPL-2.0-only"),
-			},
-			FoundBy: "sbom-cataloger",
-			PURL:    "pkg:apk/alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
+			FoundBy:   "sbom-cataloger",
+			PURL:      "pkg:apk/alpine/scanelf@1.3.4-r0?arch=x86_64&upstream=pax-utils&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:scanelf:scanelf:1.3.4-r0:*:*:*:*:*:*:*",
 			),
@@ -237,11 +235,9 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.35.0-r17",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
-				pkg.NewLicense("GPL-2.0-only"),
-			},
-			FoundBy: "sbom-cataloger",
-			PURL:    "pkg:apk/alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("GPL-2.0-only")),
+			FoundBy:   "sbom-cataloger",
+			PURL:      "pkg:apk/alpine/ssl_client@1.35.0-r17?arch=x86_64&upstream=busybox&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:ssl-client:ssl-client:1.35.0-r17:*:*:*:*:*:*:*",
 				"cpe:2.3:a:ssl-client:ssl_client:1.35.0-r17:*:*:*:*:*:*:*",
@@ -256,11 +252,9 @@ func Test_parseSBOM(t *testing.T) {
 			Version:   "1.2.12-r3",
 			Type:      "apk",
 			Locations: source.NewLocationSet(source.NewLocation("sbom.syft.json")),
-			Licenses: []pkg.License{
-				pkg.NewLicense("Zlib"),
-			},
-			FoundBy: "sbom-cataloger",
-			PURL:    "pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
+			Licenses:  pkg.NewLicenseSet(pkg.NewLicense("Zlib")),
+			FoundBy:   "sbom-cataloger",
+			PURL:      "pkg:apk/alpine/zlib@1.2.12-r3?arch=x86_64&upstream=zlib&distro=alpine-3.16.3",
 			CPEs: mustCPEs(
 				"cpe:2.3:a:zlib:zlib:1.2.12-r3:*:*:*:*:*:*:*",
 			),

--- a/syft/pkg/package.go
+++ b/syft/pkg/package.go
@@ -23,7 +23,7 @@ type Package struct {
 	Version      string             // the version of the package
 	FoundBy      string             `hash:"ignore" cyclonedx:"foundBy"` // the specific cataloger that discovered this package
 	Locations    source.LocationSet // the locations that lead to the discovery of this package (note: this is not necessarily the locations that make up this package)
-	Licenses     []License          // licenses discovered with the package metadata
+	Licenses     LicenseSet         // licenses discovered with the package metadata
 	Language     Language           `hash:"ignore" cyclonedx:"language"` // the language ecosystem this package belongs to (e.g. JavaScript, Python, etc)
 	Type         Type               `cyclonedx:"type"`                   // the package type (e.g. Npm, Yarn, Python, Rpm, Deb, etc)
 	CPEs         []cpe.CPE          `hash:"ignore"`                      // all possible Common Platform Enumerators (note: this is NOT included in the definition of the ID since all fields on a CPE are derived from other fields)

--- a/syft/pkg/package_test.go
+++ b/syft/pkg/package_test.go
@@ -27,10 +27,10 @@ func TestIDUniqueness(t *testing.T) {
 		Locations: source.NewLocationSet(
 			originalLocation,
 		),
-		Licenses: []License{
+		Licenses: NewLicenseSet(
 			NewLicense("MIT"),
 			NewLicense("cc0-1.0"),
-		},
+		),
 		Language: "math",
 		Type:     PythonPkg,
 		CPEs: []cpe.CPE{
@@ -79,13 +79,13 @@ func TestIDUniqueness(t *testing.T) {
 			expectedIDComparison: assert.Equal,
 		},
 		{
-			name: "licenses order is ignored",
+			name: "licenses order is consistent",
 			transform: func(pkg Package) Package {
 				// note: same as the original package, only a different order
-				pkg.Licenses = []License{
+				pkg.Licenses = NewLicenseSet(
 					NewLicense("cc0-1.0"),
 					NewLicense("MIT"),
-				}
+				)
 				return pkg
 			},
 			expectedIDComparison: assert.Equal,
@@ -111,7 +111,7 @@ func TestIDUniqueness(t *testing.T) {
 		{
 			name: "licenses is reflected",
 			transform: func(pkg Package) Package {
-				pkg.Licenses = []License{NewLicense("new!")}
+				pkg.Licenses = NewLicenseSet(NewLicense("new!"))
 				return pkg
 			},
 			expectedIDComparison: assert.NotEqual,
@@ -412,7 +412,26 @@ func TestPackage_Merge(t *testing.T) {
 						return true
 					},
 				),
+				cmp.Comparer(
+					func(x, y LicenseSet) bool {
+						xs := x.ToSlice()
+						ys := y.ToSlice()
+
+						if len(xs) != len(ys) {
+							return false
+						}
+						for i, xe := range xs {
+							ye := ys[i]
+							if !licenseComparer(xe, ye) {
+								return false
+							}
+						}
+
+						return true
+					},
+				),
 				cmp.Comparer(locationComparer),
+				cmp.Comparer(licenseComparer),
 			); diff != "" {
 				t.Errorf("unexpected result from parsing (-expected +actual)\n%s", diff)
 			}
@@ -422,6 +441,10 @@ func TestPackage_Merge(t *testing.T) {
 
 func locationComparer(x, y source.Location) bool {
 	return cmp.Equal(x.Coordinates, y.Coordinates) && cmp.Equal(x.VirtualPath, y.VirtualPath)
+}
+
+func licenseComparer(x, y License) bool {
+	return cmp.Equal(x, y, cmp.Comparer(locationComparer))
 }
 
 func TestIsValid(t *testing.T) {


### PR DESCRIPTION
### Update []License implementation => LicenseSet

This PR is a refactor updating the `pkg.Package` struct to use `LicenseSet` over `[]License`

This update provides the following upgrades:
- Deduplication/Merge capability when converting to different formats
- Stable ordering with the `ToSlice()` method
- Licenses tracked with `Hash()` method to provide uniqueness of found data 