### PR TITLE
Labeler should ignore latest version

### DIFF
--- a/.github/scripts/labeler.py
+++ b/.github/scripts/labeler.py
@@ -176,7 +176,8 @@ def filter_to_schema_files(list_of_files: list[str]) -> list[str]:
 
 def list_json_schema_files() -> list[str]:
     # list files in "schema/json" directory matching the pattern of "schema-*.json"
-    return sort_json_schema_files(list(glob.glob("schema/json/schema-*.json")))
+    # special case: always ignore the "latest" schema file
+    return sort_json_schema_files([f for f in glob.glob("schema/json/schema-*.json") if "latest" not in f])
 
 
 def run(command: str,  **kwargs) -> subprocess.CompletedProcess:
@@ -197,7 +198,7 @@ def sort_json_schema_files(files: list[str]) -> list[str]:
     # so that "schema/json/schema-1.2.1.json" comes before "schema/json/schema-1.12.1.json".
     versions = [get_semver(file) for file in files if file]
     
-    versions = sorted(versions, key=lambda s: [int(u) for u in s.split('.')])
+    versions = sorted(versions, key=lambda s: [int(u) for u in s.split('.') if "." in s])
 
     return [f"schema/json/schema-{version}.json" for version in versions]
 

--- a/.github/scripts/labeler_test.py
+++ b/.github/scripts/labeler_test.py
@@ -60,6 +60,11 @@ class Labeler(unittest.TestCase):
         expected_sorted_files = ["schema/json/schema-1.2.1.json", "schema/json/schema-1.12.1.json"]
         self.assertEqual(labeler.sort_json_schema_files(files), expected_sorted_files)
 
+        # ensure that "latest" doesn't cause a problem and is ultimately ignored
+        files = ["schema/json/schema-1.12.1.json", "schema/json/schema-_bogus.json"]
+        expected_sorted_files = ["schema/json/schema-_bogus.json", "schema/json/schema-1.12.1.json"]
+        self.assertEqual(labeler.sort_json_schema_files(files), expected_sorted_files)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes when the PR labeler encounters the new [latest version](https://github.com/anchore/syft/pull/2586) file:

```
Run python .github/scripts/labeler.py
[RUN] gh pr view 2587 --json files --jq '.files.[].path'
Traceback (most recent call last):
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 230, in <module>
    main(changed_files, merge_base_schema_files)
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 55, in main
    og_json_schema_files = list_json_schema_files()
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 179, in list_json_schema_files
    return sort_json_schema_files(list(glob.glob("schema/json/schema-*.json")))
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 200, in sort_json_schema_files
    versions = sorted(versions, key=lambda s: [int(u) for u in s.split('.')])
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 200, in <lambda>
    versions = sorted(versions, key=lambda s: [int(u) for u in s.split('.')])
  File "/home/runner/work/syft/syft/.github/scripts/labeler.py", line 200, in <listcomp>
    versions = sorted(versions, key=lambda s: [int(u) for u in s.split('.')])
ValueError: invalid literal for int() with base 10: 'latest'
```