### PR TITLE
Look for a maven version in a pom from a parent dependency management…

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -111,16 +111,22 @@ func newPackageFromPom(pom gopom.Project, dep gopom.Dependency, cfg ArchiveCatal
 	version := resolveProperty(pom, dep.Version, "version")
 
 	licenses := make([]pkg.License, 0)
-	if version != "" && cfg.UseNetwork {
-		parentLicenses := recursivelyFindLicensesFromParentPom(
-			m.PomProperties.GroupID,
-			m.PomProperties.ArtifactID,
-			version,
-			cfg)
+	if cfg.UseNetwork {
+		if version == "" {
+			// If we have no version then let's try to get it from a parent pom DependencyManagement section
+			version = recursivelyFindVersionFromParentPom(*dep.GroupID, *dep.ArtifactID, *pom.Parent.GroupID, *pom.Parent.ArtifactID, *pom.Parent.Version, cfg)
+		}
+		if version != "" {
+			parentLicenses := recursivelyFindLicensesFromParentPom(
+				m.PomProperties.GroupID,
+				m.PomProperties.ArtifactID,
+				version,
+				cfg)
 
-		if len(parentLicenses) > 0 {
-			for _, licenseName := range parentLicenses {
-				licenses = append(licenses, pkg.NewLicenseFromFields(licenseName, "", nil))
+			if len(parentLicenses) > 0 {
+				for _, licenseName := range parentLicenses {
+					licenses = append(licenses, pkg.NewLicenseFromFields(licenseName, "", nil))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
… section

A fix for https://github.com/anchore/syft/issues/2266

If a dependency in a pom.xml does not have a version, then it attempts to find the dependency defined in a parent pom.xml and gets the version from that. It needs the java "use-network" option to be set to true.