### PR TITLE
PURLs with "nuget" type are dotnet packages

### DIFF
--- a/syft/pkg/language.go
+++ b/syft/pkg/language.go
@@ -80,7 +80,7 @@ func LanguageByName(name string) Language {
 		return Rust
 	case packageurl.TypePub, string(DartPubPkg), string(Dart):
 		return Dart
-	case packageurl.TypeDotnet:
+	case packageurl.TypeDotnet, packageurl.TypeNuget:
 		return Dotnet
 	case packageurl.TypeCocoapods, packageurl.TypeSwift, string(CocoapodsPkg), string(SwiftPkg):
 		return Swift

--- a/syft/pkg/language_test.go
+++ b/syft/pkg/language_test.go
@@ -39,6 +39,10 @@ func TestLanguageFromPURL(t *testing.T) {
 			want: Dotnet,
 		},
 		{
+			purl: "pkg:nuget/Newtonsoft.Json@13.0.0",
+			want: Dotnet,
+		},
+		{
 			purl: "pkg:cargo/clap@2.33.0",
 			want: Rust,
 		},


### PR DESCRIPTION
Otherwise, Grype won't match on well-formed .NET purls from other SBOM tools.

Will fix https://github.com/anchore/grype/issues/1065 when Syft is released and Syft is bumped in Grype.