### PR TITLE
fix: panic scanning binaries without symtab

### DIFF
--- a/syft/file/cataloger/executable/macho.go
+++ b/syft/file/cataloger/executable/macho.go
@@ -57,6 +57,9 @@ func machoHasEntrypoint(f *macho.File) bool {
 }
 
 func machoHasExports(f *macho.File) bool {
+	if f == nil || f.Symtab == nil {
+		return false
+	}
 	for _, sym := range f.Symtab.Syms {
 		// look for symbols that are:
 		//  - not private and are external

--- a/syft/file/cataloger/executable/macho_test.go
+++ b/syft/file/cataloger/executable/macho_test.go
@@ -69,6 +69,11 @@ func Test_machoHasExports(t *testing.T) {
 			fixture: "bin/hello_mac",
 			want:    false,
 		},
+		{
+			name:    "gcc-amd64-darwin-exec-debug",
+			fixture: "bin/gcc-amd64-darwin-exec-debug",
+			want:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/syft/file/cataloger/executable/test-fixtures/shared-info/project/Makefile
+++ b/syft/file/cataloger/executable/test-fixtures/shared-info/project/Makefile
@@ -1,10 +1,13 @@
 # invoke all make files in subdirectories
 .PHONY: all hello libhello
 
-all: hello libhello
+all: hello libhello ../bin/gcc-amd64-darwin-exec-debug
 
 hello:
 	$(MAKE) -C hello
 
 libhello:
 	$(MAKE) -C libhello
+
+../bin/gcc-amd64-darwin-exec-debug:
+	curl -L -o ../bin/gcc-amd64-darwin-exec-debug  https://github.com/golang/tools/raw/9ed98faabadd2cb94de86d5290b1c6942b7c4877/cmd/splitdwarf/internal/macho/testdata/gcc-amd64-darwin-exec-debug


### PR DESCRIPTION
This PR fixes a panic when scanning binaries without symtab information.

Fixes #2736 