### PR TITLE
Fix attest with --key

### DIFF
--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/anchore/syft/cmd/syft/internal"
 	"io"
 	"os"
 
@@ -8,13 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
-	"github.com/anchore/stereoscope"
-	handler "github.com/anchore/syft/cmd/syft/cli/ui"
 	"github.com/anchore/syft/cmd/syft/internal/commands"
-	"github.com/anchore/syft/cmd/syft/internal/ui"
-	"github.com/anchore/syft/internal/bus"
-	"github.com/anchore/syft/internal/log"
-	"github.com/anchore/syft/internal/redact"
 )
 
 // Application constructs the `syft packages` command and aliases the root command to `syft packages`.
@@ -34,44 +29,7 @@ func Command(id clio.Identification) *cobra.Command {
 }
 
 func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Command) {
-	clioCfg := clio.NewSetupConfig(id).
-		WithGlobalConfigFlag().   // add persistent -c <path> for reading an application config from
-		WithGlobalLoggingFlags(). // add persistent -v and -q flags tied to the logging config
-		WithConfigInRootHelp().   // --help on the root command renders the full application config in the help text
-		WithUIConstructor(
-			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
-			func(cfg clio.Config) ([]clio.UI, error) {
-				noUI := ui.None(out, cfg.Log.Quiet)
-				if !cfg.Log.AllowUI(os.Stdin) || cfg.Log.Quiet {
-					return []clio.UI{noUI}, nil
-				}
-
-				return []clio.UI{
-					ui.New(out, cfg.Log.Quiet,
-						handler.New(handler.DefaultHandlerConfig()),
-					),
-					noUI,
-				}, nil
-			},
-		).
-		WithInitializers(
-			func(state *clio.State) error {
-				// clio is setting up and providing the bus, redact store, and logger to the application. Once loaded,
-				// we can hoist them into the internal packages for global use.
-				stereoscope.SetBus(state.Bus)
-				bus.Set(state.Bus)
-
-				redact.Set(state.RedactStore)
-
-				log.Set(state.Logger)
-				stereoscope.SetLogger(state.Logger)
-
-				return nil
-			},
-		).
-		WithPostRuns(func(state *clio.State, err error) {
-			stereoscope.Cleanup()
-		})
+	clioCfg := internal.AppClioSetupConfig(id, out)
 
 	app := clio.New(*clioCfg)
 

--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"github.com/anchore/syft/cmd/syft/internal"
 	"io"
 	"os"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/syft/cmd/syft/internal"
 	"github.com/anchore/syft/cmd/syft/internal/commands"
 )
 

