### PR TITLE
Fix CPE generation for k8s python client

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -356,6 +356,11 @@ var defaultCandidateRemovals = buildCandidateRemovalLookup(
 			candidateKey{PkgName: "redis"},
 			candidateRemovals{VendorsToRemove: []string{"redis"}},
 		},
+		{
+			pkg.PythonPkg,
+			candidateKey{PkgName: "kubernetes"},
+			candidateRemovals{ProductsToRemove: []string{"kubernetes"}},
+		},
 		// NPM packages
 		{
 			pkg.NpmPkg,


### PR DESCRIPTION
I was seeing the Python K8s client library getting the CPE `...:kubernetes:kubernetes:...`, which is for Kubernetes itself.

I've been looking through NVD, and I don't think there's actually a CPE assigned yet for the Python client, but they use `...:kubernetes:java:...` for the Java client, so it seemed like a good move to avoid using the `kubernetes` product for the Python library (and assume that the product would most likely be something like `python`).