### PR TITLE
fix: deterministic java purls

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java.go
+++ b/syft/pkg/cataloger/common/cpe/java.go
@@ -1,6 +1,7 @@
 package cpe
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/scylladb/go-set/strset"
@@ -287,6 +288,7 @@ func GetManifestFieldGroupIDs(manifest *pkg.JavaManifest, fields []string) (grou
 			}
 		}
 	}
+	sort.Strings(groupIDs)
 
 	return groupIDs
 }

--- a/syft/pkg/cataloger/common/cpe/java_groupid_map.go
+++ b/syft/pkg/cataloger/common/cpe/java_groupid_map.go
@@ -37,6 +37,7 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"ant-weblogic":                   "org.apache.ant",
 	"ant-xz":                         "org.apache.ant",
 	"commons-codec":                  "commons-codec",
+	"commons-logging":                "commons-logging", // see e.g. https://mvnrepository.com/artifact/commons-logging/commons-logging/1.1.1
 	"okhttp":                         "com.squareup.okhttp3",
 	"okio":                           "com.squareup.okio",
 	"spring":                         "org.springframework",

--- a/test/integration/java_purl_test.go
+++ b/test/integration/java_purl_test.go
@@ -76,9 +76,9 @@ var expectedPURLs = map[string]string{
 	"commons-jexl@1.1-hudson-20090508":                "pkg:maven/org.jvnet.hudson/commons-jexl@1.1-hudson-20090508",
 	"commons-lang@2.4":                                "pkg:maven/commons-lang/commons-lang@2.4",
 	"commons-lang@2.5":                                "pkg:maven/commons-lang/commons-lang@2.5",
-	"commons-logging@1.0.4":                           "pkg:maven/org.apache.commons.logging/commons-logging@1.0.4",
-	"commons-logging@1.1":                             "pkg:maven/org.apache.commons.logging/commons-logging@1.1",
-	"commons-logging@1.1.1":                           "pkg:maven/commons-logging/commons-logging@1.1.1",
+	"commons-logging@1.0.4":                           "pkg:maven/commons-logging/commons-logging@1.0.4", // see https://mvnrepository.com/artifact/commons-logging/commons-logging/1.0.4
+	"commons-logging@1.1":                             "pkg:maven/commons-logging/commons-logging@1.1",   // see https://mvnrepository.com/artifact/commons-logging/commons-logging/1.1
+	"commons-logging@1.1.1":                           "pkg:maven/commons-logging/commons-logging@1.1.1", // see https://mvnrepository.com/artifact/commons-logging/commons-logging/1.1.1
 	"commons-pool@1.3":                                "pkg:maven/commons-pool/commons-pool@1.3",
 	"crypto-util@1.0":                                 "pkg:maven/org.jvnet.hudson/crypto-util@1.0",
 	"cvs@1.2":                                         "pkg:maven/org.jvnet.hudson.plugins/cvs@1.2",


### PR DESCRIPTION
Previously, iterating over the map to build up a string slice of groupID candidates resulted in non-deterministic selection of the groupID. Fix that by sorting candidates, and update some integration tests that were only passing because of the issue.

There might be more discussion needed here:

1. The comment at https://github.com/anchore/syft/blob/8314c0d2cbc0732ce79b383ab260af4bd31ae1ad/syft/pkg/cataloger/java/package_url.go#L67-L69 seems like it was never true, since the array order coming back from `GetManifestFieldGroupIDs` was non-deterministic due to iterating maps
2. There's no reason to suppose that the lexicographically first group ID is a better choice than whatever group ID happened to win the map iteration.

Fixes https://github.com/anchore/syft/issues/2169, but open to discussion about whether this is the right approach.