### PR TITLE
Dont include labels for dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,19 @@
 version: 2
+
 updates:
+
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Dependabot is starting to include labels for each ecosystem that is being updated, which is great, but in a repo like syft where we have labels that represent cataloger features/bugs/etc, this is a little confusing. 

PR: https://github.com/anchore/syft/pull/2717
Log: https://github.com/anchore/syft/network/updates/800618339

<img width="242" alt="Screenshot 2024-03-15 at 10 27 54 AM" src="https://github.com/anchore/syft/assets/590471/15258c37-2d3c-4c4f-86f2-90d5dd52dcd8">

For the meantime I've deleted the `github_actions` and `github-actions` (duplicate-ish) labels.

From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels

> By default, Dependabot raises all pull requests with the dependencies label. If more than one package manager is defined, Dependabot includes an additional label on each pull request. This indicates which language or ecosystem the pull request will update, for example: java for Gradle updates and submodules for git submodule updates. Dependabot creates these default labels automatically, as necessary in your repository.
>
> Use labels to override the default labels and specify alternative labels for all pull requests raised for a package manager. If any of these labels is not defined in the repository, it is ignored. To disable all labels, including the default labels, use labels: [ ].

For the meantime I'm just going to take off the ecosystem labels, we can always override them with more labels later if we want.