### PR TITLE
fix: exclude known instrumentation jars from being erroneously identified

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -181,6 +181,13 @@ func (j *archiveParser) discoverMainPackage(ctx context.Context) (*pkg.Package, 
 		return nil, nil
 	}
 
+	// check for existence of Weave-Classes manifest key in order to exclude jars getting misrepresented as
+	// their targeted counterparts, e.g. newrelic spring and tomcat instrumentation
+	if _, ok := manifest.Main.Get("Weave-Classes"); ok {
+		log.Debugf("excluding archive due to Weave-Classes manifest entry: %s", j.location)
+		return nil, nil
+	}
+
 	// grab and assign digest for the entire archive
 	digests, err := getDigestsFromArchive(j.archivePath)
 	if err != nil {

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1168,7 +1168,6 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 		expectedPkgs          []pkg.Package
 		expectedRelationships []artifact.Relationship
 		assignParent          bool
-		want                  bool
 	}{
 		{
 			name:        "duplicate jar regression - go case (issue #2130)",
@@ -1350,6 +1349,11 @@ func Test_parseJavaArchive_regressions(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:         "exclude instrumentation jars with Weave-Classes in manifest",
+			fixtureName:  "spring-instrumentation-4.3.0-1.0",
+			expectedPkgs: nil, // we expect no packages to be discovered from this
 		},
 	}
 	for _, tt := range tests {

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
@@ -5,6 +5,7 @@ JACKSON_CORE = jackson-core-2.15.2
 SBT_JACKSON_CORE = com.fasterxml.jackson.core.jackson-core-2.15.2
 OPENSAML_CORE = opensaml-core-3.4.6
 API_ALL_SOURCES = api-all-2.0.0-sources
+SPRING_INSTRUMENTATION = spring-instrumentation-4.3.0-1.0
 
 $(CACHE_DIR):
 	mkdir -p $(CACHE_DIR)
@@ -20,3 +21,6 @@ $(CACHE_DIR)/$(OPENSAML_CORE).jar: $(CACHE_DIR)
 
 $(CACHE_DIR)/$(API_ALL_SOURCES).jar: $(CACHE_DIR)
 	cd $(API_ALL_SOURCES) && zip -r $(CACHE_PATH)/$(API_ALL_SOURCES).jar .
+
+$(CACHE_DIR)/$(SPRING_INSTRUMENTATION).jar: $(CACHE_DIR)
+	cd $(SPRING_INSTRUMENTATION) && zip -r $(CACHE_PATH)/$(SPRING_INSTRUMENTATION).jar .

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/spring-instrumentation-4.3.0-1.0/META-INF/MANIFEST.MF
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/spring-instrumentation-4.3.0-1.0/META-INF/MANIFEST.MF
@@ -1,0 +1,22 @@
+Manifest-Version: 1.0
+Implementation-Title: com.newrelic.instrumentation.spring-4.3.0
+Implementation-Version: 1.0
+Illegal-Classes: 
+Weave-Violation-Filter: METHOD_MISSING_REQUIRED_ANNOTATIONS,CLASS_MISS
+ ING_REQUIRED_ANNOTATIONS
+Reference-Classes: org/springframework/core/annotation/AnnotationUtils
+ ,org/springframework/web/bind/annotation/DeleteMapping,org/springfram
+ ework/web/bind/annotation/PatchMapping,org/springframework/web/bind/a
+ nnotation/PostMapping,org/springframework/web/bind/annotation/PutMapp
+ ing,org/springframework/web/bind/annotation/RequestMapping,org/spring
+ framework/web/method/HandlerMethod,org/springframework/web/servlet/Mo
+ delAndView
+Class-Required-Annotations: 
+Method-Required-Annotations: 
+Implementation-Title-Alias: spring_annotations
+Weave-Classes: org/springframework/web/bind/annotation/GetMapping,org/
+ springframework/web/servlet/mvc/method/AbstractHandlerMethodAdapter
+Weave-Methods: "handleInternal(Ljavax/servlet/http/HttpServletRequest;
+ Ljavax/servlet/http/HttpServletResponse;Lorg/springframework/web/meth
+ od/HandlerMethod;)Lorg/springframework/web/servlet/ModelAndView;"
+Implementation-Vendor: New Relic


### PR DESCRIPTION
This PR adds a check for known manifest keys that are likely only to be present in instrumentation jars in order to omit these from being erroneously identified as the targeted counterparts. For example, [a New Relic distribution](https://repo1.maven.org/maven2/com/newrelic/agent/java/newrelic-java/8.9.1/newrelic-java-8.9.1.zip) contains a number of jars named such as `spring-` and `tomcat-` which contain only instrumentation code, not the actual products but were being falsely identified as the corresponding `spring` and `tomcat`. This PR adds an exclusion when `Weave-Classes` is found in the manifest to at least omit these from being incorrectly identified.