### PR TITLE
Enforce breaking change bump major version

### DIFF
--- a/.chronicle.yaml
+++ b/.chronicle.yaml
@@ -1,4 +1,4 @@
-enforce-v0: true # don't make breaking-change label bump major version before 1.0.
+enforce-v0: false
 title: ""
 
 github:


### PR DESCRIPTION
This changes the behavior of [chronicle](https://github.com/anchore/chronicle) when determining the next version during release to allow bumping of the major version when there are breaking changes.