### PR TITLE
2179 jar chokes empty lines

### DIFF
--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -46,7 +46,7 @@ func parseJavaManifest(path string, reader io.Reader) (*pkg.JavaManifest, error)
 			// this is a continuation
 
 			if lastKey == "" {
-				log.Warnf("java manifest %q: found continuation with no previous key: %q", path, line)
+				log.Debugf("java manifest %q: found continuation with no previous key: %q", path, line)
 				continue
 			}
 
@@ -58,7 +58,7 @@ func parseJavaManifest(path string, reader io.Reader) (*pkg.JavaManifest, error)
 		// this is a new key-value pair
 		idx := strings.Index(line, ":")
 		if idx == -1 {
-			log.Warnf("java manifest %q: unable to split java manifest key-value pairs: %q", path, line)
+			log.Debugf("java manifest %q: unable to split java manifest key-value pairs: %q", path, line)
 			continue
 		}
 
@@ -95,7 +95,7 @@ func parseJavaManifest(path string, reader io.Reader) (*pkg.JavaManifest, error)
 					// per the manifest spec (https://docs.oracle.com/en/java/javase/11/docs/specs/jar/jar.html#jar-manifest)
 					// this should never happen. If it does, we want to know about it, but not necessarily stop
 					// cataloging entirely... for this reason we only log.
-					log.Warnf("java manifest section found without a name: %s", path)
+					log.Debugf("java manifest section found without a name: %s", path)
 					name = strconv.Itoa(i)
 				} else {
 					delete(s, "Name")

--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -32,7 +32,7 @@ func parseJavaManifest(path string, reader io.Reader) (*pkg.JavaManifest, error)
 		line := scanner.Text()
 
 		// empty lines denote section separators
-		if strings.TrimSpace(line) == "" {
+		if line == "" {
 			// we don't want to allocate a new section map that won't necessarily be used, do that once there is
 			// a non-empty line to process
 

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -101,6 +101,17 @@ func TestParseJavaManifest(t *testing.T) {
 				},
 			},
 		},
+		{
+			// regression test, we should not trim space and choke of empty space
+			// https://github.com/anchore/syft/issues/2179
+			fixture: "test-fixtures/manifest/leading-space",
+			expected: pkg.JavaManifest{
+				Main: map[string]string{
+					"Key-keykeykey": "initialconfig:com$    # aka not empty line",
+					"should":        "parse",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/java/test-fixtures/manifest/leading-space
+++ b/syft/pkg/cataloger/java/test-fixtures/manifest/leading-space
@@ -1,0 +1,5 @@
+Key-keykeykey: initialconfig:com
+continue line1,$
+continue line1,$
+    $    # aka not empty line
+should: parse


### PR DESCRIPTION
## Update Java Manifest Parser
This PR removes the `strings.TrimSpace` call which was abruptly ending a manifest parse when a continuation was expected.

This PR adds a test to make sure the continuations are included in the previous fields while still allowing the parser to move forward and catalog the entire document.

Warning levels for this function have been reduced to debug in response to the dev note from #2179 