### PR TITLE
added download locatoin (resolved) when cataloging a directory - java…

### DIFF
--- a/syft/formats/common/spdxhelpers/download_location.go
+++ b/syft/formats/common/spdxhelpers/download_location.go
@@ -20,6 +20,8 @@ func DownloadLocation(p pkg.Package) string {
 			return NoneIfEmpty(metadata.URL)
 		case pkg.NpmPackageJSONMetadata:
 			return NoneIfEmpty(metadata.URL)
+		case pkg.NpmPackageLockJSONMetadata:
+			return NoneIfEmpty(metadata.Resolved)
 		}
 	}
 	return NOASSERTION

--- a/syft/formats/common/spdxhelpers/download_location_test.go
+++ b/syft/formats/common/spdxhelpers/download_location_test.go
@@ -46,6 +46,24 @@ func Test_DownloadLocation(t *testing.T) {
 			},
 			expected: NONE,
 		},
+		{
+			name: "from npm package-lock",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageLockJSONMetadata{
+					Resolved: "http://package-lock.test",
+				},
+			},
+			expected: "http://package-lock.test",
+		},
+		{
+			name: "from npm package-lock empty",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageLockJSONMetadata{
+					Resolved: "",
+				},
+			},
+			expected: NONE,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/formats/common/spdxhelpers/download_location_test.go
+++ b/syft/formats/common/spdxhelpers/download_location_test.go
@@ -47,7 +47,7 @@ func Test_DownloadLocation(t *testing.T) {
 			expected: NONE,
 		},
 		{
-			name: "from npm package-lock",
+			name: "from npm package-lock should include resolved",
 			input: pkg.Package{
 				Metadata: pkg.NpmPackageLockJSONMetadata{
 					Resolved: "http://package-lock.test",
@@ -56,7 +56,7 @@ func Test_DownloadLocation(t *testing.T) {
 			expected: "http://package-lock.test",
 		},
 		{
-			name: "from npm package-lock empty",
+			name: "from npm package-lock empty should be NONE",
 			input: pkg.Package{
 				Metadata: pkg.NpmPackageLockJSONMetadata{
 					Resolved: "",


### PR DESCRIPTION
…script ecosystem- npm - packag-lock

added download locatoin (resolved) when cataloging a directory - javascript ecosystem- npm - packag-lock.

A starting point to **paritially** address this issue: https://github.com/anchore/syft/issues/2085 

It only helps the Javascript ecosystem - npm, when cataloging directory (**package-lock.json** in this case).

Fixes: #2129 