### PR TITLE
Minor cataloger improvements for the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,31 @@ If docker is not present, then the Podman daemon is attempted next, followed by 
 
 This default behavior can be overridden with the `default-image-pull-source` configuration option (See [Configuration](https://github.com/anchore/syft#configuration) for more details).
 
-### Default Cataloger Configuration by scan type
+### Cataloger Configuration
 
-##### Image Scanning:
+By default, a set of catalogers are chosen depending on the type of
+source that is being scanned.  However, the `--catalogers LIST` CLI
+option can be specified to override this default selection, where
+`LIST` can be one of the following:
+
+- A comma-delimited list of cataloger names (run `syft` with the `-v`
+  or `-vv` option to see the list of catalogers available).
+
+  **Note:** Syft does not currently warn if a non-existent cataloger
+  name is used in the list.
+- The keyword `ALL`, indicating that Syft should use all available
+  catalogers.
+- The keyword `ALL:IMAGE`, indicating that Syft should use the default
+  set of catalogers when container images are scanned (see below).
+- The keyword `ALL:DIRECTORY`, indicating that Syft should use the
+  default set of catalogers when directory trees are scanned (see
+  below).
+
+#### Image Scanning
+
+The following catalogers are selected by default (i.e., if
+`--catalogers` is not specified) when container images are scanned:
+
 - alpmdb
 - apkdb
 - binary
@@ -169,7 +191,11 @@ This default behavior can be overridden with the `default-image-pull-source` con
 - ruby-gemspec
 - sbom
 
-##### Directory Scanning:
+#### Directory Scanning
+
+The following catalogers are selected by default (i.e., if
+`--catalogers` is not specified) when directory trees are scanned:
+
 - alpmdb
 - apkdb
 - binary
@@ -200,7 +226,12 @@ This default behavior can be overridden with the `default-image-pull-source` con
 - rust-cargo-lock
 - sbom
 
-##### Non Default:
+#### Non Default
+
+This cataloger is not used by default.  It is only used when
+explicitly listed in `--catalogers LIST` or when `--catalogers ALL` is
+specified.
+
 - cargo-auditable-binary
 
 ### Excluding file paths

--- a/cmd/syft/cli/options/packages.go
+++ b/cmd/syft/cli/options/packages.go
@@ -46,7 +46,7 @@ func (o *PackagesOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
 		"exclude paths from being scanned using a glob expression")
 
 	cmd.Flags().StringArrayVarP(&o.Catalogers, "catalogers", "", nil,
-		"enable one or more package catalogers")
+		"list of package catalogers to use, or one of: ALL (all catalogers), ALL:IMAGE (all container image catalogers), ALL:DIRECTORY (all directory tree catalogers)")
 
 	cmd.Flags().StringVarP(&o.Name, "name", "", "",
 		"set the name of the target being analyzed")

--- a/syft/lib.go
+++ b/syft/lib.go
@@ -36,19 +36,6 @@ import (
 // (e.g. squashed source, all-layers source). Returns the discovered  set of packages, the identified Linux
 // distribution, and the source object used to wrap the data source.
 func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Collection, []artifact.Relationship, *linux.Release, error) {
-	resolver, err := src.FileResolver(cfg.Search.Scope)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("unable to determine resolver while cataloging packages: %w", err)
-	}
-
-	// find the distro
-	release := linux.IdentifyRelease(resolver)
-	if release != nil {
-		log.Infof("identified distro: %s", release.String())
-	} else {
-		log.Info("could not identify distro")
-	}
-
 	// if the catalogers have been configured, use them regardless of input type
 	var catalogers []pkg.Cataloger
 	if len(cfg.Catalogers) > 0 {
@@ -106,6 +93,19 @@ func CatalogPackages(src *source.Source, cfg cataloger.Config) (*pkg.Collection,
 		names = append(names, c.Name())
 	}
 	log.Debugf("catalogers: %s", strings.Join(names, ","))
+
+	resolver, err := src.FileResolver(cfg.Search.Scope)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to determine resolver while cataloging packages: %w", err)
+	}
+
+	// find the distro
+	release := linux.IdentifyRelease(resolver)
+	if release != nil {
+		log.Infof("identified distro: %s", release.String())
+	} else {
+		log.Info("could not identify distro")
+	}
 
 	catalog, relationships, err := cataloger.Catalog(resolver, release, cfg.Parallelism, catalogers...)
 


### PR DESCRIPTION
1. Add `ALL` (synonym for `all`), `ALL:IMAGE`, and `ALL:DIRECTORY` catalog selectors (somewhat in response to #1776)
1. Add some more INFO and DEBUG log messages about which catalogers were selected.
1. Add a sanity check: if 0 catalogers are selected, emit an error.
    * Also make the Syft CLI fail faster if 0 catalogers are selected

See the individual commits and their corresponding commit messages for details.