### PR TITLE
chore: pin all cli test FROM lines to linux/amd64

### DIFF
--- a/test/cli/test-fixtures/image-bad-binaries/Dockerfile
+++ b/test/cli/test-fixtures/image-bad-binaries/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:sid
+FROM debian:sid@sha256:bee393b48f83fdeb978ce68abb9dc955d6398b984fca88b52a09dceb45ac74b5
 ADD sources.list /etc/apt/sources.list.d/sources.list
 RUN apt update -y && apt install -y dpkg-dev
 # this as a "macho-invalid" directory which is useful for testing

--- a/test/cli/test-fixtures/image-hidden-packages/Dockerfile
+++ b/test/cli/test-fixtures/image-hidden-packages/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.9.2009
+FROM centos:7.9.2009@sha256:dead07b4d8ed7e29e98de0f4504d87e8880d4347859d839686a31da35a3b532f
 # all-layers scope should pickup on vsftpd
 RUN yum install -y vsftpd
 RUN yum remove -y vsftpd

--- a/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
+++ b/test/cli/test-fixtures/image-java-spdx-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM openjdk:11@sha256:e81b7f317654b0f26d3993e014b04bcb29250339b11b9de41e130feecd4cd43c
 
 RUN wget --no-verbose https://github.com/spdx/tools-java/releases/download/v1.1.3/tools-java-1.1.3.zip && \
 	unzip tools-java-1.1.3.zip && \

--- a/test/cli/test-fixtures/image-node-binary/Dockerfile
+++ b/test/cli/test-fixtures/image-node-binary/Dockerfile
@@ -1,1 +1,1 @@
-FROM node:19-alpine3.15
+FROM node:19-alpine3.15@sha256:07050181369f52460e788738272bcb22b71c7cfc6fafee0b5cd27d2022513a86

--- a/test/cli/test-fixtures/registry/Dockerfile
+++ b/test/cli/test-fixtures/registry/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:latest
+FROM alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33


### PR DESCRIPTION
Many of these images have a slightly different set of packages when the arm64 variant is pulled, so that leaving this digest unpinned causes the tests to fail on arm64 hosts. Pin the FROM lines to force stable platform values regardless of host architecture.

Fixes #1788.

Draft because waiting on a response to [this comment](https://github.com/anchore/syft/issues/1788#issuecomment-1721432449)