### PR TITLE
Re-add cosign signing checksums file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+      # required for goreleaser signs section with cosign
+      id-token: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -259,3 +259,16 @@ sboms:
       - "$artifact"
       - "--output"
       - "json=$document"
+
+signs:
+  - cmd: .tool/cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum


### PR DESCRIPTION
This PR re-adds the cosign signing checksums file, this time with the [appropriate token permissions](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings)