### PR TITLE
Fix: Correctly map algorithm name in CycloneDx 

### DIFF
--- a/syft/formats/common/cyclonedxhelpers/external_references.go
+++ b/syft/formats/common/cyclonedxhelpers/external_references.go
@@ -97,7 +97,7 @@ func toCycloneDXAlgorithm(algorithm string) cyclonedx.HashAlgorithm {
 		"sha256": cyclonedx.HashAlgorithm("SHA-256"),
 	}
 
-	return validMap[algorithm]
+	return validMap[strings.ToLower(algorithm)]
 }
 
 func decodeExternalReferences(c *cyclonedx.Component, metadata interface{}) {

--- a/syft/formats/common/cyclonedxhelpers/external_references_test.go
+++ b/syft/formats/common/cyclonedxhelpers/external_references_test.go
@@ -173,3 +173,27 @@ func Test_isValidExternalRef(t *testing.T) {
 		})
 	}
 }
+
+func Test_toCycloneDXAlgorithm(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected cyclonedx.HashAlgorithm
+	}{
+		{
+			name:     "valid algorithm name in upper case",
+			input:    "SHA1",
+			expected: cyclonedx.HashAlgorithm("SHA-1"),
+		},
+		{
+			name:     "valid algorithm name in lower case",
+			input:    "sha1",
+			expected: cyclonedx.HashAlgorithm("SHA-1"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, toCycloneDXAlgorithm(test.input))
+		})
+	}
+}


### PR DESCRIPTION
### Change Log
- Fixed the algorithm look up logic by converting the key (algorithm name) to lower case.
- Added unit test for `toCycloneDXAlgorithm`.

Resolves: https://github.com/anchore/syft/issues/2183

The example from the above issue now produces the following final output:
[sboms.zip](https://github.com/anchore/syft/files/12845412/sboms.zip)
