### PR TITLE
fix Windows file paths in local go mod cache

### DIFF
--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -61,11 +62,11 @@ func NewFromUnindexedDirectoryFS(fs afero.Fs, dir string, base string) file.Writ
 	}
 	wd, err := os.Getwd()
 	if err == nil {
-		if !path.IsAbs(dir) {
-			dir = path.Clean(path.Join(wd, dir))
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Clean(filepath.Join(wd, dir))
 		}
-		if base != "" && !path.IsAbs(base) {
-			base = path.Clean(path.Join(wd, base))
+		if base != "" && !filepath.IsAbs(base) {
+			base = filepath.Clean(filepath.Join(wd, base))
 		}
 	}
 	return UnindexedDirectory{

--- a/syft/pkg/cataloger/golang/config.go
+++ b/syft/pkg/cataloger/golang/config.go
@@ -2,7 +2,7 @@ package golang
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -75,11 +75,11 @@ func DefaultCatalogerConfig() CatalogerConfig {
 			if err != nil {
 				log.Debug("unable to determine user home dir: %v", err)
 			} else {
-				goPath = path.Join(homeDir, "go")
+				goPath = filepath.Join(homeDir, "go")
 			}
 		}
 		if goPath != "" {
-			g.LocalModCacheDir = path.Join(goPath, "pkg", "mod")
+			g.LocalModCacheDir = filepath.Join(goPath, "pkg", "mod")
 		}
 	}
 	return g


### PR DESCRIPTION
Previously, the file resolver was created from incorrect calls (path.Join instead of filepath.Join) which resulted Go license searches always missing on Windows. Use filepath.* functions when initializing the Go config, and when the unindexed file resolver is being created.

See #2615 - this fixes some of the specific problems reported in that issue, but I'm leaving that issue open to track better integration testing of syft and grype on Windows.

TODOs:

- [ ] unit tests
- [ ] audit other configs and go license paths for incorrect path.Join use where filepath is needed
- [ ] Add Windows CI runner to prevent introduction of this sort of bug in the future (probably separate PRs :) )