### PR TITLE
Reduce log spam on unknown relationship type

### DIFF
--- a/syft/formats/syftjson/to_syft_model.go
+++ b/syft/formats/syftjson/to_syft_model.go
@@ -194,7 +194,7 @@ func toSyftRelationship(idMap map[string]interface{}, relationship model.Relatio
 	case artifact.OwnershipByFileOverlapRelationship, artifact.ContainsRelationship, artifact.DependencyOfRelationship, artifact.EvidentByRelationship:
 	default:
 		if !strings.Contains(string(typ), "dependency-of") {
-			log.Warnf("unknown relationship type: %s", typ)
+			log.Tracef("unknown relationship type: %s", typ)
 			return nil
 		}
 		// lets try to stay as compatible as possible with similar relationship types without dropping the relationship

--- a/syft/formats/syftjson/to_syft_model.go
+++ b/syft/formats/syftjson/to_syft_model.go
@@ -194,7 +194,7 @@ func toSyftRelationship(idMap map[string]interface{}, relationship model.Relatio
 	case artifact.OwnershipByFileOverlapRelationship, artifact.ContainsRelationship, artifact.DependencyOfRelationship, artifact.EvidentByRelationship:
 	default:
 		if !strings.Contains(string(typ), "dependency-of") {
-			log.Tracef("unknown relationship type: %s", typ)
+			log.Debugf("unknown relationship type: %s", typ)
 			return nil
 		}
 		// lets try to stay as compatible as possible with similar relationship types without dropping the relationship

--- a/syft/formats/syftjson/to_syft_model_test.go
+++ b/syft/formats/syftjson/to_syft_model_test.go
@@ -228,3 +228,36 @@ func Test_toSyftFiles(t *testing.T) {
 		})
 	}
 }
+
+func Test_toSyfRelationship(t *testing.T) {
+	emptyIdMap := make(map[string]interface{})
+	emptyAliasMap := make(map[string]string)
+	type relationships struct {
+		relationship model.Relationship
+		want         *artifact.Relationship
+	}
+	tests := []struct {
+		name                string
+		idMap               map[string]interface{}
+		idAliases           map[string]string
+		args                []relationships
+		wantUnknownRelTypes map[string]int
+	}{{
+		name:                "normal relationship",
+		idMap:               emptyIdMap,
+		idAliases:           emptyAliasMap,
+		args:                []relationships{},
+		wantUnknownRelTypes: map[string]int{},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRelTypes := make(map[string]int)
+			for _, rel := range tt.args {
+				got, _ := toSyftRelationship(tt.idMap, rel.relationship, tt.idAliases)
+				assert.Equal(t, rel.want, got)
+			}
+			assert.Equal(t, tt.wantUnknownRelTypes, gotRelTypes)
+		})
+	}
+}

--- a/syft/formats/syftjson/to_syft_model_test.go
+++ b/syft/formats/syftjson/to_syft_model_test.go
@@ -1,6 +1,7 @@
 package syftjson
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/scylladb/go-set/strset"
@@ -230,7 +231,7 @@ func Test_toSyftFiles(t *testing.T) {
 	}
 }
 
-func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
+func Test_toSyfRelationship(t *testing.T) {
 	packageWithId := func(id string) *pkg.Package {
 		p := &pkg.Package{}
 		p.OverrideID(artifact.ID(id))
@@ -242,9 +243,9 @@ func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
 		name          string
 		idMap         map[string]interface{}
 		idAliases     map[string]string
-		relationships []model.Relationship
-		want          []artifact.Relationship
-		wantWarnings  []string
+		relationships model.Relationship
+		want          *artifact.Relationship
+		wantError     error
 	}{
 		{
 			name: "one relationship no warnings",
@@ -253,16 +254,16 @@ func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
 				"some-parent-id": parentPackage,
 			},
 			idAliases: map[string]string{},
-			relationships: []model.Relationship{{
+			relationships: model.Relationship{
 				Parent: "some-parent-id",
 				Child:  "some-child-id",
 				Type:   string(artifact.ContainsRelationship),
-			}},
-			want: []artifact.Relationship{{
+			},
+			want: &artifact.Relationship{
 				To:   childPackage,
 				From: parentPackage,
 				Type: artifact.ContainsRelationship,
-			}},
+			},
 		},
 		{
 			name: "relationship unknown type one warning",
@@ -271,14 +272,14 @@ func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
 				"some-parent-id": parentPackage,
 			},
 			idAliases: map[string]string{},
-			relationships: []model.Relationship{{
+			relationships: model.Relationship{
 				Parent: "some-parent-id",
 				Child:  "some-child-id",
 				Type:   "some-unknown-relationship-type",
-			}},
-			wantWarnings: []string{
-				"Omitted 1 relationship(s) of these unknown types: some-unknown-relationship-type",
 			},
+			wantError: errors.New(
+				"unknown relationship type: some-unknown-relationship-type",
+			),
 		},
 		{
 			name: "relationship missing child ID one warning",
@@ -286,14 +287,14 @@ func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
 				"some-parent-id": parentPackage,
 			},
 			idAliases: map[string]string{},
-			relationships: []model.Relationship{{
+			relationships: model.Relationship{
 				Parent: "some-parent-id",
 				Child:  "some-child-id",
 				Type:   string(artifact.ContainsRelationship),
-			}},
-			wantWarnings: []string{
-				"relationship mapping to key some-child-id is not a valid artifact.Identifiable type: <nil>",
 			},
+			wantError: errors.New(
+				"relationship mapping to key some-child-id is not a valid artifact.Identifiable type: <nil>",
+			),
 		},
 		{
 			name: "relationship missing parent ID one warning",
@@ -301,22 +302,48 @@ func Test_toSyfRelationshipsWithWarnings(t *testing.T) {
 				"some-child-id": childPackage,
 			},
 			idAliases: map[string]string{},
-			relationships: []model.Relationship{{
+			relationships: model.Relationship{
 				Parent: "some-parent-id",
 				Child:  "some-child-id",
 				Type:   string(artifact.ContainsRelationship),
-			}},
-			wantWarnings: []string{
-				"relationship mapping from key some-parent-id is not a valid artifact.Identifiable type: <nil>",
 			},
+			wantError: errors.New("relationship mapping from key some-parent-id is not a valid artifact.Identifiable type: <nil>"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotWarnings := toSyftRelationshipsWithWarnings(tt.idMap, tt.relationships, tt.idAliases)
+			got, gotErr := toSyftRelationship(tt.idMap, tt.relationships, tt.idAliases)
 			assert.Equal(t, tt.want, got)
-			assert.Equal(t, tt.wantWarnings, gotWarnings)
+			assert.Equal(t, tt.wantError, gotErr)
+		})
+	}
+}
+
+func Test_deduplicateErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		errors []error
+		want   []string
+	}{
+		{
+			name: "no errors, nil slice",
+		},
+		{
+			name: "deduplicates errors",
+			errors: []error{
+				errors.New("some error"),
+				errors.New("some error"),
+			},
+			want: []string{
+				`"some error" occurred 2 time(s)`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateErrors(tt.errors)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
An unknown relationship type doesn't mean things are incorrect; it probably means that the version of syft that generated the SBOM is ahead of the version of syft that's parsing it.

Addresses https://github.com/anchore/grype/issues/1244, but won't fix it until the version of syft that's imported by grype is updated, at https://github.com/anchore/grype/blob/75e7ef43cd03baba4c76af3751274c7aa7452f36/go.mod#L56.