### PR TITLE
Survive indexing dead symlinks

### DIFF
--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -176,6 +176,12 @@ func isRealPath(root string) (bool, error) {
 func (r *directoryIndexer) indexBranch(root string, stager *progress.Stage) ([]string, error) {
 	rootRealPath, err := filepath.EvalSymlinks(root)
 	if err != nil {
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			// we can't index the path, but we shouldn't consider this to be fatal
+			// TODO: known-unknowns
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -180,6 +180,7 @@ func (r *directoryIndexer) indexBranch(root string, stager *progress.Stage) ([]s
 		if errors.As(err, &pathErr) {
 			// we can't index the path, but we shouldn't consider this to be fatal
 			// TODO: known-unknowns
+			log.WithFields("root", root, "error", err).Trace("unable to evaluate symlink while indexing branch")
 			return nil, nil
 		}
 		return nil, err

--- a/syft/internal/fileresolver/directory_indexer_test.go
+++ b/syft/internal/fileresolver/directory_indexer_test.go
@@ -222,6 +222,18 @@ func TestDirectoryIndexer_index(t *testing.T) {
 	}
 }
 
+func TestDirectoryIndexer_index_survive_badSymlink(t *testing.T) {
+	// test-fixtures/bad-symlinks
+	// ├── root
+	// │   ├── place
+	// │   │   └── fd -> ../somewhere/self/fd
+	// │   └── somewhere
+	// ...
+	indexer := newDirectoryIndexer("test-fixtures/bad-symlinks/root/place/fd", "test-fixtures/bad-symlinks/root/place/fd")
+	_, _, err := indexer.build()
+	require.NoError(t, err)
+}
+
 func TestDirectoryIndexer_SkipsAlreadyVisitedLinkDestinations(t *testing.T) {
 	var observedPaths []string
 	pathObserver := func(p string, _ os.FileInfo, _ error) error {

--- a/syft/internal/fileresolver/test-fixtures/bad-symlinks/root/place/fd
+++ b/syft/internal/fileresolver/test-fixtures/bad-symlinks/root/place/fd
@@ -1,0 +1,1 @@
+../somewhere/self/fd


### PR DESCRIPTION
Related to https://github.com/anchore/syft/issues/2627 , we want to be able to survive the indexing process even when we are indexing a new branch in the directory tree that happens to be a symlink pointing to a non existent file. Ultimately this will be recorded as a known-unknown, but for now we at least want to survive when this occurs and allow for the SBOM to be created.