### PR TITLE
Troubleshoot homebrew release workflow

### DIFF
--- a/.github/workflows/release-homebrew.yaml
+++ b/.github/workflows/release-homebrew.yaml
@@ -10,12 +10,33 @@ jobs:
   homebrew:
     runs-on: ubuntu-20.04
     steps:
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+        with:
+          # we need to be able to get the commit for a tag
+          fetch-depth: 0
+
+      - name: Get release info
+        id: release_info
+        run: |
+          echo -n "tag_name=$(gh release view --json tagName --jq '.tagName')" | tee -a $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get commit info
+        id: git_info
+        run: |
+          git checkout ${{ steps.release_info.outputs.tag_name }}
+          echo -n "commit=$(git rev-parse HEAD)" | tee -a $GITHUB_OUTPUT
+
       - name: Update Homebrew formula
         uses: dawidd6/action-homebrew-bump-formula@d3667e5ae14df19579e4414897498e3e88f2f458 # v3.10.0
         with:
           token: ${{ secrets.HOMEBREW_TOKEN }}
           org: anchore
           formula: syft
+          tag: ${{ steps.release_info.outputs.tag_name }}
+          revision: ${{ steps.git_info.outputs.commit }}
 
       - uses: 8398a7/action-slack@fbd6aa58ba854a740e11a35d0df80cb5d12101d8 #v3.15.1
         if: ${{ failure() }}


### PR DESCRIPTION
I don't this think fully fixes the homebrew workflow, however, it seems that someone has already put in a PR for the latest syft release, I'll have to give this a go on the next release. These changes improve the behavior, but I was still running into a failure due to token permissions and forking.