### PR TITLE
fix: SPDX tag value version selector

### DIFF
--- a/cmd/syft/internal/options/format.go
+++ b/cmd/syft/internal/options/format.go
@@ -3,6 +3,7 @@ package options
 import (
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/syft/format"
+	"github.com/anchore/syft/syft/format/spdxtagvalue"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -41,9 +42,10 @@ func (o Format) Encoders() ([]sbom.FormatEncoder, error) {
 	return format.EncodersConfig{
 		Template:      o.Template.config(),
 		SyftJSON:      o.SyftJSON.config(),
-		SPDXJSON:      o.SPDXJSON.config(format.AllVersions),      // we support multiple versions, not just a single version
-		CyclonedxJSON: o.CyclonedxJSON.config(format.AllVersions), // we support multiple versions, not just a single version
-		CyclonedxXML:  o.CyclonedxXML.config(format.AllVersions),  // we support multiple versions, not just a single version
+		SPDXJSON:      o.SPDXJSON.config(format.AllVersions),                   // we support multiple versions, not just a single version
+		SPDXTagValue:  spdxtagvalue.EncoderConfig{Version: format.AllVersions}, // we support multiple versions, not just a single version
+		CyclonedxJSON: o.CyclonedxJSON.config(format.AllVersions),              // we support multiple versions, not just a single version
+		CyclonedxXML:  o.CyclonedxXML.config(format.AllVersions),               // we support multiple versions, not just a single version
 	}.Encoders()
 }
 

--- a/test/cli/all_formats_expressible_test.go
+++ b/test/cli/all_formats_expressible_test.go
@@ -39,3 +39,40 @@ func TestAllFormatsExpressible(t *testing.T) {
 		})
 	}
 }
+
+func Test_formatVersionsExpressible(t *testing.T) {
+	tests := []struct {
+		format    string
+		assertion traitAssertion
+	}{
+		{
+			format:    "spdx@2.1",
+			assertion: assertInOutput("SPDXVersion: SPDX-2.1"),
+		},
+		{
+			format:    "spdx@2.2",
+			assertion: assertInOutput("SPDXVersion: SPDX-2.2"),
+		},
+		{
+			format:    "spdx@2.3",
+			assertion: assertInOutput("SPDXVersion: SPDX-2.3"),
+		},
+		{
+			format:    "spdx-json@2.2",
+			assertion: assertInOutput(`"spdxVersion":"SPDX-2.2"`),
+		},
+		{
+			format:    "spdx-json@2.3",
+			assertion: assertInOutput(`"spdxVersion":"SPDX-2.3"`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.format, func(t *testing.T) {
+			args := []string{"dir:./test-fixtures/image-pkg-coverage", "-o", test.format}
+			cmd, stdout, stderr := runSyft(t, nil, args...)
+			test.assertion(t, stdout, stderr, cmd.ProcessState.ExitCode())
+			logOutputOnFailure(t, cmd, stdout, stderr)
+		})
+	}
+}


### PR DESCRIPTION
Using SPDX Tag-Value with a version selector was not working, instead defaulting to the latest version (`2.3`). This PR corrects the issue so selecting other versions works as expected, e.g. `spdx@2.2`.