### PR TITLE
accept main.version ldflags even without vcs

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -347,7 +347,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			},
 		},
 		{
-			name: "parse main mod and replace devel version with one from ldflags",
+			name: "parse main mod and replace devel version with one from ldflags with vcs. build settings",
 			arch: archDetails,
 			mod: &debug.BuildInfo{
 				GoVersion: goCompiledVersion,
@@ -387,6 +387,135 @@ func TestBuildGoPkgInfo(t *testing.T) {
 							"vcs.revision": "41bc6bb410352845f22766e27dd48ba93aa825a4",
 							"vcs.time":     "2022-10-14T19:54:57Z",
 							"-ldflags":     `build	-ldflags="-w -s -extldflags '-static' -X github.com/anchore/syft/internal/version.version=0.79.0`,
+						},
+						MainModule: "github.com/anchore/syft",
+					},
+				},
+			},
+		},
+		{
+			name: "parse main mod and replace devel version with one from ldflags without any vcs. build settings",
+			arch: archDetails,
+			mod: &debug.BuildInfo{
+				GoVersion: goCompiledVersion,
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "GOARCH", Value: archDetails},
+					{Key: "GOOS", Value: "darwin"},
+					{Key: "GOAMD64", Value: "v1"},
+					{Key: "-ldflags", Value: `build	-ldflags="-w -s -extldflags '-static' -X github.com/anchore/syft/internal/version.version=0.79.0`},
+				},
+			},
+			expected: []pkg.Package{
+				{
+					Name:     "github.com/anchore/syft",
+					Language: pkg.Go,
+					Type:     pkg.GoModulePkg,
+					Version:  "v0.79.0",
+					PURL:     "pkg:golang/github.com/anchore/syft@v0.79.0",
+					Locations: file.NewLocationSet(
+						file.NewLocationFromCoordinates(
+							file.Coordinates{
+								RealPath:     "/a-path",
+								FileSystemID: "layer-id",
+							},
+						).WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+					),
+					MetadataType: pkg.GolangBinMetadataType,
+					Metadata: pkg.GolangBinMetadata{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						BuildSettings: map[string]string{
+							"GOARCH":   archDetails,
+							"GOOS":     "darwin",
+							"GOAMD64":  "v1",
+							"-ldflags": `build	-ldflags="-w -s -extldflags '-static' -X github.com/anchore/syft/internal/version.version=0.79.0`,
+						},
+						MainModule: "github.com/anchore/syft",
+					},
+				},
+			},
+		},
+		{
+			name: "parse main mod and replace devel version with one from ldflags main.version without any vcs. build settings",
+			arch: archDetails,
+			mod: &debug.BuildInfo{
+				GoVersion: goCompiledVersion,
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "GOARCH", Value: archDetails},
+					{Key: "GOOS", Value: "darwin"},
+					{Key: "GOAMD64", Value: "v1"},
+					{Key: "-ldflags", Value: `build	-ldflags="-w -s -extldflags '-static' -X main.version=0.79.0`},
+				},
+			},
+			expected: []pkg.Package{
+				{
+					Name:     "github.com/anchore/syft",
+					Language: pkg.Go,
+					Type:     pkg.GoModulePkg,
+					Version:  "v0.79.0",
+					PURL:     "pkg:golang/github.com/anchore/syft@v0.79.0",
+					Locations: file.NewLocationSet(
+						file.NewLocationFromCoordinates(
+							file.Coordinates{
+								RealPath:     "/a-path",
+								FileSystemID: "layer-id",
+							},
+						).WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+					),
+					MetadataType: pkg.GolangBinMetadataType,
+					Metadata: pkg.GolangBinMetadata{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						BuildSettings: map[string]string{
+							"GOARCH":   archDetails,
+							"GOOS":     "darwin",
+							"GOAMD64":  "v1",
+							"-ldflags": `build	-ldflags="-w -s -extldflags '-static' -X main.version=0.79.0`,
+						},
+						MainModule: "github.com/anchore/syft",
+					},
+				},
+			},
+		},
+		{
+			name: "parse main mod and replace devel version with one from ldflags main.Version without any vcs. build settings",
+			arch: archDetails,
+			mod: &debug.BuildInfo{
+				GoVersion: goCompiledVersion,
+				Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
+				Settings: []debug.BuildSetting{
+					{Key: "GOARCH", Value: archDetails},
+					{Key: "GOOS", Value: "darwin"},
+					{Key: "GOAMD64", Value: "v1"},
+					{Key: "-ldflags", Value: `build	-ldflags="-w -s -extldflags '-static' -X main.Version=0.79.0`},
+				},
+			},
+			expected: []pkg.Package{
+				{
+					Name:     "github.com/anchore/syft",
+					Language: pkg.Go,
+					Type:     pkg.GoModulePkg,
+					Version:  "v0.79.0",
+					PURL:     "pkg:golang/github.com/anchore/syft@v0.79.0",
+					Locations: file.NewLocationSet(
+						file.NewLocationFromCoordinates(
+							file.Coordinates{
+								RealPath:     "/a-path",
+								FileSystemID: "layer-id",
+							},
+						).WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+					),
+					MetadataType: pkg.GolangBinMetadataType,
+					Metadata: pkg.GolangBinMetadata{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						BuildSettings: map[string]string{
+							"GOARCH":   archDetails,
+							"GOOS":     "darwin",
+							"GOAMD64":  "v1",
+							"-ldflags": `build	-ldflags="-w -s -extldflags '-static' -X main.Version=0.79.0`,
 						},
 						MainModule: "github.com/anchore/syft",
 					},


### PR DESCRIPTION
syft's workaround for the go binary `(devel)` issue is [here](https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/golang/parse_go_binary.go#L85-L120).

It looks at `ldflags` and, if it cannot find a valid `main.version` (or similar), it tries to calculate the go pseudo-version, which needs vcs info.

The current design does not check `ldflags` unless it finds vcs info _first_. Of course, if it finds `ldflags` info, it doesn't actually need the `vcs` info.

This PR changes it around so that it first tries to read `ldflags` and only after it fails to do so, does it try vcs.

I also added tests for this specific case, as well as adding tests for `main.version` and `main.Version`.