### PR TITLE
Don't use the actual redis or grpc CPEs for gems

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -461,6 +461,17 @@ var defaultCandidateRemovals = buildCandidateRemovalLookup(
 				VendorsToRemove:  []string{"gradle"},
 			},
 		},
+		// Ruby packages
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "redis"},
+			candidateRemovals{ProductsToRemove: []string{"redis"}},
+		},
+		{
+			pkg.GemPkg,
+			candidateKey{PkgName: "grpc"},
+			candidateRemovals{ProductsToRemove: []string{"grpc"}},
+		},
 	})
 
 // buildCandidateLookup is a convenience function for creating the defaultCandidateAdditions set


### PR DESCRIPTION
Matches using CPEs `redis:redis` and `grpc:grpc` for **_Ruby Gems_** will always be incorrect.