### PR TITLE
Use the json schema as input for templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ select-catalogers: []
 format:
  
   # default value for all formats that support the "pretty" option (default is unset)
+  # SYFT_FORMAT_PRETTY env var
   pretty: 
 
   # all syft-json format options
@@ -562,6 +563,7 @@ format:
 
     # include space indention and newlines (inherits default value from 'format.pretty' or 'false' if parent is unset)
     # note: inherits default value from 'format.pretty' or 'false' if parent is unset
+    # SYFT_FORMAT_JSON_PRETTY env var
     pretty: false
     
     # transform any syft-json output to conform to an approximation of the v11.0.1 schema. This includes:
@@ -571,21 +573,30 @@ format:
     # that output might not strictly be json schema v11 compliant, however, for consumers that require time to port
     # over to the final syft 1.0 json output this option can be used to ease the transition.
     #
-    # Note: long term support for this option is not guaranteed.
+    # Note: long term support for this option is not guaranteed (it may change or break at any time).
+    # SYFT_FORMAT_JSON_LEGACY env var
     legacy: false
 
   # all template format options
   template:
     # path to the template file to use when rendering the output with the `template` output format. 
     # Note that all template paths are based on the current syft-json schema.
-    # SYFT_TEMPLATE_PATH env var / -t flag 
+    # SYFT_FORMAT_TEMPLATE_PATH env var / -t flag 
     path: ""
+    
+    # if true, uses the go structs for the syft-json format for templating. 
+    # if false, uses the syft-json output for templating (which follows the syft JSON schema exactly).
+    #
+    # Note: long term support for this option is not guaranteed (it may change or break at any time).
+    # SYFT_FORMAT_TEMPLATE_LEGACY env var
+    legacy: false
 
   # all spdx-json format options
   spdx-json:
 
     # include space indention and newlines
     # note: inherits default value from 'format.pretty' or 'false' if parent is unset
+    # SYFT_FORMAT_SPDX_JSON_PRETTY env var
     pretty: false
 
   # all cyclonedx-json format options
@@ -593,6 +604,7 @@ format:
 
      # include space indention and newlines
      # note: inherits default value from 'format.pretty' or 'false' if parent is unset
+     # SYFT_FORMAT_CYCLONEDX_JSON_PRETTY env var
      pretty: false
 
   # all cyclonedx-xml format options
@@ -600,6 +612,7 @@ format:
 
      # include space indention
      # note: inherits default value from 'format.pretty' or 'false' if parent is unset
+     # SYFT_FORMAT_CYCLONEDX_XML_PRETTY env var
      pretty: false
 
 

