### PR TITLE
fix: update glob to use newer usr/lib/sysimage path

### DIFF
--- a/syft/pkg/rpm_metadata.go
+++ b/syft/pkg/rpm_metadata.go
@@ -13,7 +13,7 @@ import (
 // Packages is the legacy Berkely db based format
 // Packages.db is the "ndb" format used in SUSE
 // rpmdb.sqlite is the sqlite format used in fedora + derivates
-const RpmDBGlob = "**/{var/lib,usr/share}/rpm/{Packages,Packages.db,rpmdb.sqlite}"
+const RpmDBGlob = "**/{var/lib,usr/share,usr/lib/sysimage}/rpm/{Packages,Packages.db,rpmdb.sqlite}"
 
 // Used in CBL-Mariner distroless images
 const RpmManifestGlob = "**/var/lib/rpmmanifest/container-manifest-2"


### PR DESCRIPTION
## Summary

See the below link:
https://fedoraproject.org/wiki/Changes/RelocateRPMToUsr

Photon does not soft link the old location of `var/lib` to the newer location like other distros. We should account for this in our RpmDBGlob search by including a search for the newer path

#### Fix ScreenShot

Note the second run of syft is the latest version. The first run has the current branches code
<img width="893" alt="Screenshot 2023-08-03 at 7 08 14 PM" src="https://github.com/anchore/syft/assets/32073428/9dcbfea7-9f9e-476e-a5df-21d838641fb0">

