### PR TITLE
Prevent erroneous output to stdout

### DIFF
--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -91,5 +91,8 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 		cranecmd.NewCmdAuthLogin(id.Name), // syft login uses the same command as crane
 	)
 
+	// explicitly set Cobra output to the real stdout to write things like errors and help
+	rootCmd.SetOut(out)
+
 	return app, rootCmd
 }

--- a/cmd/syft/cli/commands/attest.go
+++ b/cmd/syft/cli/commands/attest.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/cli/options"
-	"github.com/anchore/syft/cmd/syft/internal/ui"
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/log"
@@ -63,9 +62,6 @@ func Attest(app clio.Application) *cobra.Command {
 		Args:    validatePackagesArgs,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			restoreStdout := ui.CaptureStdoutToTraceLog()
-			defer restoreStdout()
-
 			return runAttest(id, &opts, args[0])
 		},
 	}, &opts)

--- a/cmd/syft/cli/commands/convert.go
+++ b/cmd/syft/cli/commands/convert.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/cli/options"
-	"github.com/anchore/syft/cmd/syft/internal/ui"
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/format"
@@ -48,9 +47,6 @@ func Convert(app clio.Application) *cobra.Command {
 		Args:    validateConvertArgs,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			restoreStdout := ui.CaptureStdoutToTraceLog()
-			defer restoreStdout()
-
 			return RunConvert(opts, args[0])
 		},
 	}, opts)

--- a/cmd/syft/cli/commands/packages.go
+++ b/cmd/syft/cli/commands/packages.go
@@ -10,7 +10,6 @@ import (
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/cmd/syft/cli/eventloop"
 	"github.com/anchore/syft/cmd/syft/cli/options"
-	"github.com/anchore/syft/cmd/syft/internal/ui"
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/file"
@@ -86,9 +85,6 @@ func Packages(app clio.Application) *cobra.Command {
 		Args:    validatePackagesArgs,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			restoreStdout := ui.CaptureStdoutToTraceLog()
-			defer restoreStdout()
-
 			return runPackages(id, opts, args[0])
 		},
 	}, opts)

--- a/cmd/syft/cli/commands/root.go
+++ b/cmd/syft/cli/commands/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/syft/cmd/syft/internal/ui"
 )
 
 func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
@@ -21,6 +22,9 @@ func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
 		Example: packagesCmd.Example,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			restoreStdout := ui.CaptureStdoutToTraceLog()
+			defer restoreStdout()
+
 			return runPackages(id, opts, args[0])
 		},
 	}, opts)

--- a/cmd/syft/cli/commands/root.go
+++ b/cmd/syft/cli/commands/root.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
-	"github.com/anchore/syft/cmd/syft/internal/ui"
 )
 
 func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
@@ -22,9 +21,6 @@ func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
 		Example: packagesCmd.Example,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			restoreStdout := ui.CaptureStdoutToTraceLog()
-			defer restoreStdout()
-
 			return runPackages(id, opts, args[0])
 		},
 	}, opts)

--- a/cmd/syft/main.go
+++ b/cmd/syft/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/cli"
 	"github.com/anchore/syft/cmd/syft/internal"
+	"github.com/anchore/syft/cmd/syft/internal/ui"
 )
 
 // applicationName is the non-capitalized name of the application (do not change this)
@@ -29,6 +30,9 @@ func main() {
 			GitDescription: gitDescription,
 		},
 	)
+
+	restoreStdout := ui.CaptureStdoutToTraceLog()
+	defer restoreStdout()
 
 	app.Run()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461
-	github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc
+	github.com/anchore/clio v0.0.0-20231127185633-c8add3960ac8
 	github.com/anchore/fangs v0.0.0-20231103141714-84c94dc43a2e
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461 h1:xGu4/uMWucwWV0YV3fpFIQZ6KVfS/Wfhmma8t0s0vRo=
 github.com/anchore/bubbly v0.0.0-20230801194016-acdb4981b461/go.mod h1:Ger02eh5NpPm2IqkPAy396HU1KlK3BhOeCljDYXySSk=
-github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc h1:A1KFO+zZZmbNlz1+WKsCF0RKVx6XRoxsAG3lrqH9hUQ=
-github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc/go.mod h1:QeWvNzxsrUNxcs6haQo3OtISfXUXW0qAuiG4EQiz0GU=
+github.com/anchore/clio v0.0.0-20231127185633-c8add3960ac8 h1:HybOmsN92kk+XQ2oU6bfxZ8DDPiGPuQgmyTIaSeMggA=
+github.com/anchore/clio v0.0.0-20231127185633-c8add3960ac8/go.mod h1:jRKis2BJUyCfHirnm6WlLoTM1r0PiIAd71E28jgyVnk=
 github.com/anchore/fangs v0.0.0-20231103141714-84c94dc43a2e h1:O8ZubApaSl7dRzKNvyfGq9cLIPLQ5v3Iz0Y3huHKCgg=
 github.com/anchore/fangs v0.0.0-20231103141714-84c94dc43a2e/go.mod h1:yPsN3NUGhU5dcBtYBa1dMNzGu1yT5ZAfSjKq9DY4aV8=
 github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a h1:nJ2G8zWKASyVClGVgG7sfM5mwoZlZ2zYpIzN2OhjWkw=

--- a/test/cli/symlink_test.go
+++ b/test/cli/symlink_test.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_RequestedPathIncludesSymlink(t *testing.T) {


### PR DESCRIPTION
This PR adjusts the behavior for Syft to capture stdout globally instead of per-command, if it's decided to be safer to use a stdout allowlist instead of a denylist of commands as is implemented today.