### PR TITLE
Fix diff error obfuscating binary test failures message

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -953,8 +953,8 @@ func assertPackagesAreEqual(t *testing.T, expected pkg.Package, p pkg.Package) {
 				cmp.Transformer("Locations", func(l file.LocationSet) []file.Location {
 					return l.ToSlice()
 				}),
-				cmpopts.IgnoreUnexported(pkg.Package{}, file.Location{}),
-				cmpopts.IgnoreFields(pkg.Package{}, "CPEs", "FoundBy", "MetadataType", "Type"),
+				cmpopts.IgnoreUnexported(pkg.Package{}, file.LocationData{}),
+				cmpopts.IgnoreFields(pkg.Package{}, "CPEs", "FoundBy", "Type", "Locations", "Licenses"),
 			))
 	}
 }


### PR DESCRIPTION
Before this change there were a lot of fatal errors

i.e.
```
Exception has occurred: panic
"MetadataType: does not exist"
```

```
Exception has occurred: panic
"cannot handle unexported field at Locations({pkg.Package}.Locations)...
```

```
Exception has occurred: panic
"cannot handle unexported field at {pkg.Package}.Licenses.set:\n\t\"g...
```

After the change:

```
Error:      	locations do not match; expected: haproxy1 got: haproxy
```