### PR TITLE
Refine license searching from groupIDFromJavaMetadata to allow for ha…

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -268,6 +268,16 @@ func findLicenseFromJavaMetadata(name string, manifest *pkg.JavaManifest, versio
 		log.Tracef("unable to get parent pom from Maven central: %v", err)
 	}
 
+	if len(pomLicenses) == 0 {
+		// Try removing the last part of the groupId, as sometimes it duplicates the artifactId
+		packages := strings.Split(groupID, ".")
+		groupID = strings.Join(packages[:len(packages)-1], ".")
+		pomLicenses, err = recursivelyFindLicensesFromParentPom(groupID, name, version, j.cfg)
+		if err != nil {
+			log.Tracef("unable to get parent pom from Maven central: %v", err)
+		}
+	}
+
 	if len(pomLicenses) > 0 {
 		pkgLicenses := pkg.NewLicensesFromLocation(j.location, pomLicenses...)
 		if pkgLicenses != nil {


### PR DESCRIPTION
…ving the artfactId in the groupId

Sometimes, the groupId that is obtained from groupIDFromJavaMetadata is not quite correct, in that it contains some version of the artifactId in the path. For example:

https://repo1.maven.org/maven2/com/jayway/jsonpath/json-path/2.4.0/

Syft doesn't find a license because the groupId is com.jayway.jsonpath.json-path instead of com.jayway.jsonpath. Also:

https://repo1.maven.org/maven2/com/google/api/api-common/2.2.0/

Syft doesn't find a license because the groupId is com.google.api.apicommon instead of com.google.api.

The PR falls back to stripping the last package name from the groupId to see if it can find a pom from Maven central. Licenses are found correctly for the two examples above.