### PR TITLE
fix: conan poco project cpe

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -351,6 +351,12 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "node"},
 			candidateAddition{AdditionalProducts: []string{"nodejs", "node.js"}},
 		},
+		// Conan packages
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "poco"},
+			candidateAddition{AdditionalVendors: []string{"pocoproject"}},
+		},
 	})
 
 var defaultCandidateRemovals = buildCandidateRemovalLookup(


### PR DESCRIPTION
The official NVD-assigned CPE for poco is `pocoproject:poco`

Fixes: https://github.com/anchore/grype/issues/1737 