### PR TITLE
chore: restore cataloger.DefaultConfig

### DIFF
--- a/syft/pkg/cataloger/config.go
+++ b/syft/pkg/cataloger/config.go
@@ -18,6 +18,16 @@ type Config struct {
 	ExcludeBinaryOverlapByOwnership bool
 }
 
+func DefaultConfig() Config {
+	return Config{
+		Search:                          DefaultSearchConfig(),
+		Parallelism:                     1,
+		LinuxKernel:                     kernel.DefaultLinuxCatalogerConfig(),
+		Python:                          python.DefaultCatalogerConfig(),
+		ExcludeBinaryOverlapByOwnership: true,
+	}
+}
+
 func (c Config) Java() java.Config {
 	return java.Config{
 		SearchUnindexedArchives: c.Search.IncludeUnindexedArchives,

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -1,15 +1,13 @@
 package integration
 
 import (
+	"github.com/anchore/syft/syft/pkg/cataloger"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/stereoscope/pkg/imagetest"
 	"github.com/anchore/syft/syft"
-	"github.com/anchore/syft/syft/pkg/cataloger"
-	"github.com/anchore/syft/syft/pkg/cataloger/kernel"
-	"github.com/anchore/syft/syft/pkg/cataloger/python"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 )
@@ -26,7 +24,7 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 		theSource.Close()
 	})
 
-	c := defaultConfig()
+	c := cataloger.DefaultConfig()
 	c.Catalogers = catalogerCfg
 
 	c.Search.Scope = scope
@@ -54,16 +52,6 @@ func catalogFixtureImage(t *testing.T, fixtureImageName string, scope source.Sco
 	}, theSource
 }
 
-func defaultConfig() cataloger.Config {
-	return cataloger.Config{
-		Search:                          cataloger.DefaultSearchConfig(),
-		Parallelism:                     1,
-		LinuxKernel:                     kernel.DefaultLinuxCatalogerConfig(),
-		Python:                          python.DefaultCatalogerConfig(),
-		ExcludeBinaryOverlapByOwnership: true,
-	}
-}
-
 func catalogDirectory(t *testing.T, dir string) (sbom.SBOM, source.Source) {
 	userInput := "dir:" + dir
 	detection, err := source.Detect(userInput, source.DefaultDetectConfig())
@@ -75,7 +63,7 @@ func catalogDirectory(t *testing.T, dir string) (sbom.SBOM, source.Source) {
 	})
 
 	// TODO: this would be better with functional options (after/during API refactor)
-	c := defaultConfig()
+	c := cataloger.DefaultConfig()
 	c.Search.Scope = source.AllLayersScope
 	pkgCatalog, relationships, actualDistro, err := syft.CatalogPackages(theSource, c)
 	if err != nil {


### PR DESCRIPTION
The `cataloger.DefaultConfig` was removed due to only being used in tests within this repo, but as it is used downstream, this PR restores the function.