### PR TITLE
Fix: repeatedly dereference pom variables

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -235,59 +235,66 @@ func cleanDescription(original *string) (cleaned string) {
 func resolveProperty(pom gopom.Project, property *string, propertyName string) string {
 	propertyCase := safeString(property)
 	log.WithFields("existingPropertyValue", propertyCase, "propertyName", propertyName).Trace("resolving property")
-	return propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
-		propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
-		entries := pomProperties(pom)
-		if value, ok := entries[propertyName]; ok {
-			return resolveProperty(pom, &value, propertyName) // recursively resolve in case a variable points to a variable.
-		}
+	for propertyMatcher.MatchString(propertyCase) {
+		oldPropertyCase := propertyCase
+		propertyCase = propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
+			propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
+			entries := pomProperties(pom)
+			if value, ok := entries[propertyName]; ok {
+				return value
+			}
 
-		// if we don't find anything directly in the pom properties,
-		// see if we have a project.x expression and process this based
-		// on the xml tags in gopom
-		parts := strings.Split(propertyName, ".")
-		numParts := len(parts)
-		if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
-			pomValue := reflect.ValueOf(pom)
-			pomValueType := pomValue.Type()
-			for partNum := 1; partNum < numParts; partNum++ {
-				if pomValueType.Kind() != reflect.Struct {
-					break
-				}
-				part := parts[partNum]
-				for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
-					f := pomValueType.Field(fieldNum)
-					tag := f.Tag.Get("xml")
-					tag = strings.Split(tag, ",")[0]
-					// a segment of the property name matches the xml tag for the field,
-					// so we need to recurse down the nested structs or return a match
-					// if we're done.
-					if part == tag {
-						pomValue = pomValue.Field(fieldNum)
-						pomValueType = pomValue.Type()
-						if pomValueType.Kind() == reflect.Ptr {
-							// we were recursing down the nested structs, but one of the steps
-							// we need to take is a nil pointer, so give up and return the original match
-							if pomValue.IsNil() {
-								return match
-							}
-							pomValue = pomValue.Elem()
-							if !pomValue.IsZero() {
-								// we found a non-zero value whose tag matches this part of the property name
-								pomValueType = pomValue.Type()
-							}
-						}
-						// If this was the last part of the property name, return the value
-						if partNum == numParts-1 {
-							return fmt.Sprintf("%v", pomValue.Interface())
-						}
+			// if we don't find anything directly in the pom properties,
+			// see if we have a project.x expression and process this based
+			// on the xml tags in gopom
+			parts := strings.Split(propertyName, ".")
+			numParts := len(parts)
+			if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
+				pomValue := reflect.ValueOf(pom)
+				pomValueType := pomValue.Type()
+				for partNum := 1; partNum < numParts; partNum++ {
+					if pomValueType.Kind() != reflect.Struct {
 						break
+					}
+					part := parts[partNum]
+					for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
+						f := pomValueType.Field(fieldNum)
+						tag := f.Tag.Get("xml")
+						tag = strings.Split(tag, ",")[0]
+						// a segment of the property name matches the xml tag for the field,
+						// so we need to recurse down the nested structs or return a match
+						// if we're done.
+						if part == tag {
+							pomValue = pomValue.Field(fieldNum)
+							pomValueType = pomValue.Type()
+							if pomValueType.Kind() == reflect.Ptr {
+								// we were recursing down the nested structs, but one of the steps
+								// we need to take is a nil pointer, so give up and return the original match
+								if pomValue.IsNil() {
+									return match
+								}
+								pomValue = pomValue.Elem()
+								if !pomValue.IsZero() {
+									// we found a non-zero value whose tag matches this part of the property name
+									pomValueType = pomValue.Type()
+								}
+							}
+							// If this was the last part of the property name, return the value
+							if partNum == numParts-1 {
+								return fmt.Sprintf("%v", pomValue.Interface())
+							}
+							break
+						}
 					}
 				}
 			}
+			return match
+		})
+		if oldPropertyCase == propertyCase {
+			break // don't loop forever if replaceAll is making no changes
 		}
-		return match
-	})
+	}
+	return propertyCase
 }
 
 func pomProperties(p gopom.Project) map[string]string {

--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -235,66 +235,59 @@ func cleanDescription(original *string) (cleaned string) {
 func resolveProperty(pom gopom.Project, property *string, propertyName string) string {
 	propertyCase := safeString(property)
 	log.WithFields("existingPropertyValue", propertyCase, "propertyName", propertyName).Trace("resolving property")
-	for propertyMatcher.MatchString(propertyCase) {
-		oldPropertyCase := propertyCase
-		propertyCase = propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
-			propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
-			entries := pomProperties(pom)
-			if value, ok := entries[propertyName]; ok {
-				return value
-			}
+	return propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
+		propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
+		entries := pomProperties(pom)
+		if value, ok := entries[propertyName]; ok {
+			return resolveProperty(pom, &value, propertyName) // recursively resolve in case a variable points to a variable.
+		}
 
-			// if we don't find anything directly in the pom properties,
-			// see if we have a project.x expression and process this based
-			// on the xml tags in gopom
-			parts := strings.Split(propertyName, ".")
-			numParts := len(parts)
-			if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
-				pomValue := reflect.ValueOf(pom)
-				pomValueType := pomValue.Type()
-				for partNum := 1; partNum < numParts; partNum++ {
-					if pomValueType.Kind() != reflect.Struct {
-						break
-					}
-					part := parts[partNum]
-					for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
-						f := pomValueType.Field(fieldNum)
-						tag := f.Tag.Get("xml")
-						tag = strings.Split(tag, ",")[0]
-						// a segment of the property name matches the xml tag for the field,
-						// so we need to recurse down the nested structs or return a match
-						// if we're done.
-						if part == tag {
-							pomValue = pomValue.Field(fieldNum)
-							pomValueType = pomValue.Type()
-							if pomValueType.Kind() == reflect.Ptr {
-								// we were recursing down the nested structs, but one of the steps
-								// we need to take is a nil pointer, so give up and return the original match
-								if pomValue.IsNil() {
-									return match
-								}
-								pomValue = pomValue.Elem()
-								if !pomValue.IsZero() {
-									// we found a non-zero value whose tag matches this part of the property name
-									pomValueType = pomValue.Type()
-								}
+		// if we don't find anything directly in the pom properties,
+		// see if we have a project.x expression and process this based
+		// on the xml tags in gopom
+		parts := strings.Split(propertyName, ".")
+		numParts := len(parts)
+		if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
+			pomValue := reflect.ValueOf(pom)
+			pomValueType := pomValue.Type()
+			for partNum := 1; partNum < numParts; partNum++ {
+				if pomValueType.Kind() != reflect.Struct {
+					break
+				}
+				part := parts[partNum]
+				for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
+					f := pomValueType.Field(fieldNum)
+					tag := f.Tag.Get("xml")
+					tag = strings.Split(tag, ",")[0]
+					// a segment of the property name matches the xml tag for the field,
+					// so we need to recurse down the nested structs or return a match
+					// if we're done.
+					if part == tag {
+						pomValue = pomValue.Field(fieldNum)
+						pomValueType = pomValue.Type()
+						if pomValueType.Kind() == reflect.Ptr {
+							// we were recursing down the nested structs, but one of the steps
+							// we need to take is a nil pointer, so give up and return the original match
+							if pomValue.IsNil() {
+								return match
 							}
-							// If this was the last part of the property name, return the value
-							if partNum == numParts-1 {
-								return fmt.Sprintf("%v", pomValue.Interface())
+							pomValue = pomValue.Elem()
+							if !pomValue.IsZero() {
+								// we found a non-zero value whose tag matches this part of the property name
+								pomValueType = pomValue.Type()
 							}
-							break
 						}
+						// If this was the last part of the property name, return the value
+						if partNum == numParts-1 {
+							return fmt.Sprintf("%v", pomValue.Interface())
+						}
+						break
 					}
 				}
 			}
-			return match
-		})
-		if oldPropertyCase == propertyCase {
-			break // don't loop forever if replaceAll is making no changes
 		}
-	}
-	return propertyCase
+		return match
+	})
 }
 
 func pomProperties(p gopom.Project) map[string]string {

--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -230,71 +230,74 @@ func cleanDescription(original *string) (cleaned string) {
 // resolveProperty emulates some maven property resolution logic by looking in the project's variables
 // as well as supporting the project expressions like ${project.parent.groupId}.
 // If no match is found, the entire expression including ${} is returned
-//
-//nolint:gocognit
 func resolveProperty(pom gopom.Project, property *string, propertyName string) string {
 	propertyCase := safeString(property)
 	log.WithFields("existingPropertyValue", propertyCase, "propertyName", propertyName).Trace("resolving property")
-	for propertyMatcher.MatchString(propertyCase) {
-		oldPropertyCase := propertyCase
-		propertyCase = propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
-			propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
-			entries := pomProperties(pom)
-			if value, ok := entries[propertyName]; ok {
-				return value
-			}
+	seenBeforePropertyNames := map[string]struct{}{
+		propertyName: {},
+	}
+	return recursiveResolveProperty(pom, propertyCase, seenBeforePropertyNames)
+}
 
-			// if we don't find anything directly in the pom properties,
-			// see if we have a project.x expression and process this based
-			// on the xml tags in gopom
-			parts := strings.Split(propertyName, ".")
-			numParts := len(parts)
-			if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
-				pomValue := reflect.ValueOf(pom)
-				pomValueType := pomValue.Type()
-				for partNum := 1; partNum < numParts; partNum++ {
-					if pomValueType.Kind() != reflect.Struct {
-						break
-					}
-					part := parts[partNum]
-					for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
-						f := pomValueType.Field(fieldNum)
-						tag := f.Tag.Get("xml")
-						tag = strings.Split(tag, ",")[0]
-						// a segment of the property name matches the xml tag for the field,
-						// so we need to recurse down the nested structs or return a match
-						// if we're done.
-						if part == tag {
-							pomValue = pomValue.Field(fieldNum)
-							pomValueType = pomValue.Type()
-							if pomValueType.Kind() == reflect.Ptr {
-								// we were recursing down the nested structs, but one of the steps
-								// we need to take is a nil pointer, so give up and return the original match
-								if pomValue.IsNil() {
-									return match
-								}
-								pomValue = pomValue.Elem()
-								if !pomValue.IsZero() {
-									// we found a non-zero value whose tag matches this part of the property name
-									pomValueType = pomValue.Type()
-								}
+//nolint:gocognit
+func recursiveResolveProperty(pom gopom.Project, propertyCase string, seenPropertyNames map[string]struct{}) string {
+	return propertyMatcher.ReplaceAllStringFunc(propertyCase, func(match string) string {
+		propertyName := strings.TrimSpace(match[2 : len(match)-1]) // remove leading ${ and trailing }
+		if _, seen := seenPropertyNames[propertyName]; seen {
+			return propertyCase
+		}
+		entries := pomProperties(pom)
+		if value, ok := entries[propertyName]; ok {
+			seenPropertyNames[propertyName] = struct{}{}
+			return recursiveResolveProperty(pom, value, seenPropertyNames) // recursively resolve in case a variable points to a variable.
+		}
+
+		// if we don't find anything directly in the pom properties,
+		// see if we have a project.x expression and process this based
+		// on the xml tags in gopom
+		parts := strings.Split(propertyName, ".")
+		numParts := len(parts)
+		if numParts > 1 && strings.TrimSpace(parts[0]) == "project" {
+			pomValue := reflect.ValueOf(pom)
+			pomValueType := pomValue.Type()
+			for partNum := 1; partNum < numParts; partNum++ {
+				if pomValueType.Kind() != reflect.Struct {
+					break
+				}
+				part := parts[partNum]
+				for fieldNum := 0; fieldNum < pomValueType.NumField(); fieldNum++ {
+					f := pomValueType.Field(fieldNum)
+					tag := f.Tag.Get("xml")
+					tag = strings.Split(tag, ",")[0]
+					// a segment of the property name matches the xml tag for the field,
+					// so we need to recurse down the nested structs or return a match
+					// if we're done.
+					if part == tag {
+						pomValue = pomValue.Field(fieldNum)
+						pomValueType = pomValue.Type()
+						if pomValueType.Kind() == reflect.Ptr {
+							// we were recursing down the nested structs, but one of the steps
+							// we need to take is a nil pointer, so give up and return the original match
+							if pomValue.IsNil() {
+								return match
 							}
-							// If this was the last part of the property name, return the value
-							if partNum == numParts-1 {
-								return fmt.Sprintf("%v", pomValue.Interface())
+							pomValue = pomValue.Elem()
+							if !pomValue.IsZero() {
+								// we found a non-zero value whose tag matches this part of the property name
+								pomValueType = pomValue.Type()
 							}
-							break
 						}
+						// If this was the last part of the property name, return the value
+						if partNum == numParts-1 {
+							return fmt.Sprintf("%v", pomValue.Interface())
+						}
+						break
 					}
 				}
 			}
-			return match
-		})
-		if oldPropertyCase == propertyCase {
-			break // don't loop forever if replaceAll is making no changes
 		}
-	}
-	return propertyCase
+		return match
+	})
 }
 
 func pomProperties(p gopom.Project) map[string]string {

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -558,9 +558,6 @@ func Test_resolveProperty(t *testing.T) {
 			name:     "resolution halts even if cyclic",
 			property: "${springboot.version}",
 			pom: gopom.Project{
-				Parent: &gopom.Parent{
-					Version: stringPointer("${springboot.version}"),
-				},
 				Properties: &gopom.Properties{
 					Entries: map[string]string{
 						"springboot.version": "${springboot.version}",
@@ -587,9 +584,6 @@ func Test_resolveProperty(t *testing.T) {
 			name:     "resolution  halts even if cyclic involving parent",
 			property: "${cyclic.version}",
 			pom: gopom.Project{
-				Parent: &gopom.Parent{
-					Version: stringPointer("${cyclic.version}"),
-				},
 				Properties: &gopom.Properties{
 					Entries: map[string]string{
 						"other.version":      "${cyclic.version}",

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -539,6 +539,67 @@ func Test_resolveProperty(t *testing.T) {
 			},
 			expected: "${springboot.version}",
 		},
+		{
+			name:     "resolution halts even if it resolves to a variable",
+			property: "${springboot.version}",
+			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("${undefined.version}"),
+				},
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"springboot.version": "${project.parent.version}",
+					},
+				},
+			},
+			expected: "${undefined.version}",
+		},
+		{
+			name:     "resolution halts even if cyclic",
+			property: "${springboot.version}",
+			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("${springboot.version}"),
+				},
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"springboot.version": "${springboot.version}",
+					},
+				},
+			},
+			expected: "${springboot.version}",
+		},
+		{
+			name:     "resolution halts even if cyclic more steps",
+			property: "${cyclic.version}",
+			pom: gopom.Project{
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"other.version":      "${cyclic.version}",
+						"springboot.version": "${other.version}",
+						"cyclic.version":     "${springboot.version}",
+					},
+				},
+			},
+			expected: "${cyclic.version}",
+		},
+		{
+			name:     "resolution  halts even if cyclic involving parent",
+			property: "${cyclic.version}",
+			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("${cyclic.version}"),
+				},
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"other.version":      "${cyclic.version}",
+						"springboot.version": "${other.version}",
+						"cyclic.version":     "${springboot.version}",
+					},
+				},
+			},
+			expected: "${cyclic.version}",
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -514,6 +514,31 @@ func Test_resolveProperty(t *testing.T) {
 			},
 			expected: "${project.parent.groupId}",
 		},
