### PR TITLE
fix: trim path from deps.json in portable way

### DIFF
--- a/syft/pkg/cataloger/dotnet/package.go
+++ b/syft/pkg/cataloger/dotnet/package.go
@@ -37,7 +37,7 @@ func newDotnetDepsPackage(nameVersion string, lib dotnetDepsLibrary, locations .
 }
 
 func getDepsJSONFilePrefix(p string) string {
-	r := regexp.MustCompile(`([^\/]+)\.deps\.json$`)
+	r := regexp.MustCompile(`([^\\\/]+)\.deps\.json$`)
 	match := r.FindStringSubmatch(p)
 	if len(match) > 1 {
 		return match[1]

--- a/syft/pkg/cataloger/dotnet/package_test.go
+++ b/syft/pkg/cataloger/dotnet/package_test.go
@@ -1,0 +1,40 @@
+package dotnet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_getDepsJSONFilePrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "windows-style full path",
+			path: `C:\Code\Projects\My-Project\My.Rest.Project.deps.json`,
+			want: "My.Rest.Project",
+		},
+		{
+			name: "leading backslash",
+			path: `\My.Project.deps.json`,
+			want: "My.Project",
+		},
+		{
+			name: "unix-style path with lots of prefixes",
+			path: "/my/cool/project/cool-project.deps.json",
+			want: "cool-project",
+		},
+		{
+			name: "unix-style relative path",
+			path: "cool-project/my-dotnet-project.deps.json",
+			want: "my-dotnet-project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, getDepsJSONFilePrefix(tt.path), "getDepsJSONFilePrefix(%v)", tt.path)
+		})
+	}
+}


### PR DESCRIPTION
Previously, the path trimming regex would leave leading path separator in place on Windows.

Probably a better long term fix is to a library path operation.

Fixes #2264 

## TODO

- [x] unit tests
- [x] ~use something more like filepath.Basename + removeSuffix~ (actually, we can't do this because the artifact being scanned might not use the same path separators as the host where syft is running).
- [x] Research why this was introduced - #2264 gives us a narrow range of commits to look in. Maybe something change with the resolvers? Maybe the regex just changed?

@wagoodman and I talked about this, and it doesn't seem like an underlying bug in the file abstraction, so I'm considering the investigation that was the last todo completed.