### PR TITLE
Wire though maven-url to java config

### DIFF
--- a/cmd/syft/cli/options/catalog.go
+++ b/cmd/syft/cli/options/catalog.go
@@ -141,7 +141,7 @@ func (cfg Catalog) ToCatalogerConfig() cataloger.Config {
 		},
 		Java: javaCataloger.DefaultCatalogerOpts().
 			WithUseNetwork(cfg.Java.UseNetwork).
-			WithMavenCentralURL(cfg.Java.MavenURL).
+			WithMavenURL(cfg.Java.MavenURL).
 			WithMaxParentRecursiveDepth(cfg.Java.MaxParentRecursiveDepth),
 		Python: pythonCataloger.CatalogerConfig{
 			GuessUnpinnedRequirements: cfg.Python.GuessUnpinnedRequirements,

--- a/syft/pkg/cataloger/config.go
+++ b/syft/pkg/cataloger/config.go
@@ -38,6 +38,7 @@ func (c Config) JavaConfig() java.Config {
 		SearchUnindexedArchives: c.Search.IncludeUnindexedArchives,
 		SearchIndexedArchives:   c.Search.IncludeIndexedArchives,
 		UseNetwork:              c.Java.UseNetwork,
+		MavenBaseURL:            c.Java.MavenURL,
 		MaxParentRecursiveDepth: c.Java.MaxParentRecursiveDepth,
 	}
 }

--- a/syft/pkg/cataloger/java/options.go
+++ b/syft/pkg/cataloger/java/options.go
@@ -13,7 +13,7 @@ func (j CatalogerOpts) WithUseNetwork(input bool) CatalogerOpts {
 	return j
 }
 
-func (j CatalogerOpts) WithMavenCentralURL(input string) CatalogerOpts {
+func (j CatalogerOpts) WithMavenURL(input string) CatalogerOpts {
 	if input != "" {
 		j.MavenURL = input
 	}


### PR DESCRIPTION
A bug crept in to the code in the refactoring of the PR I submitted to recursively find a license in maven central - the Maven URL is never actually wired through to the Java config and so the maven base URL is always empty.

I also changed a function name to make it clearer that the maven URL might be a custom one and not just maven central.

FAO @spiffcs 