### PR TITLE
Add additional license filenames

### DIFF
--- a/internal/licenses/list.go
+++ b/internal/licenses/list.go
@@ -18,6 +18,7 @@ var (
 		"LICENSE",
 		"LICENSE.md",
 		"LICENSE.markdown",
+		"license.txt",
 		"LICENSE.txt",
 		"LICENSE-2.0.txt",
 		"LICENCE-2.0.txt",
@@ -47,6 +48,8 @@ var (
 		"MIT_LICENCE",
 		"UNLICENSE",
 		"UNLICENCE",
+		"AL2.0",
+		"LGPL2.1",
 	}
 
 	FileNameSet = internal.NewStringSet(FileNames...)

--- a/internal/licenses/list.go
+++ b/internal/licenses/list.go
@@ -3,7 +3,8 @@ package licenses
 import "github.com/anchore/syft/internal"
 
 // all of these taken from https://github.com/golang/pkgsite/blob/8996ff632abee854aef1b764ca0501f262f8f523/internal/licenses/licenses.go#L338
-// which unfortunately is not exported. But fortunately is under BSD-style license.
+// which unfortunately is not exported. But fortunately is under BSD-style license. Take note that this list has
+// been manually updated to include more license filenames (see https://github.com/anchore/syft/pull/2227).
 
 var (
 	FileNames = []string{


### PR DESCRIPTION
These additions help Syft to correctly identify licenses for:

- The widely deployed Spring framework (https://repo1.maven.org/maven2/org/springframework/spring-core/6.0.12/) which has a license in META-INF/license.txt
- https://repo1.maven.org/maven2/net/java/dev/jna/jna-platform/5.13.0/ which has licenses in AL2.0 and LGPL2.1 filenames.

For the first point we could instead do a case insensitive check on the filenames, but I thought that was probably overkill.