### PR TITLE
Set precedence for root options

### DIFF
--- a/cmd/syft/cli/options/root.go
+++ b/cmd/syft/cli/options/root.go
@@ -2,8 +2,9 @@ package options
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/anchore/syft/internal"
 )
 
 type RootOptions struct {
@@ -15,23 +16,19 @@ type RootOptions struct {
 var _ Interface = (*RootOptions)(nil)
 
 func (o *RootOptions) AddFlags(cmd *cobra.Command, v *viper.Viper) error {
+	// load environment variables
+	v.SetEnvPrefix(internal.ApplicationName)
+	v.AllowEmptyEnv(true)
+	v.AutomaticEnv()
+
 	cmd.PersistentFlags().StringVarP(&o.Config, "config", "c", "", "application config file")
 	cmd.PersistentFlags().CountVarP(&o.Verbose, "verbose", "v", "increase verbosity (-v = info, -vv = debug)")
 	cmd.PersistentFlags().BoolVarP(&o.Quiet, "quiet", "q", false, "suppress all logging output")
 
-	return bindRootConfigOptions(cmd.PersistentFlags(), v)
-}
+	// Set precedence order of flag -> env -> defaults
+	o.Config = v.GetString("config")
+	o.Quiet = v.GetBool("quiet")
+	o.Verbose = v.GetInt("verbose")
 
-//nolint:revive
-func bindRootConfigOptions(flags *pflag.FlagSet, v *viper.Viper) error {
-	if err := v.BindPFlag("config", flags.Lookup("config")); err != nil {
-		return err
-	}
-	if err := v.BindPFlag("verbosity", flags.Lookup("verbose")); err != nil {
-		return err
-	}
-	if err := v.BindPFlag("quiet", flags.Lookup("quiet")); err != nil {
-		return err
-	}
 	return nil
 }

--- a/internal/config/application.go
+++ b/internal/config/application.go
@@ -110,11 +110,6 @@ func (cfg *Application) LoadAllValues(v *viper.Viper, configPath string) error {
 	// load default config values into viper
 	loadDefaultValues(v)
 
-	// load environment variables
-	v.SetEnvPrefix(internal.ApplicationName)
-	v.AllowEmptyEnv(true)
-	v.AutomaticEnv()
-
 	// unmarshal fully populated viper object onto config
 	err := v.Unmarshal(cfg)
 	if err != nil {


### PR DESCRIPTION
Allows RootOptions to be set using command line flags or alternatively through an environmental variable.  Maintains the priority order described in Application.LoadAllValues.

Fixes #1986