### PR TITLE
fix: hardcode xalan group ID

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java_groupid_map.go
+++ b/syft/pkg/cataloger/common/cpe/java_groupid_map.go
@@ -1199,4 +1199,5 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"spring-webflow":                                           "org.springframework.webflow",
 	"spring-ws":                                                "org.springframework.ws",
 	"spring-xml":                                               "org.springframework.ws",
+	"xalan":                                                    "xalan", // see https://mvnrepository.com/artifact/xalan/xalan/2.7.2
 }


### PR DESCRIPTION
According to maven central, the package called "xalan" should just have the group ID xalan, but currently syft isn't able to find that (see https://mvnrepository.com/artifact/xalan/xalan/2.7.2)

Right now Grype fails to find https://github.com/advisories/GHSA-9339-86wc-4qgf because syft is generating the wrong group ID when scanning xalan jars.

Manual testing done:

``` sh
$ curl -s -o ~/work/scratch/xalan-2.7.2.jar https://repo1.maven.org/maven2/xalan/xalan/2.7.2/xalan-2.7.2.jar
$ syft -q -o json ~/work/scratch/xalan-2.7.2.jar | grype
No vulnerabilities found
$ go run cmd/syft/main.go -q -o json ~/work/scratch/xalan-2.7.2.jar | grype
NAME   INSTALLED  FIXED-IN  TYPE          VULNERABILITY        SEVERITY
xalan  2.7.2      2.7.3     java-archive  GHSA-9339-86wc-4qgf  High
```
