### PR TITLE
Fix version detection in Java archive name parsing

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -47,8 +47,8 @@ import (
 //	my-http2-server-5		-->	name="my-http2-server", version="5"
 //	jetpack-build235-rc5	-->	name="jetpack", version="build2.0-rc5"
 //	ironman-r4-2009			--> name="ironman", version="r4-2009"
-var nameAndVersionPattern = regexp.MustCompile(`(?Ui)^(?P<name>(?:[[:alpha:]][[:word:].]*(?:\.[[:alpha:]][[:word:].]*)*-?)+)(?:-(?P<version>(\d.*|(build\d*.*)|(rc?\d+(?:^[[:alpha:]].*)?))))?$`)
-var secondaryVersionPattern = regexp.MustCompile(`(?:[._-](?P<version>(\d.*|(build\d*.*)|(rc?\d+(?:^[[:alpha:]].*)?))))?$`)
+var nameAndVersionPattern = regexp.MustCompile(`(?Ui)^(?P<name>(?:[[:alpha:]][[:word:].]*(?:\.[[:alpha:]][[:word:].]*)*-?)+)(?:-(?P<version>(\d.*|(build\d+.*)|(rc?\d+(?:^[[:alpha:]].*)?))))?$`)
+var secondaryVersionPattern = regexp.MustCompile(`(?:[._-](?P<version>(\d.*|(build\d+.*)|(rc?\d+(?:^[[:alpha:]].*)?))))?$`)
 
 type archiveFilename struct {
 	raw     string

--- a/syft/pkg/cataloger/java/archive_filename_test.go
+++ b/syft/pkg/cataloger/java/archive_filename_test.go
@@ -173,6 +173,13 @@ func TestExtractInfoFromJavaArchiveFilename(t *testing.T) {
 			name:      "jboss-saaj-api_1.4_spec",
 			ty:        pkg.JavaPkg,
 		},
+		{
+			filename:  "/usr/share/java/gradle/lib/gradle-build-cache-8.1.1.jar",
+			version:   "8.1.1",
+			extension: "jar",
+			name:      "gradle-build-cache",
+			ty:        pkg.JavaPkg,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
There was a bug, caused by someone who shall remain nameless, where parsing the package name and version from a Java archive filename treated any strings that began with "build" as versions.

This leads to a large number of **false positives in Grype** because it feeds invalid versions into Grype's version comparison logic.

I believe the original intent was to ensure build numbers were treated as version components, which is valid, but when the package name included "build" with no number directly following (such as in `gradle-build-cache-8.1.1`), the "build" was automatically starting the version data, not continuing the package name data.

This has been addressed by changing `*` to `+` in a regex. 😆 