### PR TITLE
feat: index known cpes for PHP extensions

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/data/cpe-index.json
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/data/cpe-index.json
@@ -1031,6 +1031,19 @@
       "zjjserver": "cpe:2.3:a:zjjserver_project:zjjserver:*:*:*:*:*:node.js:*:*",
       "zwserver": "cpe:2.3:a:zwserver_project:zwserver:*:*:*:*:*:node.js:*:*"
     },
+    "php_pear": {
+      "Archive_Tar": "cpe:2.3:a:php:pear_archive_tar:*:*:*:*:*:*:*:*",
+      "HTML_AJAX": "cpe:2.3:a:pear:html_ajax:*:*:*:*:*:*:*:*",
+      "HTML_QuickForm": "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*",
+      "PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
+      "XML_RPC": "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*"
+    },
+    "php_pecl": {
+      "imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
+      "memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
+      "pecl_http": "cpe:2.3:a:php:pecl_http:*:*:*:*:*:*:*:*",
+      "xhprof": "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+    },
     "pypi": {
       "0.0.1": "cpe:2.3:a:pypi:pypi:*:*:*:*:*:*:*:*",
       "AAmiles": "cpe:2.3:a:pypi:aamiles:*:*:*:*:*:pypi:*:*",

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate_test.go
@@ -151,6 +151,58 @@ func Test_addEntryFuncs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:             "addEntryForPHPPeclPackage",
+			addEntryFunc:     addEntryForPHPPeclPackage,
+			inputRef:         "https://pecl.php.net/package/imagick/something/something/v4007.0",
+			inputCpeItemName: "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
+			expectedIndexed: dictionary.Indexed{
+				EcosystemPackages: map[string]dictionary.Packages{
+					dictionary.EcosystemPHPPecl: {
+						"imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
+					},
+				},
+			},
+		},
+		{
+			name:             "addEntryForPHPPeclPackage http changelog",
+			addEntryFunc:     addEntryForPHPPeclPackage,
+			inputRef:         "http://pecl.php.net/package-changelog.php?package=memcached&amp;release",
+			inputCpeItemName: "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
+			expectedIndexed: dictionary.Indexed{
+				EcosystemPackages: map[string]dictionary.Packages{
+					dictionary.EcosystemPHPPecl: {
+						"memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
+					},
+				},
+			},
+		},
+		{
+			name:             "addEntryForPHPPearPackage",
+			addEntryFunc:     addEntryForPHPPearPackage,
+			inputRef:         "https://pear.php.net/package/PEAR/download",
+			inputCpeItemName: "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
+			expectedIndexed: dictionary.Indexed{
+				EcosystemPackages: map[string]dictionary.Packages{
+					dictionary.EcosystemPHPPear: {
+						"PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
+					},
+				},
+			},
+		},
+		{
+			name:             "addEntryForPHPPearPackage http changelog",
+			addEntryFunc:     addEntryForPHPPearPackage,
+			inputRef:         "http://pear.php.net/package-changelog.php?package=abcdefg&amp;release",
+			inputCpeItemName: "cpe:2.3:a:php:abcdefg:*:*:*:*:*:*:*:*",
+			expectedIndexed: dictionary.Indexed{
+				EcosystemPackages: map[string]dictionary.Packages{
+					dictionary.EcosystemPHPPear: {
+						"abcdefg": "cpe:2.3:a:php:abcdefg:*:*:*:*:*:*:*:*",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/expected-cpe-index.json
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/expected-cpe-index.json
@@ -13,6 +13,16 @@
       "unicode": "cpe:2.3:a:unicode_project:unicode:*:*:*:*:*:node.js:*:*",
       "unicorn-list": "cpe:2.3:a:unicorn-list_project:unicorn-list:*:*:*:*:*:node.js:*:*"
     },
+    "php_pear": {
+      "HTML_QuickForm": "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*",
+      "PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
+      "XML_RPC": "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*"
+    },
+    "php_pecl": {
+      "imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
+      "memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
+      "xhprof": "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+    },
     "rubygems": {
       "openssl": "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:*:*:*"
     },

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/official-cpe-dictionary_v2.3.xml
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/official-cpe-dictionary_v2.3.xml
@@ -24873,4 +24873,114 @@
     </references>
     <cpe-23:cpe23-item name="cpe:2.3:a:zzzcms:zzzphp:2.1.0:*:*:*:*:*:*:*"/>
   </cpe-item>
+  <cpe-item name="cpe:/a:php:xhprof:0.9.1">
+    <title xml:lang="en-US">PHP XHProf 0.9.1</title>
+    <references>
+      <reference href="http://pecl.php.net/package-changelog.php?package=xhprof&amp;release=0.9.4">product changelog</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xhprof:0.9.1:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:xhprof:0.9.2">
+    <title xml:lang="en-US">PHP XHProf 0.9.2</title>
+    <references>
+      <reference href="http://pecl.php.net/package-changelog.php?package=xhprof&amp;release=0.9.4">product changelog</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xhprof:0.9.2:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:xhprof:0.9.3">
+    <title xml:lang="en-US">PHP XHProf 0.9.3</title>
+    <references>
+      <reference href="http://pecl.php.net/package-changelog.php?package=xhprof&amp;release=0.9.4">product changelog</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xhprof:0.9.3:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:memcached:0.1.0">
+    <title xml:lang="en-US">PHP memecached 0.1.0</title>
+    <references>
+      <reference href="https://pecl.php.net/package-changelog.php?package=memcached&amp;release">Change Log</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:memcached:0.1.0:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:memcached:0.1.2">
+    <title xml:lang="en-US">PHP memecached 0.1.2</title>
+    <references>
+      <reference href="https://pecl.php.net/package-changelog.php?package=memcached&amp;release">Change Log</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:memcached:0.1.2:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:memcached:0.1.3">
+    <title xml:lang="en-US">PHP memecached 0.1.3</title>
+    <references>
+      <reference href="https://pecl.php.net/package-changelog.php?package=memcached&amp;release">Change Log</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:memcached:0.1.3:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:imagick:3.3.0">
+    <title xml:lang="en-US">PHP Imagick 3.3.0</title>
+    <references>
+      <reference href="http://pecl.php.net/package/imagick">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:imagick:3.3.0:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:imagick:3.4.0:-">
+    <title xml:lang="en-US">PHP Imagick 3.4.0</title>
+    <references>
+      <reference href="http://pecl.php.net/package/imagick">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:imagick:3.4.0:-:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:xml_rpc:1.4.4::~~~pear~~">
+    <title xml:lang="en-US">PHP XML_RPC 1.4.4 for Pear</title>
+    <references>
+      <reference href="https://pear.php.net/package/XML_RPC/download/">Version</reference>
+      <reference href="https://pear.php.net/package/XML_RPC/">Product</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xml_rpc:1.4.4:*:*:*:*:pear:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:xml_rpc:1.4.5::~~~pear~~">
+    <title xml:lang="en-US">PHP XML_RPC 1.4.5 for Pear</title>
+    <references>
+      <reference href="https://pear.php.net/package/XML_RPC/download/">Version</reference>
+      <reference href="https://pear.php.net/package/XML_RPC/">Product</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xml_rpc:1.4.5:*:*:*:*:pear:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:xml_rpc:1.4.6::~~~pear~~">
+    <title xml:lang="en-US">PHP XML_RPC 1.4.6 for Pear</title>
+    <references>
+      <reference href="https://pear.php.net/package/XML_RPC/download/">Version</reference>
+      <reference href="https://pear.php.net/package/XML_RPC/">Product</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:xml_rpc:1.4.6:*:*:*:*:pear:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:pear:1.0:-">
+    <title xml:lang="en-US">PHP PEAR 1.0</title>
+    <references>
+      <reference href="https://pear.php.net/package/PEAR/download/">Change Log</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:pear:1.0:-:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:php:pear:1.0:b1">
+    <title xml:lang="en-US">PHP PEAR 1.0 Beta 1</title>
+    <references>
+      <reference href="https://pear.php.net/package/PEAR/download/">Change Log</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:php:pear:1.0:b1:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:html_quickform_project:html_quickform:2.0">
+    <title xml:lang="en-US">HTML_QuickForm project HTML_QuickForm 2.0</title>
+    <references>
+      <reference href="http://pear.php.net/package/HTML_QuickForm/">Project</reference>
+      <reference href="http://pear.php.net/package/HTML_QuickForm/download">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:html_quickform_project:html_quickform:2.0:*:*:*:*:*:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:html_quickform_project:html_quickform:2.1">
+    <title xml:lang="en-US">HTML_QuickForm project HTML_QuickForm 2.1</title>
+    <references>
+      <reference href="http://pear.php.net/package/HTML_QuickForm/">Project</reference>
+      <reference href="http://pear.php.net/package/HTML_QuickForm/download">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:html_quickform_project:html_quickform:2.1:*:*:*:*:*:*:*"/>
+  </cpe-item>
 </cpe-list>

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/types.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/types.go
@@ -4,6 +4,8 @@ const (
 	EcosystemNPM            = "npm"
 	EcosystemRubyGems       = "rubygems"
 	EcosystemPyPI           = "pypi"
+	EcosystemPHPPear        = "php_pear"
+	EcosystemPHPPecl        = "php_pecl"
 	EcosystemJenkinsPlugins = "jenkins_plugins"
 	EcosystemRustCrates     = "rust_crates"
 )

--- a/syft/pkg/cataloger/internal/cpegenerate/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate.go
@@ -86,6 +86,9 @@ func FromDictionaryFind(p pkg.Package) (cpe.CPE, bool) {
 	case pkg.RustPkg:
 		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemRustCrates][p.Name]
 
+	case pkg.PhpPeclPkg:
+		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemPHPPecl][p.Name]
+
 	default:
 		// The dictionary doesn't support this package type yet.
 		return cpe.CPE{}, false


### PR DESCRIPTION
Indexes known CPEs from `pecl.php.net` and `pear.php.net`

This will depend on https://github.com/anchore/syft/pull/2775 which in turn depends on the package-url spec discussion in https://github.com/package-url/purl-spec/pull/300 before we know how to actually make use of it