### PR TITLE
fix: return empty string if dereferncing pom var fails

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -236,7 +236,11 @@ func resolveProperty(pom gopom.Project, property *string, propertyName string) s
 	seenBeforePropertyNames := map[string]struct{}{
 		propertyName: {},
 	}
-	return recursiveResolveProperty(pom, propertyCase, seenBeforePropertyNames)
+	result := recursiveResolveProperty(pom, propertyCase, seenBeforePropertyNames)
+	if propertyMatcher.MatchString(result) {
+		return "" // dereferencing variable failed; fall back to empty string
+	}
+	return result
 }
 
 //nolint:gocognit

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -502,7 +502,7 @@ func Test_resolveProperty(t *testing.T) {
 			pom: gopom.Project{
 				Parent: nil,
 			},
-			expected: "${project.parent.groupId}",
+			expected: "",
 		},
 		{
 			name:     "nil string pointer halts search",
@@ -512,7 +512,7 @@ func Test_resolveProperty(t *testing.T) {
 					GroupID: nil,
 				},
 			},
-			expected: "${project.parent.groupId}",
+			expected: "",
 		},
 		{
 			name:     "double dereference",
@@ -537,7 +537,7 @@ func Test_resolveProperty(t *testing.T) {
 					Version: stringPointer("1.2.3"),
 				},
 			},
-			expected: "${springboot.version}",
+			expected: "",
 		},
 		{
 			name:     "resolution halts even if it resolves to a variable",
@@ -552,7 +552,7 @@ func Test_resolveProperty(t *testing.T) {
 					},
 				},
 			},
-			expected: "${undefined.version}",
+			expected: "",
 		},
 		{
 			name:     "resolution halts even if cyclic",
@@ -564,7 +564,7 @@ func Test_resolveProperty(t *testing.T) {
 					},
 				},
 			},
-			expected: "${springboot.version}",
+			expected: "",
 		},
 		{
 			name:     "resolution halts even if cyclic more steps",
@@ -578,7 +578,7 @@ func Test_resolveProperty(t *testing.T) {
 					},
 				},
 			},
-			expected: "${cyclic.version}",
+			expected: "",
 		},
 		{
 			name:     "resolution  halts even if cyclic involving parent",
@@ -592,7 +592,7 @@ func Test_resolveProperty(t *testing.T) {
 					},
 				},
 			},
-			expected: "${cyclic.version}",
+			expected: "",
 		},
 	}
 

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -584,9 +584,12 @@ func Test_resolveProperty(t *testing.T) {
 			name:     "resolution  halts even if cyclic involving parent",
 			property: "${cyclic.version}",
 			pom: gopom.Project{
+				Parent: &gopom.Parent{
+					Version: stringPointer("${cyclic.version}"),
+				},
 				Properties: &gopom.Properties{
 					Entries: map[string]string{
-						"other.version":      "${cyclic.version}",
+						"other.version":      "${parent.version}",
 						"springboot.version": "${other.version}",
 						"cyclic.version":     "${springboot.version}",
 					},


### PR DESCRIPTION
Previously, Syft would attempt to dereference pom variables, but if it detected a cycle or failed to get back to a non-variable value, it would return the last variable. Instead, return an empty string. Otherwise, certain jars will have versions like "${project.version}" in the SBOM, which is not helpful.

This is a follow up to #2783 and improves the behavior around #2776.