### PR TITLE
Add metadata types to all CPE test fixtures

### DIFF
--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -354,11 +354,12 @@ func TestGeneratePackageCPEs(t *testing.T) {
 		{
 			name: "cloudbees jenkins package identified via groupId",
 			p: pkg.Package{
-				Name:     "name",
-				Version:  "3.2",
-				FoundBy:  "some-analyzer",
-				Language: pkg.Java,
-				Type:     pkg.JenkinsPluginPkg,
+				Name:         "name",
+				Version:      "3.2",
+				FoundBy:      "some-analyzer",
+				Language:     pkg.Java,
+				Type:         pkg.JenkinsPluginPkg,
+				MetadataType: pkg.JavaMetadataType,
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
 						GroupID: "com.cloudbees.jenkins.plugins",
@@ -368,16 +369,18 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:cloudbees:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
 			name: "jenkins.io package identified via groupId prefix",
 			p: pkg.Package{
-				Name:     "name",
-				Version:  "3.2",
-				FoundBy:  "some-analyzer",
-				Language: pkg.Java,
-				Type:     pkg.JenkinsPluginPkg,
+				Name:         "name",
+				Version:      "3.2",
+				FoundBy:      "some-analyzer",
+				Language:     pkg.Java,
+				Type:         pkg.JenkinsPluginPkg,
+				MetadataType: pkg.JavaMetadataType,
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
 						GroupID: "io.jenkins.plugins.name.something",
@@ -389,16 +392,19 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:name:something:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:something:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:something:something:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:something:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
 			name: "jenkins.io package identified via groupId",
 			p: pkg.Package{
-				Name:     "name",
-				Version:  "3.2",
-				FoundBy:  "some-analyzer",
-				Language: pkg.Java,
-				Type:     pkg.JenkinsPluginPkg,
+				Name:         "name",
+				Version:      "3.2",
+				FoundBy:      "some-analyzer",
+				Language:     pkg.Java,
+				Type:         pkg.JenkinsPluginPkg,
+				MetadataType: pkg.JavaMetadataType,
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
 						GroupID: "io.jenkins.plugins",
@@ -407,16 +413,18 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
 			name: "jenkins-ci.io package identified via groupId",
 			p: pkg.Package{
-				Name:     "name",
-				Version:  "3.2",
-				FoundBy:  "some-analyzer",
-				Language: pkg.Java,
-				Type:     pkg.JenkinsPluginPkg,
+				Name:         "name",
+				Version:      "3.2",
+				FoundBy:      "some-analyzer",
+				Language:     pkg.Java,
+				Type:         pkg.JenkinsPluginPkg,
+				MetadataType: pkg.JavaMetadataType,
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
 						GroupID: "io.jenkins-ci.plugins",
@@ -425,16 +433,20 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
 			name: "jenkins-ci.org package identified via groupId",
 			p: pkg.Package{
-				Name:     "name",
-				Version:  "3.2",
-				FoundBy:  "some-analyzer",
-				Language: pkg.Java,
-				Type:     pkg.JenkinsPluginPkg,
+				Name:         "name",
+				Version:      "3.2",
+				FoundBy:      "some-analyzer",
+				Language:     pkg.Java,
+				Type:         pkg.JenkinsPluginPkg,
+				MetadataType: pkg.JavaMetadataType,
 				Metadata: pkg.JavaMetadata{
 					PomProperties: &pkg.PomProperties{
 						GroupID: "org.jenkins-ci.plugins",
@@ -443,6 +455,9 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{


### PR DESCRIPTION
There is an issue with some of the existing tests for CPE generation where we will assert that a subset of the actual CPEs are generated. This is due to to not all test fixtures having the metadata-type specified (which, when there is data in the metadata field, should always be specified). When fixed the CPE geneneration tests begin to fail:
```
=== RUN   TestGeneratePackageCPEs/cloudbees_jenkins_package_identified_via_groupId
   generate_test.go:716: found extra CPEs:
   generate_test.go:718:    "cpe:2.3:a:cloudbees:name:3.2:*:*:*:*:*:*:*",
=== RUN   TestGeneratePackageCPEs/jenkins.io_package_identified_via_groupId_prefix
   generate_test.go:716: found extra CPEs:
   generate_test.go:718:    "cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
   generate_test.go:718:    "cpe:2.3:a:jenkins:something:3.2:*:*:*:*:*:*:*",
=== RUN   TestGeneratePackageCPEs/jenkins.io_package_identified_via_groupId
   generate_test.go:716: found extra CPEs:
   generate_test.go:718:    "cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
=== RUN   TestGeneratePackageCPEs/jenkins-ci.io_package_identified_via_groupId
   generate_test.go:716: found extra CPEs:
   generate_test.go:718:    "cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
   generate_test.go:718:    "cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
   generate_test.go:718:    "cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",
=== RUN   TestGeneratePackageCPEs/jenkins-ci.org_package_identified_via_groupId
   generate_test.go:716: found extra CPEs:
   generate_test.go:718:    "cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
   generate_test.go:718:    "cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
   generate_test.go:718:    "cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",

```

This PR adjusts the tests to reflect the reality of what is being generated today and makes no attempt to fix the CPE generation behavior.