### PR TITLE
Adding the ability to retrieve remote licenses from package-lock.json

### DIFF
--- a/syft/pkg/cataloger/javascript/cataloger.go
+++ b/syft/pkg/cataloger/javascript/cataloger.go
@@ -17,8 +17,9 @@ func NewPackageCataloger() pkg.Cataloger {
 // NewLockCataloger returns a new cataloger object for NPM (and NPM-adjacent, such as yarn) lock files.
 func NewLockCataloger(cfg CatalogerConfig) pkg.Cataloger {
 	yarnLockAdapter := newGenericYarnLockAdapter(cfg)
+	packageLockAdapter := newGenericPackageLockAdapter(cfg)
 	return generic.NewCataloger("javascript-lock-cataloger").
-		WithParserByGlobs(parsePackageLock, "**/package-lock.json").
+		WithParserByGlobs(packageLockAdapter.parsePackageLock, "**/package-lock.json").
 		WithParserByGlobs(yarnLockAdapter.parseYarnLock, "**/yarn.lock").
 		WithParserByGlobs(parsePnpmLock, "**/pnpm-lock.yaml")
 }

--- a/syft/pkg/cataloger/javascript/parse_package_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock_test.go
@@ -106,7 +106,8 @@ func TestParsePackageLock(t *testing.T) {
 		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
 	}
 
-	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+	adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expectedPkgs, expectedRelationships)
 }
 
 func TestParsePackageLockV2(t *testing.T) {
@@ -169,7 +170,8 @@ func TestParsePackageLockV2(t *testing.T) {
 	for i := range expectedPkgs {
 		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
 	}
-	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+	adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expectedPkgs, expectedRelationships)
 }
 
 func TestParsePackageLockV3(t *testing.T) {
@@ -220,7 +222,8 @@ func TestParsePackageLockV3(t *testing.T) {
 	for i := range expectedPkgs {
 		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
 	}
-	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+	adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expectedPkgs, expectedRelationships)
 }
 
 func TestParsePackageLockAlias(t *testing.T) {
@@ -279,7 +282,8 @@ func TestParsePackageLockAlias(t *testing.T) {
 		for i := range expected {
 			expected[i].Locations.Add(file.NewLocation(pl))
 		}
-		pkgtest.TestFileParser(t, pl, parsePackageLock, expected, expectedRelationships)
+		adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+		pkgtest.TestFileParser(t, pl, adapter.parsePackageLock, expected, expectedRelationships)
 	}
 }
 
@@ -326,5 +330,6 @@ func TestParsePackageLockLicenseWithArray(t *testing.T) {
 	for i := range expectedPkgs {
 		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
 	}
-	pkgtest.TestFileParser(t, fixture, parsePackageLock, expectedPkgs, expectedRelationships)
+	adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expectedPkgs, expectedRelationships)
 }


### PR DESCRIPTION
Extending https://github.com/anchore/syft/pull/2338 to also be able to retrieve remote licenses from package.lock. I only tested v2 package-lock.json.