### PR TITLE
chore: enable automatic approval of dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -1,0 +1,10 @@
+name: Dependabot Automation
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  run:
+    uses: anchore/workflows/.github/workflows/dependabot-automation.yaml@main


### PR DESCRIPTION
To reduce toil in this repo, enable dependabot PRs to be automatically approved, but not merged. They are not automatically merged because if the default GitHub token is used to automatically merge a PR, the resulting commit will not trigger workflows on main. Rather than generate a more potent token, just automatically review them, which reduces toil by eliminating several clicks and page loads for maintainers who are trying to merge dependabot PRs.

Copied from anchore/grype-db#222.