### PR TITLE
Drop go-multierror dependency

### DIFF
--- a/cmd/syft/cli/options/format_cyclonedx_json.go
+++ b/cmd/syft/cli/options/format_cyclonedx_json.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/hashicorp/go-multierror"
+	"errors"
 
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/sbom"
@@ -18,17 +18,17 @@ func DefaultFormatCyclonedxJSON() FormatCyclonedxJSON {
 func (o FormatCyclonedxJSON) formatEncoders() ([]sbom.FormatEncoder, error) {
 	var (
 		encs []sbom.FormatEncoder
-		errs error
+		errs []error
 	)
 	for _, v := range cyclonedxjson.SupportedVersions() {
 		enc, err := cyclonedxjson.NewFormatEncoderWithConfig(o.buildConfig(v))
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = append(errs, err)
 		} else {
 			encs = append(encs, enc)
 		}
 	}
-	return encs, errs
+	return encs, errors.Join(errs...)
 }
 
 func (o FormatCyclonedxJSON) buildConfig(version string) cyclonedxjson.EncoderConfig {

--- a/cmd/syft/cli/options/format_cyclonedx_xml.go
+++ b/cmd/syft/cli/options/format_cyclonedx_xml.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/hashicorp/go-multierror"
+	"errors"
 
 	"github.com/anchore/syft/syft/format/cyclonedxxml"
 	"github.com/anchore/syft/syft/sbom"
@@ -18,17 +18,17 @@ func DefaultFormatCyclonedxXML() FormatCyclonedxXML {
 func (o FormatCyclonedxXML) formatEncoders() ([]sbom.FormatEncoder, error) {
 	var (
 		encs []sbom.FormatEncoder
-		errs error
+		errs []error
 	)
 	for _, v := range cyclonedxxml.SupportedVersions() {
 		enc, err := cyclonedxxml.NewFormatEncoderWithConfig(o.buildConfig(v))
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = append(errs, err)
 		} else {
 			encs = append(encs, enc)
 		}
 	}
-	return encs, errs
+	return encs, errors.Join(errs...)
 }
 
 func (o FormatCyclonedxXML) buildConfig(version string) cyclonedxxml.EncoderConfig {

--- a/cmd/syft/cli/options/format_spdx_json.go
+++ b/cmd/syft/cli/options/format_spdx_json.go
@@ -1,7 +1,7 @@
 package options
 
 import (
-	"github.com/hashicorp/go-multierror"
+	"errors"
 
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/sbom"
@@ -18,17 +18,17 @@ func DefaultFormatSPDXJSON() FormatSPDXJSON {
 func (o FormatSPDXJSON) formatEncoders() ([]sbom.FormatEncoder, error) {
 	var (
 		encs []sbom.FormatEncoder
-		errs error
+		errs []error
 	)
 	for _, v := range spdxjson.SupportedVersions() {
 		enc, err := spdxjson.NewFormatEncoderWithConfig(o.buildConfig(v))
 		if err != nil {
-			errs = multierror.Append(errs, err)
+			errs = append(errs, err)
 		} else {
 			encs = append(encs, enc)
 		}
 	}
-	return encs, errs
+	return encs, errors.Join(errs...)
 }
 
 func (o FormatSPDXJSON) buildConfig(v string) spdxjson.EncoderConfig {

--- a/cmd/syft/cli/options/output.go
+++ b/cmd/syft/cli/options/output.go
@@ -1,11 +1,11 @@
 package options
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/scylladb/go-set/strset"
 
 	"github.com/anchore/clio"
@@ -49,14 +49,14 @@ func DefaultOutput() Output {
 }
 
 func (o *Output) PostLoad() error {
-	var errs error
+	var errs []error
 	for _, loader := range []clio.PostLoader{&o.OutputFile, &o.Format} {
 		if err := loader.PostLoad(); err != nil {
-			errs = multierror.Append(errs, err)
+			errs = append(errs, err)
 		}
 	}
 
-	return errs
+	return errors.Join(errs...)
 }
 
 func (o *Output) AddFlags(flags clio.FlagSet) {

--- a/cmd/syft/internal/ui/event_writer.go
+++ b/cmd/syft/internal/ui/event_writer.go
@@ -1,12 +1,12 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/hashicorp/go-multierror"
 	"github.com/wagoodman/go-partybus"
 
 	"github.com/anchore/syft/internal/log"
@@ -41,7 +41,7 @@ func writeEvents(out, err io.Writer, quiet bool, events ...partybus.Event) error
 		},
 	}
 
-	var errs error
+	var errs []error
 	for _, h := range handles {
 		if quiet && h.respectQuiet {
 			continue
@@ -53,11 +53,11 @@ func writeEvents(out, err io.Writer, quiet bool, events ...partybus.Event) error
 			}
 
 			if err := h.dispatch(h.writer, e); err != nil {
-				errs = multierror.Append(errs, err)
+				errs = append(errs, err)
 			}
 		}
 	}
-	return errs
+	return errors.Join(errs...)
 }
 
 func writeReports(writer io.Writer, events ...partybus.Event) error {

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/google/licensecheck v0.3.1
 	github.com/google/uuid v1.5.0
 	github.com/gookit/color v1.5.4
-	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.7.0
 	github.com/jinzhu/copier v0.4.0

--- a/syft/file/location.go
+++ b/syft/file/location.go
@@ -1,9 +1,8 @@
 package file
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/stereoscope/pkg/image"
@@ -33,18 +32,18 @@ type LocationMetadata struct {
 }
 
 func (m *LocationMetadata) merge(other LocationMetadata) error {
-	var errs error
+	var errs []error
 	for k, v := range other.Annotations {
 		if otherV, ok := m.Annotations[k]; ok {
 			if v != otherV {
 				err := fmt.Errorf("unable to merge location metadata: conflicting values for key=%q: %q != %q", k, v, otherV)
-				errs = multierror.Append(errs, err)
+				errs = append(errs, err)
 				continue
 			}
 		}
 		m.Annotations[k] = v
 	}
-	return errs
+	return errors.Join(errs...)
 }
 
 func (l Location) WithAnnotation(key, value string) Location {


### PR DESCRIPTION
Doing a little bit of dependency graph gardening and found this in our deps. We should be able to drop it since `errors.Join` is ~equivalent.