### PR TITLE
FIx: CPE validation correctly returns error

### DIFF
--- a/syft/cpe/cpe.go
+++ b/syft/cpe/cpe.go
@@ -95,7 +95,7 @@ func NewAttributes(cpeStr string) (Attributes, error) {
 	}
 
 	// ensure that this Attributes can be validated after being fully sanitized
-	if ValidateString(c.String()) != nil {
+	if err = ValidateString(c.String()); err != nil {
 		return Attributes{}, err
 	}
 

--- a/syft/cpe/cpe_test.go
+++ b/syft/cpe/cpe_test.go
@@ -17,6 +17,7 @@ func Test_NewAttributes(t *testing.T) {
 		name     string
 		input    string
 		expected Attributes
+		wantErr  require.ErrorAssertionFunc
 	}{
 		{
 			name:     "gocase",
@@ -33,14 +34,21 @@ func Test_NewAttributes(t *testing.T) {
 			input:    `cpe:/a:%240.99_kindle_books_project:%240.99_kindle_books:6::~~~android~~`,
 			expected: MustAttributes(`cpe:2.3:a:\$0.99_kindle_books_project:\$0.99_kindle_books:6:*:*:*:*:android:*:*`),
 		},
+		{
+			name:    "null byte in version for some reason",
+			input:   "cpe:2.3:a:oracle:openjdk:11.0.22+7\u0000-J-ms8m:*:*:*:*:*:*:*",
+			wantErr: require.Error,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			actual, err := NewAttributes(test.input)
-			if err != nil {
-				t.Fatalf("got an error while creating Attributes: %+v", err)
+			if test.wantErr != nil {
+				test.wantErr(t, err)
+				return
 			}
+			require.NoError(t, err)
 
 			if d := cmp.Diff(actual, test.expected); d != "" {
 				t.Errorf("Attributes mismatch (-want +got):\n%s", d)

--- a/syft/pkg/collection_test.go
+++ b/syft/pkg/collection_test.go
@@ -381,7 +381,7 @@ func TestCatalog_MergeRecords(t *testing.T) {
 					Type: RpmPkg,
 				},
 				{
-					CPEs: []cpe.CPE{cpe.Must("cpe:2.3:b:package:1:1:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource)},
+					CPEs: []cpe.CPE{cpe.Must("cpe:2.3:a:package:2:2:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource)},
 					Locations: file.NewLocationSet(
 						file.NewVirtualLocationFromCoordinates(
 							file.Coordinates{


### PR DESCRIPTION
Previously, this method incorrectly return an empty Attributes object and a nil error, leading to callers attempting to use the empty attributes object.

We need to be careful with this, because turning on validation that previously had no effect is always a little scary. Creating for discussion for now.