### PR TITLE
fix: gradle lockfile parser groupId handling

### DIFF
--- a/syft/pkg/cataloger/java/parse_gradle_lockfile.go
+++ b/syft/pkg/cataloger/java/parse_gradle_lockfile.go
@@ -57,7 +57,16 @@ func parseGradleLockfile(_ file.Resolver, _ *generic.Environment, reader file.Lo
 			Language:     pkg.Java,
 			Type:         pkg.JavaPkg,
 			MetadataType: pkg.JavaMetadataType,
+			Metadata: pkg.JavaMetadata{
+				PomProject: &pkg.PomProject{
+					GroupID:    dep.Group,
+					ArtifactID: dep.Name,
+					Version:    dep.Version,
+					Name:       dep.Name,
+				},
+			},
 		}
+		mappedPkg.SetID()
 		pkgs = append(pkgs, mappedPkg)
 	}
 

--- a/syft/pkg/cataloger/java/parse_gradle_lockfile_test.go
+++ b/syft/pkg/cataloger/java/parse_gradle_lockfile_test.go
@@ -17,11 +17,24 @@ func Test_parserGradleLockfile(t *testing.T) {
 			input: "test-fixtures/gradle/gradle.lockfile",
 			expected: []pkg.Package{
 				{
+					Name:         "commons-text",
+					Version:      "1.8",
+					Language:     pkg.Java,
+					Type:         pkg.JavaPkg,
+					MetadataType: pkg.JavaMetadataType,
+					Metadata: pkg.JavaMetadata{
+						PomProject: &pkg.PomProject{GroupID: "org.apache.commons", ArtifactID: "commons-text", Version: "1.8", Name: "commons-text"},
+					},
+				},
+				{
 					Name:         "hamcrest-core",
 					Version:      "1.3",
 					Language:     pkg.Java,
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
+					Metadata: pkg.JavaMetadata{
+						PomProject: &pkg.PomProject{GroupID: "org.hamcrest", ArtifactID: "hamcrest-core", Version: "1.3", Name: "hamcrest-core"},
+					},
 				},
 				{
 					Name:         "joda-time",
@@ -29,6 +42,9 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Language:     pkg.Java,
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
+					Metadata: pkg.JavaMetadata{
+						PomProject: &pkg.PomProject{GroupID: "joda-time", ArtifactID: "joda-time", Version: "2.2", Name: "joda-time"},
+					},
 				},
 				{
 					Name:         "junit",
@@ -36,6 +52,9 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Language:     pkg.Java,
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
+					Metadata: pkg.JavaMetadata{
+						PomProject: &pkg.PomProject{GroupID: "junit", ArtifactID: "junit", Version: "4.12", Name: "junit"},
+					},
 				},
 			},
 		},

--- a/syft/pkg/cataloger/java/test-fixtures/gradle/gradle.lockfile
+++ b/syft/pkg/cataloger/java/test-fixtures/gradle/gradle.lockfile
@@ -5,3 +5,4 @@ joda-time:joda-time:2.2=compileClasspath,runtimeClasspath,testCompileClasspath,t
 junit:junit:4.12=testCompileClasspath,testRuntimeClasspath
 org.hamcrest:hamcrest-core:1.3=testCompileClasspath,testRuntimeClasspath
 empty=annotationProcessor,testAnnotationProcessor
+org.apache.commons:commons-text:1.8=compileClasspath


### PR DESCRIPTION
This PR corrects an issue where the Gradle lockfile parser was neither taking into account the `groupId` nor creating a `JavaMetadata` object, despite indicating the `MetadataType` was java metadata. This resulted in, among other things, CPEs being generated incorrectly for the entries in the lockfile.

Fixes: #1957