### PR TITLE
Fix panic condition on docker pull failure

### DIFF
--- a/cmd/syft/cli/packages/packages.go
+++ b/cmd/syft/cli/packages/packages.go
@@ -3,7 +3,6 @@ package packages
 import (
 	"context"
 	"fmt"
-	"github.com/anchore/syft/internal/log"
 
 	"github.com/wagoodman/go-partybus"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/config"
 	"github.com/anchore/syft/internal/file"
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/version"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/artifact"

--- a/cmd/syft/cli/ui/handle_pull_docker_image.go
+++ b/cmd/syft/cli/ui/handle_pull_docker_image.go
@@ -2,17 +2,18 @@ package ui
 
 import (
 	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/dustin/go-humanize"
 	"github.com/wagoodman/go-partybus"
 	"github.com/wagoodman/go-progress"
-	"strings"
 
 	"github.com/anchore/bubbly/bubbles/taskprogress"
 	stereoscopeParsers "github.com/anchore/stereoscope/pkg/event/parsers"
 	"github.com/anchore/stereoscope/pkg/image/docker"
 	"github.com/anchore/syft/internal/log"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 var _ interface {
@@ -21,7 +22,6 @@ var _ interface {
 } = (*dockerPullProgressAdapter)(nil)
 
 type dockerPullStatus interface {
-	Error() error
 	Complete() bool
 	Layers() []docker.LayerID
 	Current(docker.LayerID) docker.LayerState
@@ -92,25 +92,10 @@ func (d dockerPullProgressAdapter) Current() int64 {
 }
 
 func (d dockerPullProgressAdapter) Error() error {
-	err := d.status.Error()
-	if err != nil {
-		return err
-	}
-
 	if d.status.Complete() {
 		return progress.ErrCompleted
 	}
-	for _, l := range d.status.Layers() {
-		cur := d.status.Current(l)
-		phaseErr := cur.PhaseProgress.Error()
-		dlErr := cur.DownloadProgress.Error()
-		if phaseErr != nil && !progress.IsErrCompleted(phaseErr) {
-			return phaseErr
-		}
-		if dlErr != nil && !progress.IsErrCompleted(dlErr) {
-			return dlErr
-		}
-	}
+	// TODO: return intermediate error indications
 	return nil
 }
 
@@ -121,11 +106,6 @@ func (d dockerPullProgressAdapter) Stage() string {
 // Render crafts the given docker image pull status summarized into a single line.
 func (f dockerPullStatusFormatter) Render(pullStatus dockerPullStatus) string {
 	var size, current uint64
-
-	err := pullStatus.Error()
-	if err != nil && !progress.IsErrCompleted(err) {
-		return "NOPE"
-	}
 
 	layers := pullStatus.Layers()
 	status := make(map[docker.LayerID]docker.LayerState)

--- a/cmd/syft/internal/ui/ui.go
+++ b/cmd/syft/internal/ui/ui.go
@@ -82,12 +82,14 @@ func (m *UI) Teardown(force bool) error {
 	if !force {
 		m.handler.Running.Wait()
 		m.program.Quit()
-		//m.running.Wait() // TODO?
+		// typically in all cases we would want to wait for the UI to finish. However there are still error cases
+		// that are not accounted for, resulting in hangs. For now, we'll just wait for the UI to finish in the
+		// happy path only. There will always be an indication of the problem to the user via reporting the error
+		// string from the worker (outside of the UI after teardown).
+		m.running.Wait()
 	} else {
 		m.program.Kill()
 	}
-
-	m.running.Wait() // TODO?
 
 	// TODO: allow for writing out the full log output to the screen (only a partial log is shown currently)
 	// this needs coordination to know what the last frame event is to change the state accordingly (which isn't possible now)

--- a/cmd/syft/internal/ui/ui.go
+++ b/cmd/syft/internal/ui/ui.go
@@ -82,11 +82,12 @@ func (m *UI) Teardown(force bool) error {
 	if !force {
 		m.handler.Running.Wait()
 		m.program.Quit()
+		//m.running.Wait() // TODO?
 	} else {
 		m.program.Kill()
 	}
 
-	m.running.Wait()
+	m.running.Wait() // TODO?
 
 	// TODO: allow for writing out the full log output to the screen (only a partial log is shown currently)
 	// this needs coordination to know what the last frame event is to change the state accordingly (which isn't possible now)


### PR DESCRIPTION
When pulling a docker image and there is an issue, there is a panic when attempting to close the source:
```
❯ go run ./cmd/syft python:slim -o json
  ⠼ Pulling image
 panic: value method github.com/anchore/syft/syft/source.StereoscopeImageSource.Close called using nil *StereoscopeImageSource pointer
 
 goroutine 9 [running]:
 github.com/anchore/syft/syft/source.(*StereoscopeImageSource).Close(0xc00011c3e0?)
         <autogenerated>:1 +0x86
 github.com/anchore/syft/cmd/syft/cli/packages.execWorker.func1()
         /Users/wagoodman/code/syft/cmd/syft/cli/packages/packages.go:109 +0x92a
created by github.com/anchore/syft/cmd/syft/cli/packages.execWorker
        /Users/wagoodman/code/syft/cmd/syft/cli/packages/packages.go:57 +0xf7
 exit status 2
```

When fixing the panic, it was noticed that the UI was hung (but no more panicing!). There seems to be an underlying issue to fix in last-event handling in the syft event loop and error conditions in stereoscope, both of which have been deferred. In the meantime there was an additional change to not wait for the UI to teardown in kill situations, resulting in the following output:

```
❯ go run ./cmd/syft python:slims -o json
 ⠦ Pulling image                   
2023/07/27 11:18:59 error during command execution: 1 error occurred:
        * failed to construct source from user input "python:slims": unable to load image: unable to use DockerDaemon source: pull failed: Error response from daemon: manifest for python:slims not found: manifest unknown: manifest unknown

exit status 1
```