### PR TITLE
fix: remove second call to finalize as the task handles it

### DIFF
--- a/syft/create_sbom.go
+++ b/syft/create_sbom.go
@@ -11,7 +11,6 @@ import (
 	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/syft/internal/bus"
-	"github.com/anchore/syft/internal/relationship"
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/internal/task"
 	"github.com/anchore/syft/syft/artifact"
@@ -77,8 +76,6 @@ func CreateSBOM(ctx context.Context, src source.Source, cfg *CreateSBOMConfig) (
 
 	packageCatalogingProgress.SetCompleted()
 	catalogingProgress.SetCompleted()
-
-	relationship.Finalize(builder, cfg.Relationships, src)
 
 	return &s, nil
 }

--- a/test/integration/regression_sbom_duplicate_relationships_test.go
+++ b/test/integration/regression_sbom_duplicate_relationships_test.go
@@ -1,0 +1,26 @@
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/syft/syft/source"
+)
+
+func TestRelationshipsUnique(t *testing.T) {
+	// This test is to ensure that the relationships are deduplicated in the final SBOM.
+	// It is not a test of the relationships themselves.
+	// This test is a regression test for #syft/2509
+	sbom, _ := catalogFixtureImage(t, "image-pkg-coverage", source.SquashedScope)
+	observedRelationships := strset.New()
+
+	for _, rel := range sbom.Relationships {
+		unique := fmt.Sprintf("%s:%s:%s", rel.From.ID(), rel.To.ID(), rel.Type)
+		if observedRelationships.Has(unique) {
+			t.Errorf("duplicate relationship found: %s", unique)
+		}
+		observedRelationships.Add(unique)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2509 

This PR removes the double call to `relationships.Finalize`.

To validate the fix run the following using the latest release of syft:
```
syft cgr.dev/chainguard/coredns@sha256:238f7d4cff40ffa7262ae5508481722fe3213e4aae1e61a1425f07f4ae2e4d71 -qo json | jq .artifactRelationships > test.json
```

Then using this gist you can evaluate the output relationships from above and find the dupes:
https://gist.github.com/spiffcs/72b641f04ac79d160ce079bcd3816382

```
Duplicate relationship: Parent=007a689559786815, Child=0fdca611631006c5 Type=ownership-by-file-overlap
Duplicate relationship: Parent=007a689559786815, Child=fe672ea9910662d8 Type=evident-by
Duplicate relationship: Parent=014167b5dbcc5b66, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=02619b1e06d34738, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=03dd022f997618f7, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=04e552bdca0b46d0, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=0c54b26b7af957a5, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=0dbbe7127f2505bf, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=0e1e0f87146ef9a2, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=0f024cac5c4c3f57, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=0fdca611631006c5, Child=d2414b428d31083d Type=evident-by
Duplicate relationship: Parent=19408370ed916ebd, Child=2d14b57d501102cf Type=evident-by
Duplicate relationship: Parent=1e3d85055de3fdbe, Child=2d14b57d501102cf Type=evident-by
...
```

Run the same command as above using the tip of this branch:
```
go run cmd/syft/main.go cgr.dev/chainguard/coredns@sha256:238f7d4cff40ffa7262ae5508481722fe3213e4aae1e61a1425f07f4ae2e4d71 -qo json | jq .artifactRelationships > test.json
```

And then rerun the gist again on the output:
https://gist.github.com/spiffcs/72b641f04ac79d160ce079bcd3816382

There should no longer be any duplicates shown in the output
```
...
```

An integration test has also been added to project against this regression going forward where duplicate edges are not tolerated for the given `image-pkg-coverage`. The test was checked for failure against the change and shown to fail if the second `Finalize` call was not removed

<img width="1324" alt="Screenshot 2024-01-19 at 2 02 45 PM" src="https://github.com/anchore/syft/assets/32073428/1ea62606-9322-4dfd-88dc-07046219a175">