### PR TITLE
Add license for golang stdlib

### DIFF
--- a/syft/pkg/cataloger/golang/cataloger.go
+++ b/syft/pkg/cataloger/golang/cataloger.go
@@ -87,6 +87,7 @@ func newGoStdLib(version string, location file.LocationSet) *pkg.Package {
 		PURL:      packageURL("stdlib", strings.TrimPrefix(version, "go")),
 		CPEs:      []cpe.CPE{stdlibCpe},
 		Locations: location,
+		Licenses:  pkg.NewLicenseSet(pkg.NewLicense("BSD-3-Clause")),
 		Language:  pkg.Go,
 		Type:      pkg.GoModulePkg,
 		Metadata: pkg.GolangBinaryBuildinfoEntry{


### PR DESCRIPTION
Add the correct license for the golang stdlib (https://pkg.go.dev/std)