### PR TITLE
Create chronicle config

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,0 +1,1 @@
+enforce-v0: true # don't make breaking-change lable bump major version before 1.0.

--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,1 +1,1 @@
-enforce-v0: true # don't make breaking-change lable bump major version before 1.0.
+enforce-v0: true # don't make breaking-change label bump major version before 1.0.


### PR DESCRIPTION
Track a chronicle config file that causes chronicle to bump minor version instead of major version in response to the "breaking-change" label for pre-1.0 releases.