### PR TITLE
feat: add bash classifier

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -667,6 +667,18 @@ func Test_Cataloger_DefaultClassifiers_PositiveCases(t *testing.T) {
 				Metadata:  metadata("nginx-binary"),
 			},
 		},
+		{
+			name:       "positive-bash-5.2.15",
+			fixtureDir: "test-fixtures/classifiers/positive/bash-5.2.15",
+			expected: pkg.Package{
+				Name:      "bash",
+				Version:   "5.2.15",
+				Type:      "binary",
+				PURL:      "pkg:generic/bash@5.2.15",
+				Locations: locations("bash"),
+				Metadata:  metadata("bash-binary"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -269,6 +269,20 @@ var defaultClassifiers = []classifier{
 			cpe.Must("cpe:2.3:a:nginx:nginx:*:*:*:*:*:*:*:*"),
 		},
 	},
+	{
+		Class:    "bash-binary",
+		FileGlob: "**/bash",
+		EvidenceMatcher: fileContentsVersionMatcher(
+			// @(#)Bash version 5.2.15(1) release GNU
+			// @(#)Bash version 5.2.0(1) alpha GNU
+			// @(#)Bash version 5.2.0(1) beta GNU
+			// @(#)Bash version 5.2.0(1) rc4 GNU
+			`(?m)@\(#\)Bash version (?P<version>[0-9]+\.[0-9]+\.[0-9]+)\([0-9]\) [a-z0-9]+ GNU`,
+		),
+		Package: "bash",
+		PURL:    mustPURL("pkg:generic/bash@version"),
+		CPEs:    singleCPE("cpe:2.3:a:gnu:bash:*:*:*:*:*:*:*:*"),
+	},
 }
 
 // in both binaries and shared libraries, the version pattern is [NUL]3.11.2[NUL]

--- a/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/bash-5.2.15/bash
+++ b/syft/pkg/cataloger/binary/test-fixtures/classifiers/positive/bash-5.2.15/bash
@@ -1,0 +1,1 @@
+@(#)Bash version 5.2.15(1) release GNU


### PR DESCRIPTION
This PR adds a binary cataloger for bash

- As I can not judge version of alpha/beta (alpha1 or alpha2) in version information, alpha/beta/rc is not desplayed

Fixes #1963 