### PR TITLE
fix: background reader apart from global handler for testing

### DIFF
--- a/cmd/syft/cli/ui/handle_attestation_test.go
+++ b/cmd/syft/cli/ui/handle_attestation_test.go
@@ -28,7 +28,7 @@ func TestHandler_handleAttestationStarted(t *testing.T) {
 			// note: this model depends on a background reader. Multiple iterations ensures that the
 			// reader has time to at least start and process the test fixture before the runModel
 			// test harness completes (which is a fake event loop anyway).
-			iterations: 100,
+			iterations: 1,
 			eventFn: func(t *testing.T) partybus.Event {
 				reader := strings.NewReader("contents\nof\nstuff!")
 
@@ -61,7 +61,7 @@ func TestHandler_handleAttestationStarted(t *testing.T) {
 			// note: this model depends on a background reader. Multiple iterations ensures that the
 			// reader has time to at least start and process the test fixture before the runModel
 			// test harness completes (which is a fake event loop anyway).
-			iterations: 100,
+			iterations: 1,
 			eventFn: func(t *testing.T) partybus.Event {
 				reader := strings.NewReader("contents\nof\nstuff!")
 
@@ -123,7 +123,7 @@ func TestHandler_handleAttestationStarted(t *testing.T) {
 					Time:     time.Now(),
 					Sequence: log.sequence,
 					ID:       log.id,
-				})
+				}, log.reader.running)
 				t.Log(got)
 				snaps.MatchSnapshot(t, got)
 			})

--- a/cmd/syft/cli/ui/util_test.go
+++ b/cmd/syft/cli/ui/util_test.go
@@ -2,13 +2,14 @@ package ui
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"unsafe"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-func runModel(t testing.TB, m tea.Model, iterations int, message tea.Msg) string {
+func runModel(t testing.TB, m tea.Model, iterations int, message tea.Msg, h ...*sync.WaitGroup) string {
 	t.Helper()
 	if iterations == 0 {
 		iterations = 1
@@ -28,6 +29,12 @@ func runModel(t testing.TB, m tea.Model, iterations int, message tea.Msg) string
 			nextCmds = append(nextCmds, next)
 		}
 		cmd = tea.Batch(nextCmds...)
+	}
+
+	for _, each := range h {
+		if each != nil {
+			each.Wait()
+		}
 	}
 	return m.View()
 }


### PR DESCRIPTION
Add individual WG to background reader to track/block on buffer being read for snapshot tests

This should fix the race condition in CI rather than bumping iterations n number of times like we had in the past