### PR TITLE
fix: allow valid cyclonedx input with no components

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -23,7 +23,7 @@ func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 			return err
 		}
 		// random JSON does not necessarily cause an error (e.g. SPDX)
-		if (cyclonedx.BOM{} == *bom || bom.Components == nil) {
+		if (cyclonedx.BOM{} == *bom || ((format == cyclonedx.BOMFileFormatXML && bom.XMLNS == "") || bom.Components == nil)) {
 			return fmt.Errorf("not a valid CycloneDX document")
 		}
 		return nil

--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -25,15 +25,10 @@ func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 		if err != nil {
 			return err
 		}
-		// random JSON does not necessarily cause an error (e.g. SPDX)
-		if format == cyclonedx.BOMFileFormatXML {
-			if (!strings.Contains(bom.XMLNS, cycloneDXXmlSchema) || cyclonedx.BOM{} == *bom) {
-				return fmt.Errorf("not a valid CycloneDX document")
-			}
-		} else {
-			if (bom.Components == nil || cyclonedx.BOM{} == *bom) {
-				return fmt.Errorf("not a valid CycloneDX document")
-			}
+
+		xmlWithoutNS := format == cyclonedx.BOMFileFormatXML && !strings.Contains(bom.XMLNS, cycloneDXXmlSchema)
+		if (cyclonedx.BOM{} == *bom || bom.Components == nil || xmlWithoutNS) {
+			return fmt.Errorf("not a valid CycloneDX document")
 		}
 		return nil
 	}

--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -3,6 +3,7 @@ package cyclonedxhelpers
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
+const cycloneDXXmlSchema = "http://cyclonedx.org/schema/bom"
+
 func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 	return func(reader io.Reader) error {
 		bom := &cyclonedx.BOM{}
@@ -23,8 +26,14 @@ func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 			return err
 		}
 		// random JSON does not necessarily cause an error (e.g. SPDX)
-		if (cyclonedx.BOM{} == *bom || ((format == cyclonedx.BOMFileFormatXML && bom.XMLNS == "") || bom.Components == nil)) {
-			return fmt.Errorf("not a valid CycloneDX document")
+		if format == cyclonedx.BOMFileFormatXML {
+			if (!strings.Contains(bom.XMLNS, cycloneDXXmlSchema) || cyclonedx.BOM{} == *bom) {
+				return fmt.Errorf("not a valid CycloneDX document")
+			}
+		} else {
+			if (bom.Components == nil || cyclonedx.BOM{} == *bom) {
+				return fmt.Errorf("not a valid CycloneDX document")
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
This resolves https://github.com/anchore/grype/issues/1005

The cyclonedx-go library returns Nil when presented with:

```xml
<components></components>
```

But returns an empty slice when presented with:

```json
"components": []
```

The fix is to check if the format is XML, then inspect the XMLNS field and for other formats inspect the Components field