### PR TITLE
Consider filesystem types for mount points when ignoring system paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/anchore/bubbly v0.0.0-20231115134915-def0aba654a9
 	github.com/anchore/clio v0.0.0-20240209204744-cb94e40a4f65
 	github.com/anchore/fangs v0.0.0-20231201140849-5075d28d6d8b
+	github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 	github.com/anchore/go-logger v0.0.0-20230725134548-c21dafa1ec5a
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
@@ -53,6 +54,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/sys/mountinfo v0.7.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pelletier/go-toml v1.9.5
@@ -79,8 +81,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.29.2
 )
-
-require github.com/anchore/go-collections v0.0.0-20240216171411-9321230ce537
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
@@ -161,7 +161,6 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/sys/mountinfo v0.6.2 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/muesli/ansi v0.0.0-20211031195517-c9f0611b6c70 // indirect

--- a/go.sum
+++ b/go.sum
@@ -571,8 +571,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
-github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/mountinfo v0.7.1 h1:/tTvQaSJRr2FshkhXiIpux6fQ2Zvc4j7tAhMTStAG2g=
+github.com/moby/sys/mountinfo v0.7.1/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
 github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/signal v0.7.0 h1:25RW3d5TnQEoKvRbEKUGay6DCQ46IxAVTT9CUMgmsSI=

--- a/syft/internal/fileresolver/directory.go
+++ b/syft/internal/fileresolver/directory.go
@@ -14,12 +14,6 @@ import (
 	"github.com/anchore/syft/syft/internal/windows"
 )
 
-var unixSystemRuntimePrefixes = []string{
-	"/proc",
-	"/dev",
-	"/sys",
-}
-
 var ErrSkipPath = errors.New("skip path")
 
 var _ file.Resolver = (*Directory)(nil)

--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -472,18 +472,20 @@ func keepUnixSystemMountPaths(infos []*mountinfo.Info) []string {
 		if info == nil {
 			continue
 		}
-		// on a unix system you may see:
-		// - tmpfs: a memory-based filesystem (e.g. /tmp, /dev, /sys/firmware)
-		// - devtmpfs: a virtual filesystem that provides access to devices (e.g. /dev)
-		// - shm: a shared memory filesystem (e.g. /dev/shm)
-		// - proc: a virtual filesystem that provides access to process information (e.g. /proc)
-		// - sysfs: a virtual filesystem that provides access to kernel information (e.g. /sys)
-
-		// on a darwin system you may see:
-		// - devfs: a virtual filesystem that provides access to devices (e.g. /dev)
+		// we're only interested in ignoring the logical filesystems typically found at these mount points:
+		// - /proc
+		//     - procfs
+		//     - proc
+		// - /sys
+		//     - sysfs
+		// - /dev
+		//     - devfs - BSD/darwin flavored systems and old linux systems
+		//     - devtmpfs - driver core maintained /dev tmpfs
+		//     - udev - userspace implementation that replaced devfs
+		//     - tmpfs - used for /dev in special instances (within a container)
 
 		switch info.FSType {
-		case "tmpfs", "devfs", "devtmpfs", "shm", "proc", "sysfs":
+		case "proc", "procfs", "sysfs", "devfs", "devtmpfs", "udev", "tmpfs":
 			log.WithFields("mountpoint", info.Mountpoint).Debug("ignoring system mountpoint")
 
 			mountPaths = append(mountPaths, info.Mountpoint)

--- a/syft/internal/fileresolver/directory_test.go
+++ b/syft/internal/fileresolver/directory_test.go
@@ -1109,6 +1109,10 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 }
 
 func Test_isUnixSystemRuntimePath(t *testing.T) {
+	unixSubject := unixSystemMountFinder{
+		// mock out detecting the mount points
+		disallowedMountPaths: []string{"/proc", "/sys", "/dev"},
+	}
 	tests := []struct {
 		path     string
 		expected error
@@ -1144,7 +1148,7 @@ func Test_isUnixSystemRuntimePath(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, disallowUnixSystemRuntimePath("", test.path, nil, nil))
+			assert.Equal(t, test.expected, unixSubject.disallowUnixSystemRuntimePath("", test.path, nil, nil))
 		})
 	}
 }

--- a/syft/internal/fileresolver/directory_test.go
+++ b/syft/internal/fileresolver/directory_test.go
@@ -1108,51 +1108,6 @@ func Test_directoryResolver_FileContentsByLocation(t *testing.T) {
 	}
 }
 
-func Test_isUnixSystemRuntimePath(t *testing.T) {
-	unixSubject := unixSystemMountFinder{
-		// mock out detecting the mount points
-		disallowedMountPaths: []string{"/proc", "/sys", "/dev"},
-	}
-	tests := []struct {
-		path     string
-		expected error
-	}{
-		{
-			path: "proc/place",
-		},
-		{
-			path:     "/proc/place",
-			expected: fs.SkipDir,
-		},
-		{
-			path:     "/proc",
-			expected: fs.SkipDir,
-		},
-		{
-			path: "/pro/c",
-		},
-		{
-			path: "/pro",
-		},
-		{
-			path:     "/dev",
-			expected: fs.SkipDir,
-		},
-		{
-			path:     "/sys",
-			expected: fs.SkipDir,
-		},
-		{
-			path: "/something/sys",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.path, func(t *testing.T) {
-			assert.Equal(t, test.expected, unixSubject.disallowUnixSystemRuntimePath("", test.path, nil, nil))
-		})
-	}
-}
-
 func Test_SymlinkLoopWithGlobsShouldResolve(t *testing.T) {
 	test := func(t *testing.T) {
 		resolver, err := NewFromDirectory("./test-fixtures/symlinks-loop", "")


### PR DESCRIPTION
Implements [the suggestion](https://github.com/anchore/syft/issues/2667#issuecomment-1964744118) from @klakin-pivotal to look at the system mounts and determine if the filesystem types indicate which parts of the overall filetree to ignore when indexing for the directory file resolver.

Replaces #2668 

Fixes https://github.com/anchore/syft/issues/2667