### PR TITLE
fix: in some cases, try to use pom info to guess name and version to top level jar

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -159,9 +159,11 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		projects, _ := pomProjectByParentPath(j.archivePath, j.location, pomMatches)
 
 		for parentPath, propertiesObj := range properties {
-			pomPropertiesObject = propertiesObj
-			if proj, exists := projects[parentPath]; exists {
-				pomProjectObject = proj
+			if propertiesObj.ArtifactID != "" && j.fileInfo.name != "" && strings.HasPrefix(propertiesObj.ArtifactID, j.fileInfo.name) {
+				pomPropertiesObject = propertiesObj
+				if proj, exists := projects[parentPath]; exists {
+					pomProjectObject = proj
+				}
 			}
 		}
 	}

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -223,9 +223,9 @@ func (j *archiveParser) guessMainPackageNameAndVersionFromPomInfo() (string, str
 	pomMatches := j.fileManifest.GlobMatch(pomXMLGlob)
 	var pomPropertiesObject pkg.PomProperties
 	var pomProjectObject pkg.PomProject
-	if len(pomPropertyMatches) == 1 && len(pomMatches) == 1 {
-		// we have exactly 1 pom.properties in the archive; assume it represents the
-		// package we're scanning
+	if len(pomPropertyMatches) == 1 || len(pomMatches) == 1 {
+		// we have exactly 1 pom.properties or pom.xml in the archive; assume it represents the
+		// package we're scanning if the names seem like a plausible match
 		properties, _ := pomPropertiesByParentPath(j.archivePath, j.location, pomPropertyMatches)
 		projects, _ := pomProjectByParentPath(j.archivePath, j.location, pomMatches)
 

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -148,7 +148,6 @@ func (j *archiveParser) parse() ([]pkg.Package, []artifact.Relationship, error) 
 
 // discoverMainPackage parses the root Java manifest used as the parent package to all discovered nested packages.
 func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
-
 	// search and parse java manifest files
 	manifestMatches := j.fileManifest.GlobMatch(manifestGlob)
 	if len(manifestMatches) > 1 {
@@ -218,6 +217,7 @@ func (j *archiveParser) discoverMainPackage() (*pkg.Package, error) {
 		},
 	}, nil
 }
+
 func (j *archiveParser) guessMainPackageNameAndVersionFromPomInfo() (string, string) {
 	pomPropertyMatches := j.fileManifest.GlobMatch(pomPropertiesGlob)
 	pomMatches := j.fileManifest.GlobMatch(pomXMLGlob)

--- a/test/integration/regression_java_virtualpath_test.go
+++ b/test/integration/regression_java_virtualpath_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJavaVirtualPath(t *testing.T) {
+func TestWarCatalogedCorrectlyIfRenamed(t *testing.T) {
+	// install hudson-war@2.2.1 and renames the file to `/hudson.war`
+	// TODO: is this better expressed in syft/pkg/cataloger/java/archive_parser_test.go?
 	sbom, _ := catalogFixtureImage(t, "image-java-virtualpath-regression", source.SquashedScope, nil)
 
 	badPURL := "pkg:maven/hudson/hudson@2.2.1"

--- a/test/integration/regression_java_virtualpath_test.go
+++ b/test/integration/regression_java_virtualpath_test.go
@@ -1,0 +1,34 @@
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/source"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJavaVirtualPath(t *testing.T) {
+	sbom, _ := catalogFixtureImage(t, "image-java-virtualpath-regression", source.SquashedScope, nil)
+
+	badPURL := "pkg:maven/hudson/hudson@2.2.1"
+	goodPURL := "pkg:maven/org.jvnet.hudson.main/hudson-war@2.2.1"
+	foundCorrectPackage := false
+	badVirtualPath := "/hudson.war:org.jvnet.hudson.main:hudson-war"
+	goodVirtualPath := "/hudson.war"
+	for _, p := range sbom.Artifacts.Packages.Sorted() {
+		if p.Type == pkg.JavaPkg && strings.Contains(p.Name, "hudson") {
+			assert.NotEqual(t, badPURL, p.PURL, "must not find bad purl %q", badPURL)
+			virtPath := ""
+			if meta, ok := p.Metadata.(pkg.JavaMetadata); ok {
+				virtPath = meta.VirtualPath
+				if p.PURL == goodPURL && virtPath == goodVirtualPath {
+					foundCorrectPackage = true
+				}
+			}
+			assert.NotEqual(t, badVirtualPath, virtPath, "must not find bad virtual path %q", badVirtualPath)
+		}
+	}
+	assert.True(t, foundCorrectPackage, "must find correct package, but did not")
+}

--- a/test/integration/regression_java_virtualpath_test.go
+++ b/test/integration/regression_java_virtualpath_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestWarCatalogedCorrectlyIfRenamed(t *testing.T) {
 	// install hudson-war@2.2.1 and renames the file to `/hudson.war`
-	// TODO: is this better expressed in syft/pkg/cataloger/java/archive_parser_test.go?
 	sbom, _ := catalogFixtureImage(t, "image-java-virtualpath-regression", source.SquashedScope, nil)
 
 	badPURL := "pkg:maven/hudson/hudson@2.2.1"

--- a/test/integration/regression_java_virtualpath_test.go
+++ b/test/integration/regression_java_virtualpath_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWarCatalogedCorrectlyIfRenamed(t *testing.T) {

--- a/test/integration/test-fixtures/image-java-virtualpath-regression/Dockerfile
+++ b/test/integration/test-fixtures/image-java-virtualpath-regression/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+RUN wget https://repo1.maven.org/maven2/org/jvnet/hudson/main/hudson-war/2.2.1/hudson-war-2.2.1.war
+
+RUN mv hudson-war-2.2.1.war hudson.war
+
+


### PR DESCRIPTION
Implements the following changes in the java archive parser's `discoverMainPackage()` method:
if there is exactly one pom.xml and pom.properties in the jar and if the filename is a prefix of the artifact ID on the pom.properties, prefer, in order, for name and version:
1. A non-empty string on pom.properties
2. A non-empty string on pom.xml
3. A name based on the filename of the top-level jar
4. Name info from the manifest.

Definitely open to feedback and refactoring here, but wanted to show a working fix before spending too much time making it look great.

Fixes https://github.com/anchore/syft/issues/2077