### PR TITLE
docs: clarify reasoning of default catalogers for images or directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ This default behavior can be overridden with the `default-image-pull-source` con
 
 ### Default Cataloger Configuration by scan type
 
+Syft uses different default sets of catalogers depending on what it is scanning: a container image or a directory on disk. The default catalogers for an image scan assumes that package installation steps have already been completed. For example, Syft will identify Python packages that have egg or wheel metadata files under a site-packages directory, since this indicates software actually installed on an image.
+
+However, if you are scanning a directory, Syft doesn't assume that all relevant software is installed, and will use catalogers that can identify declared dependencies that may not yet be installed on the final system: for example, dependencies listed in a Python requirements.txt.
+
+You can override the list of enabled/disabled catalogers by using the "catalogers" keyword in the [Syft configuration file](https://github.com/anchore/syft#configuration).
+
 ##### Image Scanning:
 - alpmdb
 - apkdb


### PR DESCRIPTION
Add some explanation around why there are different default sets of catalogers for image scans versus directory scans. Hopefully clarify questions related to #1776.

Signed-off-by: Timothy Gerla <tim@gerla.net>