### PR TITLE
fix: SPDX license values and download location

### DIFF
--- a/syft/formats/common/spdxhelpers/license.go
+++ b/syft/formats/common/spdxhelpers/license.go
@@ -70,7 +70,7 @@ func parseLicenses(raw []pkg.License) (concluded, declared []spdxLicense) {
 
 		candidate := spdxLicense{}
 		if l.SPDXExpression != "" {
-			candidate.id = SanitizeElementID(l.SPDXExpression)
+			candidate.id = l.SPDXExpression
 		} else {
 			// we did not find a valid SPDX license ID so treat as separate license
 			if len(l.Value) <= 64 {
@@ -78,10 +78,8 @@ func parseLicenses(raw []pkg.License) (concluded, declared []spdxLicense) {
 				// just use it directly so the id is more readable
 				candidate.id = spdxlicense.LicenseRefPrefix + SanitizeElementID(l.Value)
 			} else {
-				h := sha256.New()
-				h.Write([]byte(l.Value))
-				bs := h.Sum(nil)
-				candidate.id = fmt.Sprintf("%s%x", spdxlicense.LicenseRefPrefix, bs)
+				hash := sha256.Sum256([]byte(l.Value))
+				candidate.id = fmt.Sprintf("%s%x", spdxlicense.LicenseRefPrefix, hash)
 			}
 			candidate.value = l.Value
 		}

--- a/syft/formats/common/spdxhelpers/license.go
+++ b/syft/formats/common/spdxhelpers/license.go
@@ -1,6 +1,8 @@
 package spdxhelpers
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
 
 	"github.com/anchore/syft/internal/spdxlicense"
@@ -27,29 +29,18 @@ func License(p pkg.Package) (concluded, declared string) {
 	// https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/
 	pc, pd := parseLicenses(p.Licenses.ToSlice())
 
-	for i, v := range pc {
-		if strings.HasPrefix(v, spdxlicense.LicenseRefPrefix) {
-			pc[i] = SanitizeElementID(v)
-		}
-	}
-
-	for i, v := range pd {
-		if strings.HasPrefix(v, spdxlicense.LicenseRefPrefix) {
-			pd[i] = SanitizeElementID(v)
-		}
-	}
-
 	return joinLicenses(pc), joinLicenses(pd)
 }
 
-func joinLicenses(licenses []string) string {
+func joinLicenses(licenses []spdxLicense) string {
 	if len(licenses) == 0 {
 		return NOASSERTION
 	}
 
 	var newLicenses []string
 
-	for _, v := range licenses {
+	for _, l := range licenses {
+		v := l.id
 		// check if license does not start or end with parens
 		if !strings.HasPrefix(v, "(") && !strings.HasSuffix(v, ")") {
 			// if license contains AND, OR, or WITH, then wrap in parens
@@ -66,14 +57,33 @@ func joinLicenses(licenses []string) string {
 	return strings.Join(newLicenses, " AND ")
 }
 
-func parseLicenses(raw []pkg.License) (concluded, declared []string) {
+type spdxLicense struct {
+	id    string
+	value string
+}
+
+func parseLicenses(raw []pkg.License) (concluded, declared []spdxLicense) {
 	for _, l := range raw {
-		var candidate string
+		if l.Value == "" {
+			continue
+		}
+
+		candidate := spdxLicense{}
 		if l.SPDXExpression != "" {
-			candidate = l.SPDXExpression
+			candidate.id = SanitizeElementID(l.SPDXExpression)
 		} else {
 			// we did not find a valid SPDX license ID so treat as separate license
-			candidate = spdxlicense.LicenseRefPrefix + l.Value
+			if len(l.Value) <= 64 {
+				// if the license text is less than the size of the hash,
+				// just use it directly so the id is more readable
+				candidate.id = spdxlicense.LicenseRefPrefix + SanitizeElementID(l.Value)
+			} else {
+				h := sha256.New()
+				h.Write([]byte(l.Value))
+				bs := h.Sum(nil)
+				candidate.id = fmt.Sprintf("%s%x", spdxlicense.LicenseRefPrefix, bs)
+			}
+			candidate.value = l.Value
 		}
 
 		switch l.Type {
@@ -83,5 +93,6 @@ func parseLicenses(raw []pkg.License) (concluded, declared []string) {
 			declared = append(declared, candidate)
 		}
 	}
+
 	return concluded, declared
 }

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/spdxlicense"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
@@ -495,10 +496,7 @@ func parseSPDXLicenses(p *spdx.Package) []pkg.License {
 }
 
 func cleanSPDXID(id string) string {
-	if strings.HasPrefix(id, "LicenseRef-") {
-		return strings.TrimPrefix(id, "LicenseRef-")
-	}
-	return id
+	return strings.TrimPrefix(id, spdxlicense.LicenseRefPrefix)
 }
 
 //nolint:funlen

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONDirectoryEncoder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONDirectoryEncoder.golden
@@ -65,7 +65,7 @@
    "name": "some/path",
    "SPDXID": "SPDXRef-DocumentRoot-Directory-some-path",
    "supplier": "NOASSERTION",
-   "downloadLocation": "",
+   "downloadLocation": "NOASSERTION",
    "filesAnalyzed": false,
    "primaryPackagePurpose": "FILE"
   }

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
@@ -66,7 +66,7 @@
    "SPDXID": "SPDXRef-DocumentRoot-Image-user-image-input",
    "versionInfo": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
    "supplier": "NOASSERTION",
-   "downloadLocation": "",
+   "downloadLocation": "NOASSERTION",
    "filesAnalyzed": false,
    "checksums": [
     {

--- a/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/formats/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -66,7 +66,7 @@
    "SPDXID": "SPDXRef-DocumentRoot-Image-user-image-input",
    "versionInfo": "sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368",
    "supplier": "NOASSERTION",
-   "downloadLocation": "",
+   "downloadLocation": "NOASSERTION",
    "filesAnalyzed": false,
    "checksums": [
     {

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXJSONSPDXIDs.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXJSONSPDXIDs.golden
@@ -13,6 +13,7 @@ Created: redacted
 PackageName: foobar/baz
 SPDXID: SPDXRef-DocumentRoot-Directory-foobar-baz
 PackageSupplier: NOASSERTION
+PackageDownloadLocation: NOASSERTION
 PrimaryPackagePurpose: FILE
 FilesAnalyzed: false
 

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -52,6 +52,7 @@ PackageName: user-image-input
 SPDXID: SPDXRef-DocumentRoot-Image-user-image-input
 PackageVersion: sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368
 PackageSupplier: NOASSERTION
+PackageDownloadLocation: NOASSERTION
 PrimaryPackagePurpose: CONTAINER
 FilesAnalyzed: false
 PackageChecksum: SHA256: 2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueDirectoryEncoder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueDirectoryEncoder.golden
@@ -13,6 +13,7 @@ Created: redacted
 PackageName: some/path
 SPDXID: SPDXRef-DocumentRoot-Directory-some-path
 PackageSupplier: NOASSERTION
+PackageDownloadLocation: NOASSERTION
 PrimaryPackagePurpose: FILE
 FilesAnalyzed: false
 

--- a/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
+++ b/syft/formats/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
@@ -14,6 +14,7 @@ PackageName: user-image-input
 SPDXID: SPDXRef-DocumentRoot-Image-user-image-input
 PackageVersion: sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368
 PackageSupplier: NOASSERTION
+PackageDownloadLocation: NOASSERTION
 PrimaryPackagePurpose: CONTAINER
 FilesAnalyzed: false
 PackageChecksum: SHA256: 2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368

--- a/test/cli/spdx_tooling_validation_test.go
+++ b/test/cli/spdx_tooling_validation_test.go
@@ -85,7 +85,11 @@ func TestSpdxValidationTooling(t *testing.T) {
 
 				validateCmd := exec.Command("make", "validate", fileArg, mountArg, imageArg)
 				validateCmd.Dir = filepath.Join(cwd, "test-fixtures", "image-java-spdx-tools")
-				runAndShow(t, validateCmd)
+
+				stdout, stderr, err := runCommand(validateCmd, map[string]string{})
+				if err != nil {
+					t.Fatalf("invalid SPDX document:%v\nSTDOUT:\n%s\nSTDERR:\n%s", err, stdout, stderr)
+				}
 			})
 		}
 	}

--- a/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
+++ b/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-RUN wget https://github.com/spdx/tools-java/releases/download/v1.1.3/tools-java-1.1.3.zip && \
+RUN wget --no-verbose https://github.com/spdx/tools-java/releases/download/v1.1.3/tools-java-1.1.3.zip && \
 	unzip tools-java-1.1.3.zip && \
 	rm tools-java-1.1.3.zip
 

--- a/test/cli/utils_test.go
+++ b/test/cli/utils_test.go
@@ -1,11 +1,9 @@
 package cli
 
 import (
-	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -16,8 +14,6 @@ import (
 	"syscall"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/stereoscope/pkg/imagetest"
 )
@@ -30,30 +26,6 @@ func logOutputOnFailure(t testing.TB, cmd *exec.Cmd, stdout, stderr string) {
 		t.Log("STDERR:\n", stderr)
 		t.Log("COMMAND:", strings.Join(cmd.Args, " "))
 	}
-}
-
-func runAndShow(t *testing.T, cmd *exec.Cmd) {
-	t.Helper()
-
-	stderr, err := cmd.StderrPipe()
-	require.NoErrorf(t, err, "could not get stderr: +v", err)
-
-	stdout, err := cmd.StdoutPipe()
-	require.NoErrorf(t, err, "could not get stdout: +v", err)
-
-	err = cmd.Start()
-	require.NoErrorf(t, err, "failed to start cmd: %+v", err)
-
-	show := func(label string, reader io.ReadCloser) {
-		scanner := bufio.NewScanner(reader)
-		scanner.Split(bufio.ScanLines)
-		for scanner.Scan() {
-			t.Logf("%s: %s", label, scanner.Text())
-		}
-	}
-
-	show("out", stdout)
-	show("err", stderr)
 }
 
 func setupPKI(t *testing.T, pw string) func() {


### PR DESCRIPTION
I noticed that we are using parts of the `LicenseRef-` ID for the other license value, which has had unsupported SPDXID characters swapped to dashes. This PR corrects that issue as well as an omitted PackageDownloadLocation, which was producing invalid SPDX documents. Additionally, this enables the SPDX tool validator failures to fail CLI tests.