### PR TITLE
fix the help output of power-user

### DIFF
--- a/cmd/syft/cli/commands/poweruser.go
+++ b/cmd/syft/cli/commands/poweruser.go
@@ -21,7 +21,7 @@ import (
 
 const powerUserExample = `  {{.appName}} {{.command}} <image>
   DEPRECATED - THIS COMMAND WILL BE REMOVED in v1.0.0
-  Only image sources are supported (e.g. docker: , podman: , docker-archive: , oci: , etc.), the directory source (dir:) is not supported, template outputs are not supported.
+  Template outputs are not supported.
   All behavior is controlled via application configuration and environment variables (see https://github.com/anchore/syft#configuration)
 `
 


### PR DESCRIPTION
Cloeses #2046 
the stdout of power-user --help specifies that it doesn't support fs, which is wrong.
removed the line.
