### PR TITLE
chore: do not HTML escape PackageURLs

### DIFF
--- a/syft/formats/github/format.go
+++ b/syft/formats/github/format.go
@@ -15,13 +15,11 @@ func Format() sbom.Format {
 		func(writer io.Writer, sbom sbom.SBOM) error {
 			bom := toGithubModel(&sbom)
 
-			bytes, err := json.MarshalIndent(bom, "", "  ")
-			if err != nil {
-				return err
-			}
-			_, err = writer.Write(bytes)
+			encoder := json.NewEncoder(writer)
+			encoder.SetEscapeHTML(false)
+			encoder.SetIndent("", "  ")
 
-			return err
+			return encoder.Encode(bom)
 		},
 		nil,
 		nil,


### PR DESCRIPTION
`sbom-action` issue https://github.com/anchore/sbom-action/issues/414 indicates that there is an issue with GitHub accepting PURLs that contain backslashes (even if they are valid JSON escape sequences). This PR adjust the GitHub output to _not_ HTML escape.