### PR TITLE
fix: update cataloger to check for expressions before split

### DIFF
--- a/syft/pkg/cataloger/apkdb/package.go
+++ b/syft/pkg/cataloger/apkdb/package.go
@@ -4,13 +4,20 @@ import (
 	"strings"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/license"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 )
 
 func newPackage(d parsedData, release *linux.Release, dbLocation source.Location) pkg.Package {
-	licenseStrings := strings.Split(d.License, " ")
+	// check if license is a valid spdx expression before splitting
+	licenseStrings := []string{d.License}
+	_, err := license.ParseExpression(d.License)
+	if err != nil {
+		// invalid so update to split on space
+		licenseStrings = strings.Split(d.License, " ")
+	}
 
 	p := pkg.Package{
 		Name:         d.Package,

--- a/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/apkdb/parse_apk_db_test.go
@@ -701,7 +701,7 @@ func TestMultiplePackages(t *testing.T) {
 			Name:    "libc-utils",
 			Version: "0.7.2-r0",
 			Licenses: pkg.NewLicenseSet(
-				pkg.NewLicenseFromLocations("BSD", location),
+				pkg.NewLicenseFromLocations("MPL-2.0 AND MIT", location),
 			),
 			Type:         pkg.ApkPkg,
 			PURL:         "pkg:apk/alpine/libc-utils@0.7.2-r0?arch=x86_64&upstream=libc-dev&distro=alpine-3.12",

--- a/syft/pkg/cataloger/apkdb/test-fixtures/multiple
+++ b/syft/pkg/cataloger/apkdb/test-fixtures/multiple
@@ -6,7 +6,7 @@ S:1175
 I:4096
 T:Meta package to pull in correct libc
 U:http://alpinelinux.org
-L:BSD
+L:MPL-2.0 AND MIT
 o:libc-dev
 m:Natanael Copa <ncopa@alpinelinux.org>
 t:1575749004


### PR DESCRIPTION
Fixes: #1817 

Bug fix for Alpine cataloger to check for valid expressions on the parsed entry before splitting the licenses into individual entities.