### PR TITLE
New version notice only showing the version and no text

### DIFF
--- a/cmd/syft/internal/ui/__snapshots__/post_ui_event_writer_test.snap
+++ b/cmd/syft/internal/ui/__snapshots__/post_ui_event_writer_test.snap
@@ -27,12 +27,7 @@ report 1!!>
                     
 <notification 2>
 <notification 3>
-                        
-                        
-<my app can be updated!!
-...to this version>     
-                        
-                        
+A newer version of syft is available for download: v0.33.0 (installed version is [not provided])
 
 ---
 

--- a/cmd/syft/internal/ui/post_ui_event_writer.go
+++ b/cmd/syft/internal/ui/post_ui_event_writer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/wagoodman/go-partybus"
 
 	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/version"
 	"github.com/anchore/syft/syft/event"
 	"github.com/anchore/syft/syft/event/parsers"
 )
@@ -118,11 +119,13 @@ func writeAppUpdate(writer io.Writer, events ...partybus.Event) error {
 	style := lipgloss.NewStyle().Foreground(lipgloss.Color("13")).Italic(true)
 
 	for _, e := range events {
-		notice, err := parsers.ParseCLIAppUpdateAvailable(e)
+		newVersion, err := parsers.ParseCLIAppUpdateAvailable(e)
 		if err != nil {
 			log.WithFields("error", err).Warn("failed to parse app update notification")
 			continue
 		}
+
+		notice := fmt.Sprintf("A newer version of syft is available for download: %s (installed version is %s)", newVersion, version.FromBuild().Version)
 
 		if _, err := fmt.Fprintln(writer, style.Render(notice)); err != nil {
 			// don't let this be fatal

--- a/cmd/syft/internal/ui/post_ui_event_writer_test.go
+++ b/cmd/syft/internal/ui/post_ui_event_writer_test.go
@@ -35,7 +35,7 @@ func Test_postUIEventWriter_write(t *testing.T) {
 				},
 				{
 					Type:  event.CLIAppUpdateAvailable,
-					Value: "\n\n<my app can be updated!!\n...to this version>\n\n",
+					Value: "v0.33.0",
 				},
 				{
 					Type:  event.CLINotification,


### PR DESCRIPTION
Just like in https://github.com/anchore/grype/pull/1445 , Currently when running grype and there is a new version available the version is shown with no other context. This PR addresses this by filling in the notice text.