### PR TITLE
Condense binary cataloger config in JSON output

### DIFF
--- a/syft/pkg/cataloger/binary/cataloger.go
+++ b/syft/pkg/cataloger/binary/cataloger.go
@@ -4,6 +4,8 @@ Package binary provides a concrete Cataloger implementations for surfacing possi
 package binary
 
 import (
+	"encoding/json"
+
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
@@ -26,6 +28,15 @@ func NewCataloger(cfg CatalogerConfig) pkg.Cataloger {
 	return &Cataloger{
 		classifiers: cfg.Classifiers,
 	}
+}
+
+func (cfg CatalogerConfig) MarshalJSON() ([]byte, error) {
+	// only keep the class names
+	var names []string
+	for _, cls := range cfg.Classifiers {
+		names = append(names, cls.Class)
+	}
+	return json.Marshal(names)
 }
 
 // Cataloger is the cataloger responsible for surfacing evidence of a very limited set of binary files,

--- a/syft/pkg/cataloger/binary/classifier.go
+++ b/syft/pkg/cataloger/binary/classifier.go
@@ -5,6 +5,7 @@ import (
 	"debug/elf"
 	"debug/macho"
 	"debug/pe"
+	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -42,6 +43,31 @@ type Classifier struct {
 
 	// CPEs are the specific CPEs we want to include for this binary with updated version information
 	CPEs []cpe.CPE `json:"cpes"`
+}
+
+func (cfg Classifier) MarshalJSON() ([]byte, error) {
+	type marshalled struct {
+		Class    string   `json:"class"`
+		FileGlob string   `json:"fileGlob"`
+		Package  string   `json:"package"`
+		PURL     string   `json:"purl"`
+		CPEs     []string `json:"cpes"`
+	}
+
+	var marshalledCPEs []string
+	for _, c := range cfg.CPEs {
+		marshalledCPEs = append(marshalledCPEs, c.BindToFmtString())
+	}
+
+	m := marshalled{
+		Class:    cfg.Class,
+		FileGlob: cfg.FileGlob,
+		Package:  cfg.Package,
+		PURL:     cfg.PURL.String(),
+		CPEs:     marshalledCPEs,
+	}
+
+	return json.Marshal(m)
 }
 
 // EvidenceMatcher is a function called to catalog Packages that match some sort of evidence


### PR DESCRIPTION
The last rebase of #1383 resulted in bringing in changes from #2469 , which makes the configuration in the JSON output prohibitively large:
```
syft <anything> -o json | jq '.descriptor.configuration.packages'
```

```json 
    "packages": {
      "binary": {
        "classifiers": [
          {
            "class": "python-binary",
            "cpes": [
              {
                "Edition": "",
                "Language": "",
                "Other": "",
                "Part": "a",
                "Product": "python",
                "SWEdition": "",
                "TargetHW": "",
                "TargetSW": "",
                "Update": "",
                "Vendor": "python_software_foundation",
                "Version": ""
              },
              {
                "Edition": "",
                "Language": "",
                "Other": "",
                "Part": "a",
                "Product": "python",
                "SWEdition": "",
                "TargetHW": "",
                "TargetSW": "",
                "Update": "",
                "Vendor": "python",
                "Version": ""
              }
            ],
            "fileGlob": "**/python*",
            "package": "python",
            "purl": {
              "Name": "python",
              "Namespace": "",
              "Qualifiers": [],
              "Subpath": "",
              "Type": "generic",
              "Version": "version"
            }
          },

...
```

Note that the binary classifiers are now shown, however, every field in CPEs is shown (as well as others on the config).

This PR makes a few changes:
- Marshalling the binary `Classifier` struct will serialize CPEs to a string
- Marshalling the binary `CatalogerConfig` struct will only show the class names configured. Since the behavior is not reproducible from a description alone (the evidence parameter, the most important one, is a function) it is not really worth showing the additional fields.