### PR TITLE
fix: allow cyclonedx json input with no components

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/decoder.go
+++ b/syft/formats/common/cyclonedxhelpers/decoder.go
@@ -27,7 +27,8 @@ func GetValidator(format cyclonedx.BOMFileFormat) sbom.Validator {
 		}
 
 		xmlWithoutNS := format == cyclonedx.BOMFileFormatXML && !strings.Contains(bom.XMLNS, cycloneDXXmlSchema)
-		if (cyclonedx.BOM{} == *bom || bom.Components == nil || xmlWithoutNS) {
+		xmlWithoutComponents := format == cyclonedx.BOMFileFormatXML && bom.Components == nil
+		if (cyclonedx.BOM{} == *bom || xmlWithoutComponents || xmlWithoutNS) {
 			return fmt.Errorf("not a valid CycloneDX document")
 		}
 		return nil


### PR DESCRIPTION
According to [cyclonedx json reference](https://cyclonedx.org/docs/1.4/json/#services) the components field is not mandatory.
This can be verified, by generating a cyclonedx json report using https://github.com/CycloneDX/cyclonedx-maven-plugin in a small maven project.

A missing components field will lead to:
`error during command execution: failed to decode SBOM: unable to identify format`

This fixes the error and still respects [this pr](https://github.com/anchore/syft/pull/1873).