### PR TITLE
fix(cdx): validate external refs before encoding

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/external_references.go
+++ b/syft/formats/common/cyclonedxhelpers/external_references.go
@@ -2,6 +2,7 @@ package cyclonedxhelpers
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
@@ -15,9 +16,11 @@ import (
 func encodeExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 	var refs []cyclonedx.ExternalReference
 	if hasMetadata(p) {
+		// Skip adding extracted URL and Homepage metadata
+		// as "external_reference" if the metadata isn't IRI-compliant
 		switch metadata := p.Metadata.(type) {
 		case pkg.ApkMetadata:
-			if metadata.URL != "" {
+			if metadata.URL != "" && isValidExternalRef(metadata.URL) {
 				refs = append(refs, cyclonedx.ExternalReference{
 					URL:  metadata.URL,
 					Type: cyclonedx.ERTypeDistribution,
@@ -31,20 +34,20 @@ func encodeExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 				})
 			}
 		case pkg.NpmPackageJSONMetadata:
-			if metadata.URL != "" {
+			if metadata.URL != "" && isValidExternalRef(metadata.URL) {
 				refs = append(refs, cyclonedx.ExternalReference{
 					URL:  metadata.URL,
 					Type: cyclonedx.ERTypeDistribution,
 				})
 			}
-			if metadata.Homepage != "" {
+			if metadata.Homepage != "" && isValidExternalRef(metadata.Homepage) {
 				refs = append(refs, cyclonedx.ExternalReference{
 					URL:  metadata.Homepage,
 					Type: cyclonedx.ERTypeWebsite,
 				})
 			}
 		case pkg.GemMetadata:
-			if metadata.Homepage != "" {
+			if metadata.Homepage != "" && isValidExternalRef(metadata.Homepage) {
 				refs = append(refs, cyclonedx.ExternalReference{
 					URL:  metadata.Homepage,
 					Type: cyclonedx.ERTypeWebsite,
@@ -157,4 +160,10 @@ func refComment(c *cyclonedx.Component, typ cyclonedx.ExternalReferenceType) str
 		return r.Comment
 	}
 	return ""
+}
+
+// isValidExternalRef checks for IRI-comppliance for input string to be added into "external_reference"
+func isValidExternalRef(s string) bool {
+	parsed, err := url.Parse(s)
+	return err == nil && parsed != nil && parsed.Host != ""
 }

--- a/syft/formats/common/cyclonedxhelpers/external_references_test.go
+++ b/syft/formats/common/cyclonedxhelpers/external_references_test.go
@@ -32,7 +32,7 @@ func Test_encodeExternalReferences(t *testing.T) {
 			},
 		},
 		{
-			name: "from npm",
+			name: "from npm with valid URL",
 			input: pkg.Package{
 				Metadata: pkg.NpmPackageJSONMetadata{
 					URL: "http://a-place.gov",
@@ -40,6 +40,18 @@ func Test_encodeExternalReferences(t *testing.T) {
 			},
 			expected: &[]cyclonedx.ExternalReference{
 				{URL: "http://a-place.gov", Type: cyclonedx.ERTypeDistribution},
+			},
+		},
+		{
+			name: "from npm with invalid URL but valid Homepage",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageJSONMetadata{
+					URL:      "b-place",
+					Homepage: "http://b-place.gov",
+				},
+			},
+			expected: &[]cyclonedx.ExternalReference{
+				{URL: "http://b-place.gov", Type: cyclonedx.ERTypeWebsite},
 			},
 		},
 		{
@@ -129,6 +141,35 @@ func Test_encodeExternalReferences(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, encodeExternalReferences(test.input))
+		})
+	}
+}
+
+func Test_isValidExternalRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "valid URL for external_reference, git protocol",
+			input:    "git+https://github.com/abc/def.git",
+			expected: true,
+		},
+		{
+			name:     "valid URL for external_reference, git protocol",
+			input:    "git+https://github.com/abc/def.git",
+			expected: true,
+		},
+		{
+			name:     "invalid URL for external_reference",
+			input:    "abc/def",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isValidExternalRef(test.input))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2079

## PR description
Validate extracted metadata before encoding into output file as `external_references`.

## Notes
- [x] Test added