### PR TITLE
fix: add panic recovery for license parse

### DIFF
--- a/syft/license/license.go
+++ b/syft/license/license.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/github/go-spdx/v2/spdxexp"
 
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/spdxlicense"
 )
 
@@ -17,15 +18,25 @@ const (
 )
 
 func ParseExpression(expression string) (string, error) {
+	// https://github.com/anchore/syft/issues/1837
+	// The current spdx library can panic when parsing some expressions
+	// This is a temporary fix to recover and patch until we can investigate and contribute
+	// a fix to the upstream github library
+	defer func() {
+		if r := recover(); r != nil {
+			log.Trace("recovered in parseExpression", r)
+		}
+	}()
+
 	licenseID, exists := spdxlicense.ID(expression)
 	if exists {
 		return licenseID, nil
 	}
-
 	// If it doesn't exist initially in the SPDX list it might be a more complex expression
 	// ignored variable is any invalid expressions
 	// TODO: contribute to spdxexp to expose deprecated license IDs
 	// https://github.com/anchore/syft/issues/1814
+
 	valid, _ := spdxexp.ValidateLicenses([]string{expression})
 	if !valid {
 		return "", fmt.Errorf("failed to validate spdx expression: %s", expression)

--- a/syft/pkg/license.go
+++ b/syft/pkg/license.go
@@ -62,7 +62,7 @@ func (l Licenses) Swap(i, j int) {
 func NewLicense(value string) License {
 	spdxExpression, err := license.ParseExpression(value)
 	if err != nil {
-		log.Trace("unable to parse license expression: %w", err)
+		log.Trace("unable to parse license expression for %q: %w", value, err)
 	}
 
 	return License{


### PR DESCRIPTION
Closes #1837 

With this fix we can release v0.81.1 as a patch which will defer the panic caused by the call to `ValidateLicenses`

Tested against the example in the issue using `syft` from this branch and `grype v0.62.0`
```bash
go run cmd/syft/main.go -o json lscr.io/linuxserver/webtop:alpine-openbox | grype
```
<img width="1337" alt="Screenshot 2023-05-23 at 12 00 31 PM" src="https://github.com/anchore/syft/assets/32073428/eaccae93-eef8-413d-aa20-cf6203b81e40">