### PR TITLE
Fix removing labels in 'Detect schema changes' job

### DIFF
--- a/.github/scripts/labeler.py
+++ b/.github/scripts/labeler.py
@@ -56,6 +56,8 @@ def main(changed_files: str | None = None, merge_base_schema_files: str | None =
 
     pr_json_schema_files = filter_to_schema_files(pr_changed_files)
 
+    pr_labels = get_pr_labels(pr_number)
+
     # print("schema files in pr:   ", summarize_schema_files(pr_json_schema_files))
     # print("og schema files:      ", summarize_schema_files(og_json_schema_files))
 
@@ -76,7 +78,8 @@ def main(changed_files: str | None = None, merge_base_schema_files: str | None =
         add_label(pr_number, JSON_SCHEMA_LABEL)
 
     else:
-        remove_label(pr_number, JSON_SCHEMA_LABEL)
+        if JSON_SCHEMA_LABEL in pr_labels:
+            remove_label(pr_number, JSON_SCHEMA_LABEL)
 
     # new schema files should be scrutinized, comparing the latest and added versions to see if it's a breaking
     # change (major version bump). Warn about it on the PR via adding a breaking-change label...
@@ -84,7 +87,8 @@ def main(changed_files: str | None = None, merge_base_schema_files: str | None =
         print("\nBreaking change detected...")
         add_label(pr_number, BREAKING_CHANGE_LABEL)
     else:
-        remove_label(pr_number, BREAKING_CHANGE_LABEL)
+        if BREAKING_CHANGE_LABEL in pr_labels:        
+            remove_label(pr_number, BREAKING_CHANGE_LABEL)
 
     # modifying an existing schema could be a breaking change, we should warn about it on the PR via a comment...
     # removing schema files should never be allowed, we should warn about it on the PR via a comment...
@@ -163,6 +167,17 @@ def get_pr_changed_files(pr_number: str) -> list[str]:
     
     list_of_files = result.stdout.splitlines()
     return list_of_files
+
+
+def get_pr_labels(pr_number: str) -> list[str]:
+    result = run(f"gh pr view {pr_number} --json labels --jq '.labels[].name'", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        print("Unable to get list of labels on PR")
+        print(str(result.stderr))
+        sys.exit(1)
+    
+    list_of_labels = result.stdout.splitlines()
+    return list_of_labels
 
 
 def filter_to_schema_files(list_of_files: list[str]) -> list[str]:

--- a/.github/scripts/labeler.py
+++ b/.github/scripts/labeler.py
@@ -119,7 +119,7 @@ def add_label(pr_number: str, label: str):
     # run "gh pr edit --add-label <label>"
     result = run(f"gh pr edit {pr_number} --add-label {label}", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
-        print(f"Unable to add  {label!r} label to PR with")
+        print(f"Unable to add '{label!r}' label to PR, error:")
         print(str(result.stderr))
         sys.exit(1)
 
@@ -128,7 +128,7 @@ def remove_label(pr_number: str, label: str):
     # run "gh pr edit --remove-label <label>"
     result = run(f"gh pr edit {pr_number} --remove-label {label}", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
-        print(f"Unable to label PR with {label!r}")
+        print(f"Unable to remove '{label!r}' label from PR, error:")
         print(str(result.stderr))
         sys.exit(1)
 


### PR DESCRIPTION
The builds were failing on trying to remove a label that is not present in the PR. This PR adds a checks if the label is set on a PR before removing.

But also the error message is wrong (example failed [workflow](https://github.com/anchore/syft/actions/runs/8658807959/job/23743407645#step:3:16)):
```
[RUN] gh pr edit 2769 --remove-label json-schema
Unable to label PR with 'json-schema'
```
This PR also corrects the above error message and makes the error message for adding a label more clear.