### PR TITLE
Check maven central as well for licenses in parents poms for nested jars

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -444,7 +444,7 @@ func (j *archiveParser) discoverPkgsFromAllMavenFiles(parentPkg *pkg.Package) ([
 			pomProject = proj
 		}
 
-		pkgFromPom := newPackageFromMavenData(propertiesObj, pomProject, parentPkg, j.location)
+		pkgFromPom := newPackageFromMavenData(propertiesObj, pomProject, parentPkg, j.location, j.cfg)
 		if pkgFromPom != nil {
 			pkgs = append(pkgs, *pkgFromPom)
 		}
@@ -635,7 +635,7 @@ func pomProjectByParentPath(archivePath string, location file.Location, extractP
 
 // newPackageFromMavenData processes a single Maven POM properties for a given parent package, returning all listed Java packages found and
 // associating each discovered package to the given parent package. Note the pom.xml is optional, the pom.properties is not.
-func newPackageFromMavenData(pomProperties pkg.JavaPomProperties, parsedPomProject *parsedPomProject, parentPkg *pkg.Package, location file.Location) *pkg.Package {
+func newPackageFromMavenData(pomProperties pkg.JavaPomProperties, parsedPomProject *parsedPomProject, parentPkg *pkg.Package, location file.Location, cfg Config) *pkg.Package {
 	// keep the artifact name within the virtual path if this package does not match the parent package
 	vPathSuffix := ""
 	groupID := ""
@@ -660,6 +660,9 @@ func newPackageFromMavenData(pomProperties pkg.JavaPomProperties, parsedPomProje
 	var pkgPomProject *pkg.JavaPomProject
 	licenses := make([]pkg.License, 0)
 	if parsedPomProject != nil {
+		if cfg.UseNetwork {
+			findPomLicenses(parsedPomProject, cfg)
+		}
 		pkgPomProject = parsedPomProject.JavaPomProject
 		licenses = append(licenses, parsedPomProject.Licenses...)
 	}

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1089,7 +1089,7 @@ func Test_newPackageFromMavenData(t *testing.T) {
 			}
 			test.expectedParent.Locations = locations
 
-			actualPackage := newPackageFromMavenData(test.props, test.project, test.parent, file.NewLocation(virtualPath))
+			actualPackage := newPackageFromMavenData(test.props, test.project, test.parent, file.NewLocation(virtualPath), Config{})
 			if test.expectedPackage == nil {
 				require.Nil(t, actualPackage)
 			} else {


### PR DESCRIPTION
The code currently only checks Maven Central for a license in a parent pom for the topmost package, and not for any embedded jars.

With this PR it detects a license correctly for xbean-spring which is embedded inside activemq-osgi: https://repo1.maven.org/maven2/org/apache/activemq/activemq-osgi/5.18.2/

