### PR TITLE
fix: add correct vendor for dnsmasq CPE

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -344,6 +344,17 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "wpa_supplicant"},
 			candidateAddition{AdditionalVendors: []string{"w1.fi"}},
 		},
+		{
+			pkg.ApkPkg,
+			candidateKey{PkgName: "dnsmasq", Vendor: "dnsmasq"},
+			candidateAddition{AdditionalVendors: []string{"thekelleys"}},
+		},
+		// Debian packages
+		{
+			pkg.DebPkg,
+			candidateKey{PkgName: "dnsmasq", Vendor: "dnsmasq"},
+			candidateAddition{AdditionalVendors: []string{"thekelleys"}},
+		},
 		//
 		// Binary packages
 		{


### PR DESCRIPTION
This PR adds an appropriate vendor for `dnsmasq` for APK and DPKG.

Partially fixes #2636