### PR TITLE
add CPE generation for Django

### DIFF
--- a/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/common/cpe/candidate_by_package_type.go
@@ -183,6 +183,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "pip"},
 			candidateAddition{AdditionalVendors: []string{"pypa"}},
 		},
+		{
+			pkg.PythonPkg,
+			candidateKey{PkgName: "Django"},
+			candidateAddition{AdditionalVendors: []string{"djangoproject"}},
+		},
 		// Alpine packages
 		{
 			pkg.ApkPkg,

--- a/syft/pkg/cataloger/common/cpe/generate_test.go
+++ b/syft/pkg/cataloger/common/cpe/generate_test.go
@@ -896,6 +896,14 @@ func TestCandidateVendor(t *testing.T) {
 			},
 			expected: []string{"apache"},
 		},
+		{
+			name: "Django",
+			p: pkg.Package{
+				Name: "Django",
+				Type: pkg.PythonPkg,
+			},
+			expected: []string{"djangoproject" /* <-- known good names | default guess --> */, "Django"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR adds a CPE generation for Django

- In my understanding, syft + grype support Django via GHSA dataset
- If user uses syft SBOM + some tool which supports only NVD (not support GHSA), user will be able to detect Django vuluneravilities by this PR
- If some vuluneravilities are registered on only NVD, user will be able to detect Django vuluneravilities by this PR.
  - Sometimes NVD updates their old data, but GHSA will not fetch those data

Fixes #1298 

----

I prepared sample image and check.

Dockerfile
```
FROM python:latest
COPY requirements.txt requirements.txt
RUN pip3 install -r requirements.txt
```

requirements.txt
```
Django==4.0.0
```

```
$ grype version
Application:          grype
Version:              0.65.2
Syft Version:         v0.87.1
BuildDate:            2023-08-17T20:03:30Z
GitCommit:            51223cd0b1069c7c7bbc27af1deec3e96ad3e07d
GitDescription:       v0.65.2
Platform:             linux/amd64
GoVersion:            go1.19.12
Compiler:             gc
Supported DB Schema:  5

$ grype django_local | grep Django
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                  django_local:latest
 ✔ Parsed image                                                                                              sha256:8b0a740ad3bfc81618163a33be43fb2cab85771026775bfd73a1a46ccbba9c3d
 ✔ Cataloged packages              [444 packages]
 ✔ Scanned for vulnerabilities     [770 vulnerabilities]
   ├── 6 critical, 55 high, 179 medium, 43 low, 458 negligible (29 unknown)
   └── 13 fixed
Django                        4.0                   4.0.4        python  GHSA-w24h-v9qh-8gxj  Critical
Django                        4.0                   4.1.9        python  GHSA-r3xc-prgr-mg9p  Critical
Django                        4.0                   4.0.6        python  GHSA-p64x-8rxx-wf6q  Critical
Django                        4.0                   4.0.4        python  GHSA-2gwj-7jmv-h26r  Critical
Django                        4.0                   4.0.8        python  GHSA-qrw5-5h28-6cmg  High
Django                        4.0                   4.1.10       python  GHSA-jh3w-4vvf-mjgr  High
Django                        4.0                   4.0.7        python  GHSA-8x94-hmjh-97hq  High
Django                        4.0                   4.0.1        python  GHSA-8c5j-9r9f-c6w8  High
Django                        4.0                   4.0.2        python  GHSA-6cw3-g6wv-c2xv  High
Django                        4.0                   4.0.1        python  GHSA-53qw-q765-4fww  High
Django                        4.0                   4.0.10       python  GHSA-2hrw-hx67-34x6  High
Django                        4.0                   4.0.1        python  GHSA-jrh2-hc4r-7jwx  Medium
Django                        4.0                   4.0.2        python  GHSA-95rw-fx8r-36v6  Medium
```

after this PR
```
$ go run cmd/syft/main.go django_local -o json | grype | grep Django
 ✔ Loaded image                                                                                                                                                  django_local:latest   ✔ Parsed image                                                                                              sha256:8b0a740ad3bfc81618163a33be43fb2cab85771026775bfd73a1a46ccbba9c3d
 ✔ Cataloged packages              [445 packages]
[0024]  WARN document has schema version 10.0.1, but parser has older schema version (10.0.0) from-lib=syft
Django                        4.0                   4.0.4        python  GHSA-w24h-v9qh-8gxj  Critical
Django                        4.0                   4.1.9        python  GHSA-r3xc-prgr-mg9p  Critical
Django                        4.0                   4.0.6        python  GHSA-p64x-8rxx-wf6q  Critical
Django                        4.0                   4.0.4        python  GHSA-2gwj-7jmv-h26r  Critical
Django                        4.0                                python  CVE-2023-31047       Critical
Django                        4.0                                python  CVE-2022-34265       Critical
Django                        4.0                                python  CVE-2022-28347       Critical
Django                        4.0                                python  CVE-2022-28346       Critical
Django                        4.0                   4.0.8        python  GHSA-qrw5-5h28-6cmg  High
Django                        4.0                   4.1.10       python  GHSA-jh3w-4vvf-mjgr  High
Django                        4.0                   4.0.7        python  GHSA-8x94-hmjh-97hq  High
Django                        4.0                   4.0.1        python  GHSA-8c5j-9r9f-c6w8  High
Django                        4.0                   4.0.2        python  GHSA-6cw3-g6wv-c2xv  High
Django                        4.0                   4.0.1        python  GHSA-53qw-q765-4fww  High
Django                        4.0                   4.0.10       python  GHSA-2hrw-hx67-34x6  High
Django                        4.0                                python  CVE-2023-36053       High
Django                        4.0                                python  CVE-2023-24580       High
Django                        4.0                                python  CVE-2023-23969       High
Django                        4.0                                python  CVE-2022-41323       High
Django                        4.0                                python  CVE-2022-36359       High
Django                        4.0                                python  CVE-2022-23833       High
Django                        4.0                                python  CVE-2021-45116       High
Django                        4.0                                python  CVE-2021-45115       High
Django                        4.0                   4.0.1        python  GHSA-jrh2-hc4r-7jwx  Medium
Django                        4.0                   4.0.2        python  GHSA-95rw-fx8r-36v6  Medium
Django                        4.0                                python  CVE-2022-22818       Medium
Django                        4.0                                python  CVE-2021-45452       Medium
```

CVE-2023-23969 is detected newly since impacted version information of NVD and GHSA are different.
// This will not be good, but behavior of syft + grype is proper I think.
https://github.com/advisories/GHSA-q2jf-h9jm-m7p4
https://nvd.nist.gov/vuln/detail/CVE-2023-23969