### PR TITLE
fix(java): improve identification for io.projectreactor.netty artifacts

### DIFF
--- a/syft/pkg/cataloger/common/cpe/java_groupid_map.go
+++ b/syft/pkg/cataloger/common/cpe/java_groupid_map.go
@@ -1492,4 +1492,9 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"org.eclipse.update.configurator":                          "org.eclipse.platform",
 	"org.eclipse.update.core":                                  "org.eclipse.platform",
 	"org.eclipse.urischeme":                                    "org.eclipse.platform",
+	"reactor-netty":                                            "io.projectreactor.netty",
+	"reactor-netty-core":                                       "io.projectreactor.netty",
+	"reactor-netty-http":                                       "io.projectreactor.netty",
+	"reactor-netty-http-brave":                                 "io.projectreactor.netty",
+	"reactor-netty-incubator-quic":                             "io.projectreactor.netty.incubator",
 }


### PR DESCRIPTION
grype fails to match vulns such as https://github.com/advisories/GHSA-q24v-hpg3-v3jp because syft generates an incorrect groupid (`io.projectreactor.netty.reactor-netty-http` rather than just `io.projectreactor.netty`) for `reactor-netty*` artifacts.  This adds a manual mapping to the correct expected maven namespace for these artifacts when no better source of identification is available 