### PR TITLE
Fix homebrew post-release workflow

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -1,8 +1,10 @@
 name: "Release Homebrew"
 
 on:
+  workflow_dispatch:
   release:
-    types: [published]
+    types:
+      - released
 
 jobs:
   homebrew:


### PR DESCRIPTION
It looks like for the first release we expected the homebrew release workflow to run it was not triggered. I've adjusted the event types to account for this (🤞 ) and also added `workflow_dispatch` to trigger outside of a release.