### PR TITLE
Fix quiet flag

### DIFF
--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -29,7 +29,7 @@ func New(id clio.Identification) clio.Application {
 			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
 			func(cfg clio.Config) ([]clio.UI, error) {
 				noUI := ui.None(cfg.Log.Quiet)
-				if !cfg.Log.AllowUI(os.Stdin) {
+				if !cfg.Log.AllowUI(os.Stdin) || cfg.Log.Quiet {
 					return []clio.UI{noUI}, nil
 				}
 

--- a/test/cli/packages_cmd_test.go
+++ b/test/cli/packages_cmd_test.go
@@ -37,6 +37,24 @@ func TestPackagesCmdFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "quiet-flag-with-logger",
+			args: []string{"packages", "-qvv", "-o", "json", coverageImage},
+			assertions: []traitAssertion{
+				assertJsonReport,
+				assertNoStderr,
+				assertSuccessfulReturnCode,
+			},
+		},
+		{
+			name: "quiet-flag-with-tui",
+			args: []string{"packages", "-q", "-o", "json", coverageImage},
+			assertions: []traitAssertion{
+				assertJsonReport,
+				assertNoStderr,
+				assertSuccessfulReturnCode,
+			},
+		},
+		{
 			name: "multiple-output-flags",
 			args: []string{"packages", "-o", "table", "-o", "json=" + tmp + ".tmp/multiple-output-flag-test.json", coverageImage},
 			assertions: []traitAssertion{

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -83,6 +83,13 @@ func assertNotInOutput(data string) traitAssertion {
 	}
 }
 
+func assertNoStderr(tb testing.TB, _, stderr string, _ int) {
+	tb.Helper()
+	if len(stderr) > 0 {
+		tb.Errorf("expected stderr to be empty, but got %q", stderr)
+	}
+}
+
 func assertInOutput(data string) traitAssertion {
 	return func(tb testing.TB, stdout, stderr string, _ int) {
 		tb.Helper()


### PR DESCRIPTION
Currently the quiet flag is only responsive with the logger UI, but not the text UI. This PR fixes this regression.