### PR TITLE
Detect a license file in the root directory or META-INF of a jar

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -158,6 +158,15 @@ func TestParseJar(t *testing.T) {
 					Language:     pkg.Java,
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
+					Licenses: pkg.NewLicenseSet(
+						pkg.License{
+							Value:          "Apache-2.0",
+							SPDXExpression: "Apache-2.0",
+							Type:           license.Concluded,
+							URLs:           internal.NewStringSet(),
+							Locations:      file.NewLocationSet(file.NewLocation("test-fixtures/java-builds/packages/example-java-app-gradle-0.1.0.jar")),
+						},
+					),
 					Metadata: pkg.JavaMetadata{
 						VirtualPath: "test-fixtures/java-builds/packages/example-java-app-gradle-0.1.0.jar",
 						Manifest: &pkg.JavaManifest{
@@ -223,6 +232,15 @@ func TestParseJar(t *testing.T) {
 					Language:     pkg.Java,
 					Type:         pkg.JavaPkg,
 					MetadataType: pkg.JavaMetadataType,
+					Licenses: pkg.NewLicenseSet(
+						pkg.License{
+							Value:          "Apache-2.0",
+							SPDXExpression: "Apache-2.0",
+							Type:           license.Concluded,
+							URLs:           internal.NewStringSet(),
+							Locations:      file.NewLocationSet(file.NewLocation("test-fixtures/java-builds/packages/example-java-app-maven-0.1.0.jar")),
+						},
+					),
 					Metadata: pkg.JavaMetadata{
 						VirtualPath: "test-fixtures/java-builds/packages/example-java-app-maven-0.1.0.jar",
 						Manifest: &pkg.JavaManifest{


### PR DESCRIPTION
Closes #2147

If the jar doesn't have a Bundle-License in the Manifest, or a pom.xml in the archive with the declared license, it falls back to look for a valid license in either the root directory of the jar or in META-INF. I don't think it's necessary to check anywhere else for a license in a jar.

With this fix Syft correctly detects licenses for:

- https://repo1.maven.org/maven2/xerces/xercesImpl/2.12.2/ (META-INF/LICENSE)
- https://repo1.maven.org/maven2/org/apache/xmlbeans/xmlbeans/5.1.1/ (LICENSE.txt in root directory)