### PR TITLE
SPDX file has duplicate sha256 tag in versionInfo

### DIFF
--- a/syft/source/file_source.go
+++ b/syft/source/file_source.go
@@ -108,10 +108,6 @@ func deriveIDFromFile(cfg FileConfig) (artifact.ID, string) {
 		info += fmt.Sprintf(":%s@%s", cfg.Alias.Name, cfg.Alias.Version)
 	}
 
-	if d != "" {
-		d = fmt.Sprintf("sha256:%s", d)
-	}
-
 	return artifactIDFromDigest(digest.SHA256.FromString(info).String()), d
 }
 

--- a/syft/source/file_source_test.go
+++ b/syft/source/file_source_test.go
@@ -211,10 +211,11 @@ func createArchive(t testing.TB, sourceDirPath, destinationArchivePath string, l
 
 func Test_FileSource_ID(t *testing.T) {
 	tests := []struct {
-		name    string
-		cfg     FileConfig
-		want    artifact.ID
-		wantErr require.ErrorAssertionFunc
+		name       string
+		cfg        FileConfig
+		want       artifact.ID
+		wantDigest string
+		wantErr    require.ErrorAssertionFunc
 	}{
 		{
 			name:    "empty",
@@ -236,9 +237,10 @@ func Test_FileSource_ID(t *testing.T) {
 			wantErr: require.Error,
 		},
 		{
-			name: "with path",
-			cfg:  FileConfig{Path: "./test-fixtures/image-simple/Dockerfile"},
-			want: artifact.ID("db7146472cf6d49b3ac01b42812fb60020b0b4898b97491b21bb690c808d5159"),
+			name:       "with path",
+			cfg:        FileConfig{Path: "./test-fixtures/image-simple/Dockerfile"},
+			want:       artifact.ID("db7146472cf6d49b3ac01b42812fb60020b0b4898b97491b21bb690c808d5159"),
+			wantDigest: "sha256:38601c0bb4269a10ce1d00590ea7689c1117dd9274c758653934ab4f2016f80f",
 		},
 		{
 			name: "with path and alias",
@@ -249,7 +251,8 @@ func Test_FileSource_ID(t *testing.T) {
 					Version: "version-me-this!",
 				},
 			},
-			want: artifact.ID("3c713003305ac6605255cec8bf4ea649aa44b2b9a9f3a07bd683869d1363438a"),
+			want:       artifact.ID("3c713003305ac6605255cec8bf4ea649aa44b2b9a9f3a07bd683869d1363438a"),
+			wantDigest: "sha256:38601c0bb4269a10ce1d00590ea7689c1117dd9274c758653934ab4f2016f80f",
 		},
 		{
 			name: "other fields do not affect ID",
@@ -259,7 +262,8 @@ func Test_FileSource_ID(t *testing.T) {
 					Paths: []string{"a", "b"},
 				},
 			},
-			want: artifact.ID("db7146472cf6d49b3ac01b42812fb60020b0b4898b97491b21bb690c808d5159"),
+			want:       artifact.ID("db7146472cf6d49b3ac01b42812fb60020b0b4898b97491b21bb690c808d5159"),
+			wantDigest: "sha256:38601c0bb4269a10ce1d00590ea7689c1117dd9274c758653934ab4f2016f80f",
 		},
 	}
 	for _, tt := range tests {
@@ -272,7 +276,8 @@ func Test_FileSource_ID(t *testing.T) {
 			if err != nil {
 				return
 			}
-			assert.Equalf(t, tt.want, s.ID(), "ID()")
+			assert.Equalf(t, tt.want, s.ID(), "ID() mismatch")
+			assert.Equalf(t, tt.wantDigest, s.digestForVersion, "digestForVersion mismatch")
 		})
 	}
 }


### PR DESCRIPTION
I noticed when generating a SPDX SBOM for https://repo1.maven.org/maven2/org/apache/activemq/activemq-osgi/5.18.2/ that it outputs:

```
 {
   "name": "activemq-osgi-5.18.2.jar",
   "SPDXID": "SPDXRef-DocumentRoot-File-activemq-osgi-5.18.2.jar",
   "versionInfo": "sha256:sha256:cfbaa968953d5c3a45c8d1e6fcdbcd22aa448baceebb00879084da0a38f1392d",
   "supplier": "NOASSERTION",
   "downloadLocation": "NOASSERTION",
   "filesAnalyzed": false,
   "checksums": [
    {
     "algorithm": "SHA256",
     "checksumValue": "cfbaa968953d5c3a45c8d1e6fcdbcd22aa448baceebb00879084da0a38f1392d"
    }
   ],
   "primaryPackagePurpose": "FILE"
  }
~
```

Note duplicate sha256 tag for versionInfo. This is because in fileSource.deriveIDFromFile, the digest algorithm is already encoded in the digest String.