### PR TITLE
Update README.md to use canonical output format names (fixes #2269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,16 +244,16 @@ syft <image> -o <format>
 ```
 
 Where the `formats` available are:
-- `json`: Use this to get as much information out of Syft as possible!
-- `text`: A row-oriented, human-and-machine-friendly output.
+- `syft-json`: Use this to get as much information out of Syft as possible!
+- `syft-text`: A row-oriented, human-and-machine-friendly output.
 - `cyclonedx-xml`: A XML report conforming to the [CycloneDX 1.4 specification](https://cyclonedx.org/specification/overview/).
 - `cyclonedx-json`: A JSON report conforming to the [CycloneDX 1.4 specification](https://cyclonedx.org/specification/overview/).
 - `spdx-tag-value`: A tag-value formatted report conforming to the [SPDX 2.3 specification](https://spdx.github.io/spdx-spec/v2.3/).
 - `spdx-tag-value@2.2`: A tag-value formatted report conforming to the [SPDX 2.2 specification](https://spdx.github.io/spdx-spec/v2.2.2/).
 - `spdx-json`: A JSON report conforming to the [SPDX 2.3 JSON Schema](https://github.com/spdx/spdx-spec/blob/v2.3/schemas/spdx-schema.json).
 - `spdx-json@2.2`: A JSON report conforming to the [SPDX 2.2 JSON Schema](https://github.com/spdx/spdx-spec/blob/v2.2/schemas/spdx-schema.json).
-- `github`: A JSON report conforming to GitHub's dependency snapshot format.
-- `table`: A columnar summary (default).
+- `github-json`: A JSON report conforming to GitHub's dependency snapshot format.
+- `syft-table`: A columnar summary (default).
 - `template`: Lets the user specify the output format. See ["Using templates"](#using-templates) below.
 
 ## Using templates
@@ -266,7 +266,7 @@ Syft lets you define custom output formats, using [Go templates](https://pkg.go.
 
 - Specify the path to the template file (`-t ./path/to/custom.template`).
 
-- Syft's template processing uses the same data models as the `json` output format — so if you're wondering what data is available as you author a template, you can use the output from `syft <image> -o json` as a reference.
+- Syft's template processing uses the same data models as the `syft-json` output format — so if you're wondering what data is available as you author a template, you can use the output from `syft <image> -o syft-json` as a reference.
 
 **Example:** You could make Syft output data in CSV format by writing a Go template that renders CSV data and then running `syft <image> -o template -t ~/path/to/csv.tmpl`.
 
@@ -297,7 +297,7 @@ Syft can also output _multiple_ files in differing formats by appending
 `=<file>` to the option, for example to output Syft JSON and SPDX JSON:
 
 ```shell
-syft <image> -o json=sbom.syft.json -o spdx-json=sbom.spdx.json
+syft <image> -o syft-json=sbom.syft.json -o spdx-json=sbom.spdx.json
 ```
 
 ## Private Registry Authentication
@@ -454,13 +454,13 @@ Configuration search paths:
 Configuration options (example values are the default):
 
 ```yaml
-# the output format(s) of the SBOM report (options: table, text, json, spdx, ...)
+# the output format(s) of the SBOM report (options: syft-table, syft-text, syft-json, spdx-json, ...)
 # same as -o, --output, and SYFT_OUTPUT env var
 # to specify multiple output files in differing formats, use a list:
 # output:
-#   - "json=<syft-json-output-file>"
+#   - "syft-json=<syft-json-output-file>"
 #   - "spdx-json=<spdx-json-output-file>"
-output: "table"
+output: "syft-table"
 
 # suppress all output (except for the SBOM report)
 # same as -q ; SYFT_QUIET env var


### PR DESCRIPTION
Fixes #2269 

Signed-off-by: Timothy Gerla <tim@gerla.net>
