### PR TITLE
Fix syft-json snapshot test to use pretty json

### DIFF
--- a/syft/format/syftjson/encoder_test.go
+++ b/syft/format/syftjson/encoder_test.go
@@ -297,10 +297,15 @@ func TestEncodeFullJSONDocument(t *testing.T) {
 		},
 	}
 
+	cfg := DefaultEncoderConfig()
+	cfg.Pretty = true
+	enc, err := NewFormatEncoderWithConfig(cfg)
+	require.NoError(t, err)
+
 	testutil.AssertEncoderAgainstGoldenSnapshot(t,
 		testutil.EncoderSnapshotTestConfig{
 			Subject:                     s,
-			Format:                      NewFormatEncoder(),
+			Format:                      enc,
 			UpdateSnapshot:              *updateSnapshot,
 			PersistRedactionsInSnapshot: true,
 			IsJSON:                      true,


### PR DESCRIPTION
Without this fix, capturing fixtures will result in hard-to-read failures in testing. (broken off from #1383 )