### PR TITLE
Update the CPE generation for spring-security-core

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -33,6 +33,12 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateAddition{AdditionalProducts: []string{"spring_framework", "springsource_spring_framework"}, AdditionalVendors: []string{"pivotal_software", "springsource", "vmware"}},
 		},
 		{
+			// example image: docker.io/jenkins/jenkins:latest
+			pkg.JavaPkg,
+			candidateKey{PkgName: "spring-security-core"},
+			candidateAddition{AdditionalProducts: []string{"spring_security"}, AdditionalVendors: []string{"vmware"}},
+		},
+		{
 			// example image: docker.io/nuxeo:latest
 			pkg.JavaPkg,
 			candidateKey{PkgName: "elasticsearch"}, // , Vendor: "elasticsearch"},

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -769,6 +769,14 @@ func TestCandidateProducts(t *testing.T) {
 			expected: []string{"spring_framework", "springsource_spring_framework" /* <-- known good names | default guess --> */, "springframework"},
 		},
 		{
+			name: "spring-security-core",
+			p: pkg.Package{
+				Name: "spring-security-core",
+				Type: pkg.JavaPkg,
+			},
+			expected: []string{"spring-security-core", "spring_security", "spring_security_core"},
+		},
+		{
 			name: "java",
 			p: pkg.Package{
 				Name:     "some-java-package-with-group-id",

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -866,6 +866,14 @@ func TestCandidateVendor(t *testing.T) {
 			expected: []string{"elastic" /* <-- known good names | default guess --> */, "elasticsearch"},
 		},
 		{
+			name: "spring-security",
+			p: pkg.Package{
+				Name: "spring-security-core",
+				Type: pkg.JavaPkg,
+			},
+			expected: []string{"vmware" /* <-- known good names | default guess --> */, "spring", "spring-security", "spring-security-core", "spring_security_core", "spring_security"},
+		},
+		{
 			name: "log4j",
 			p: pkg.Package{
 				Name: "log4j",


### PR DESCRIPTION
This commit update the CPE generation to include vmware:spring_security in the CPE name which is what NVD uses for spring security vulnerabilities such as https://nvd.nist.gov/vuln/detail/CVE-2023-20862