### PR TITLE
Restore io.Reader in format API

### DIFF
--- a/syft/format/decoders.go
+++ b/syft/format/decoders.go
@@ -28,11 +28,11 @@ func Decoders() []sbom.FormatDecoder {
 }
 
 // Identify takes a set of bytes and attempts to identify the format of the SBOM.
-func Identify(reader io.ReadSeeker) (sbom.FormatID, string) {
+func Identify(reader io.Reader) (sbom.FormatID, string) {
 	return staticDecoders.Identify(reader)
 }
 
 // Decode takes a set of bytes and attempts to decode it into an SBOM.
-func Decode(reader io.ReadSeeker) (*sbom.SBOM, sbom.FormatID, string, error) {
+func Decode(reader io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) {
 	return staticDecoders.Decode(reader)
 }

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -276,18 +276,14 @@ func TestSelectName(t *testing.T) {
 			expected: "atlassian-gadgets-api",
 		},
 		{
-			desc: "Filename has period that is not groupid + artifact id",
-			manifest: pkg.JavaManifest{
-				Main: map[string]string{},
-			},
+			desc:     "Filename has period that is not groupid + artifact id",
+			manifest: pkg.JavaManifest{},
 			archive:  newJavaArchiveFilename("/something/http4s-crypto_2.12-0.1.0.jar"),
 			expected: "http4s-crypto_2.12",
 		},
 		{
-			desc: "Filename has period that is not groupid + artifact id, kafka",
-			manifest: pkg.JavaManifest{
-				Main: map[string]string{},
-			},
+			desc:     "Filename has period that is not groupid + artifact id, kafka",
+			manifest: pkg.JavaManifest{},
 			archive:  newJavaArchiveFilename("/something//kafka_2.13-3.2.2.jar"),
 			expected: "kafka_2.13", // see https://mvnrepository.com/artifact/org.apache.kafka/kafka_2.13/3.2.2
 		},


### PR DESCRIPTION
#2515 accidentally was functionally reverted with https://github.com/anchore/syft/pull/2533 . This PR restores this functionality