### PR TITLE
fix: only output valid cyclonedx license choices

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/component_test.go
+++ b/syft/formats/common/cyclonedxhelpers/component_test.go
@@ -184,7 +184,6 @@ func Test_encodeCompomentType(t *testing.T) {
 						Value: "go-module",
 					},
 				},
-				Licenses: &cyclonedx.Licenses{},
 			},
 		},
 		{
@@ -204,7 +203,6 @@ func Test_encodeCompomentType(t *testing.T) {
 						Value: "binary",
 					},
 				},
-				Licenses: &cyclonedx.Licenses{},
 			},
 		},
 	}

--- a/syft/formats/common/cyclonedxhelpers/component_test.go
+++ b/syft/formats/common/cyclonedxhelpers/component_test.go
@@ -184,6 +184,7 @@ func Test_encodeCompomentType(t *testing.T) {
 						Value: "go-module",
 					},
 				},
+				Licenses: &cyclonedx.Licenses{},
 			},
 		},
 		{
@@ -203,6 +204,7 @@ func Test_encodeCompomentType(t *testing.T) {
 						Value: "binary",
 					},
 				},
+				Licenses: &cyclonedx.Licenses{},
 			},
 		},
 	}

--- a/syft/formats/common/cyclonedxhelpers/licenses.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses.go
@@ -12,43 +12,35 @@ import (
 
 // This should be a function that just surfaces licenses already validated in the package struct
 func encodeLicenses(p pkg.Package) *cyclonedx.Licenses {
-	spdxc, otherc, ex := separateLicenses(p)
-	if len(otherc) > 0 {
+	spdx, other, ex := separateLicenses(p)
+	out := spdx
+	out = append(out, other...)
+
+	if len(other) > 0 || len(spdx) > 0 {
 		// found non spdx related licenses
 		// build individual license choices for each
 		// complex expressions are not combined and set as NAME fields
 		for _, e := range ex {
-			otherc = append(otherc, cyclonedx.LicenseChoice{
+			if e == "" {
+				continue
+			}
+			out = append(out, cyclonedx.LicenseChoice{
 				License: &cyclonedx.License{
 					Name: e,
 				},
 			})
 		}
-		otherc = append(otherc, spdxc...)
-		return &otherc
-	}
-
-	if len(spdxc) > 0 {
-		for _, l := range ex {
-			spdxc = append(spdxc, cyclonedx.LicenseChoice{
-				License: &cyclonedx.License{
-					Name: l,
-				},
+	} else if len(ex) > 0 {
+		// only expressions found
+		e := mergeSPDX(ex)
+		if e != "" {
+			out = append(out, cyclonedx.LicenseChoice{
+				Expression: e,
 			})
 		}
-		return &spdxc
 	}
 
-	if len(ex) > 0 {
-		// only expressions found
-		var expressions cyclonedx.Licenses
-		expressions = append(expressions, cyclonedx.LicenseChoice{
-			Expression: mergeSPDX(ex),
-		})
-		return &expressions
-	}
-
-	return nil
+	return &out
 }
 
 func decodeLicenses(c *cyclonedx.Component) []pkg.License {
@@ -185,20 +177,20 @@ func reduceOuter(expression string) string {
 
 	for _, c := range expression {
 		if string(c) == "(" && openCount > 0 {
-			fmt.Fprintf(&sb, "%c", c)
+			_, _ = fmt.Fprintf(&sb, "%c", c)
 		}
 		if string(c) == "(" {
 			openCount++
 			continue
 		}
 		if string(c) == ")" && openCount > 1 {
-			fmt.Fprintf(&sb, "%c", c)
+			_, _ = fmt.Fprintf(&sb, "%c", c)
 		}
 		if string(c) == ")" {
 			openCount--
 			continue
 		}
-		fmt.Fprintf(&sb, "%c", c)
+		_, _ = fmt.Fprintf(&sb, "%c", c)
 	}
 
 	return sb.String()

--- a/syft/formats/common/cyclonedxhelpers/licenses.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses.go
@@ -40,7 +40,11 @@ func encodeLicenses(p pkg.Package) *cyclonedx.Licenses {
 		}
 	}
 
-	return &out
+	if len(out) > 0 {
+		return &out
+	}
+
+	return nil
 }
 
 func decodeLicenses(c *cyclonedx.Component) []pkg.License {

--- a/syft/formats/common/cyclonedxhelpers/licenses_test.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses_test.go
@@ -20,7 +20,7 @@ func Test_encodeLicense(t *testing.T) {
 		{
 			name:     "no licenses",
 			input:    pkg.Package{},
-			expected: nil,
+			expected: &cyclonedx.Licenses{},
 		},
 		{
 			name: "no SPDX licenses",
@@ -48,12 +48,12 @@ func Test_encodeLicense(t *testing.T) {
 			expected: &cyclonedx.Licenses{
 				{
 					License: &cyclonedx.License{
-						Name: "FOOBAR",
+						ID: "MIT",
 					},
 				},
 				{
 					License: &cyclonedx.License{
-						ID: "MIT",
+						Name: "FOOBAR",
 					},
 				},
 			},
@@ -97,17 +97,6 @@ func Test_encodeLicense(t *testing.T) {
 			expected: &cyclonedx.Licenses{
 				{
 					License: &cyclonedx.License{
-						Name: "FakeLicense",
-						URL:  "htts://someurl.com",
-					},
-				},
-				{
-					License: &cyclonedx.License{
-						Name: "MIT AND GPL-3.0-only",
-					},
-				},
-				{
-					License: &cyclonedx.License{
 						ID:  "MIT",
 						URL: "https://opensource.org/licenses/MIT",
 					},
@@ -116,6 +105,17 @@ func Test_encodeLicense(t *testing.T) {
 					License: &cyclonedx.License{
 						ID:  "MIT",
 						URL: "https://spdx.org/licenses/MIT.html",
+					},
+				},
+				{
+					License: &cyclonedx.License{
+						Name: "FakeLicense",
+						URL:  "htts://someurl.com",
+					},
+				},
+				{
+					License: &cyclonedx.License{
+						Name: "MIT AND GPL-3.0-only",
 					},
 				},
 			},

--- a/syft/formats/common/cyclonedxhelpers/licenses_test.go
+++ b/syft/formats/common/cyclonedxhelpers/licenses_test.go
@@ -18,9 +18,8 @@ func Test_encodeLicense(t *testing.T) {
 		expected *cyclonedx.Licenses
 	}{
 		{
-			name:     "no licenses",
-			input:    pkg.Package{},
-			expected: &cyclonedx.Licenses{},
+			name:  "no licenses",
+			input: pkg.Package{},
 		},
 		{
 			name: "no SPDX licenses",


### PR DESCRIPTION
CycloneDX was potentially outputting invalid licenses, e.g. `"license": [{}]` (note the lack of required `expression`, `license`.`id`/`name` parameters). This PR ensures required parameters are output for CycloneDX licenses.

Fixes #1877