### PR TITLE
Fix file digest cataloger when passed explicit coordinates

### DIFF
--- a/syft/file/cataloger/filedigest/cataloger.go
+++ b/syft/file/cataloger/filedigest/cataloger.go
@@ -37,7 +37,11 @@ func (i *Cataloger) Catalog(resolver file.Resolver, coordinates ...file.Coordina
 		locations = intCataloger.AllRegularFiles(resolver)
 	} else {
 		for _, c := range coordinates {
-			locations = append(locations, file.NewLocationFromCoordinates(c))
+			locs, err := resolver.FilesByPath(c.RealPath)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get file locations for path %q: %w", c.RealPath, err)
+			}
+			locations = append(locations, locs...)
 		}
 	}
 

--- a/syft/file/cataloger/filemetadata/cataloger_test.go
+++ b/syft/file/cataloger/filemetadata/cataloger_test.go
@@ -168,7 +168,6 @@ func TestFileMetadataCataloger_GivenCoordinates(t *testing.T) {
 		path     string
 		exists   bool
 		expected file.Metadata
-		err      bool
 	}{
 		{
 			path:   "/file-1.txt",


### PR DESCRIPTION
This is the same fix as done in #2370 but for the file digest cataloger.

(Found while working on #1383 )