### PR TITLE
chore: remove unneeded arch switch in unit test

### DIFF
--- a/syft/internal/fileresolver/container_image_all_layers_test.go
+++ b/syft/internal/fileresolver/container_image_all_layers_test.go
@@ -1,9 +1,7 @@
 package fileresolver
 
 import (
-	"fmt"
 	"io"
-	"runtime"
 	"sort"
 	"testing"
 
@@ -523,11 +521,6 @@ func Test_imageAllLayersResolver_resolvesLinks(t *testing.T) {
 func TestAllLayersResolver_AllLocations(t *testing.T) {
 	img := imagetest.GetFixtureImage(t, "docker-archive", "image-files-deleted")
 
-	arch := "x86_64"
-	if runtime.GOARCH == "arm64" {
-		arch = "aarch64"
-	}
-
 	resolver, err := NewFromContainerImageAllLayers(img)
 	assert.NoError(t, err)
 
@@ -638,9 +631,9 @@ func TestAllLayersResolver_AllLocations(t *testing.T) {
 		"/lib/apk/db/triggers",
 		"/lib/apk/exec",
 		"/lib/firmware",
-		fmt.Sprintf("/lib/ld-musl-%s.so.1", arch),
+		"/lib/ld-musl-x86_64.so.1",
 		"/lib/libapk.so.3.12.0",
-		fmt.Sprintf("/lib/libc.musl-%s.so.1", arch),
+		"/lib/libc.musl-x86_64.so.1",
 		"/lib/libcrypto.so.3",
 		"/lib/libssl.so.3",
 		"/lib/libz.so.1",


### PR DESCRIPTION
Now that the test fixture pins to a particular digest, there's no need for platform specific architecture switches in this test.