### PR TITLE
Expose javascript fields in cataloger configuration

### DIFF
--- a/syft/pkg/cataloger/javascript/config.go
+++ b/syft/pkg/cataloger/javascript/config.go
@@ -3,25 +3,25 @@ package javascript
 const npmBaseURL = "https://registry.npmjs.org"
 
 type CatalogerConfig struct {
-	searchRemoteLicenses bool
-	npmBaseURL           string
+	SearchRemoteLicenses bool   `json:"search-remote-licenses" yaml:"search-remote-licenses" mapstructure:"search-remote-licenses"`
+	NPMBaseURL           string `json:"npm-base-url" yaml:"npm-base-url" mapstructure:"npm-base-url"`
 }
 
 func DefaultCatalogerConfig() CatalogerConfig {
 	return CatalogerConfig{
-		searchRemoteLicenses: false,
-		npmBaseURL:           npmBaseURL,
+		SearchRemoteLicenses: false,
+		NPMBaseURL:           npmBaseURL,
 	}
 }
 
 func (j CatalogerConfig) WithSearchRemoteLicenses(input bool) CatalogerConfig {
-	j.searchRemoteLicenses = input
+	j.SearchRemoteLicenses = input
 	return j
 }
 
 func (j CatalogerConfig) WithNpmBaseURL(input string) CatalogerConfig {
 	if input != "" {
-		j.npmBaseURL = input
+		j.NPMBaseURL = input
 	}
 	return j
 }

--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -113,8 +113,8 @@ func newPnpmPackage(resolver file.Resolver, location file.Location, name, versio
 func newYarnLockPackage(cfg CatalogerConfig, resolver file.Resolver, location file.Location, name, version string) pkg.Package {
 	var licenseSet pkg.LicenseSet
 
-	if cfg.searchRemoteLicenses {
-		license, err := getLicenseFromNpmRegistry(cfg.npmBaseURL, name, version)
+	if cfg.SearchRemoteLicenses {
+		license, err := getLicenseFromNpmRegistry(cfg.NPMBaseURL, name, version)
 		if err == nil && license != "" {
 			licenses := pkg.NewLicensesFromValues(license)
 			licenseSet = pkg.NewLicenseSet(licenses...)

--- a/syft/pkg/cataloger/javascript/parse_yarn_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_yarn_lock_test.go
@@ -204,7 +204,7 @@ func TestSearchYarnForLicenses(t *testing.T) {
 	}{
 		{
 			name:   "search remote licenses returns the expected licenses when search is set to true",
-			config: CatalogerConfig{searchRemoteLicenses: true},
+			config: CatalogerConfig{SearchRemoteLicenses: true},
 			requestHandlers: []handlerPath{
 				{
 					// https://registry.yarnpkg.com/@babel/code-frame/7.10.4
@@ -232,7 +232,7 @@ func TestSearchYarnForLicenses(t *testing.T) {
 			for _, handler := range tc.requestHandlers {
 				mux.HandleFunc(handler.path, handler.handler)
 			}
-			tc.config.npmBaseURL = url
+			tc.config.NPMBaseURL = url
 			adapter := newGenericYarnLockAdapter(tc.config)
 			pkgtest.TestFileParser(t, fixture, adapter.parseYarnLock, tc.expectedPackages, nil)
 		})


### PR DESCRIPTION
Today the javascript cataloger configuration does not expose the fields on the config struct. There are two reasons to expose these fields:

- it will be necessary to create a JSON representation of the config struct in #1383  (which is why struct tags were added)
- simple options should be allowed to be set simply without requiring behavior (methods to be called)

This does not remove any of the builder/fluent API methods in place now.