### PR TITLE
Rename binary cataloger to be more unique

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -126,7 +126,7 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 		IncludeUnindexedArchives: cfg.Package.SearchUnindexedArchives,
 	}
 	return pkgcataloging.Config{
-		Binary: binary.DefaultCatalogerConfig(),
+		Binary: binary.DefaultClassifierCatalogerConfig(),
 		Golang: golang.DefaultCatalogerConfig().
 			WithSearchLocalModCacheLicenses(cfg.Golang.SearchLocalModCacheLicenses).
 			WithLocalModCacheDir(cfg.Golang.LocalModCacheDir).

--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -112,7 +112,7 @@ func DefaultPackageTaskFactories() PackageTaskFactories {
 		// other package catalogers ///////////////////////////////////////////////////////////////////////////
 		newPackageTaskFactory(
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
-				return binary.NewCataloger(cfg.PackagesConfig.Binary)
+				return binary.NewClassifierCataloger(cfg.PackagesConfig.Binary)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary",
 		),

--- a/syft/cataloging/pkgcataloging/config.go
+++ b/syft/cataloging/pkgcataloging/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Config struct {
-	Binary      binary.CatalogerConfig            `yaml:"binary" json:"binary" mapstructure:"binary"`
+	Binary      binary.ClassifierCatalogerConfig  `yaml:"binary" json:"binary" mapstructure:"binary"`
 	Golang      golang.CatalogerConfig            `yaml:"golang" json:"golang" mapstructure:"golang"`
 	JavaArchive java.ArchiveCatalogerConfig       `yaml:"java-archive" json:"java-archive" mapstructure:"java-archive"`
 	JavaScript  javascript.CatalogerConfig        `yaml:"javascript" json:"javascript" mapstructure:"javascript"`
@@ -20,7 +20,7 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Binary:      binary.DefaultCatalogerConfig(),
+		Binary:      binary.DefaultClassifierCatalogerConfig(),
 		Golang:      golang.DefaultCatalogerConfig(),
 		LinuxKernel: kernel.DefaultLinuxKernelCatalogerConfig(),
 		Python:      python.DefaultCatalogerConfig(),
@@ -28,7 +28,7 @@ func DefaultConfig() Config {
 	}
 }
 
-func (c Config) WithBinaryConfig(cfg binary.CatalogerConfig) Config {
+func (c Config) WithBinaryConfig(cfg binary.ClassifierCatalogerConfig) Config {
 	c.Binary = cfg
 	return c
 }

--- a/syft/pkg/cataloger/binary/cataloger.go
+++ b/syft/pkg/cataloger/binary/cataloger.go
@@ -15,23 +15,23 @@ import (
 
 const catalogerName = "binary-cataloger"
 
-type CatalogerConfig struct {
+type ClassifierCatalogerConfig struct {
 	Classifiers []Classifier `yaml:"classifiers" json:"classifiers" mapstructure:"classifiers"`
 }
 
-func DefaultCatalogerConfig() CatalogerConfig {
-	return CatalogerConfig{
+func DefaultClassifierCatalogerConfig() ClassifierCatalogerConfig {
+	return ClassifierCatalogerConfig{
 		Classifiers: DefaultClassifiers(),
 	}
 }
 
-func NewCataloger(cfg CatalogerConfig) pkg.Cataloger {
+func NewClassifierCataloger(cfg ClassifierCatalogerConfig) pkg.Cataloger {
 	return &cataloger{
 		classifiers: cfg.Classifiers,
 	}
 }
 
-func (cfg CatalogerConfig) MarshalJSON() ([]byte, error) {
+func (cfg ClassifierCatalogerConfig) MarshalJSON() ([]byte, error) {
 	// only keep the class names
 	var names []string
 	for _, cls := range cfg.Classifiers {

--- a/syft/pkg/cataloger/binary/cataloger_test.go
+++ b/syft/pkg/cataloger/binary/cataloger_test.go
@@ -888,7 +888,7 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.logicalFixture, func(t *testing.T) {
-			c := NewCataloger(DefaultCatalogerConfig())
+			c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 			// logicalFixture is the logical path to the full binary or snippet. This is relative to the test-fixtures/classifiers/snippets
 			// or test-fixtures/classifiers/bin directory . Snippets are searched for first, and if not found, then existing binaries are
@@ -933,7 +933,7 @@ func Test_Cataloger_DefaultClassifiers_PositiveCases_Image(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewCataloger(DefaultCatalogerConfig())
+			c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 			img := imagetest.GetFixtureImage(t, "docker-archive", test.fixtureImage)
 			src, err := source.NewFromStereoscopeImageObject(img, test.fixtureImage, nil)
@@ -964,7 +964,7 @@ func Test_Cataloger_DefaultClassifiers_PositiveCases_Image(t *testing.T) {
 }
 
 func TestClassifierCataloger_DefaultClassifiers_NegativeCases(t *testing.T) {
-	c := NewCataloger(DefaultCatalogerConfig())
+	c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 	src, err := source.NewFromDirectoryPath("test-fixtures/classifiers/negative")
 	assert.NoError(t, err)
@@ -1006,13 +1006,13 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		config     CatalogerConfig
+		config     ClassifierCatalogerConfig
 		fixtureDir string
 		expected   *pkg.Package
 	}{
 		{
 			name: "empty-negative",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 				Classifiers: []Classifier{},
 			},
 			fixtureDir: "test-fixtures/custom/go-1.14",
@@ -1020,7 +1020,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 		},
 		{
 			name: "default-positive",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 				Classifiers: defaultClassifers,
 			},
 			fixtureDir: "test-fixtures/custom/go-1.14",
@@ -1028,7 +1028,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 		},
 		{
 			name: "nodefault-negative",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 				Classifiers: []Classifier{fooClassifier},
 			},
 			fixtureDir: "test-fixtures/custom/go-1.14",
@@ -1036,7 +1036,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 		},
 		{
 			name: "default-extended-positive",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 				Classifiers: append(
 					append([]Classifier{}, defaultClassifers...),
 					fooClassifier,
@@ -1047,7 +1047,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 		},
 		{
 			name: "default-custom-negative",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 
 				Classifiers: append(
 					append([]Classifier{}, defaultClassifers...),
@@ -1066,7 +1066,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 		},
 		{
 			name: "default-cutsom-positive",
-			config: CatalogerConfig{
+			config: ClassifierCatalogerConfig{
 				Classifiers: append(
 					append([]Classifier{}, defaultClassifers...),
 					fooClassifier,
@@ -1078,7 +1078,7 @@ func Test_Cataloger_CustomClassifiers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewCataloger(test.config)
+			c := NewClassifierCataloger(test.config)
 
 			src, err := source.NewFromDirectoryPath(test.fixtureDir)
 			require.NoError(t, err)
@@ -1249,7 +1249,7 @@ func (p *panicyResolver) FileMetadataByLocation(_ file.Location) (file.Metadata,
 var _ file.Resolver = (*panicyResolver)(nil)
 
 func Test_Cataloger_ResilientToErrors(t *testing.T) {
-	c := NewCataloger(DefaultCatalogerConfig())
+	c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 	resolver := &panicyResolver{}
 	_, _, err := c.Catalog(context.Background(), resolver)
@@ -1261,13 +1261,13 @@ func TestCatalogerConfig_MarshalJSON(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		cfg     CatalogerConfig
+		cfg     ClassifierCatalogerConfig
 		want    string
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
 			name: "only show names of classes",
-			cfg: CatalogerConfig{
+			cfg: ClassifierCatalogerConfig{
 				Classifiers: []Classifier{
 					{
 						Class:           "class",


### PR DESCRIPTION
Package catalogers and configurations should be named as specifically as possible to allow room for multiple implementations. In this case #2396 will land potentially another binary cataloger. Renaming this post v1 of syft will require bumping the major version.