### PR TITLE
fix: inconsistent removal of binaries by file overlap

### DIFF
--- a/syft/lib.go
+++ b/syft/lib.go
@@ -92,8 +92,7 @@ func CatalogPackages(src source.Source, cfg cataloger.Config) (*pkg.Collection, 
 }
 
 func removeRelationshipsByID(relationships []artifact.Relationship, id artifact.ID) []artifact.Relationship {
-	// https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating
-	filtered := relationships[:0]
+	var filtered []artifact.Relationship
 	for _, r := range relationships {
 		if r.To.ID() != id && r.From.ID() != id {
 			filtered = append(filtered, r)

--- a/syft/lib_test.go
+++ b/syft/lib_test.go
@@ -1,0 +1,42 @@
+package syft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func Test_removeRelationshipsByID(t *testing.T) {
+	p1 := pkg.Package{}
+	p1.OverrideID("1")
+
+	p2 := pkg.Package{}
+	p2.OverrideID("2")
+
+	p3 := pkg.Package{}
+	p3.OverrideID("3")
+
+	rel := func(pkgs ...pkg.Package) (out []artifact.Relationship) {
+		for _, p := range pkgs {
+			out = append(out, artifact.Relationship{
+				From: p,
+				To:   p,
+				Type: artifact.OwnershipByFileOverlapRelationship,
+			})
+		}
+		return
+	}
+
+	relationships := rel(p1, p2, p3)
+
+	for _, r := range relationships {
+		if r.From.ID() == "1" || r.From.ID() == "2" {
+			relationships = removeRelationshipsByID(relationships, r.From.ID())
+		}
+	}
+
+	require.Equal(t, rel(p3), relationships)
+}


### PR DESCRIPTION
This PR corrects an issue where binary packages removed by ownership-by-file-overlap relationships were inconsistently removing entries.

Fixes: #2035