### PR TITLE
Pad artifact IDs

### DIFF
--- a/syft/artifact/id.go
+++ b/syft/artifact/id.go
@@ -22,5 +22,5 @@ func IDByHash(obj interface{}) (ID, error) {
 		return "", fmt.Errorf("could not build ID for object=%+v: %w", obj, err)
 	}
 
-	return ID(fmt.Sprintf("%x", f)), nil
+	return ID(fmt.Sprintf("%016x", f)), nil
 }

--- a/syft/formats/syftjson/test-fixtures/snapshot/TestEncodeFullJSONDocument.golden
+++ b/syft/formats/syftjson/test-fixtures/snapshot/TestEncodeFullJSONDocument.golden
@@ -91,7 +91,7 @@
    }
   },
   {
-   "id": "e7c88bd18e11b0b",
+   "id": "0e7c88bd18e11b0b",
    "location": {
     "path": "/a/place/a"
    },


### PR DESCRIPTION
Otherwise the hash can sometimes be short if it results in a low uint64.

This seems to be the cause of this failure: https://github.com/anchore/sbom-action/actions/runs/5270697648/jobs/9530548662?pr=418#step:6:2913

We think that padding these makes sense. Once syft hits 1.0, we'd like them to be stable, so if we want to introduce padding we want to do it while we're pre 1.0.

This was discovered while working on https://github.com/anchore/sbom-action/issues/419, because it caused snapshot failures on https://github.com/anchore/sbom-action/pull/418

There doesn't seem to be a great way to get a unit test around this format string, and I doubt it will ever change once committed, so performed a small experiment (in addition to updating the snapshot test) to prove this does what we want. Playground at https://go.dev/play/p/fF7C7KS0kVh, code below in case those links are short lived:

``` go
package main

import (
	"fmt"
	"math"
)

func main() {
	var x uint64 = 17
	fmt.Printf("Without padding: %x\n", x)
	fmt.Printf("With padding: %016x\n", x)
	fmt.Printf("Correct length: %d (expect 16)\n", len(fmt.Sprintf("%016x", x)))
	fmt.Println("Checking maximums")
	max := uint64(math.MaxUint64) // otherwise somehow is an int and overflows
	fmt.Printf("math.MaxUint64 in hex, same regardless of padding: %x : %016x\n", max, max)
}
```

which prints

```
Without padding: 11
With padding: 0000000000000011
Correct length: 16 (expect 16)
Checking maximums
math.MaxUint64 in hex, same regardless of padding: ffffffffffffffff : ffffffffffffffff
```