### PR TITLE
fix: `if` with identical `then` and `else` blocks in cli/options/writer_test.go

### DIFF
--- a/cmd/syft/cli/options/writer_test.go
+++ b/cmd/syft/cli/options/writer_test.go
@@ -183,11 +183,7 @@ func Test_newSBOMMultiWriter(t *testing.T) {
 				switch w := mw.writers[i].(type) {
 				case *sbomStreamWriter:
 					assert.Equal(t, string(w.format.ID()), e.format)
-					if e.file != "" {
-						assert.NotNil(t, w.out)
-					} else {
-						assert.NotNil(t, w.out)
-					}
+					assert.NotNil(t, w.out)
 					if e.file != "" {
 						assert.FileExists(t, tmp+e.file)
 					}


### PR DESCRIPTION
Closes #2192 by replacing the conditional with just the content of one of its branches.

 