### PR TITLE
fix(install): actually return right error codes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -694,6 +694,7 @@ main() (
 set +u
 if [ -z "${TEST_INSTALL_SH}" ]; then
   set -u
-  exit $(main "$@")
+  main "$@"
+  exit $?
 fi
 set -u


### PR DESCRIPTION
Previously exit was called with the stdout content of the main function. This did not make sense and
resulted in the script not returning the expected exit codes when main returned a non-zero code.

Strangely enough this broken code was introduced in response to #1566 but I do not see how it ever worked unless the script used to echo its intended exit code.