### PR TITLE
fix: logging level for parsing potential PE files

### DIFF
--- a/syft/pkg/cataloger/dotnet/parse_dotnet_portable_executable.go
+++ b/syft/pkg/cataloger/dotnet/parse_dotnet_portable_executable.go
@@ -26,27 +26,29 @@ func parseDotnetPortableExecutable(_ file.Resolver, _ *generic.Environment, f fi
 
 	peFile, err := pe.NewBytes(by, &pe.Options{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create PE file instance: %w", err)
+		// TODO: known-unknown
+		log.Tracef("unable to create PE instance for file '%s': %v", f.RealPath, err)
+		return nil, nil, nil
 	}
 
 	err = peFile.Parse()
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to parse PE file: %w", err)
+		// TODO: known-unknown
+		log.Tracef("unable to parse PE file '%s': %v", f.RealPath, err)
+		return nil, nil, nil
 	}
 
 	versionResources, err := peFile.ParseVersionResources()
 	if err != nil {
-		// this is not a fatal error, just log and continue
-		// TODO: consider this case for "known unknowns" (same goes for cases below)
-		log.Tracef("unable to parse version resources in PE file: %s", f.RealPath)
+		// TODO: known-unknown
+		log.Tracef("unable to parse version resources in PE file: %s: %v", f.RealPath, err)
 		return nil, nil, nil
 	}
 
 	dotNetPkg, err := buildDotNetPackage(versionResources, f)
 	if err != nil {
-		// this is not a fatal error, just log and continue
-		// TODO: consider this case for "known unknowns" (same goes for cases below)
-		log.Tracef("unable to build dotnet package: %w", err)
+		// TODO: known-unknown
+		log.Tracef("unable to build dotnet package: %v", err)
 		return nil, nil, nil
 	}
 


### PR DESCRIPTION
While looking in to an issue that a library parsing DotNET Portable Executables was writing to stdout, I noticed a number of warnings show up, for example, running:
```
syft --platform windows/amd64 registry:mcr.microsoft.com/windows/servercore:ltsc2019
```

Resulted in:
```
 ✔ Parsed image                                                                                           sha256:c632661e39bb365cf34bfdd943baa4ce5ba1ebdd713d790d1af0b9da20ae0bea
 ✔ Cataloged packages              [4566 packages]  
[0084]  WARN cataloger failed cataloger=dotnet-portable-executable-cataloger error=unable to parse PE file: DOS Header magic not found location=/Files/Windows/WinSxS/x86_microsoft
[0084]  WARN cataloger failed cataloger=dotnet-portable-executable-cataloger error=unable to parse PE file: DOS Header magic not found location=/Files/Windows/WinSxS/x86_microsoft
[0084]  WARN cataloger failed cataloger=dotnet-portable-executable-cataloger error=unable to parse PE file: DOS Header magic not found location=/Files/Windows/WinSxS/x86_microsoft
```

This PR adjusts the warnings to DEBUG level, e.g. nothing is printed by default but using the `-vv` option, you'd see:
```
...
[0083] DEBUG unable to parse PE file '/Files/Windows/WinSxS/x86_microsoft-windows-d..s-commandline-tools_31bf3856ad364e35_10.0.17763.1_none_5c764e9c11f85b2a/dsquery.exe': DOS Header magic not found
[0083] DEBUG unable to parse PE file '/Files/Windows/WinSxS/x86_microsoft-windows-d..s-commandline-tools_31bf3856ad364e35_10.0.17763.1_none_5c764e9c11f85b2a/dsrm.exe': DOS Header magic not found
...
```

We can see that these are just `.exe` files, many of which are not portable executables, so we really shouldn't be warning about them.