### PR TITLE
docs: add simplest example from regsitry

### DIFF
--- a/examples/source_from_registry/main.go
+++ b/examples/source_from_registry/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/format/syftjson"
+)
+
+// This example demonstrates how to create an SBOM, pulling only from "registry", with error handling omitted
+func main() {
+	image := "alpine:3.19"
+
+	src, _ := syft.GetSource(context.Background(), image, syft.DefaultGetSourceConfig().WithSources("registry"))
+
+	sbom, _ := syft.CreateSBOM(context.Background(), src, syft.DefaultCreateSBOMConfig())
+
+	_ = syftjson.NewFormatEncoder().Encode(os.Stdout, *sbom)
+}


### PR DESCRIPTION
This just adds another simple example of the Syft API usage, which demonstrates how to use a specific source.