### PR TITLE
fix: read direct package files when decoding SPDX tag-value

### DIFF
--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -342,7 +342,14 @@ func toFileMetadata(f *spdx.File) (meta file.Metadata) {
 }
 
 func toSyftRelationships(spdxIDMap map[string]any, doc *spdx.Document) []artifact.Relationship {
-	var out []artifact.Relationship
+	out := collectDocRelationships(spdxIDMap, doc)
+
+	out = append(out, collectPackageFileRelationships(spdxIDMap, doc)...)
+
+	return out
+}
+
+func collectDocRelationships(spdxIDMap map[string]any, doc *spdx.Document) (out []artifact.Relationship) {
 	for _, r := range doc.Relationships {
 		// FIXME what to do with r.RefA.DocumentRefID and r.RefA.SpecialID
 		if r.RefA.DocumentRefID != "" && requireAndTrimPrefix(r.RefA.DocumentRefID, "DocumentRef-") != string(doc.SPDXIdentifier) {
@@ -393,8 +400,11 @@ func toSyftRelationships(spdxIDMap map[string]any, doc *spdx.Document) []artifac
 			})
 		}
 	}
+	return out
+}
 
-	// add relationships for direct files
+// collectPackageFileRelationships add relationships for direct files
+func collectPackageFileRelationships(spdxIDMap map[string]any, doc *spdx.Document) (out []artifact.Relationship) {
 	for _, p := range doc.Packages {
 		a := spdxIDMap[string(p.PackageSPDXIdentifier)]
 		from, fromOk := a.(pkg.Package)
@@ -414,7 +424,6 @@ func toSyftRelationships(spdxIDMap map[string]any, doc *spdx.Document) []artifac
 			})
 		}
 	}
-
 	return out
 }
 

--- a/syft/formats/common/spdxhelpers/to_syft_model.go
+++ b/syft/formats/common/spdxhelpers/to_syft_model.go
@@ -286,6 +286,16 @@ func collectSyftPackages(s *sbom.SBOM, spdxIDMap map[string]any, packages []*spd
 }
 
 func collectSyftFiles(s *sbom.SBOM, spdxIDMap map[string]any, doc *spdx.Document) {
+	for _, p := range doc.Packages {
+		for _, f := range p.Files {
+			l := toSyftLocation(f)
+			spdxIDMap[string(f.FileSPDXIdentifier)] = l
+
+			s.Artifacts.FileMetadata[l.Coordinates] = toFileMetadata(f)
+			s.Artifacts.FileDigests[l.Coordinates] = toFileDigests(f)
+		}
+	}
+
 	for _, f := range doc.Files {
 		l := toSyftLocation(f)
 		spdxIDMap[string(f.FileSPDXIdentifier)] = l
@@ -383,6 +393,28 @@ func toSyftRelationships(spdxIDMap map[string]any, doc *spdx.Document) []artifac
 			})
 		}
 	}
+
+	// add relationships for direct files
+	for _, p := range doc.Packages {
+		a := spdxIDMap[string(p.PackageSPDXIdentifier)]
+		from, fromOk := a.(pkg.Package)
+		if !fromOk {
+			continue
+		}
+		for _, f := range p.Files {
+			b := spdxIDMap[string(f.FileSPDXIdentifier)]
+			to, toLocationOk := b.(file.Location)
+			if !toLocationOk {
+				continue
+			}
+			out = append(out, artifact.Relationship{
+				From: from,
+				To:   to,
+				Type: artifact.ContainsRelationship,
+			})
+		}
+	}
+
 	return out
 }
 

--- a/syft/formats/spdxtagvalue/decoder_test.go
+++ b/syft/formats/spdxtagvalue/decoder_test.go
@@ -1,13 +1,14 @@
 package spdxtagvalue
 
 import (
-	"github.com/anchore/syft/syft/file"
-	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/file"
 )
 
 // TODO: this is a temporary coverage see below

--- a/syft/formats/spdxtagvalue/decoder_test.go
+++ b/syft/formats/spdxtagvalue/decoder_test.go
@@ -1,7 +1,10 @@
 package spdxtagvalue
 
 import (
+	"github.com/anchore/syft/syft/file"
+	"github.com/stretchr/testify/require"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +36,60 @@ func TestSPDXTagValueDecoder(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func Test_packageDirectFiles(t *testing.T) {
+	contents := `
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: Some-SBOM
+DocumentNamespace: https://example.org/some/namespace
+Creator: Organization: Some-organization
+Creator: Tool: Some-tool Version: 1.0
+Created: 2021-12-29T17:02:21Z
+PackageName: Some-package
+PackageVersion: 5.1.2
+SPDXID: SPDXRef-Package-43c51b08-cc7e-406d-8ad9-34aa292d1157
+PackageSupplier: Organization: Some-organization
+PackageDownloadLocation: https://example.org/download/location
+FilesAnalyzed: true
+PackageLicenseInfoFromFiles: NOASSERTION
+PackageVerificationCode: 23460C5559C8D4DE3F6504E0E84E844CAC8B1D95
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+PackageChecksum: SHA1: 23460C5559C8D4DE3F6504E0E84E844CAC8B1D95
+FileName: Some-file-name
+SPDXID: SPDXRef-99545d55-933d-4e08-9eb5-9d826111cb79
+FileContributor: Some-file-contributor
+FileType: BINARY
+FileChecksum: SHA1: 23460C5559C8D4DE3F6504E0E84E844CAC8B1D95
+LicenseConcluded: NOASSERTION
+LicenseInfoInFile: NOASSERTION
+FileCopyrightText: NOASSERTION
+`
+
+	s, err := decoder(strings.NewReader(contents))
+	require.NoError(t, err)
+
+	pkgs := s.Artifacts.Packages.Sorted()
+	assert.Len(t, pkgs, 1)
+	assert.Len(t, s.Artifacts.FileMetadata, 1)
+	assert.Len(t, s.Relationships, 1)
+	p := pkgs[0]
+	r := s.Relationships[0]
+	f := file.Location{}
+	for c := range s.Artifacts.FileMetadata {
+		f = file.Location{
+			LocationData: file.LocationData{
+				Coordinates: c,
+				VirtualPath: "",
+			},
+			LocationMetadata: file.LocationMetadata{},
+		}
+		break // there should only be 1
+	}
+	assert.Equal(t, p.ID(), r.From.ID())
+	assert.Equal(t, f.ID(), r.To.ID())
 }


### PR DESCRIPTION
This PR corrects an issue that when decoding SPDX tag-value direct package files are omitted.

Fixes #2013 