### PR TITLE
Mark duplicated rows in table output

### DIFF
--- a/syft/format/table/encoder_test.go
+++ b/syft/format/table/encoder_test.go
@@ -23,7 +23,7 @@ func TestTableEncoder(t *testing.T) {
 	)
 }
 
-func TestRemoveDuplicateRows(t *testing.T) {
+func Test_markDuplicateRows(t *testing.T) {
 	data := [][]string{
 		{"1", "2", "3"},
 		{"a", "b", "c"},
@@ -35,13 +35,13 @@ func TestRemoveDuplicateRows(t *testing.T) {
 	}
 
 	expected := [][]string{
-		{"1", "2", "3"},
-		{"a", "b", "c"},
-		{"4", "5", "6"},
-		{"1", "2", "1"},
+		{"1", "2", "3", "(+2 duplicates)"},
+		{"a", "b", "c", "(+1 duplicate)"},
+		{"4", "5", "6", ""},
+		{"1", "2", "1", ""},
 	}
 
-	actual := removeDuplicateRows(data)
+	actual := markDuplicateRows(data)
 
 	if diffs := deep.Equal(expected, actual); len(diffs) > 0 {
 		t.Errorf("found diffs!")

--- a/syft/format/table/test-fixtures/snapshot/TestTableEncoder.golden
+++ b/syft/format/table/test-fixtures/snapshot/TestTableEncoder.golden
@@ -1,3 +1,3 @@
-NAME       VERSION  TYPE   
-package-1  1.0.1    python  
-package-2  2.0.1    deb     
+NAME       VERSION  TYPE     
+package-1  1.0.1    python    
+package-2  2.0.1    deb       


### PR DESCRIPTION
The number of rows in the table output does not always match the TUI package counts when there are duplicate packages found (in terms of a `(name, version, type)` tuple). This PR adjusts the output to specifically indicate which rows are duplicated and by how much.

Closes #2672 