### PR TITLE
fix: Better test for group ID in filename

### DIFF
--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -165,14 +165,14 @@ func extractNameFromArchiveFilename(a archiveFilename) string {
 
 		// Maybe the filename is like groupid + . + artifactid. If so, return artifact id.
 		fields := strings.Split(a.name, ".")
-		maybeGroupId := true
+		maybeGroupID := true
 		for _, f := range fields {
 			if !isValidJavaIdentifier(f) {
-				maybeGroupId = false
+				maybeGroupID = false
 				break
 			}
 		}
-		if maybeGroupId {
+		if maybeGroupID {
 			return fields[len(fields)-1]
 		}
 	}

--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/pkg"
@@ -162,11 +163,38 @@ func extractNameFromArchiveFilename(a archiveFilename) string {
 			return a.name
 		}
 
+		// Maybe the filename is like groupid + . + artifactid. If so, return artifact id.
 		fields := strings.Split(a.name, ".")
-		return fields[len(fields)-1]
+		maybeGroupId := true
+		for _, f := range fields {
+			if !isValidJavaIdentifier(f) {
+				maybeGroupId = false
+				break
+			}
+		}
+		if maybeGroupId {
+			return fields[len(fields)-1]
+		}
 	}
 
 	return a.name
+}
+
+func isValidJavaIdentifier(field string) bool {
+	runes := []rune(field)
+	if len(runes) == 0 {
+		return false
+	}
+	// check whether first rune can start an identifier name in Java
+	// Java identifier start = [Lu]|[Ll]|[Lt]|[Lm]|[Lo]|[Nl]|[Sc]|[Pc]
+	// see https://developer.classpath.org/doc/java/lang/Character-source.html
+	// line 3295
+	r := runes[0]
+	return unicode.Is(unicode.Lu, r) ||
+		unicode.Is(unicode.Ll, r) || unicode.Is(unicode.Lt, r) ||
+		unicode.Is(unicode.Lm, r) || unicode.Is(unicode.Lo, r) ||
+		unicode.Is(unicode.Nl, r) ||
+		unicode.Is(unicode.Sc, r) || unicode.Is(unicode.Pc, r)
 }
 
 func selectName(manifest *pkg.JavaManifest, filenameObj archiveFilename) string {

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -210,6 +210,14 @@ func TestSelectName(t *testing.T) {
 			expected: "atlassian-gadgets-api",
 		},
 		{
+			desc: "Filename has period that is not groupid + artifact id",
+			manifest: pkg.JavaManifest{
+				Main: map[string]string{},
+			},
+			archive:  newJavaArchiveFilename("/something/http4s-crypto_2.12-0.1.0.jar"),
+			expected: "http4s-crypto_2.12",
+		},
+		{
 			desc: "Skip stripping groupId prefix from archive filename for org.eclipse",
 			manifest: pkg.JavaManifest{
 				Main: map[string]string{

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -218,6 +218,14 @@ func TestSelectName(t *testing.T) {
 			expected: "http4s-crypto_2.12",
 		},
 		{
+			desc: "Filename has period that is not groupid + artifact id, kafka",
+			manifest: pkg.JavaManifest{
+				Main: map[string]string{},
+			},
+			archive:  newJavaArchiveFilename("/something//kafka_2.13-3.2.2.jar"),
+			expected: "kafka_2.13", // see https://mvnrepository.com/artifact/org.apache.kafka/kafka_2.13/3.2.2
+		},
+		{
 			desc: "Skip stripping groupId prefix from archive filename for org.eclipse",
 			manifest: pkg.JavaManifest{
 				Main: map[string]string{


### PR DESCRIPTION
This fixes an issue where filenames containing a period that aren't a group ID, such as some-jar.12.jar, would be mistakenly be reported as having the name "12" by syft, instead of the name "some-jar.12".

Fixes #2563.