### PR TITLE
Add more functionality to the ErLang parser

### DIFF
--- a/syft/pkg/cataloger/erlang/erlang_parser.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser.go
@@ -141,8 +141,20 @@ func parseErlangNode(data []byte, i *int) (erlangNode, error) {
 	c := data[*i]
 	switch c {
 	case '[', '{':
+		offset := *i + 1
+		skipWhitespace(data, &offset)
+		c2 := data[offset]
+
+		// Add support for empty lists
+		if (c == '[' && c2 == ']') || (c == '{' && c2 == '}') {
+			*i = offset + 1
+			return node(nil), nil
+		}
+
 		return parseErlangList(data, i)
 	case '"':
+		fallthrough
+	case '\'':
 		return parseErlangString(data, i)
 	case '<':
 		return parseErlangAngleString(data, i)

--- a/syft/pkg/cataloger/erlang/erlang_parser.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser.go
@@ -217,7 +217,7 @@ func parseErlangString(data []byte, i *int) (erlangNode, error) {
 		buf.WriteByte(c)
 		*i++
 	}
-	return node(buf.String()), nil
+	return node(nil), fmt.Errorf("unterminated string at %d", *i)
 }
 
 func parseErlangList(data []byte, i *int) (erlangNode, error) {

--- a/syft/pkg/cataloger/erlang/erlang_parser_test.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser_test.go
@@ -48,12 +48,27 @@ func Test_parseErlang(t *testing.T) {
 ]}`,
 		},
 		{
+			name: "valid strings",
+			content: `
+{strings, [
+ "foo", 'bar'
+]}`,
+		},
+		{
 			name:    "invalid string content",
 			wantErr: require.Error,
 			content: `
 {"1.2.0
 ">>},
 ].`,
+		},
+		{
+			name:    "string mismach",
+			wantErr: require.Error,
+			content: `
+{bad_string, [
+ 'foo"
+ ]}`,
 		},
 		{
 			name:    "invalid content",

--- a/syft/pkg/cataloger/erlang/erlang_parser_test.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser_test.go
@@ -40,6 +40,14 @@ func Test_parseErlang(t *testing.T) {
 ].`,
 		},
 		{
+			name: "empty list",
+			content: `
+{test, [
+ {with_space, [ ]},
+ {without_space, []}
+]}`,
+		},
+		{
 			name:    "invalid string content",
 			wantErr: require.Error,
 			content: `

--- a/syft/pkg/cataloger/erlang/erlang_parser_test.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser_test.go
@@ -77,6 +77,25 @@ func Test_parseErlang(t *testing.T) {
 {"1.2.0"}.
 ].`,
 		},
+		{
+			name: "valid comments",
+			content: `
+{ comments, [
+	{ foo, bar },
+	%% this is a comment
+	% this is also a comment
+	{ hello, 'bar' }, %%inline comment
+	{ baz }
+]}`,
+		},
+		{
+			name: "starts with a comments",
+			content: `
+%% starts with comment
+{ comments, [
+	{ foo, bar }
+]}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Functionality:
* Empty lists
* Single quote strings
* Comments

This allow supporting this erlang file from RabbitMQ (edited for brevity)

```erlang
{application, 'rabbit', [
	{description, "RabbitMQ"},
	{vsn, "3.12.10"},
	{id, "v3.12.9-9-g1f61ca8"},
	{modules, ['amqqueue','background_gc']},
	{optional_applications, []},
	{env, [
	    {memory_monitor_interval, 2500},
	    {disk_free_limit, 50000000}, %% 50MB
	    {msg_store_index_module, rabbit_msg_store_ets_index},
	    {backing_queue_module, rabbit_variable_queue},
	    %% 0 ("no limit") would make a better default, but that
	    %% breaks the QPid Java client
	    {frame_max, 131072},
	    %% see rabbitmq-server#1593
	    {channel_max, 2047}
	  ]}
]}.
```