### PR TITLE
Use common archive catalog configuration

### DIFF
--- a/syft/cataloging/config.go
+++ b/syft/cataloging/config.go
@@ -4,3 +4,10 @@ type ArchiveSearchConfig struct {
 	IncludeIndexedArchives   bool `yaml:"include-indexed-archives" json:"include-indexed-archives" mapstructure:"include-indexed-archives"`
 	IncludeUnindexedArchives bool `yaml:"include-unindexed-archives" json:"include-unindexed-archives" mapstructure:"include-unindexed-archives"`
 }
+
+func DefaultArchiveSearchConfig() ArchiveSearchConfig {
+	return ArchiveSearchConfig{
+		IncludeIndexedArchives:   true,
+		IncludeUnindexedArchives: false,
+	}
+}

--- a/syft/pkg/cataloger/java/config.go
+++ b/syft/pkg/cataloger/java/config.go
@@ -13,10 +13,7 @@ type ArchiveCatalogerConfig struct {
 
 func DefaultArchiveCatalogerConfig() ArchiveCatalogerConfig {
 	return ArchiveCatalogerConfig{
-		ArchiveSearchConfig: cataloging.ArchiveSearchConfig{
-			IncludeIndexedArchives:   true,
-			IncludeUnindexedArchives: false,
-		},
+		ArchiveSearchConfig:     cataloging.DefaultArchiveSearchConfig(),
 		UseNetwork:              false,
 		MavenBaseURL:            mavenBaseURL,
 		MaxParentRecursiveDepth: 5,


### PR DESCRIPTION
This modifies the java cataloger configuration to use the common ArchiveSearchConfig default constructor (also added in this PR). This sets a pattern where other catalogers that want to use this common behavior can at least inherit from a single source of truth. 

(Work broken off from #1383)