### PR TITLE
Add exact syntax of the conversion formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ syft convert <ORIGINAL-SBOM-FILE> -o <NEW-SBOM-FORMAT>[=<NEW-SBOM-FILE>]
 This feature is experimental and data might be lost when converting formats. Packages are the main SBOM component easily transferable across formats, whereas files and relationships, as well as other information Syft doesn't support, are more likely to be lost.
 
 We support formats with wide community usage AND good encode/decode support by Syft. The supported formats are:
-- Syft JSON
-- SPDX 2.2 JSON
-- SPDX 2.2 tag-value
-- CycloneDX 1.4 JSON
-- CycloneDX 1.4 XML
+- Syft JSON (```-o syft-json```)
+- SPDX 2.2 JSON (```-o spdx-json```)
+- SPDX 2.2 tag-value (```-o spdx-tag-value```)
+- CycloneDX 1.4 JSON (```-o cyclonedx-json```)
+- CycloneDX 1.4 XML (```-o cyclonedx-xml```)
 
 Conversion example:
 ```sh


### PR DESCRIPTION
It was not clear what was the exact syntax of the conversion command.

You had to do "syft convert -h" to know.
