### PR TITLE
Normalize enums to lowercase with hyphens

### DIFF
--- a/syft/source/scope.go
+++ b/syft/source/scope.go
@@ -7,11 +7,11 @@ type Scope string
 
 const (
 	// UnknownScope is the default scope
-	UnknownScope Scope = "UnknownScope"
+	UnknownScope Scope = "unknown-scope"
 	// SquashedScope indicates to only catalog content visible from the squashed filesystem representation (what can be seen only within the container at runtime)
-	SquashedScope Scope = "Squashed"
+	SquashedScope Scope = "squashed"
 	// AllLayersScope indicates to catalog content on all layers, regardless if it is visible from the container at runtime.
-	AllLayersScope Scope = "AllLayers"
+	AllLayersScope Scope = "all-layers"
 )
 
 // AllScopes is a slice containing all possible scope options
@@ -23,9 +23,9 @@ var AllScopes = []Scope{
 // ParseScope returns a scope as indicated from the given string.
 func ParseScope(userStr string) Scope {
 	switch strings.ToLower(userStr) {
-	case strings.ToLower(SquashedScope.String()):
+	case SquashedScope.String():
 		return SquashedScope
-	case "all-layers", strings.ToLower(AllLayersScope.String()):
+	case "alllayers", AllLayersScope.String():
 		return AllLayersScope
 	}
 	return UnknownScope

--- a/syft/source/scope_test.go
+++ b/syft/source/scope_test.go
@@ -1,0 +1,57 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseScope(t *testing.T) {
+	tests := []struct {
+		name string
+		want Scope
+	}{
+		// go cases
+		{
+			name: "squashed",
+			want: SquashedScope,
+		},
+		{
+			name: "all-layers",
+			want: AllLayersScope,
+		},
+		// fall back to unknown
+		{
+			name: "make-believe",
+			want: UnknownScope,
+		},
+		{
+			name: "",
+			want: UnknownScope,
+		},
+		{
+			name: " ",
+			want: UnknownScope,
+		},
+		// to support the original value
+
+		{
+			name: "Squashed",
+			want: SquashedScope,
+		},
+		{
+			name: "AllLayers",
+			want: AllLayersScope,
+		},
+		// case insensitive
+		{
+			name: "alLlaYerS",
+			want: AllLayersScope,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParseScope(tt.name))
+		})
+	}
+}


### PR DESCRIPTION
This changes all instances of enum-like values in the API to lowercase / hyphen delimited. The only remaining instance is `source.Scope`. 

(This is work split off from #1383 )