### PR TITLE
Remove erroneous Java CPEs from generation

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -377,6 +377,90 @@ var defaultCandidateRemovals = buildCandidateRemovalLookup(
 			candidateKey{PkgName: "docker"},
 			candidateRemovals{VendorsToRemove: []string{"docker"}},
 		},
+		// Java packages
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-builder-support"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-model"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-repository-metadata"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-settings"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-settings-builder"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-api"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-connector-basic"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-impl"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-named-locks"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-spi"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-transport-file"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-transport-http"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-transport-wagon"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-resolver-util"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "maven-shared-utils"},
+			candidateRemovals{ProductsToRemove: []string{"maven"}},
+		},
+		{
+			pkg.JavaPkg,
+			candidateKey{PkgName: "gradle-enterprise"},
+			candidateRemovals{
+				ProductsToRemove: []string{"gradle-enterprise"},
+				VendorsToRemove:  []string{"gradle"},
+			},
+		},
 	})
 
 // buildCandidateLookup is a convenience function for creating the defaultCandidateAdditions set


### PR DESCRIPTION
Per discussion w/ @wagoodman: filter out CPEs known to be incorrect, specifically as CPEs that match non-Maven components to Maven vulnerabilities.

Also adds one case for counting a "Gradle Enterprise" plugin as Gradle Enterprise itself.