### PR TITLE
Add support for linux/arm64 for java openjdk binary classifier

### DIFF
--- a/syft/pkg/cataloger/binary/default_classifiers.go
+++ b/syft/pkg/cataloger/binary/default_classifiers.go
@@ -69,10 +69,18 @@ var defaultClassifiers = []classifier{
 	{
 		Class:    "java-binary-openjdk",
 		FileGlob: "**/java",
-		EvidenceMatcher: fileContentsVersionMatcher(
-			// [NUL]openjdk[NUL]java[NUL]0.0[NUL]11.0.17+8-LTS[NUL]
-			// [NUL]openjdk[NUL]java[NUL]1.8[NUL]1.8.0_352-b08[NUL]
-			`(?m)\x00openjdk\x00java\x00(?P<release>[0-9]+[.0-9]*)\x00(?P<version>[0-9]+[^\x00]+)\x00`),
+		EvidenceMatcher: evidenceMatchers(
+			fileContentsVersionMatcher(
+				// covers linux/amd64
+				// [NUL]openjdk[NUL]java[NUL]0.0[NUL]11.0.17+8-LTS[NUL]
+				// [NUL]openjdk[NUL]java[NUL]1.8[NUL]1.8.0_352-b08[NUL]
+				`(?m)\x00openjdk\x00java\x00(?P<release>[0-9]+[.0-9]*)\x00(?P<version>[0-9]+[^\x00]+)\x00`,
+			),
+			fileContentsVersionMatcher(
+				// covers linux/arm64
+				`(?m)(?P<release>[0-9]+[.0-9]*)(\x00)+(?P<version>[0-9]+[^\x00]+)(\x00)+openjdk(\x00)+java\x00`,
+			),
+		),
 		Package: "java",
 		PURL:    mustPURL("pkg:generic/java@version"),
 		// TODO the updates might need to be part of the CPE, like: 1.8.0:update152


### PR DESCRIPTION
Attempts to match on the following section in a linux/arm64 binary:
```
❯ file bin-java
bin-java: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, not stripped

❯ xxd -s 0x00000970 -l 100 bin-java
00000970: f763 43a9 fd7b c4a8 c003 5fd6 c003 5fd6  .cC..{...._..._.
00000980: fd7b bfa9 fd03 0091 fd7b c1a8 c003 5fd6  .{.......{...._.
00000990: 0100 0200 0000 0000 312e 3800 0000 0000  ........1.8.....
000009a0: 312e 382e 305f 3339 322d 6230 3800 0000  1.8.0_392-b08...
000009b0: 6f70 656e 6a64 6b00 6a61 7661 0000 0000  openjdk.java....
000009c0: 011b 033b 1c00 0000 0200 0000 44ff ffff  ...;........D...
000009d0: 3800 0000                                8...
```

Before change:
```
❯ syft --platform linux/arm64 docker.io/eclipse-temurin:8u392-b08-jdk | grep binary
 ✔ Pulled image
 ✔ Loaded image                                                                                                                                          index.docker.io/library/eclipse-temurin:8u392-b08-jdk
 ✔ Parsed image                                                                                                                        sha256:f6657e24bf8ef61a6623c0c73d1d922a3162ebb160d12d617f94fcc2cd4a46cb
 ✔ Cataloged packages              [151 packages]
bash                 5.1.16                                   binary
```

After change:
```
❯ go run ./cmd/syft --platform linux/arm64 docker.io/eclipse-temurin:8u392-b08-jdk | grep binary
 ✔ Loaded image                                                                                                                                          index.docker.io/library/eclipse-temurin:8u392-b08-jdk
 ✔ Parsed image                                                                                                                        sha256:f6657e24bf8ef61a6623c0c73d1d922a3162ebb160d12d617f94fcc2cd4a46cb
 ✔ Cataloged packages              [152 packages]
bash                 5.1.16                                   binary
java                 1.8.0_392-b08                            binary
```

TODO:
- [ ] add tests