### PR TITLE
update cosign to v2 release (different go module)

### DIFF
--- a/.github/workflows/update-bootstrap-tools.yml
+++ b/.github/workflows/update-bootstrap-tools.yml
@@ -28,7 +28,7 @@ jobs:
           GORELEASER_LATEST_VERSION=$(go list -m -json github.com/goreleaser/goreleaser@latest 2>/dev/null | jq -r '.Version')
           GOSIMPORTS_LATEST_VERSION=$(go list -m -json github.com/rinchsan/gosimports@latest 2>/dev/null | jq -r '.Version')
           YAJSV_LATEST_VERSION=$(go list -m -json github.com/neilpa/yajsv@latest 2>/dev/null | jq -r '.Version')
-          COSIGN_LATEST_VERSION=$(go list -m -json github.com/sigstore/cosign@latest 2>/dev/null | jq -r '.Version')
+          COSIGN_LATEST_VERSION=$(go list -m -json github.com/sigstore/cosign/v2@latest 2>/dev/null | jq -r '.Version')
           GLOW_LATEST_VERSION=$(go list -m -json github.com/charmbracelet/glow@latest 2>/dev/null | jq -r '.Version')
           
           # update version variables in the Makefile

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BOUNCER_VERSION := v0.4.0
 CHRONICLE_VERSION := v0.6.0
 GORELEASER_VERSION := v1.18.2
 YAJSV_VERSION := v1.4.1
-COSIGN_VERSION := v1.13.1
+COSIGN_VERSION := v2.0.2
 QUILL_VERSION := v0.2.0
 GLOW_VERSION := v1.5.0
 
@@ -90,7 +90,7 @@ bootstrap-tools: $(TEMP_DIR)
 	# the only difference between goimports and gosimports is that gosimports removes extra whitespace between import blocks (see https://github.com/golang/go/issues/20818)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/rinchsan/gosimports/cmd/gosimports@$(GOSIMPORTS_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/neilpa/yajsv@$(YAJSV_VERSION)
-	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/sigstore/cosign/cmd/cosign@$(COSIGN_VERSION)
+	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/sigstore/cosign/v2/cmd/cosign@$(COSIGN_VERSION)
 	GOBIN="$(realpath $(TEMP_DIR))" go install github.com/charmbracelet/glow@$(GLOW_VERSION)
 
 .PHONY: bootstrap-go


### PR DESCRIPTION
This updates the bootstrap tool version of github.com/sigstore/cosign to be the recent v2 release, which is in a different versioned go module. 