### PR TITLE
Fix considering base path when ignoring known bad unix paths

### DIFF
--- a/syft/internal/fileresolver/directory_indexer_test.go
+++ b/syft/internal/fileresolver/directory_indexer_test.go
@@ -135,7 +135,7 @@ func TestDirectoryIndexer_handleFileAccessErr(t *testing.T) {
 }
 
 func TestDirectoryIndexer_IncludeRootPathInIndex(t *testing.T) {
-	filterFn := func(path string, _ os.FileInfo, _ error) error {
+	filterFn := func(_, path string, _ os.FileInfo, _ error) error {
 		if path != "/" {
 			return fs.SkipDir
 		}
@@ -224,7 +224,7 @@ func TestDirectoryIndexer_index(t *testing.T) {
 
 func TestDirectoryIndexer_SkipsAlreadyVisitedLinkDestinations(t *testing.T) {
 	var observedPaths []string
-	pathObserver := func(p string, _ os.FileInfo, _ error) error {
+	pathObserver := func(_, p string, _ os.FileInfo, _ error) error {
 		fields := strings.Split(p, "test-fixtures/symlinks-prune-indexing")
 		if len(fields) < 2 {
 			return nil
@@ -380,6 +380,87 @@ func Test_allContainedPaths(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, allContainedPaths(tt.path))
+		})
+	}
+}
+
+func Test_relativePath(t *testing.T) {
+	tests := []struct {
+		name      string
+		basePath  string
+		givenPath string
+		want      string
+	}{
+		{
+			name:      "root: same relative path",
+			basePath:  "a/b/c",
+			givenPath: "a/b/c",
+			want:      "/",
+		},
+		{
+			name:      "root: same absolute path",
+			basePath:  "/a/b/c",
+			givenPath: "/a/b/c",
+			want:      "/",
+		},
+		{
+			name:      "contained path: relative",
+			basePath:  "a/b/c",
+			givenPath: "a/b/c/dev",
+			want:      "/dev",
+		},
+		{
+			name:      "contained path: absolute",
+			basePath:  "/a/b/c",
+			givenPath: "/a/b/c/dev",
+			want:      "/dev",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, relativePath(tt.basePath, tt.givenPath))
+		})
+	}
+}
+
+func Test_disallowUnixSystemRuntimePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		path    string
+		wantErr require.ErrorAssertionFunc
+	}{
+		{
+			name:    "no base, matching path",
+			base:    "",
+			path:    "/dev",
+			wantErr: require.Error,
+		},
+		{
+			name:    "no base, non-matching path",
+			base:    "",
+			path:    "/not-dev",
+			wantErr: require.NoError,
+		},
+		{
+			name:    "base, matching path",
+			base:    "/a/b/c",
+			path:    "/a/b/c/dev",
+			wantErr: require.Error,
+		},
+		{
+			name:    "base, non-matching path due to bad relative alignment",
+			base:    "/a/b/c",
+			path:    "/dev",
+			wantErr: require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			tt.wantErr(t, disallowUnixSystemRuntimePath(tt.base, tt.path, nil, nil))
 		})
 	}
 }

--- a/syft/internal/fileresolver/directory_test.go
+++ b/syft/internal/fileresolver/directory_test.go
@@ -918,7 +918,7 @@ func Test_isUnallowableFileType(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, disallowByFileType("dont/care", test.info, nil))
+			assert.Equal(t, test.expected, disallowByFileType("", "dont/care", test.info, nil))
 		})
 	}
 }
@@ -999,7 +999,7 @@ func Test_IndexingNestedSymLinks(t *testing.T) {
 }
 
 func Test_IndexingNestedSymLinks_ignoredIndexes(t *testing.T) {
-	filterFn := func(path string, _ os.FileInfo, _ error) error {
+	filterFn := func(_, path string, _ os.FileInfo, _ error) error {
 		if strings.HasSuffix(path, string(filepath.Separator)+"readme") {
 			return ErrSkipPath
 		}
@@ -1144,7 +1144,7 @@ func Test_isUnixSystemRuntimePath(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, disallowUnixSystemRuntimePath(test.path, nil, nil))
+			assert.Equal(t, test.expected, disallowUnixSystemRuntimePath("", test.path, nil, nil))
 		})
 	}
 }

--- a/syft/source/directory_source.go
+++ b/syft/source/directory_source.go
@@ -197,7 +197,7 @@ func getDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 	}
 
 	return []fileresolver.PathIndexVisitor{
-		func(path string, info os.FileInfo, _ error) error {
+		func(_, path string, info os.FileInfo, _ error) error {
 			for _, exclusion := range exclusions {
 				// this is required to handle Windows filepaths
 				path = filepath.ToSlash(path)

--- a/syft/source/directory_source_test.go
+++ b/syft/source/directory_source_test.go
@@ -392,7 +392,7 @@ func Test_getDirectoryExclusionFunctions_crossPlatform(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, f := range fns {
-				result := f(test.path, test.finfo, nil)
+				result := f("", test.path, test.finfo, nil)
 				require.Equal(t, test.walkHint, result)
 			}
 		})

--- a/syft/source/file_source.go
+++ b/syft/source/file_source.go
@@ -177,7 +177,7 @@ func (s FileSource) FileResolver(_ Scope) (file.Resolver, error) {
 		exclusionFunctions = append([]fileresolver.PathIndexVisitor{
 
 			// note: we should exclude these kinds of paths first before considering any other user-provided exclusions
-			func(p string, _ os.FileInfo, _ error) error {
+			func(_, p string, _ os.FileInfo, _ error) error {
 				if p == absParentDir {
 					// this is the root directory... always include it
 					return nil


### PR DESCRIPTION
Fixes #2627

This updates the logic when considering paths to ignore/filter out during the indexing phase of the directory file resolver. Currently we ignore known common paths that mount to filesystems that provide no packages (e.g. `/dev` and `/proc`). This currently doesn't consider cases when the filesystem being scanned isn't mounted at root (when there is a `base-path` to consider). For example, when scanning `/some/mount/path` and there is a path `/some/mount/path/dev`, we should be considering that latter path during indexing to be `/dev`. Ultimately the index value is correct, but filter functions do not have the option to observe the value of `base-path` (i.e. `/some/mount/path`) to calculate the relative path of the target.

This PR changes the behavior to allow filter functions to have access to `base-path`. We currently have some filter functions that need to consider the relative path and some that need to consider the real path, so a further-upstream-change of this function could not be made (that is, pass down the relative path into the filter functions).