--- a/cmd/syft/internal/clio_setup_config.go
+++ b/cmd/syft/internal/clio_setup_config.go
@@ -1,6 +1,9 @@
 package internal
 
 import (
+	"io"
+	"os"
+
 	"github.com/anchore/clio"
 	"github.com/anchore/stereoscope"
 	ui2 "github.com/anchore/syft/cmd/syft/cli/ui"
@@ -8,8 +11,6 @@ import (
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/redact"
-	"io"
-	"os"
 )
 
 func AppClioSetupConfig(id clio.Identification, out io.Writer) *clio.SetupConfig {

--- a/cmd/syft/internal/clio_setup_config.go
+++ b/cmd/syft/internal/clio_setup_config.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"github.com/anchore/clio"
+	"github.com/anchore/stereoscope"
+	ui2 "github.com/anchore/syft/cmd/syft/cli/ui"
+	"github.com/anchore/syft/cmd/syft/internal/ui"
+	"github.com/anchore/syft/internal/bus"
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/redact"
+	"io"
+	"os"
+)
+
+func AppClioSetupConfig(id clio.Identification, out io.Writer) *clio.SetupConfig {
+	clioCfg := clio.NewSetupConfig(id).
+		WithGlobalConfigFlag().   // add persistent -c <path> for reading an application config from
+		WithGlobalLoggingFlags(). // add persistent -v and -q flags tied to the logging config
+		WithConfigInRootHelp().   // --help on the root command renders the full application config in the help text
+		WithUIConstructor(
+			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
+			func(cfg clio.Config) ([]clio.UI, error) {
+				noUI := ui.None(out, cfg.Log.Quiet)
+				if !cfg.Log.AllowUI(os.Stdin) || cfg.Log.Quiet {
+					return []clio.UI{noUI}, nil
+				}
+
+				return []clio.UI{
+					ui.New(out, cfg.Log.Quiet,
+						ui2.New(ui2.DefaultHandlerConfig()),
+					),
+					noUI,
+				}, nil
+			},
+		).
+		WithInitializers(
+			func(state *clio.State) error {
+				// clio is setting up and providing the bus, redact store, and logger to the application. Once loaded,
+				// we can hoist them into the internal packages for global use.
+				stereoscope.SetBus(state.Bus)
+				bus.Set(state.Bus)
+
+				redact.Set(state.RedactStore)
+
+				log.Set(state.Logger)
+				stereoscope.SetLogger(state.Logger)
+
+				return nil
+			},
+		).
+		WithPostRuns(func(state *clio.State, err error) {
+			stereoscope.Cleanup()
+		})
+	return clioCfg
+}

--- a/cmd/syft/internal/clio_setup_config.go
+++ b/cmd/syft/internal/clio_setup_config.go
@@ -15,9 +15,9 @@ import (
 
 func AppClioSetupConfig(id clio.Identification, out io.Writer) *clio.SetupConfig {
 	clioCfg := clio.NewSetupConfig(id).
-		WithGlobalConfigFlag(). // add persistent -c <path> for reading an application config from
+		WithGlobalConfigFlag().   // add persistent -c <path> for reading an application config from
 		WithGlobalLoggingFlags(). // add persistent -v and -q flags tied to the logging config
-		WithConfigInRootHelp(). // --help on the root command renders the full application config in the help text
+		WithConfigInRootHelp().   // --help on the root command renders the full application config in the help text
 		WithUIConstructor(
 			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
 			func(cfg clio.Config) ([]clio.UI, error) {

--- a/cmd/syft/internal/clio_setup_config.go
+++ b/cmd/syft/internal/clio_setup_config.go
@@ -10,16 +10,13 @@ import (
 	"github.com/anchore/syft/internal/redact"
 	"io"
 	"os"
-	"sync"
 )
-
-var initOnce sync.Once
 
 func AppClioSetupConfig(id clio.Identification, out io.Writer) *clio.SetupConfig {
 	clioCfg := clio.NewSetupConfig(id).
-		WithGlobalConfigFlag().   // add persistent -c <path> for reading an application config from
+		WithGlobalConfigFlag(). // add persistent -c <path> for reading an application config from
 		WithGlobalLoggingFlags(). // add persistent -v and -q flags tied to the logging config
-		WithConfigInRootHelp().   // --help on the root command renders the full application config in the help text
+		WithConfigInRootHelp(). // --help on the root command renders the full application config in the help text
 		WithUIConstructor(
 			// select a UI based on the logging configuration and state of stdin (if stdin is a tty)
 			func(cfg clio.Config) ([]clio.UI, error) {
@@ -40,15 +37,13 @@ func AppClioSetupConfig(id clio.Identification, out io.Writer) *clio.SetupConfig
 			func(state *clio.State) error {
 				// clio is setting up and providing the bus, redact store, and logger to the application. Once loaded,
 				// we can hoist them into the internal packages for global use.
-				initOnce.Do(func() {
-					stereoscope.SetBus(state.Bus)
-					bus.Set(state.Bus)
+				stereoscope.SetBus(state.Bus)
+				bus.Set(state.Bus)
 
-					redact.Set(state.RedactStore)
+				redact.Set(state.RedactStore)
 
-					log.Set(state.Logger)
-					stereoscope.SetLogger(state.Logger)
-				})
+				log.Set(state.Logger)
+				stereoscope.SetLogger(state.Logger)
 				return nil
 			},
 		).

--- a/cmd/syft/internal/commands/attest.go
+++ b/cmd/syft/internal/commands/attest.go
@@ -42,7 +42,7 @@ type attestOptions struct {
 	options.Output      `yaml:",inline" mapstructure:",squash"`
 	options.UpdateCheck `yaml:",inline" mapstructure:",squash"`
 	options.Catalog     `yaml:",inline" mapstructure:",squash"`
-	options.Attest      `yaml:",inline" mapstructure:",squash"`
+	Attest              options.Attest `yaml:"attest" mapstructure:"attest"`
 }
 
 func Attest(app clio.Application) *cobra.Command {

--- a/cmd/syft/internal/commands/attest_test.go
+++ b/cmd/syft/internal/commands/attest_test.go
@@ -278,6 +278,8 @@ func Test_attestCLIWiring(t *testing.T) {
 		Name:    "syft",
 		Version: "testing",
 	}
+	cfg := internal.AppClioSetupConfig(id, io.Discard)
+	a := clio.New(*cfg)
 	tests := []struct {
 		name          string
 		assertionFunc func(*testing.T, *cobra.Command, []string, ...any)
@@ -309,7 +311,7 @@ func Test_attestCLIWiring(t *testing.T) {
 					t.Setenv(k, v)
 				}
 			}
-			app := testutils.NewForTesting(t, internal.AppClioSetupConfig(id, io.Discard), tt.assertionFunc)
+			app := testutils.WrapForTesting(t, a, tt.assertionFunc)
 			cmd := Attest(app)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()

--- a/cmd/syft/internal/commands/attest_test.go
+++ b/cmd/syft/internal/commands/attest_test.go
@@ -279,7 +279,6 @@ func Test_attestCLIWiring(t *testing.T) {
 		Version: "testing",
 	}
 	cfg := internal.AppClioSetupConfig(id, io.Discard)
-	a := clio.New(*cfg)
 	tests := []struct {
 		name          string
 		assertionFunc func(*testing.T, *cobra.Command, []string, ...any)
@@ -311,7 +310,7 @@ func Test_attestCLIWiring(t *testing.T) {
 					t.Setenv(k, v)
 				}
 			}
-			app := testutils.WrapForTesting(t, a, tt.assertionFunc)
+			app := testutils.NewForTesting(t, cfg, tt.assertionFunc)
 			cmd := Attest(app)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()

--- a/cmd/syft/internal/commands/attest_test.go
+++ b/cmd/syft/internal/commands/attest_test.go
@@ -4,21 +4,21 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/anchore/clio/testutils"
-	"github.com/anchore/syft/cmd/syft/internal"
-	"github.com/google/go-cmp/cmp"
-	"github.com/spf13/cobra"
 	"io"
 	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/go-set/strset"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/clio/cliotestutils"
+	"github.com/anchore/syft/cmd/syft/internal"
 	"github.com/anchore/syft/cmd/syft/internal/options"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
@@ -310,7 +310,7 @@ func Test_attestCLIWiring(t *testing.T) {
 					t.Setenv(k, v)
 				}
 			}
-			app := testutils.NewForTesting(t, cfg, tt.assertionFunc)
+			app := cliotestutils.NewApplication(t, cfg, tt.assertionFunc)
 			cmd := Attest(app)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
@@ -319,7 +319,7 @@ func Test_attestCLIWiring(t *testing.T) {
 	}
 }
 
-func hasAttestOpts(wantOpts options.Attest) testutils.AssertionFunc {
+func hasAttestOpts(wantOpts options.Attest) cliotestutils.AssertionFunc {
 	return func(t *testing.T, _ *cobra.Command, _ []string, cfgs ...any) {
 		assert.Equal(t, len(cfgs), 1)
 		attestOpts, ok := cfgs[0].(*attestOptions)

--- a/cmd/syft/internal/commands/commands_test.go
+++ b/cmd/syft/internal/commands/commands_test.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
-	gologgerredact "github.com/anchore/go-logger/adapter/redact"
-	"github.com/anchore/syft/internal/redact"
 	"os"
 	"testing"
+
+	gologgerredact "github.com/anchore/go-logger/adapter/redact"
+	"github.com/anchore/syft/internal/redact"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/syft/internal/commands/commands_test.go
+++ b/cmd/syft/internal/commands/commands_test.go
@@ -1,0 +1,19 @@
+package commands
+
+import (
+	gologgerredact "github.com/anchore/go-logger/adapter/redact"
+	"github.com/anchore/syft/internal/redact"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Initialize global state needed to test clio/cobra commands directly
+	// Should be kept minimal.
+
+	// Initialize redact store once for all tests in the commands package
+	// Redact store must be wired up here because syft will panic unless
+	// a redact store is wired up exactly once
+	redact.Set(gologgerredact.NewStore())
+	os.Exit(m.Run())
+}

--- a/cmd/syft/internal/options/attest.go
+++ b/cmd/syft/internal/options/attest.go
@@ -4,6 +4,8 @@ import (
 	"github.com/anchore/clio"
 )
 
+var _ clio.FlagAdder = (*Attest)(nil)
+
 type Attest struct {
 	// IMPORTANT: do not show the attestation key/password in any YAML/JSON output (sensitive information)
 	Key      secret `yaml:"key" json:"key" mapstructure:"key"`
@@ -12,6 +14,6 @@ type Attest struct {
 
 var _ clio.FlagAdder = (*Attest)(nil)
 
-func (o Attest) AddFlags(flags clio.FlagSet) {
+func (o *Attest) AddFlags(flags clio.FlagSet) {
 	flags.StringVarP((*string)(&o.Key), "key", "k", "the key to use for the attestation")
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9
-	github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc
+	github.com/anchore/clio v0.0.0-20240131202212-9eba61247448
 	github.com/anchore/fangs v0.0.0-20231201140849-5075d28d6d8b
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9 h1:p0ZIe0htYOX284Y4axJaGBvXHU0VCCzLN5Wf5XbKStU=
 github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9/go.mod h1:3ZsFB9tzW3vl4gEiUeuSOMDnwroWxIxJelOOHUp8dSw=
-github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc h1:A1KFO+zZZmbNlz1+WKsCF0RKVx6XRoxsAG3lrqH9hUQ=
-github.com/anchore/clio v0.0.0-20231016125544-c98a83e1c7fc/go.mod h1:QeWvNzxsrUNxcs6haQo3OtISfXUXW0qAuiG4EQiz0GU=
+github.com/anchore/clio v0.0.0-20240131202212-9eba61247448 h1:ZgecmkxhH5im+9jPs7Ra1Thmv/p4IBDsoCFD6W8pENg=
+github.com/anchore/clio v0.0.0-20240131202212-9eba61247448/go.mod h1:t5Mld8naKcG8RTPjW/2n7bfyBKFl1A6PvtXw+v64gK0=
 github.com/anchore/fangs v0.0.0-20231201140849-5075d28d6d8b h1:L/djgY7ZbZ/38+wUtdkk398W3PIBJLkt1N8nU/7e47A=
 github.com/anchore/fangs v0.0.0-20231201140849-5075d28d6d8b/go.mod h1:TLcE0RE5+8oIx2/NPWem/dq1DeaMoC+fPEH7hoSzPLo=
 github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a h1:nJ2G8zWKASyVClGVgG7sfM5mwoZlZ2zYpIzN2OhjWkw=

--- a/test/cli/scan_cmd_test.go
+++ b/test/cli/scan_cmd_test.go
@@ -191,6 +191,7 @@ func TestPackagesCmdFlags(t *testing.T) {
 			},
 		},
 		{
+			// TODO: this could be a unit test
 			name: "responds-to-package-cataloger-search-options",
 			args: []string{"--help"},
 			env: map[string]string{


### PR DESCRIPTION
Pull request adding a new testing pattern for CLIs, based on work over in clio: https://github.com/anchore/clio/pull/37

Some feedback on this PR might inform https://github.com/anchore/clio/pull/37, and this is meant to be merged after https://github.com/anchore/clio/pull/37.

Fixes https://github.com/anchore/syft/issues/2544

## Testing
* Pulls in updated clio to add unit tests for `SYFT_ATTEST_PASSWORD` env var and `--key` flag on `attest` subcommand.
* https://oci.dag.dev/?blob=ghcr.io%2Fwillmurphyscode%2Ftest_image%40sha256%3A7c20f7ae24e5e9abe27e4fbb21d4a217715ffd29c32085fc47ebde8c08da06ff&jq=.payload&jq=base64+-d&jq=jq&mt=application%2Fvnd.dsse.envelope.v1%2Bjson&size=10752 attestation was created by pushing a test image to ghcr and attesting it with local build of syft on this branch. (Command was: `SYFT_ATTEST_PASSWORD=<some-password> go run cmd/syft/main.go attest ghcr.io/willmurphyscode/test_image:latest --key ../scratch/empty/cosign.key`)