### PR TITLE
Refactor --output help text and deprecate --file.

### DIFF
--- a/cmd/syft/cli/options/output.go
+++ b/cmd/syft/cli/options/output.go
@@ -31,7 +31,7 @@ func DefaultOutput() MultiOutput {
 
 func (o *MultiOutput) AddFlags(flags clio.FlagSet) {
 	flags.StringArrayVarP(&o.Outputs, "output", "o",
-		fmt.Sprintf("report output to target (<format>=<file>), formats=%v", formats.AllIDs()))
+		fmt.Sprintf("report output format (<format>=<file> to output to a file), formats=%v", formats.AllIDs()))
 
 	flags.StringVarP(&o.OutputTemplatePath, "template", "t",
 		"specify the path to a Go template file")
@@ -77,7 +77,7 @@ var _ interface {
 func (o *OutputFile) AddFlags(flags clio.FlagSet) {
 	flags.StringVarP(&o.File, "file", "",
 		"file to write the default report output to (default is STDOUT)")
-	
+
 	if pfp, ok := flags.(fangs.PFlagSetProvider); ok {
 		flagSet := pfp.PFlagSet()
 		flagSet.Lookup("file").Deprecated = "use: output"

--- a/cmd/syft/cli/options/output.go
+++ b/cmd/syft/cli/options/output.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/fangs"
 	"github.com/anchore/syft/syft/formats"
 	"github.com/anchore/syft/syft/formats/table"
 	"github.com/anchore/syft/syft/formats/template"
@@ -63,7 +64,7 @@ func (o *SingleOutput) SBOMWriter(file string) (sbom.Writer, error) {
 	return makeSBOMWriter([]string{o.Output}, file, o.OutputTemplatePath)
 }
 
-// OutputFile is only the --file argument
+// Deprecated: OutputFile is only the --file argument
 type OutputFile struct {
 	File string `yaml:"file" json:"file" mapstructure:"file"` // --file, the file to write report output to
 }
@@ -76,6 +77,11 @@ var _ interface {
 func (o *OutputFile) AddFlags(flags clio.FlagSet) {
 	flags.StringVarP(&o.File, "file", "",
 		"file to write the default report output to (default is STDOUT)")
+	
+	if pfp, ok := flags.(fangs.PFlagSetProvider); ok {
+		flagSet := pfp.PFlagSet()
+		flagSet.Lookup("file").Deprecated = "use: output"
+	}
 }
 
 func (o *OutputFile) PostLoad() error {

--- a/cmd/syft/cli/options/output.go
+++ b/cmd/syft/cli/options/output.go
@@ -30,7 +30,7 @@ func DefaultOutput() MultiOutput {
 
 func (o *MultiOutput) AddFlags(flags clio.FlagSet) {
 	flags.StringArrayVarP(&o.Outputs, "output", "o",
-		fmt.Sprintf("report output format, options=%v", formats.AllIDs()))
+		fmt.Sprintf("report output to target (<format>=<file>), formats=%v", formats.AllIDs()))
 
 	flags.StringVarP(&o.OutputTemplatePath, "template", "t",
 		"specify the path to a Go template file")


### PR DESCRIPTION
### Change Log

- Added usage syntax to CLI help text for `--output` option for better understanding. The new help text looks like:
``` text 
-o, --output stringArray       report output format (<format>=<file> to output to a file), formats=[syft-json github-json syft-table syft-text template cyclonedx-xml cyclonedx-json spdx-tag-value spdx-json] (default [syft-table])
```

- Marked the `--file` option as deprecated, suggesting to use `--output` as an alternative. The new help text looks like:
``` text
--file string              file to write the default report output to (default is STDOUT) (DEPRECATED: use: output)  
```

Resolves: https://github.com/anchore/syft/issues/2165