### PR TITLE
java: fix wrong filename-based guessed archive version

### DIFF
--- a/cmd/syft/cli/options/output.go
+++ b/cmd/syft/cli/options/output.go
@@ -3,7 +3,7 @@ package options
 import (
 	"fmt"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/syft/formats"

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zyedidia/generic v1.2.2-0.20230320175451-4410d2372cb1
 	golang.org/x/crypto v0.13.0 // indirect
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	golang.org/x/mod v0.12.0
 	golang.org/x/net v0.15.0
 	golang.org/x/term v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -785,8 +785,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
-golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/syft/formats/common/cyclonedxhelpers/format.go
+++ b/syft/formats/common/cyclonedxhelpers/format.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"time"
 
+	"slices"
+
 	"github.com/CycloneDX/cyclonedx-go"
 	"github.com/google/uuid"
-	"golang.org/x/exp/slices"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"

--- a/syft/formats/common/spdxhelpers/to_format_model.go
+++ b/syft/formats/common/spdxhelpers/to_format_model.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"slices"
+
 	"github.com/docker/distribution/reference"
 	"github.com/spdx/tools-golang/spdx"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/internal"
@@ -722,7 +722,11 @@ func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 
 	var result []*spdx.OtherLicense
 
-	ids := maps.Keys(licenses)
+	var ids []string
+	for licenseId := range licenses {
+		ids = append(ids, licenseId)
+	}
+
 	slices.Sort(ids)
 	for _, id := range ids {
 		license := licenses[id]

--- a/syft/formats/formats.go
+++ b/syft/formats/formats.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/formats/cyclonedxjson"

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"time"
 
+	"slices"
+
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
-	"golang.org/x/exp/slices"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"

--- a/syft/pkg/cataloger/common/cpe/dictionary/index-generator/generate.go
+++ b/syft/pkg/cataloger/common/cpe/dictionary/index-generator/generate.go
@@ -9,8 +9,9 @@ import (
 	"log"
 	"strings"
 
+	"slices"
+
 	"github.com/facebookincubator/nvdtools/wfn"
-	"golang.org/x/exp/slices"
 
 	"github.com/anchore/syft/syft/pkg/cataloger/common/cpe/dictionary"
 )

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -230,7 +230,7 @@ func (j *archiveParser) guessMainPackageNameAndVersionFromPomInfo() (string, str
 		projects, _ := pomProjectByParentPath(j.archivePath, j.location, pomMatches)
 
 		for parentPath, propertiesObj := range properties {
-			if propertiesObj.ArtifactID != "" && j.fileInfo.name != "" && strings.HasPrefix(propertiesObj.ArtifactID, j.fileInfo.name) {
+			if propertiesObj.ArtifactID != "" {
 				pomPropertiesObject = propertiesObj
 				if proj, exists := projects[parentPath]; exists {
 					pomProjectObject = proj

--- a/syft/pkg/cataloger/package_exclusions.go
+++ b/syft/pkg/cataloger/package_exclusions.go
@@ -1,7 +1,7 @@
 package cataloger
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"

--- a/syft/sbom/sbom.go
+++ b/syft/sbom/sbom.go
@@ -3,7 +3,7 @@ package sbom
 import (
 	"sort"
 
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"

--- a/test/integration/test-fixtures/image-java-virtualpath-regression/Dockerfile
+++ b/test/integration/test-fixtures/image-java-virtualpath-regression/Dockerfile
@@ -2,6 +2,5 @@ FROM alpine:3.18.3@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3
 
 RUN wget https://repo1.maven.org/maven2/org/jvnet/hudson/main/hudson-war/2.2.1/hudson-war-2.2.1.war
 
-RUN mv hudson-war-2.2.1.war hudson.war
-
+RUN mv hudson-war-2.2.1.war hudson-bogus.war
 


### PR DESCRIPTION
Fixes #2130 

Also switch `slices` usage to standard library's instead of relying to `golang/x/exp/slices`