### PR TITLE
fix(java): add manual groupid mappings for org.apache.velocity jars

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java_groupid_map.go
+++ b/syft/pkg/cataloger/common/cpe/java_groupid_map.go
@@ -70,4 +70,10 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"spring-webflow":                 "org.springframework.webflow",
 	"spring-webflux":                 "org.springframework",
 	"spring-webmvc":                  "org.springframework",
+	"spring-velocity-support":        "org.apache.velocity",
+	"velocity":                       "org.apache.velocity",
+	"velocity-engine-core":           "org.apache.velocity",
+	"velocity-engine-parent":         "org.apache.velocity",
+	"velocity-engine-scripting":      "org.apache.velocity",
+	"velocity-tools":                 "org.apache.velocity",
 }


### PR DESCRIPTION
Older syft versions correctly identified the maven groupId for the velocity jars as `org.apache.velocity`, but some of our recent adjustments caused these to start being reported as just `org.apache`, so this adds a manual namespace mapping to fall back on to correct the regression for this specific case