### PR TITLE
fix: add support for Dart SDK package dependencies

### DIFF
--- a/syft/pkg/cataloger/dart/parse_pubspec_lock.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec_lock.go
@@ -1,11 +1,12 @@
 package dart
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
@@ -31,11 +32,37 @@ type pubspecLockPackage struct {
 }
 
 type pubspecLockDescription struct {
+	isString bool
+	str      string
+	object   pubspecLockDescriptionObject
+}
+
+type pubspecLockDescriptionObject struct {
 	Name        string `yaml:"name" mapstructure:"name"`
 	URL         string `yaml:"url" mapstructure:"url"`
 	Path        string `yaml:"path" mapstructure:"path"`
 	Ref         string `yaml:"ref" mapstructure:"ref"`
 	ResolvedRef string `yaml:"resolved-ref" mapstructure:"resolved-ref"`
+}
+
+func (s *pubspecLockDescription) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		// this is a string
+		s.isString = true
+		s.str = value.Value // Or Unmarshal again, not sure
+		return nil
+	}
+	if value.Kind == yaml.MappingNode {
+		// Unmarshal to s.myStruct
+		var t pubspecLockDescriptionObject
+		if err := value.Decode(&t); err != nil {
+			return err
+		}
+		s.isString = false
+		s.object = t
+		return nil
+	}
+	return errors.New("Unexpected type: Expected string or Description map")
 }
 
 func parsePubspecLock(_ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
@@ -71,23 +98,23 @@ func parsePubspecLock(_ file.Resolver, _ *generic.Environment, reader file.Locat
 }
 
 func (p *pubspecLockPackage) getVcsURL() string {
-	if p.Source == "git" {
-		if p.Description.Path == "." {
-			return fmt.Sprintf("%s@%s", p.Description.URL, p.Description.ResolvedRef)
+	if p.Source == "git" && !p.Description.isString {
+		if p.Description.object.Path == "." {
+			return fmt.Sprintf("%s@%s", p.Description.object.URL, p.Description.object.ResolvedRef)
 		}
 
-		return fmt.Sprintf("%s@%s#%s", p.Description.URL, p.Description.ResolvedRef, p.Description.Path)
+		return fmt.Sprintf("%s@%s#%s", p.Description.object.URL, p.Description.object.ResolvedRef, p.Description.object.Path)
 	}
 
 	return ""
 }
 
 func (p *pubspecLockPackage) getHostedURL() string {
-	if p.Source == "hosted" && p.Description.URL != defaultPubRegistry {
-		u, err := url.Parse(p.Description.URL)
+	if p.Source == "hosted" && !p.Description.isString && p.Description.object.URL != defaultPubRegistry {
+		u, err := url.Parse(p.Description.object.URL)
 		if err != nil {
 			log.Debugf("Unable to parse registry url %w", err)
-			return p.Description.URL
+			return p.Description.object.URL
 		}
 		return u.Host
 	}

--- a/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
@@ -80,6 +80,19 @@ func TestParsePubspecLock(t *testing.T) {
 			},
 		},
 		{
+			Name:         "flutter",
+			Version:      "0.0.0",
+			PURL:         "pkg:pub/flutter@0.0.0",
+			Locations:    fixtureLocationSet,
+			Language:     pkg.Dart,
+			Type:         pkg.DartPubPkg,
+			MetadataType: pkg.DartPubMetadataType,
+			Metadata: pkg.DartPubMetadata{
+				Name:    "flutter",
+				Version: "0.0.0",
+			},
+		},
+		{
 			Name:         "key_binder",
 			Version:      "1.11.20",
 			PURL:         "pkg:pub/key_binder@1.11.20?vcs_url=git%40github.com:Workiva/key_binder.git%403f7b3a6350e73c7dcac45301c0e18fbd42af02f7",

--- a/syft/pkg/cataloger/dart/test-fixtures/pubspec.lock
+++ b/syft/pkg/cataloger/dart/test-fixtures/pubspec.lock
@@ -36,6 +36,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.0"
+  flutter:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   key_binder:
     dependency: "direct main"
     description:


### PR DESCRIPTION
SDK package dependencies such as Flutter cause yaml parsing errors. Update the parser so that lockfiles including these packages can be evaluated.