### PR TITLE
fix: index file itself when file scan path has symlink

### DIFF
--- a/syft/source/file_source_test.go
+++ b/syft/source/file_source_test.go
@@ -48,6 +48,22 @@ func TestNewFromFile(t *testing.T) {
 			},
 			expRefs: 1,
 		},
+		{
+			desc:  "normal path",
+			input: "test-fixtures/actual-path/empty",
+			testPathFn: func(resolver file.Resolver) ([]file.Location, error) {
+				return resolver.FilesByPath("empty")
+			},
+			expRefs: 1,
+		},
+		{
+			desc:  "path containing symlink",
+			input: "test-fixtures/symlink/empty",
+			testPathFn: func(resolver file.Resolver) ([]file.Location, error) {
+				return resolver.FilesByPath("empty")
+			},
+			expRefs: 1,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {

--- a/syft/source/test-fixtures/symlink
+++ b/syft/source/test-fixtures/symlink
@@ -1,0 +1,1 @@
+actual-path

--- a/test/cli/symlink_test.go
+++ b/test/cli/symlink_test.go
@@ -1,0 +1,13 @@
+package cli
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_RequestedPathIncludesSymlink(t *testing.T) {
+	// path contains a symlink
+	path := "test/cli/test-fixtures/image-pkg-coverage/pkgs/java/example-java-app-maven-0.1.0.jar"
+	_, stdout, _ := runSyft(t, nil, "packages", path)
+	assert.Contains(t, stdout, "example-java-app-maven")
+}

--- a/test/cli/symlink_test.go
+++ b/test/cli/symlink_test.go
@@ -7,7 +7,7 @@ import (
 
 func Test_RequestedPathIncludesSymlink(t *testing.T) {
 	// path contains a symlink
-	path := "test/cli/test-fixtures/image-pkg-coverage/pkgs/java/example-java-app-maven-0.1.0.jar"
+	path := "test-fixtures/image-pkg-coverage/pkgs/java/example-java-app-maven-0.1.0.jar"
 	_, stdout, _ := runSyft(t, nil, "packages", path)
 	assert.Contains(t, stdout, "example-java-app-maven")
 }


### PR DESCRIPTION
Previously, building the index of the filesystem when source was file would fail if part of the path syft was passed to the file included a symlinked directory, resulting in cataloging misses.

Fixes #2355. 

Note that this doesn't fix #1962 yet. I'll see if it can.