+		{
+			name:     "double dereference",
+			property: "${springboot.version}",
+			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("1.2.3"),
+				},
+				Properties: &gopom.Properties{
+					Entries: map[string]string{
+						"springboot.version": "${project.parent.version}",
+					},
+				},
+			},
+			expected: "1.2.3",
+		},
+		{
+			name:     "map missing stops double dereference",
+			property: "${springboot.version}",
+			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("1.2.3"),
+				},
+			},
+			expected: "${springboot.version}",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously, if there was more than one layer of variable indirection in the pom property (propert A says it has the same value as property B, property B says it has the same value as property C), then Syft would only dereference one layer. Add a loop to dereference variables until either dereferencing fails, or until the variable is completely dereferenced back to a literal.

Fixes https://github.com/anchore/syft/issues/2776

Manual testing on repro example from that issue:

``` sh
❯ diff <(syft -q dir:spring-boot-empty-project | awk '{print $1 " "  $2 " " $3}') <(/tmp/syft -q dir:spring-boot-empty-project | awk '{print $1 " " $2 " " $3}')
9c9
< spring-boot-starter-actuator ${project.parent.version} java-archive
---
> spring-boot-starter-actuator 3.2.4 java-archive
11,15c11,15
< spring-boot-starter-data-mongodb ${project.parent.version} java-archive
< spring-boot-starter-security ${project.parent.version} java-archive
< spring-boot-starter-test ${project.parent.version} java-archive
< spring-boot-starter-validation ${project.parent.version} java-archive
< spring-boot-starter-web ${project.parent.version} java-archive
---
> spring-boot-starter-data-mongodb 3.2.4 java-archive
> spring-boot-starter-security 3.2.4 java-archive
> spring-boot-starter-test 3.2.4 java-archive
> spring-boot-starter-validation 3.2.4 java-archive
> spring-boot-starter-web 3.2.4 java-archive
```