### PR TITLE
Fix: don't validate pom declared group

### DIFF
--- a/syft/pkg/cataloger/java/package_url.go
+++ b/syft/pkg/cataloger/java/package_url.go
@@ -84,7 +84,7 @@ func groupIDFromPomProperties(properties *pkg.PomProperties) (groupID string) {
 		return groupID
 	}
 
-	if looksLikeGroupID(properties.GroupID) {
+	if properties.GroupID != "" {
 		return cleanGroupID(properties.GroupID)
 	}
 

--- a/syft/pkg/cataloger/java/package_url_test.go
+++ b/syft/pkg/cataloger/java/package_url_test.go
@@ -10,10 +10,12 @@ import (
 
 func Test_packageURL(t *testing.T) {
 	tests := []struct {
+		name   string
 		pkg    pkg.Package
 		expect string
 	}{
 		{
+			name: "maven",
 			pkg: pkg.Package{
 				Name:         "example-java-app-maven",
 				Version:      "0.1.0",
@@ -37,6 +39,32 @@ func Test_packageURL(t *testing.T) {
 				},
 			},
 			expect: "pkg:maven/org.anchore/example-java-app-maven@0.1.0",
+		},
+		{
+			name: "POM has explicit group ID without . in it",
+			pkg: pkg.Package{
+				Name:         "example-java-app-maven",
+				Version:      "0.1.0",
+				Language:     pkg.Java,
+				Type:         pkg.JavaPkg,
+				MetadataType: pkg.JavaMetadataType,
+				Metadata: pkg.JavaMetadata{
+					VirtualPath: "test-fixtures/java-builds/packages/example-java-app-maven-0.1.0.jar",
+					Manifest: &pkg.JavaManifest{
+						Main: map[string]string{
+							"Manifest-Version": "1.0",
+						},
+					},
+					PomProperties: &pkg.PomProperties{
+						Path:       "META-INF/maven/org.anchore/example-java-app-maven/pom.properties",
+						GroupID:    "commons",
+						ArtifactID: "example-java-app-maven",
+						Version:    "0.1.0",
+						Extra:      make(map[string]string),
+					},
+				},
+			},
+			expect: "pkg:maven/commons/example-java-app-maven@0.1.0",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
If a POM file has a declared group ID, use it to construct the PURL, even if it doesn't have `.` in it.