### PR TITLE
chore: Trace log pom property reflect usage

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -450,7 +450,7 @@ func Test_resolveProperty(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			resolved := resolveProperty(test.pom, stringPointer(test.property))
+			resolved := resolveProperty(test.pom, stringPointer(test.property), test.name)
 			assert.Equal(t, test.expected, resolved)
 		})
 	}


### PR DESCRIPTION
This reflect code occasionally throws an obscure panic, but not enough information is logged before the panic to know why it panicked. Log enough to tell what property and package are being analyzed when the panic occurs.

Test command:

``` sh
go run cmd/syft/main.go -vvvv ./test/integration/test-fixtures/image-pkg-coverage/pkgs/java/example-java-app-maven-0.1.0.jar
```

Example of new logging:

``` log
...
[0000] TRACE parsing file contents path=/example-java-app-maven-0.1.0.jar
[0000] TRACE parsing pom.xml artifactID=example-java-app-maven name= path=META-INF/maven/org.anchore/example-java-app-maven/pom.xml projectURL=
[0000] TRACE resolving property existingPropertyValue=org.anchore propertyName=groupId
[0000] TRACE resolving property existingPropertyValue=0.1.0 propertyName=version
[0000] TRACE parsing pom.xml artifactID=joda-time name=Joda-Time path=META-INF/maven/joda-time/joda-time/pom.xml projectURL=http://www.joda.org/joda-time/
[0000] TRACE resolving property existingPropertyValue=joda-time propertyName=groupId
[0000] TRACE resolving property existingPropertyValue=2.9.2 propertyName=version
...
```