### PR TITLE
Include binary cataloger configuration defaults

### DIFF
--- a/syft/cataloging/pkgcataloging/config.go
+++ b/syft/cataloging/pkgcataloging/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
+		Binary:      binary.DefaultCatalogerConfig(),
 		Golang:      golang.DefaultCatalogerConfig(),
 		LinuxKernel: kernel.DefaultLinuxCatalogerConfig(),
 		Python:      python.DefaultCatalogerConfig(),


### PR DESCRIPTION
This adds the binary cataloger configuration defaults to the default package config. This was missed on a rebase of the #1383 .