### PR TITLE
fix: add BOMRef to CycloneDX OS Component

### DIFF
--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -1,6 +1,7 @@
 package cyclonedxhelpers
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -82,10 +83,12 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 	if len(props) > 0 {
 		properties = &props
 	}
+	bomRef := fmt.Sprintf("os:%s@%s", distro.ID, distro.VersionID)
 	return []cyclonedx.Component{
 		{
-			Type: cyclonedx.ComponentTypeOS,
-			// FIXME is it idiomatic to be using SWID here for specific name and version information?
+			BOMRef: bomRef,
+			Type:   cyclonedx.ComponentTypeOS,
+			// is it idiomatic to be using SWID here for specific name and version information?
 			SWID: &cyclonedx.SWID{
 				TagID:   distro.ID,
 				Name:    distro.ID,
@@ -94,7 +97,7 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 			Description: distro.PrettyName,
 			Name:        distro.ID,
 			Version:     distro.VersionID,
-			// TODO should we add a PURL?
+			// should we add a PURL?
 			CPE:                formatCPE(distro.CPEName),
 			ExternalReferences: eRefs,
 			Properties:         properties,

--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -83,10 +83,9 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 	if len(props) > 0 {
 		properties = &props
 	}
-	bomRef := fmt.Sprintf("os:%s@%s", distro.ID, distro.VersionID)
 	return []cyclonedx.Component{
 		{
-			BOMRef: bomRef,
+			BOMRef: toOSBomRef(distro.ID, distro.VersionID),
 			Type:   cyclonedx.ComponentTypeOS,
 			// is it idiomatic to be using SWID here for specific name and version information?
 			SWID: &cyclonedx.SWID{
@@ -103,6 +102,16 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 			Properties:         properties,
 		},
 	}
+}
+
+func toOSBomRef(name string, version string) string {
+	if name == "" {
+		name = "UNKNOWN_NAME"
+	}
+	if version == "" {
+		version = "UNKNOWN_VERSION"
+	}
+	return fmt.Sprintf("os:%s@%s", name, version)
 }
 
 func formatCPE(cpeString string) string {

--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -106,10 +106,10 @@ func toOSComponent(distro *linux.Release) []cyclonedx.Component {
 
 func toOSBomRef(name string, version string) string {
 	if name == "" {
-		name = "UNKNOWN_NAME"
+		return "os:unknown"
 	}
 	if version == "" {
-		version = "UNKNOWN_VERSION"
+		return fmt.Sprintf("os:%s", name)
 	}
 	return fmt.Sprintf("os:%s@%s", name, version)
 }

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -281,3 +281,43 @@ func Test_toOsComponent(t *testing.T) {
 		})
 	}
 }
+
+func Test_toBomRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		osName    string
+		osVersion string
+		expected  string
+	}{
+		{
+			name:      "no name or version specified",
+			osName:    "",
+			osVersion: "",
+			expected:  "os:UNKNOWN_NAME@UNKNOWN_VERSION",
+		},
+		{
+			name:      "no version specified",
+			osName:    "my-name",
+			osVersion: "",
+			expected:  "os:my-name@UNKNOWN_VERSION",
+		},
+		{
+			name:      "no name specified",
+			osName:    "",
+			osVersion: "my-version",
+			expected:  "os:UNKNOWN_NAME@my-version",
+		},
+		{
+			name:      "both name and version specified",
+			osName:    "my-name",
+			osVersion: "my-version",
+			expected:  "os:my-name@my-version",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := toOSBomRef(test.osName, test.osVersion)
+			require.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -282,7 +282,7 @@ func Test_toOsComponent(t *testing.T) {
 	}
 }
 
-func Test_toBomRef(t *testing.T) {
+func Test_toOSBomRef(t *testing.T) {
 	tests := []struct {
 		name      string
 		osName    string

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers"
+	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
@@ -231,6 +232,52 @@ func Test_toBomDescriptor(t *testing.T) {
 			if d := cmp.Diff(tt.want, subject); d != "" {
 				t.Errorf("toBomDescriptor() mismatch (-want +got):\n%s", d)
 			}
+		})
+	}
+}
+
+func Test_toOsComponent(t *testing.T) {
+	tests := []struct {
+		name     string
+		release  linux.Release
+		expected cyclonedx.Component
+	}{
+		{
+			name: "basic os component",
+			release: linux.Release{
+				ID:        "myLinux",
+				VersionID: "myVersion",
+			},
+			expected: cyclonedx.Component{
+				BOMRef:  "os:myLinux@myVersion",
+				Type:    cyclonedx.ComponentTypeOS,
+				Name:    "myLinux",
+				Version: "myVersion",
+				SWID: &cyclonedx.SWID{
+					TagID:   "myLinux",
+					Name:    "myLinux",
+					Version: "myVersion",
+				},
+				Properties: &[]cyclonedx.Property{
+					{
+						Name:  "syft:distro:id",
+						Value: "myLinux",
+					},
+					{
+						Name:  "syft:distro:versionID",
+						Value: "myVersion",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotSlice := toOSComponent(&test.release)
+			require.Len(t, gotSlice, 1)
+			got := gotSlice[0]
+			require.Equal(t, test.expected, got)
 		})
 	}
 }

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -293,19 +293,19 @@ func Test_toOSBomRef(t *testing.T) {
 			name:      "no name or version specified",
 			osName:    "",
 			osVersion: "",
-			expected:  "os:UNKNOWN_NAME@UNKNOWN_VERSION",
+			expected:  "os:unknown",
 		},
 		{
 			name:      "no version specified",
 			osName:    "my-name",
 			osVersion: "",
-			expected:  "os:my-name@UNKNOWN_VERSION",
+			expected:  "os:my-name",
 		},
 		{
 			name:      "no name specified",
 			osName:    "",
 			osVersion: "my-version",
-			expected:  "os:UNKNOWN_NAME@my-version",
+			expected:  "os:unknown",
 		},
 		{
 			name:      "both name and version specified",

--- a/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -91,6 +91,7 @@
       ]
     },
     {
+      "bom-ref":"redacted",
       "type": "operating-system",
       "name": "debian",
       "version": "1.2.3",

--- a/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -100,6 +100,7 @@
       ]
     },
     {
+      "bom-ref":"redacted",
       "type": "operating-system",
       "name": "debian",
       "version": "1.2.3",

--- a/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -47,7 +47,7 @@
         <property name="syft:metadata:installedSize">0</property>
       </properties>
     </component>
-    <component type="operating-system">
+    <component bom-ref="redacted" type="operating-system">
       <name>debian</name>
       <version>1.2.3</version>
       <description>debian</description>

--- a/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -50,7 +50,7 @@
         <property name="syft:metadata:installedSize">0</property>
       </properties>
     </component>
-    <component type="operating-system">
+    <component bom-ref="redacted" type="operating-system">
       <name>debian</name>
       <version>1.2.3</version>
       <description>debian</description>


### PR DESCRIPTION
This PR adds a `BOMRef` to the output CycloneDX OS Component.

Fixes #2101 