### PR TITLE
fix: identify CycloneDX JSON without $schema

### DIFF
--- a/syft/format/cyclonedxjson/decoder.go
+++ b/syft/format/cyclonedxjson/decoder.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/CycloneDX/cyclonedx-go"
 
@@ -75,7 +74,7 @@ func (d decoder) Identify(reader io.ReadSeeker) (sbom.FormatID, string) {
 		return "", ""
 	}
 
-	id, version := getFormatInfo(doc.JSONSchema, doc.BOMFormat, doc.SpecVersion)
+	id, version := getFormatInfo(doc.BOMFormat, doc.SpecVersion)
 	if version == "" || id != ID {
 		// not a cyclonedx json document that we support
 		return "", ""
@@ -84,18 +83,13 @@ func (d decoder) Identify(reader io.ReadSeeker) (sbom.FormatID, string) {
 	return id, version
 }
 
-func getFormatInfo(schemaURI, bomFormat string, specVersion any) (sbom.FormatID, string) {
-	if !strings.Contains(schemaURI, "cyclonedx.org/schema/bom") {
-		// not a cyclonedx json document
-		return "", ""
-	}
-
+func getFormatInfo(bomFormat string, specVersion any) (sbom.FormatID, string) {
 	if bomFormat != "CycloneDX" {
 		// not a cyclonedx json document
 		return "", ""
 	}
 
-	// by this point this looks to be valid cyclonedx json, but we need to know the version
+	// by this point, it looks to be cyclonedx json, but we need to know the version
 
 	var (
 		version string

--- a/syft/format/cyclonedxjson/decoder_test.go
+++ b/syft/format/cyclonedxjson/decoder_test.go
@@ -103,6 +103,21 @@ func TestDecoder_Identify(t *testing.T) {
 		})
 	}
 
+	cases = append(cases, []testCase{
+		{
+			name:    "no-schema-1.4",
+			file:    "test-fixtures/identify/micronaut-1.4.json",
+			id:      ID,
+			version: "1.4",
+		},
+		{
+			name:    "no-schema-1.5",
+			file:    "test-fixtures/identify/micronaut-1.5.json",
+			id:      ID,
+			version: "1.5",
+		},
+	}...)
+
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			reader, err := os.Open(test.file)

--- a/syft/format/cyclonedxjson/test-fixtures/identify/micronaut-1.4.json
+++ b/syft/format/cyclonedxjson/test-fixtures/identify/micronaut-1.4.json
@@ -1,0 +1,28 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "version": 1,
+    "components": [
+        {
+            "type": "library",
+            "group": "io.netty",
+            "name": "netty-codec-http2",
+            "version": "4.1.73.Final",
+            "properties": [
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:codec:4.1.73.Final:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:netty-codec-http2:4.1.73.Final:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:netty_codec_http2:4.1.73.Final:*:*:*:*:*:*:*"
+                }
+            ]
+        }
+    ],
+    "serialNumber": "urn:uuid:43538af4-f715-3d85-9629-336fdd3790ad"
+}

--- a/syft/format/cyclonedxjson/test-fixtures/identify/micronaut-1.5.json
+++ b/syft/format/cyclonedxjson/test-fixtures/identify/micronaut-1.5.json
@@ -1,0 +1,28 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "version": 1,
+    "components": [
+        {
+            "type": "library",
+            "group": "io.netty",
+            "name": "netty-codec-http2",
+            "version": "4.1.73.Final",
+            "properties": [
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:codec:4.1.73.Final:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:netty-codec-http2:4.1.73.Final:*:*:*:*:*:*:*"
+                },
+                {
+                    "name": "syft:cpe23",
+                    "value": "cpe:2.3:a:codec:netty_codec_http2:4.1.73.Final:*:*:*:*:*:*:*"
+                }
+            ]
+        }
+    ],
+    "serialNumber": "urn:uuid:f4-f715-3d85-9629-336fdd3790ad"
+}


### PR DESCRIPTION
This PR corrects an issue that identifying CycloneDX JSON documents was being too strict, requiring the `$schema` field be present. Whether this is required or not, Syft can be a bit more lax about parsing CycloneDX JSON and just look for the `bomFormat` and `specVersion` fields.

Fixes #2299 