### PR TITLE
Turn off the SBOM cataloger by default

### DIFF
--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -123,6 +123,6 @@ func DefaultPackageTaskFactories() PackageTaskFactories {
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "linux", "kernel",
 		),
-		newSimplePackageTaskFactory(sbomCataloger.NewCataloger, pkgcataloging.ImageTag, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "sbom"), // note: not evidence of installed packages
+		newSimplePackageTaskFactory(sbomCataloger.NewCataloger, "sbom"), // note: not evidence of installed packages
 	}
 }

--- a/test/integration/package_catalogers_represented_test.go
+++ b/test/integration/package_catalogers_represented_test.go
@@ -53,6 +53,9 @@ func TestAllPackageCatalogersReachableInTasks(t *testing.T) {
 	assert.Equal(t, len(taskTagsByName), constructorCount, "mismatch in number of cataloger constructors and task names")
 
 	for taskName, tags := range taskTagsByName {
+		if taskName == "sbom-cataloger" {
+			continue // this is a special case
+		}
 		if !strset.New(tags...).HasAny(pkgcataloging.ImageTag, pkgcataloging.DirectoryTag) {
 			t.Errorf("task %q is missing 'directory' or 'image' a tag", taskName)
 		}

--- a/test/integration/sbom_cataloger_test.go
+++ b/test/integration/sbom_cataloger_test.go
@@ -4,31 +4,47 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 )
 
 func TestSbomCataloger(t *testing.T) {
-	// The image contains a go.mod file with 2 dependencies and an spdx json sbom.
-	// The go.mod file contains 2 dependencies, and the sbom includes a go dependency
-	// that overlaps with the go.mod
-	sbom, _ := catalogFixtureImage(t, "image-sbom-cataloger", source.SquashedScope, "+go-module-file-cataloger")
+	assertCount := func(t *testing.T, sbom sbom.SBOM, expectedGoModCatalogerPkgs int, expectedSbomCatalogerPkgs int) {
+		actualSbomPkgs := 0
+		actualGoModPkgs := 0
 
-	expectedSbomCatalogerPkgs := 1
-	expectedGoModCatalogerPkgs := 2
-	actualSbomPkgs := 0
-	actualGoModPkgs := 0
-	for p := range sbom.Artifacts.Packages.Enumerate(pkg.GoModulePkg) {
-		if p.FoundBy == "go-module-file-cataloger" {
-			actualGoModPkgs += 1
-		} else if p.FoundBy == "sbom-cataloger" {
-			actualSbomPkgs += 1
+		for p := range sbom.Artifacts.Packages.Enumerate(pkg.GoModulePkg) {
+			if p.FoundBy == "go-module-file-cataloger" {
+				actualGoModPkgs += 1
+			} else if p.FoundBy == "sbom-cataloger" {
+				actualSbomPkgs += 1
+			}
+		}
+
+		if actualGoModPkgs != expectedGoModCatalogerPkgs {
+			t.Errorf("unexpected number of packages from go mod cataloger: %d != %d", expectedGoModCatalogerPkgs, actualGoModPkgs)
+		}
+		if actualSbomPkgs != expectedSbomCatalogerPkgs {
+			t.Errorf("unexpected number of packages from sbom cataloger: %d != %d", expectedSbomCatalogerPkgs, actualSbomPkgs)
 		}
 	}
 
-	if actualGoModPkgs != expectedGoModCatalogerPkgs {
-		t.Errorf("unexpected number of packages from go mod cataloger: %d != %d", expectedGoModCatalogerPkgs, actualGoModPkgs)
-	}
-	if actualSbomPkgs != expectedSbomCatalogerPkgs {
-		t.Errorf("unexpected number of packages from sbom cataloger: %d != %d", expectedSbomCatalogerPkgs, actualSbomPkgs)
-	}
+	t.Run("default catalogers", func(t *testing.T) {
+		sbom, _ := catalogFixtureImage(t, "image-sbom-cataloger", source.SquashedScope, "+go-module-file-cataloger")
+
+		expectedSbomCatalogerPkgs := 0
+		expectedGoModCatalogerPkgs := 2
+		assertCount(t, sbom, expectedGoModCatalogerPkgs, expectedSbomCatalogerPkgs)
+	})
+
+	// The image contains a go.mod file with 2 dependencies and an spdx json sbom.
+	// The go.mod file contains 2 dependencies, and the sbom includes a go dependency
+	// that overlaps with the go.mod
+	t.Run("with sbom cataloger", func(t *testing.T) {
+		sbom, _ := catalogFixtureImage(t, "image-sbom-cataloger", source.SquashedScope, "+go-module-file-cataloger", "+sbom-cataloger")
+
+		expectedSbomCatalogerPkgs := 1
+		expectedGoModCatalogerPkgs := 2
+		assertCount(t, sbom, expectedGoModCatalogerPkgs, expectedSbomCatalogerPkgs)
+	})
 }


### PR DESCRIPTION
This removes the `sbom-cataloger` from the default set of catalogers used for any scan. If a user would like SBOM contents to be considered then that is an opt-in action:

```
syft --select-catalogers +sbom-cataloger
```

Fixes #1555

~Must merge #2526 first~