### PR TITLE
fix: prevent hang if stderr is tty but stdout is not

### DIFF
--- a/cmd/syft/internal/ui/select.go
+++ b/cmd/syft/internal/ui/select.go
@@ -21,7 +21,7 @@ import (
 func Select(verbose, quiet bool) (uis []clio.UI) {
 	isStdoutATty := term.IsTerminal(int(os.Stdout.Fd()))
 	isStderrATty := term.IsTerminal(int(os.Stderr.Fd()))
-	notATerminal := !isStderrATty && !isStdoutATty
+	notATerminal := !isStderrATty || !isStdoutATty
 
 	switch {
 	case runtime.GOOS == "windows" || verbose || quiet || notATerminal || !isStderrATty:


### PR DESCRIPTION
Previously, the rich TUI would be enabled if either stderr or stdout is a TTY, but this could cause syft to hang if stderr was a TTY and stdout was not, as in some cases of redirection.

Fixes https://github.com/anchore/syft/issues/1439

## Manual testing done:

```
# hangs forever:
❯ cat <(syft alpine:latest | head -n 1) <(syft alpine:latest | rg binary)
^C
# runs normally:
❯ cat <(go run cmd/syft/main.go alpine:latest | head -n 1) <(go run cmd/syft/main.go alpine:latest | rg binary)
NAME                    VERSION      TYPE
busybox                 1.36.1       binary