### PR TITLE
add PURLs when scanning Gradle lock files

### DIFF
--- a/syft/pkg/cataloger/java/parse_gradle_lockfile.go
+++ b/syft/pkg/cataloger/java/parse_gradle_lockfile.go
@@ -46,8 +46,18 @@ func parseGradleLockfile(_ file.Resolver, _ *generic.Environment, reader file.Lo
 			dependencies = append(dependencies, dep)
 		}
 	}
+
 	// map the dependencies
 	for _, dep := range dependencies {
+		archive := pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    dep.Group,
+				ArtifactID: dep.Name,
+				Version:    dep.Version,
+				Name:       dep.Name,
+			},
+		}
+
 		mappedPkg := pkg.Package{
 			Name:    dep.Name,
 			Version: dep.Version,
@@ -56,14 +66,8 @@ func parseGradleLockfile(_ file.Resolver, _ *generic.Environment, reader file.Lo
 			),
 			Language: pkg.Java,
 			Type:     pkg.JavaPkg,
-			Metadata: pkg.JavaArchive{
-				PomProject: &pkg.JavaPomProject{
-					GroupID:    dep.Group,
-					ArtifactID: dep.Name,
-					Version:    dep.Version,
-					Name:       dep.Name,
-				},
-			},
+			PURL:     packageURL(dep.Name, dep.Version, archive),
+			Metadata: archive,
 		}
 		mappedPkg.SetID()
 		pkgs = append(pkgs, mappedPkg)

--- a/syft/pkg/cataloger/java/parse_gradle_lockfile_test.go
+++ b/syft/pkg/cataloger/java/parse_gradle_lockfile_test.go
@@ -21,6 +21,7 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Version:  "1.8",
 					Language: pkg.Java,
 					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/org.apache.commons/commons-text@1.8",
 					Metadata: pkg.JavaArchive{
 						PomProject: &pkg.JavaPomProject{GroupID: "org.apache.commons", ArtifactID: "commons-text", Version: "1.8", Name: "commons-text"},
 					},
@@ -30,6 +31,7 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Version:  "1.3",
 					Language: pkg.Java,
 					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/org.hamcrest/hamcrest-core@1.3",
 					Metadata: pkg.JavaArchive{
 						PomProject: &pkg.JavaPomProject{GroupID: "org.hamcrest", ArtifactID: "hamcrest-core", Version: "1.3", Name: "hamcrest-core"},
 					},
@@ -39,6 +41,7 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Version:  "2.2",
 					Language: pkg.Java,
 					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/joda-time/joda-time@2.2",
 					Metadata: pkg.JavaArchive{
 						PomProject: &pkg.JavaPomProject{GroupID: "joda-time", ArtifactID: "joda-time", Version: "2.2", Name: "joda-time"},
 					},
@@ -48,6 +51,7 @@ func Test_parserGradleLockfile(t *testing.T) {
 					Version:  "4.12",
 					Language: pkg.Java,
 					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/junit/junit@4.12",
 					Metadata: pkg.JavaArchive{
 						PomProject: &pkg.JavaPomProject{GroupID: "junit", ArtifactID: "junit", Version: "4.12", Name: "junit"},
 					},


### PR DESCRIPTION
This adds PURLs when scanning Gradle lock files.

Unintuitively the correct PURL type appears to be `maven` as opposed to `gradle`. See https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst

- `gradle` for Gradle plugins
- `maven` for Maven JARs and related artifacts