### PR TITLE
Correcting behavior based on Syft release v0.91.0 run

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,1 +1,2 @@
 enforce-v0: true # don't make breaking-change label bump major version before 1.0.
+title: ""

--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -6,10 +6,6 @@ inputs:
     description: "Go version to install"
     required: true
     default: "1.21.x"
-  use-go-cache:
-    description: "Restore go cache"
-    required: true
-    default: "true"
   cache-key-prefix:
     description: "Prefix all cache keys with this value"
     required: true
@@ -25,6 +21,7 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # note: go mod and build is automatically cached on default with v4+
     - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
       with:
         go-version: ${{ inputs.go-version }}
@@ -36,38 +33,13 @@ runs:
         path: ${{ github.workspace }}/.tmp
         key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-tool-${{ hashFiles('Makefile') }}
 
-    # note: we need to keep restoring the go mod cache before bootstrapping tools since `go install` is used in
-    # some installations of project tools.
-    - name: Restore go module cache
-      id: go-mod-cache
-      if: inputs.use-go-cache == 'true'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-      with:
-        path: |
-          ~/go/pkg/mod
-        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-go-mod-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-go-mod-${{ inputs.go-version }}-
-
     - name: (cache-miss) Bootstrap project tools
       shell: bash
       if: steps.tool-cache.outputs.cache-hit != 'true'
       run: make bootstrap-tools
 
-    - name: Restore go build cache
-      id: go-cache
-      if: inputs.use-go-cache == 'true'
-      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
-      with:
-        path: |
-          ~/.cache/go-build
-        key: ${{ inputs.cache-key-prefix }}-${{ inputs.build-cache-key-prefix }}-${{ runner.os }}-go-build-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ inputs.cache-key-prefix }}-${{ inputs.build-cache-key-prefix }}-${{ runner.os }}-go-build-${{ inputs.go-version }}-
-
-    - name: (cache-miss) Bootstrap go dependencies
+    - name: Bootstrap go dependencies
       shell: bash
-      if: steps.go-mod-cache.outputs.cache-hit != 'true' && inputs.use-go-cache == 'true'
       run: make bootstrap-go
 
     - name: Install apt packages

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,7 +149,7 @@ jobs:
         with:
           artifact-name: sbom.spdx.json
 
-      - uses: 8398a7/action-slack@49aa08e51e8782f49c601d79ec72d07fd39a4612 #v3.15.1
+      - uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #v3.15.1
         continue-on-error: true
         with:
           status: ${{ job.status }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,9 +158,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ success() }}
-
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 #v3.1.3
-        with:
-          name: artifacts
-          path: dist/**/*
-


### PR DESCRIPTION
Adjustments to the release process based off of the last release:
- don't show the title of the changelog in the release notes
- don't upload assets in the release pipeline (as they are going to be on the github release page anyway)
- bump action-slack to the correct version pin
- there are cache collisions due to the fact that the go-setup action now enables mod and build caching by default https://github.com/actions/setup-go?tab=readme-ov-file#v4