### PR TITLE
chore: hack to output all portable executable version resources as csv

### DIFF
--- a/cmd/syft/main.go
+++ b/cmd/syft/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"os"
+
 	_ "modernc.org/sqlite"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/cli"
 	"github.com/anchore/syft/cmd/syft/internal"
+	"github.com/anchore/syft/syft/pkg/cataloger/dotnet"
 )
 
 // applicationName is the non-capitalized name of the application (do not change this)
@@ -30,5 +33,11 @@ func main() {
 		},
 	)
 
+	out := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
 	app.Run()
+
+	dotnet.AllResourcesCSV(out)
 }


### PR DESCRIPTION
This PR has a quick hack to output all portable executable resources as a CSV. This code was useful to populate [the spreadsheet here](https://docs.google.com/spreadsheets/d/1GE9T38JFgkiKzhIW7N-KDwaNiuomBojAavchZNnxfXY/edit?usp=sharing) and could be useful in the future.