### PR TITLE
fix: capture root command stdout

### DIFF
--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -91,5 +91,8 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 		cranecmd.NewCmdAuthLogin(id.Name), // syft login uses the same command as crane
 	)
 
+	// explicitly set Cobra output to the real stdout to write things like errors and help
+	rootCmd.SetOut(out)
+
 	return app, rootCmd
 }

--- a/cmd/syft/cli/commands/root.go
+++ b/cmd/syft/cli/commands/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/syft/cmd/syft/internal/ui"
 )
 
 func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
@@ -21,6 +22,9 @@ func Root(app clio.Application, packagesCmd *cobra.Command) *cobra.Command {
 		Example: packagesCmd.Example,
 		PreRunE: applicationUpdateCheck(id, &opts.UpdateCheck),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			restoreStdout := ui.CaptureStdoutToTraceLog()
+			defer restoreStdout()
+
 			return runPackages(id, opts, args[0])
 		},
 	}, opts)

--- a/test/cli/symlink_test.go
+++ b/test/cli/symlink_test.go
@@ -1,8 +1,9 @@
 package cli
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_RequestedPathIncludesSymlink(t *testing.T) {


### PR DESCRIPTION
This PR applies the fix from PR #2335 to the root command for capturing stdout.

Fixes #2356