### PR TITLE
Add download location when cataloging directory npm package lock

### DIFF
--- a/syft/formats/common/spdxhelpers/download_location.go
+++ b/syft/formats/common/spdxhelpers/download_location.go
@@ -20,6 +20,8 @@ func DownloadLocation(p pkg.Package) string {
 			return NoneIfEmpty(metadata.URL)
 		case pkg.NpmPackageJSONMetadata:
 			return NoneIfEmpty(metadata.URL)
+		case pkg.NpmPackageLockJSONMetadata:
+			return NoneIfEmpty(metadata.Resolved)
 		}
 	}
 	return NOASSERTION

--- a/syft/formats/common/spdxhelpers/download_location_test.go
+++ b/syft/formats/common/spdxhelpers/download_location_test.go
@@ -46,6 +46,24 @@ func Test_DownloadLocation(t *testing.T) {
 			},
 			expected: NONE,
 		},
+		{
+			name: "from npm package-lock",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageLockJSONMetadata{
+					Resolved: "http://package-lock.test",
+				},
+			},
+			expected: "http://package-lock.test",
+		},
+		{
+			name: "from npm package-lock empty",
+			input: pkg.Package{
+				Metadata: pkg.NpmPackageLockJSONMetadata{
+					Resolved: "",
+				},
+			},
+			expected: NONE,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/formats/common/spdxhelpers/download_location_test.go
+++ b/syft/formats/common/spdxhelpers/download_location_test.go
@@ -47,7 +47,7 @@ func Test_DownloadLocation(t *testing.T) {
 			expected: NONE,
 		},
 		{
-			name: "from npm package-lock",
+			name: "from npm package-lock should include resolved",
 			input: pkg.Package{
 				Metadata: pkg.NpmPackageLockJSONMetadata{
 					Resolved: "http://package-lock.test",
@@ -56,7 +56,7 @@ func Test_DownloadLocation(t *testing.T) {
 			expected: "http://package-lock.test",
 		},
 		{
-			name: "from npm package-lock empty",
+			name: "from npm package-lock empty should be NONE",
 			input: pkg.Package{
 				Metadata: pkg.NpmPackageLockJSONMetadata{
 					Resolved: "",


### PR DESCRIPTION
## Summary
See #2102 - this signs off the commits and sets DCO to pass while still giving credit to the author