### PR TITLE
Sign checksums file and add SBOMs on release

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -1,4 +1,6 @@
 tools:
+
+  # we want to use a pinned version of binny to manage the toolchain (so binny manages itself!)
   - name: binny
     version:
       want: v0.6.3
@@ -6,6 +8,15 @@ tools:
     with:
       repo: anchore/binny
 
+  # used to produce SBOMs during release
+  - name: syft
+    version:
+      want: latest
+    method: github-release
+    with:
+      repo: anchore/syft
+
+  # used to sign mac binaries at release
   - name: quill
     version:
       want: v0.4.1
@@ -13,6 +24,7 @@ tools:
     with:
       repo: anchore/quill
 
+  # used for linting
   - name: golangci-lint
     version:
       want: v1.55.2
@@ -20,6 +32,7 @@ tools:
     with:
       repo: golangci/golangci-lint
 
+  # used for showing the changelog at release
   - name: glow
     version:
       want: v1.5.1
@@ -27,6 +40,7 @@ tools:
     with:
       repo: charmbracelet/glow
 
+  # used for signing the checksums file at release
   - name: cosign
     version:
       want: v2.2.2
@@ -34,6 +48,7 @@ tools:
     with:
       repo: sigstore/cosign
 
+  # used in integration tests to verify JSON schemas
   - name: yajsv
     version:
       want: v1.4.1
@@ -41,6 +56,7 @@ tools:
     with:
       repo: neilpa/yajsv
 
+  # used to release all artifacts
   - name: goreleaser
     version:
       want: v1.23.0
@@ -48,6 +64,7 @@ tools:
     with:
       repo: goreleaser/goreleaser
 
+  # used for organizing imports during static analysis
   - name: gosimports
     version:
       want: v0.3.8
@@ -55,6 +72,7 @@ tools:
     with:
       repo: rinchsan/gosimports
 
+  # used at release to generate the changelog
   - name: chronicle
     version:
       want: v0.8.0
@@ -62,6 +80,7 @@ tools:
     with:
       repo: anchore/chronicle
 
+  # used during static analysis for license compliance
   - name: bouncer
     version:
       want: v0.4.0
@@ -69,6 +88,7 @@ tools:
     with:
       repo: wagoodman/go-bouncer
 
+  # used for showing benchmark testing
   - name: benchstat
     version:
       want: latest
@@ -81,6 +101,7 @@ tools:
       entrypoint: cmd/benchstat
       module: golang.org/x/perf
 
+  # used for running all local and CI tasks
   - name: task
     version:
       want: v3.33.1
@@ -88,6 +109,7 @@ tools:
     with:
       repo: go-task/task
 
+  # used for triggering a release
   - name: gh
     version:
       want: v2.42.1

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -248,6 +248,18 @@ docker_manifests:
       - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
       - ghcr.io/anchore/syft:{{.Tag}}-s390x
 
+sboms:
+  - artifacts: archive
+    # this is relative to the snapshot/dist directory, not the root of the repo
+    cmd: ../.tool/syft
+    documents:
+      - "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"
+    args:
+      - "scan"
+      - "$artifact"
+      - "--output"
+      - "json=$document"
+
 signs:
   - cmd: .tool/cosign
     signature: "${artifact}.sig"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -247,3 +247,16 @@ docker_manifests:
       - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
       - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
       - ghcr.io/anchore/syft:{{.Tag}}-s390x
+
+signs:
+  - cmd: .tool/cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum

--- a/test/install/environments/Dockerfile-alpine-3.6
+++ b/test/install/environments/Dockerfile-alpine-3.6
@@ -1,2 +1,2 @@
 FROM alpine:3.6@sha256:66790a2b79e1ea3e1dabac43990c54aca5d1ddf268d9a5a0285e4167c8b24475
-RUN apk update && apk add python3 wget unzip make ca-certificates
+RUN apk update && apk add python3 wget unzip make ca-certificates jq

--- a/test/install/environments/Dockerfile-ubuntu-20.04
+++ b/test/install/environments/Dockerfile-ubuntu-20.04
@@ -1,2 +1,2 @@
 FROM ubuntu:20.04@sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba
-RUN apt update -y && apt install make python3 curl unzip -y
+RUN apt update -y && apt install make python3 curl unzip jq -y


### PR DESCRIPTION
This PR enhances what is produced at release:
- adds signature of the checksums.txt file produced on each release
- adds SBOMs for released binary archives

Here is a tree of the snapshot dir with these changes:
```
snapshot
├── ...
├── metadata.json
├── syft_0.101.1-SNAPSHOT-edc0217a_checksums.txt
├── syft_0.101.1-SNAPSHOT-edc0217a_darwin_amd64.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_darwin_amd64.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_darwin_arm64.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_darwin_arm64.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_amd64.deb
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_amd64.rpm
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_amd64.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_amd64.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_arm64.deb
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_arm64.rpm
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_arm64.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_arm64.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_ppc64le.deb
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_ppc64le.rpm
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_ppc64le.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_ppc64le.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_s390x.deb
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_s390x.rpm
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_s390x.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_linux_s390x.tar.gz
├── syft_0.101.1-SNAPSHOT-edc0217a_windows_amd64.sbom
├── syft_0.101.1-SNAPSHOT-edc0217a_windows_amd64.zip
└── ...

```

Note that all `*.tar.gz` files have SBOMs associated, which are `file` type SBOMs of said archives:
```bash
$ cat snapshot/syft_0.101.1-SNAPSHOT-edc0217a_darwin_amd64.sbom| jq '.source'        
```
```json
{
  "id": "daef426902802aecf68fb9055ce298a0ce1d2c01be14ba549686109429f57f56",
  "name": "syft_0.101.1-SNAPSHOT-edc0217a_darwin_amd64.tar.gz",
  "version": "sha256:b4d81d25db6410efac84c3a4d06b0fefa2ad6abb06e442d743a1eb938d809555",
  "type": "file",
  "metadata": {
    "path": "syft_0.101.1-SNAPSHOT-edc0217a_darwin_amd64.tar.gz",
    "digests": [
      {
        "algorithm": "sha256",
        "value": "b4d81d25db6410efac84c3a4d06b0fefa2ad6abb06e442d743a1eb938d809555"
      }
    ],
    "mimeType": "application/gzip"
  }
}

```

We do not have SBOMs for the `deb` or `rpm` files since they are repackagings of the contents of the `.tar.gz` archives.
