### PR TITLE
README: add installation section with Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ The chocolatey distribution of syft is community maintained and not distributed 
 choco install syft -y
 ```
 
+### Scoop
+
+```powershell
+scoop install syft
+```
+
 ### Homebrew
 ```bash
 brew install syft


### PR DESCRIPTION
Hi,
I noticed that among the windows package managers, Scoop was not listed, which does support syft. So I added it to the readme. If anything is missing in the pr please tell me. 