### PR TITLE
chore: enforce race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,13 +147,14 @@ check-json-schema-drift:
 .PHONY: unit
 unit: $(TEMP_DIR) fixtures  ## Run unit tests (with coverage)
 	$(call title,Running unit tests)
-	go test -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/syft/test)
+	go test -race -coverprofile $(TEMP_DIR)/unit-coverage-details.txt $(shell go list ./... | grep -v anchore/syft/test)
 	@.github/scripts/coverage.py $(COVERAGE_THRESHOLD) $(TEMP_DIR)/unit-coverage-details.txt
 
 .PHONY: integration
 integration:  ## Run integration tests
 	$(call title,Running integration tests)
 	go test -v ./test/integration
+	go run -race cmd/syft/main.go alpine:latest
 
 .PHONY: validate-cyclonedx-schema
 validate-cyclonedx-schema:


### PR DESCRIPTION
Previously, there were some data races in syft. Right now, none are detected, so check for data races on the overall command, and on unit tests. (Checking for races on integration tests triples the time needed for those tests, from ~1 minute to ~3 minutes on my workstation, so that was not done at this time.)