### PR TITLE
fix: update java cataloger to include similar child packages, correct PURL, and correct GroupID

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -1,6 +1,7 @@
 package cpe
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/scylladb/go-set/strset"
@@ -189,6 +190,7 @@ func GroupIDsFromJavaMetadata(metadata pkg.JavaMetadata) (groupIDs []string) {
 	groupIDs = append(groupIDs, groupIDsFromPomProject(metadata.PomProject)...)
 	groupIDs = append(groupIDs, groupIDsFromJavaManifest(metadata.Manifest)...)
 
+	sort.Strings(groupIDs)
 	return groupIDs
 }
 

--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -31,13 +31,6 @@ var (
 		"Bundle-Activator",
 	}
 
-	/*
-		Long answer
-		stability is better than instability
-		correctness is better than incorrectness
-		Source of manifest truth
-		https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html
-	*/
 	secondaryJavaManifestGroupIDFields = []string{
 		"Automatic-Module-Name",
 		"Main-Class",

--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -190,11 +190,11 @@ func GroupIDFromJavaPackage(p pkg.Package) (groupID string) {
 
 // Java convention is that there is a single groupID
 func GroupIDFromJavaMetadata(metadata pkg.JavaMetadata) (groupID string) {
-	if groupID = groupIDFromPomProperties(metadata.PomProperties); groupID != "" {
+	if groupID = groupIDFromPomProject(metadata.PomProject); groupID != "" {
 		return groupID
 	}
 
-	if groupID = groupIDFromPomProject(metadata.PomProject); groupID != "" {
+	if groupID = groupIDFromPomProperties(metadata.PomProperties); groupID != "" {
 		return groupID
 	}
 
@@ -237,7 +237,7 @@ func groupIDFromPomProject(project *pkg.PomProject) (groupID string) {
 		return project.GroupID
 	}
 
-	// We didn't find a group ID so we should fall back and check the parent project
+	// We didn't find a group ID; We should fall back and check the parent project
 	if project.Parent != nil {
 		if project.Parent.GroupID != "" {
 			if startsWithTopLevelDomain(project.Parent.GroupID) {

--- a/syft/pkg/cataloger/common/cpe/java_test.go
+++ b/syft/pkg/cataloger/common/cpe/java_test.go
@@ -62,7 +62,7 @@ func Test_productsFromArtifactAndGroupIDs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(strings.Join(test.groupIDs, ",")+":"+test.artifactID, func(t *testing.T) {
-			actual := productsFromArtifactAndGroupIDs(test.artifactID, test.groupIDs)
+			actual := productsFromArtifactAndGroupID(test.artifactID, test.groupIDs)
 			assert.ElementsMatch(t, test.expected, actual, "different products")
 		})
 	}
@@ -334,7 +334,7 @@ func Test_groupIDsFromJavaPackage(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.ElementsMatch(t, test.expects, GroupIDsFromJavaPackage(test.pkg))
+			assert.ElementsMatch(t, test.expects, GroupIDFromJavaPackage(test.pkg))
 		})
 	}
 }

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -377,11 +377,9 @@ func pomProjectByParentPath(archivePath string, location file.Location, extractP
 // associating each discovered package to the given parent package. Note the pom.xml is optional, the pom.properties is not.
 func newPackageFromMavenData(pomProperties pkg.PomProperties, pomProject *pkg.PomProject, parentPkg *pkg.Package, location file.Location) *pkg.Package {
 	// keep the artifact name within the virtual path if this package does not match the parent package
-	vPathSuffix := ""
-	if !strings.HasPrefix(pomProperties.ArtifactID, parentPkg.Name) {
-		vPathSuffix += ":" + pomProperties.ArtifactID
-	}
-	virtualPath := location.AccessPath() + vPathSuffix
+	vPathSuffix := pomProperties.Path
+	accessPath := location.AccessPath()
+	virtualPath := accessPath + ":" + vPathSuffix
 
 	// discovered props = new package
 	p := pkg.Package{
@@ -410,25 +408,46 @@ func newPackageFromMavenData(pomProperties pkg.PomProperties, pomProject *pkg.Po
 }
 
 func packageIdentitiesMatch(p pkg.Package, parentPkg *pkg.Package) bool {
-	// the name/version pair matches...
-	if uniquePkgKey(&p) == uniquePkgKey(parentPkg) {
+	childMetadata, childOk := p.Metadata.(pkg.JavaMetadata)
+	parentMetadata, parentOk := parentPkg.Metadata.(pkg.JavaMetadata)
+	if !childOk || !parentOk {
+		switch {
+		case !childOk:
+			log.WithFields("package", p.String()).Warn("unable to extract java metadata to check for matching package identity")
+		case !parentOk:
+			log.WithFields("package", parentPkg.String()).Warn("unable to extract java metadata from parent for verifying virtual path")
+		}
+		// if we can't extract metadata, we can check for matching identities via the package name
+		// this is not ideal, but it's better than nothing - should not be used if we have metadata
+		if uniquePkgKey(&p) == uniquePkgKey(parentPkg) {
+			return true
+		}
+		return false
+	}
+
+	// try to determine identity with the metadata
+	parentSymbolicName := ""
+	if parentMetadata.Manifest != nil {
+		if ps, ok := parentMetadata.Manifest.Main[""]; ok {
+			// trim the parent symbolic name from the right to the first period
+			// e.g. "com.sun.xml.bind" from "com.sun.xml.bind.jaxb-core"
+			parentSymbolicName = ps
+		}
+	}
+
+	childSymbolicName := ""
+	if childMetadata.PomProperties != nil {
+		childName := p.Name
+		childGroupId := childMetadata.PomProperties.GroupID
+		childSymbolicName = childGroupId + "." + childName
+	}
+
+	if parentSymbolicName == childSymbolicName {
 		return true
 	}
 
-	metadata, ok := p.Metadata.(pkg.JavaMetadata)
-	if !ok {
-		log.WithFields("package", p.String()).Warn("unable to extract java metadata to check for matching package identity")
-		return false
-	}
-
-	parentMetadata, ok := parentPkg.Metadata.(pkg.JavaMetadata)
-	if !ok {
-		log.WithFields("package", p.String()).Warn("unable to extract java metadata from parent for verifying virtual path")
-		return false
-	}
-
 	// the virtual path matches...
-	if parentMetadata.VirtualPath == metadata.VirtualPath {
+	if parentMetadata.VirtualPath == childMetadata.VirtualPath {
 		return true
 	}
 
@@ -436,9 +455,11 @@ func packageIdentitiesMatch(p pkg.Package, parentPkg *pkg.Package) bool {
 	// note: you CANNOT use name-is-subset-of-artifact-id or vice versa --this is too generic. Shaded jars are a good
 	// example of this: where the package name is "cloudbees-analytics-segment-driver" and a child is "analytics", but
 	// they do not indicate the same package.
-	if metadata.PomProperties.ArtifactID != "" && parentPkg.Name == metadata.PomProperties.ArtifactID {
-		return true
-	}
+	// NOTE: artifactId might not be a good indicator of uniqueness since archives can contain forks with the same name
+	// from different groups (e.g. "org.glassfish.jaxb.jaxb-core" and "com.sun.xml.bind.jaxb-core")
+	//if childMetadata.PomProperties.ArtifactID != "" && parentPkg.Name == childMetadata.PomProperties.ArtifactID {
+	//	return true
+	//}
 
 	return false
 }

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -184,6 +184,8 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		log.Warnf("failed to create digest for file=%q: %+v", j.archivePath, err)
 	}
 
+	name := selectName(manifest, j.fileInfo)
+	fmt.Println("name: ", name)
 	// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
 	licenses := pkg.NewLicensesFromLocation(j.location, selectLicenses(manifest)...)
 	return &pkg.Package{

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -184,8 +184,6 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		log.Warnf("failed to create digest for file=%q: %+v", j.archivePath, err)
 	}
 
-	name := selectName(manifest, j.fileInfo)
-	fmt.Println("name: ", name)
 	// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
 	licenses := pkg.NewLicensesFromLocation(j.location, selectLicenses(manifest)...)
 	return &pkg.Package{

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -397,6 +397,8 @@ func newPackageFromMavenData(pomProperties pkg.PomProperties, pomProject *pkg.Po
 		},
 	}
 
+	// TODO: is this a merge of the two packages data?
+	// It's a bug if we try to merge logistically separate packages
 	if packageIdentitiesMatch(p, parentPkg) {
 		updateParentPackage(p, parentPkg)
 		return nil
@@ -405,6 +407,7 @@ func newPackageFromMavenData(pomProperties pkg.PomProperties, pomProject *pkg.Po
 	return &p
 }
 
+// TODO: Crux of our current change for identifying valid child packages
 func packageIdentitiesMatch(p pkg.Package, parentPkg *pkg.Package) bool {
 	childMetadata, childOk := p.Metadata.(pkg.JavaMetadata)
 	parentMetadata, parentOk := parentPkg.Metadata.(pkg.JavaMetadata)
@@ -416,20 +419,12 @@ func packageIdentitiesMatch(p pkg.Package, parentPkg *pkg.Package) bool {
 			log.WithFields("package", parentPkg.String()).Warn("unable to extract java metadata from parent for verifying virtual path")
 		}
 		// if we can't extract metadata, we can check for matching identities via the package name
-		// this is not ideal, but it's better than nothing - should not be used if we have metadata
+		// this is not ideal, but it's better than nothing - this should not be used if we have metadata
 		return uniquePkgKey(&p) == uniquePkgKey(parentPkg)
 	}
 
 	// try to determine identity with the metadata
 	parentSymbolicName := ""
-	if parentMetadata.Manifest != nil {
-		if ps, ok := parentMetadata.Manifest.Main["Bundle-SymbolicName"]; ok {
-			// trim the parent symbolic name from the right to the first period
-			// e.g. "com.sun.xml.bind" from "com.sun.xml.bind.jaxb-core"
-			parentSymbolicName = ps
-		}
-	}
-
 	childSymbolicName := ""
 	if childMetadata.PomProperties != nil {
 		childName := p.Name

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	intFile "github.com/anchore/syft/internal/file"
@@ -375,7 +376,7 @@ func pomProjectByParentPath(archivePath string, location file.Location, extractP
 // associating each discovered package to the given parent package. Note the pom.xml is optional, the pom.properties is not.
 func newPackageFromMavenData(pomProperties pkg.PomProperties, pomProject *pkg.PomProject, parentPkg *pkg.Package, location file.Location) *pkg.Package {
 	// keep the artifact name within the virtual path if this package does not match the parent package
-	vPathSuffix := pomProperties.Path
+	vPathSuffix := filepath.Clean(strings.TrimSuffix(pomProperties.Path, filepath.Base(pomProperties.Path)))
 	accessPath := location.AccessPath()
 	virtualPath := accessPath + ":" + vPathSuffix
 

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -85,6 +84,7 @@ func TestParseJar(t *testing.T) {
 	tests := []struct {
 		fixture      string
 		expected     map[string]pkg.Package
+		detectNested bool
 		ignoreExtras []string
 	}{
 		{
@@ -144,6 +144,11 @@ func TestParseJar(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			fixture:      "test-fixtures/java-builds/packages/1944-regression.war",
+			expected:     map[string]pkg.Package{},
+			detectNested: true,
 		},
 		{
 			fixture: "test-fixtures/java-builds/packages/example-java-app-gradle-0.1.0.jar",
@@ -263,7 +268,7 @@ func TestParseJar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(path.Base(test.fixture), func(t *testing.T) {
+		t.Run(test.fixture, func(t *testing.T) {
 
 			generateJavaBuildFixture(t, test.fixture)
 
@@ -279,7 +284,7 @@ func TestParseJar(t *testing.T) {
 			parser, cleanupFn, err := newJavaArchiveParser(file.LocationReadCloser{
 				Location:   file.NewLocation(fixture.Name()),
 				ReadCloser: fixture,
-			}, false)
+			}, test.detectNested)
 			defer cleanupFn()
 			require.NoError(t, err)
 

--- a/syft/pkg/cataloger/java/package_url.go
+++ b/syft/pkg/cataloger/java/package_url.go
@@ -1,6 +1,8 @@
 package java
 
 import (
+	"sort"
+
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/common/cpe"
@@ -11,6 +13,7 @@ func packageURL(name, version string, metadata pkg.JavaMetadata) string {
 	var groupID = name
 	groupIDs := cpe.GroupIDsFromJavaMetadata(metadata)
 	if len(groupIDs) > 0 {
+		sort.Strings(groupIDs)
 		groupID = groupIDs[0]
 	}
 

--- a/syft/pkg/cataloger/java/package_url.go
+++ b/syft/pkg/cataloger/java/package_url.go
@@ -1,8 +1,6 @@
 package java
 
 import (
-	"sort"
-
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/common/cpe"
@@ -10,13 +8,7 @@ import (
 
 // PackageURL returns the PURL for the specific java package (see https://github.com/package-url/purl-spec)
 func packageURL(name, version string, metadata pkg.JavaMetadata) string {
-	var groupID = name
-	groupIDs := cpe.GroupIDsFromJavaMetadata(metadata)
-	if len(groupIDs) > 0 {
-		sort.Strings(groupIDs)
-		groupID = groupIDs[0]
-	}
-
+	groupID := cpe.GroupIDFromJavaMetadata(metadata)
 	pURL := packageurl.NewPackageURL(
 		packageurl.TypeMaven, // TODO: should we filter down by package types here?
 		groupID,

--- a/syft/pkg/cataloger/java/package_url.go
+++ b/syft/pkg/cataloger/java/package_url.go
@@ -9,6 +9,12 @@ import (
 // PackageURL returns the PURL for the specific java package (see https://github.com/package-url/purl-spec)
 func packageURL(name, version string, metadata pkg.JavaMetadata) string {
 	groupID := cpe.GroupIDFromJavaMetadata(metadata)
+	if groupID == "" {
+		// we could not find the group ID in the pom xml, pom properties, or manifest
+		// last ditch use the name for cases like this
+		// https://mvnrepository.com/artifact/postgresql/postgresql/9.1-901-1.jdbc4
+		groupID = name
+	}
 	pURL := packageurl.NewPackageURL(
 		packageurl.TypeMaven, // TODO: should we filter down by package types here?
 		groupID,


### PR DESCRIPTION
## Summary

This PR aims to improve 3 related aspects of syft's java cataloging.

1. Improve PURL generation. In some cases syft is appending the artifact ID to the middle section (GroupID) of a PURL
    a. EX: `pkg:maven/org.apache.xalan/xalan@2.7.2` should be `pkg:maven/org.apache/xalan@2.7.2`
2. Improve `GroupID` detection. Currently syft does not use any hierarchy for `GroupID` detection and treats all sources as equal. It does already treat fields from files with priority. We should try to obtain a GroupID answer from `Pom Properties`, then the `Pom Project` and finally, if a GroupID has not been found, the `Manifest`. `Manifest` should not return an answer if one was found in `PomProject` was, and `PomProject` should not return a GroupID answer if `PomProperties` found one.
3. Syft eliminates java packages as duplicates if the package names match. With the enhanced GroupID detection we can extend this duplicate elimination to make sure syft is not eliminating packages with similar names, but different GroupID.
    

    - Reviewers of this PR will notice that there has been an update in how the virtual path is expressed on the java metadata. This is a consequence of new java packages being added when before they were incorrectly deduped, . Rather than `vPathSuffix += ":" + pomProperties.ArtifactID`, which just uses the ArtifactID, SBOM consumers will see the full path of the package's properties used for package creation Ex: `META-INF/maven/org.glassfish.jaxb/jaxb-core/pom.properties`. This allows for better identification for child packages that look identical, but are actually forks or similar clones:
        - Previously: `/casb.war:WEB-INF/lib/jaxb-core-2.2.11.jar:jaxb-core`
        - Now:`/casb.war:WEB-INF/lib/jaxb-core-2.2.11.jar:META-INF/maven/org.glassfish.jaxb/jaxb-core`