--- a/cmd/syft/internal/options/format_template.go
+++ b/cmd/syft/internal/options/format_template.go
@@ -10,6 +10,7 @@ var _ clio.FlagAdder = (*FormatTemplate)(nil)
 type FormatTemplate struct {
 	Enabled bool   `yaml:"-" json:"-" mapstructure:"-"`
 	Path    string `yaml:"path" json:"path" mapstructure:"path"` // -t template file to use for output
+	Legacy  bool   `yaml:"legacy" json:"legacy" mapstructure:"legacy"`
 }
 
 func DefaultFormatTemplate() FormatTemplate {
@@ -28,5 +29,6 @@ func (o *FormatTemplate) AddFlags(flags clio.FlagSet) {
 func (o FormatTemplate) config() template.EncoderConfig {
 	return template.EncoderConfig{
 		TemplatePath: o.Path,
+		Legacy:       o.Legacy,
 	}
 }

--- a/syft/format/encoders.go
+++ b/syft/format/encoders.go
@@ -72,9 +72,7 @@ func (o EncodersConfig) Encoders() ([]sbom.FormatEncoder, error) {
 }
 
 func (o EncodersConfig) templateEncoders() ([]sbom.FormatEncoder, error) {
-	enc, err := template.NewFormatEncoder(template.EncoderConfig{
-		TemplatePath: o.Template.TemplatePath,
-	})
+	enc, err := template.NewFormatEncoder(o.Template)
 	return []sbom.FormatEncoder{enc}, err
 }
 

--- a/syft/format/template/encoder_test.go
+++ b/syft/format/template/encoder_test.go
@@ -12,6 +12,42 @@ import (
 
 var updateSnapshot = flag.Bool("update-template", false, "update the *.golden files for json encoders")
 
+func TestFormatWithOption_Legacy(t *testing.T) {
+	f, err := NewFormatEncoder(EncoderConfig{
+		TemplatePath: "test-fixtures/legacy/csv.template",
+		Legacy:       true,
+	})
+	require.NoError(t, err)
+
+	testutil.AssertEncoderAgainstGoldenSnapshot(t,
+		testutil.EncoderSnapshotTestConfig{
+			Subject:                     testutil.DirectoryInput(t, t.TempDir()),
+			Format:                      f,
+			UpdateSnapshot:              *updateSnapshot,
+			PersistRedactionsInSnapshot: true,
+			IsJSON:                      false,
+		},
+	)
+}
+
+func TestFormatWithOptionAndHasField_Legacy(t *testing.T) {
+	f, err := NewFormatEncoder(EncoderConfig{
+		TemplatePath: "test-fixtures/legacy/csv-hasField.template",
+		Legacy:       true,
+	})
+	require.NoError(t, err)
+
+	testutil.AssertEncoderAgainstGoldenSnapshot(t,
+		testutil.EncoderSnapshotTestConfig{
+			Subject:                     testutil.DirectoryInputWithAuthorField(t),
+			Format:                      f,
+			UpdateSnapshot:              *updateSnapshot,
+			PersistRedactionsInSnapshot: true,
+			IsJSON:                      false,
+		},
+	)
+}
+
 func TestFormatWithOption(t *testing.T) {
 	f, err := NewFormatEncoder(EncoderConfig{
 		TemplatePath: "test-fixtures/csv.template",
@@ -44,7 +80,6 @@ func TestFormatWithOptionAndHasField(t *testing.T) {
 			IsJSON:                      false,
 		},
 	)
-
 }
 
 func TestFormatWithoutOptions(t *testing.T) {

--- a/syft/format/template/test-fixtures/csv-hasField.template
+++ b/syft/format/template/test-fixtures/csv-hasField.template
@@ -1,4 +1,4 @@
 "Package","Version Installed","Found by","Author"
-{{- range .Artifacts}}
-"{{.Name}}","{{.Version}}","{{.FoundBy}}","{{ if hasField .Metadata "Author" }}{{.Metadata.Author}}{{ else }}NO AUTHOR SUPPLIED{{end}}"
+{{- range .artifacts}}
+"{{.name}}","{{.version}}","{{.foundBy}}","{{ if index .metadata "author" }}{{.metadata.author}}{{ else }}NO AUTHOR SUPPLIED{{end}}"
 {{- end}}

--- a/syft/format/template/test-fixtures/csv.template
+++ b/syft/format/template/test-fixtures/csv.template
@@ -1,4 +1,4 @@
 "Package","Version Installed", "Found by"
-{{- range .Artifacts}}
-"{{.Name}}","{{.Version}}","{{.FoundBy}}"
+{{- range .artifacts}}
+"{{.name}}","{{.version}}","{{.foundBy}}"
 {{- end}}

--- a/syft/format/template/test-fixtures/legacy/csv-hasField.template
+++ b/syft/format/template/test-fixtures/legacy/csv-hasField.template
@@ -1,0 +1,4 @@
+"Package","Version Installed","Found by","Author"
+{{- range .Artifacts}}
+"{{.Name}}","{{.Version}}","{{.FoundBy}}","{{ if hasField .Metadata "Author" }}{{.Metadata.Author}}{{ else }}NO AUTHOR SUPPLIED{{end}}"
+{{- end}}

--- a/syft/format/template/test-fixtures/legacy/csv.template
+++ b/syft/format/template/test-fixtures/legacy/csv.template
@@ -1,0 +1,4 @@
+"Package","Version Installed", "Found by"
+{{- range .Artifacts}}
+"{{.Name}}","{{.Version}}","{{.FoundBy}}"
+{{- end}}

--- a/syft/format/template/test-fixtures/snapshot/TestFormatWithOptionAndHasField_Legacy.golden
+++ b/syft/format/template/test-fixtures/snapshot/TestFormatWithOptionAndHasField_Legacy.golden
@@ -1,0 +1,3 @@
+"Package","Version Installed","Found by","Author"
+"package-1","1.0.1","the-cataloger-1","test-author"
+"package-2","2.0.1","the-cataloger-2","NO AUTHOR SUPPLIED"

--- a/syft/format/template/test-fixtures/snapshot/TestFormatWithOption_Legacy.golden
+++ b/syft/format/template/test-fixtures/snapshot/TestFormatWithOption_Legacy.golden
@@ -1,0 +1,3 @@
+"Package","Version Installed", "Found by"
+"package-1","1.0.1","the-cataloger-1"
+"package-2","2.0.1","the-cataloger-2"

--- a/test/cli/test-fixtures/csv.template
+++ b/test/cli/test-fixtures/csv.template
@@ -1,4 +1,4 @@
 "Package","Version Installed", "Found by"
-{{- range .Artifacts}}
-"{{.Name}}","{{.Version}}","{{.FoundBy}}"
+{{- range .artifacts}}
+"{{.name}}","{{.version}}","{{.foundBy}}"
 {{- end}}


### PR DESCRIPTION
The template functionality today uses the go struct fields from the `syft/format/syftjson/model` directory as input, which means that in order to write a template you need to read the syft source code. For instance:
```
"Package","Version Installed", "Found by"
{{- range .Artifacts}}
"{{.Name}}","{{.Version}}","{{.FoundBy}}"
{{- end}}
```
- `Artifacts` approximates to `artifacts` in the json schema
- `Name` approximates to `name` in the json schema
- `Version` approximates to `version` in the json schema
- `FoundBy` approximates to `foundBy` in the json schema

This change adapts the template input to require the same fields as what you will find in the JSON output of syft (exactly what's in the json schema):

```
"Package","Version Installed", "Found by"
{{- range .artifacts}}
"{{.name}}","{{.version}}","{{.foundBy}}"
{{- end}}
```

Caveats are that struct helpers cannot be used on maps, which is what ultimately is used for templating. This means that some alterations will need to be made, for example replacing `hasField` for `index`:

```diff
2,3c2,3
< {{- range .Artifacts}}
< "{{.Name}}","{{.Version}}","{{.FoundBy}}","{{ if hasField .Metadata "Author" }}{{.Metadata.Author}}{{ else }}NO AUTHOR SUPPLIED{{end}}"
---
> {{- range .artifacts}}
> "{{.name}}","{{.version}}","{{.foundBy}}","{{ if index .metadata "author" }}{{.metadata.author}}{{ else }}NO AUTHOR SUPPLIED{{end}}"
```

Since this will impact all templates a new `SYFT_FORMAT_TEMPLATE_LEGACY`/`format.template.legacy` option has been provided that, when enabled, will use the original struct-approach.