### PR TITLE
Fix file metadata cataloger when passed explicit coordinates

### DIFF
--- a/syft/file/cataloger/filemetadata/cataloger.go
+++ b/syft/file/cataloger/filemetadata/cataloger.go
@@ -27,9 +27,16 @@ func (i *Cataloger) Catalog(resolver file.Resolver, coordinates ...file.Coordina
 		locations = func() <-chan file.Location {
 			ch := make(chan file.Location)
 			go func() {
-				close(ch)
+				defer close(ch)
 				for _, c := range coordinates {
-					ch <- file.NewLocationFromCoordinates(c)
+					locs, err := resolver.FilesByPath(c.RealPath)
+					if err != nil {
+						log.Warn("unable to get file locations for path %q: %w", c.RealPath, err)
+						continue
+					}
+					for _, loc := range locs {
+						ch <- loc
+					}
 				}
 			}()
 			return ch


### PR DESCRIPTION
There are two reasons why the file metadata cataloger is not working today when provided explicit file coordinates:
- the channel was immediately closed, so no results could have ever been provided
- we trust the user-provided coordinates exist in the resolver. This can cause a few issues relating to the stereoscope file reference object not being available (or the coordinates are not correct). Either way, the coordinates need to be resolved to a  full location object.

Note: this execution path is not used since it is only possible to catalog all locations today (instead of a certain subset, which  when done these issues start to be noticed).

(This was broken off from #1383 )