### PR TITLE
fix: update runner size to use larger HD for codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core-16gb
 
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary

Syft is seeing some failures in codeql because of HD issues. This runner update should give us enough space.