### PR TITLE
feat: support multiple known CPEs in index

### DIFF
--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -111,10 +111,10 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 			if cfg.DataGenerationConfig.GenerateCPEs {
 				// generate CPEs (note: this is excluded from package ID, so is safe to mutate)
 				// we might have binary classified CPE already with the package so we want to append here
-				dictionaryCPE, ok := cpe.DictionaryFind(p)
+				dictionaryCPEs, ok := cpe.DictionaryFind(p)
 				if ok {
-					log.Tracef("used CPE dictionary to find CPE for %s package %q: %s", p.Type, p.Name, dictionaryCPE.Attributes.BindToFmtString())
-					p.CPEs = append(p.CPEs, dictionaryCPE)
+					log.Tracef("used CPE dictionary to find CPEs for %s package %q: %s", p.Type, p.Name, dictionaryCPEs)
+					p.CPEs = append(p.CPEs, dictionaryCPEs...)
 				} else {
 					p.CPEs = append(p.CPEs, cpe.Generate(p)...)
 				}

--- a/syft/pkg/cataloger/common/cpe/create.go
+++ b/syft/pkg/cataloger/common/cpe/create.go
@@ -10,6 +10,6 @@ func Generate(p pkg.Package) []cpe.CPE {
 	return cpegenerate.FromPackageAttributes(p)
 }
 
-func DictionaryFind(p pkg.Package) (cpe.CPE, bool) {
+func DictionaryFind(p pkg.Package) ([]cpe.CPE, bool) {
 	return cpegenerate.FromDictionaryFind(p)
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/data/cpe-index.json
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/data/cpe-index.json
@@ -1,2248 +1,6772 @@
 {
   "ecosystems": {
     "jenkins_plugins": {
-      "DotCi": "cpe:2.3:a:jenkins:dotci:*:*:*:*:*:jenkins:*:*",
-      "JDK_Parameter_Plugin": "cpe:2.3:a:jenkins:jdk_parameter:*:*:*:*:*:jenkins:*:*",
-      "JiraTestResultReporter": "cpe:2.3:a:jenkins:jiratestresultreporter:*:*:*:*:*:jenkins:*:*",
-      "Parameterized-Remote-Trigger": "cpe:2.3:a:jenkins:parameterized_remote_trigger:*:*:*:*:*:jenkins:*:*",
-      "TestComplete": "cpe:2.3:a:jenkins:testcomplete_support:*:*:*:*:*:jenkins:*:*",
-      "TestFairy": "cpe:2.3:a:jenkins:testfairy:*:*:*:*:*:jenkins:*:*",
-      "absint-a3": "cpe:2.3:a:jenkins:absint_a3:*:*:*:*:*:jenkins:*:*",
-      "absint-astree": "cpe:2.3:a:jenkins:absint_astree:*:*:*:*:*:jenkins:*:*",
-      "accurev": "cpe:2.3:a:microfocus:accurev:*:*:*:*:*:jenkins:*:*",
-      "active-choices": "cpe:2.3:a:jenkins:active_choices:*:*:*:*:*:jenkins:*:*",
-      "active-directory": "cpe:2.3:a:jenkins:active_directory:*:*:*:*:*:jenkins:*:*",
-      "agent-server-parameter": "cpe:2.3:a:jenkins:agent_server_parameter:*:*:*:*:*:jenkins:*:*",
-      "alauda-kubernetes-support": "cpe:2.3:a:jenkins:alauda_kubernetes_support:*:*:*:*:*:jenkins:*:*",
-      "analysis-core": "cpe:2.3:a:jenkins:static_analysis_utilities:*:*:*:*:*:jenkins:*:*",
-      "anchore-container-scanner": "cpe:2.3:a:jenkins:anchore_container_image_scanner:*:*:*:*:*:jenkins:*:*",
-      "android-lint": "cpe:2.3:a:jenkins:android_lint:*:*:*:*:*:jenkins:*:*",
-      "ansible": "cpe:2.3:a:jenkins:ansible:*:*:*:*:*:jenkins:*:*",
-      "ansible-tower": "cpe:2.3:a:jenkins:ansible_tower:*:*:*:*:*:jenkins:*:*",
-      "app-detector": "cpe:2.3:a:jenkins:application_detector:*:*:*:*:*:jenkins:*:*",
-      "appdynamics": "cpe:2.3:a:jenkins:appdynamics:*:*:*:*:*:jenkins:*:*",
-      "applatix": "cpe:2.3:a:jenkins:applatix:*:*:*:*:*:jenkins:*:*",
-      "apprenda": "cpe:2.3:a:jenkins:apprenda:*:*:*:*:*:jenkins:*:*",
-      "aqua-microscanner": "cpe:2.3:a:jenkins:aqua_microscanner:*:*:*:*:*:jenkins:*:*",
-      "aqua-security-scanner": "cpe:2.3:a:jenkins:aqua_security_scanner:*:*:*:*:*:jenkins:*:*",
-      "aqua-serverless": "cpe:2.3:a:jenkins:aqua_security_severless_scanner:*:*:*:*:*:jenkins:*:*",
-      "artifact-repository-parameter": "cpe:2.3:a:jenkins:artifact_repository_parameter:*:*:*:*:*:jenkins:*:*",
-      "assembla": "cpe:2.3:a:jenkins:assembla:*:*:*:*:*:jenkins:*:*",
-      "assembla-auth": "cpe:2.3:a:jenkins:assembla_auth:*:*:*:*:*:jenkins:*:*",
-      "assembla-merge-request-builder": "cpe:2.3:a:jenkins:assembla_merge_request_builder:*:*:*:*:*:jenkins:*:*",
-      "atlassian-bitbucket-server-integration": "cpe:2.3:a:jenkins:bitbucket_server_integration:*:*:*:*:*:jenkins:*:*",
-      "audit-trail": "cpe:2.3:a:jenkins:audit_trail:*:*:*:*:*:jenkins:*:*",
-      "audit2db": "cpe:2.3:a:jenkins:audit_to_database:*:*:*:*:*:jenkins:*:*",
-      "autocomplete-parameter": "cpe:2.3:a:jenkins:autocomplete_parameter:*:*:*:*:*:jenkins:*:*",
-      "autonomiq": "cpe:2.3:a:jenkins:autonomiq:*:*:*:*:*:jenkins:*:*",
-      "avatar": "cpe:2.3:a:jenkins:avatar:*:*:*:*:*:jenkins:*:*",
-      "aws-beanstalk-publisher": "cpe:2.3:a:jenkins:aws_elastic_beanstalk_publisher:*:*:*:*:*:jenkins:*:*",
-      "aws-beanstalk-publisher-plugin": "cpe:2.3:a:jenkins:aws_elastic_beanstalk_publisher:*:*:*:*:*:jenkins:*:*",
-      "aws-cloudwatch-logs-publisher": "cpe:2.3:a:jenkins:aws_cloudwatch_logs_publisher:*:*:*:*:*:jenkins:*:*",
-      "aws-codebuild": "cpe:2.3:a:jenkins:aws_codebuild:*:*:*:*:*:jenkins:*:*",
-      "aws-codecommit-trigger": "cpe:2.3:a:jenkins:aws_codecommit_trigger:*:*:*:*:*:jenkins:*:*",
-      "aws-codedeploy": "cpe:2.3:a:jenkins:aws_codedeploy:*:*:*:*:*:jenkins:*:*",
-      "aws-codepipeline": "cpe:2.3:a:jenkins:aws_codepipeline:*:*:*:*:*:jenkins:*:*",
-      "aws-credentials": "cpe:2.3:a:jenkins:cloudbees_aws_credentials:*:*:*:*:*:jenkins:*:*",
-      "aws-device-farm": "cpe:2.3:a:jenkins:aws-device-farm:*:*:*:*:*:jenkins:*:*",
-      "aws-global-configuration": "cpe:2.3:a:jenkins:aws_global_configuration:*:*:*:*:*:jenkins:*:*",
-      "aws-sam": "cpe:2.3:a:jenkins:amazon_web_services_service_application_model:*:*:*:*:*:jenkins:*:*",
-      "awseb-deployment": "cpe:2.3:a:jenkins:awseb_deployment:*:*:*:*:*:jenkins:*:*",
-      "azure-acs": "cpe:2.3:a:jenkins:azure_container_service:*:*:*:*:*:jenkins:*:*",
-      "azure-ad": "cpe:2.3:a:jenkins:azure_ad:*:*:*:*:*:jenkins:*:*",
-      "azure-container-agents": "cpe:2.3:a:jenkins:azure_container_service:*:*:*:*:*:jenkins:*:*",
-      "azure-credentials": "cpe:2.3:a:jenkins:azure_credentials:*:*:*:*:*:jenkins:*:*",
-      "azure-keyvault": "cpe:2.3:a:jenkins:azure_key_vault:*:*:*:*:*:jenkins:*:*",
-      "azure-publishersettings-credentials": "cpe:2.3:a:jenkins:azure_publishersettings_credentials:*:*:*:*:*:jenkins:*:*",
-      "azure-vm-agents": "cpe:2.3:a:jenkins:azure_vm_agents:*:*:*:*:*:jenkins:*:*",
-      "backlog": "cpe:2.3:a:jenkins:backlog:*:*:*:*:*:jenkins:*:*",
-      "badge": "cpe:2.3:a:jenkins:badge:*:*:*:*:*:jenkins:*:*",
-      "bart": "cpe:2.3:a:jenkins:bart:*:*:*:*:*:jenkins:*:*",
-      "batch-task": "cpe:2.3:a:jenkins:batch_task:*:*:*:*:*:jenkins:*:*",
-      "beaker-builder": "cpe:2.3:a:jenkins:beaker_builder:*:*:*:*:*:jenkins:*:*",
-      "bearychat": "cpe:2.3:a:jenkins:bearychat:*:*:*:*:*:jenkins:*:*",
-      "benchmark-evaluator": "cpe:2.3:a:jenkins:benchmark_evaluator:*:*:*:*:*:jenkins:*:*",
-      "bigpanda-jenkins": "cpe:2.3:a:jenkins:bigpanda_notifier:*:*:*:*:*:jenkins:*:*",
-      "bitbucket-approve": "cpe:2.3:a:jenkins:bitbucket_approve:*:*:*:*:*:jenkins:*:*",
-      "bitbucket-branch-source": "cpe:2.3:a:jenkins:bitbucket_branch_source:*:*:*:*:*:jenkins:*:*",
-      "bitbucket-oauth": "cpe:2.3:a:jenkins:bitbucket_oauth:*:*:*:*:*:jenkins:*:*",
-      "bitbucket-push-and-pull-request": "cpe:2.3:a:jenkins:bitbucket_push_and_pull_request:*:*:*:*:*:jenkins:*:*",
-      "blackduck-detect": "cpe:2.3:a:jenkins:synopsys_detect:*:*:*:*:*:jenkins:*:*",
-      "blackduck-hub": "cpe:2.3:a:jenkins:black_duck_hub:*:*:*:*:*:jenkins:*:*",
-      "blueocean": "cpe:2.3:a:jenkins:blue_ocean:*:*:*:*:*:jenkins:*:*",
-      "bmc-rpd": "cpe:2.3:a:jenkins:bmc_release_package_and_deployment:*:*:*:*:*:jenkins:*:*",
-      "brakeman": "cpe:2.3:a:jenkins:brakeman:*:*:*:*:*:jenkins:*:*",
-      "bugzilla": "cpe:2.3:a:jenkins:bugzilla_plugin:*:*:*:*:*:jenkins:*:*",
-      "build-failure-analyzer": "cpe:2.3:a:jenkins:build_failure_analyzer:*:*:*:*:*:jenkins:*:*",
-      "build-metrics": "cpe:2.3:a:jenkins:build-metrics:*:*:*:*:*:jenkins:*:*",
-      "build-notifications": "cpe:2.3:a:jenkins:build_notifications:*:*:*:*:*:jenkins:*:*",
-      "build-pipeline": "cpe:2.3:a:jenkins:build_pipeline:*:*:*:*:*:jenkins:*:*",
-      "build-publisher": "cpe:2.3:a:jenkins:build-publisher:*:*:*:*:*:jenkins:*:*",
-      "build-with-parameters": "cpe:2.3:a:jenkins:build_with_parameters:*:*:*:*:*:jenkins:*:*",
-      "buildgraph-view": "cpe:2.3:a:jenkins:buildgraph-view:*:*:*:*:*:jenkins:*:*",
-      "bumblebee": "cpe:2.3:a:jenkins:bumblebee_hp_alm:*:*:*:*:*:jenkins:*:*",
-      "cas": "cpe:2.3:a:jenkins:cas:*:*:*:*:*:jenkins:*:*",
-      "cas-plugin": "cpe:2.3:a:jenkins:cas:*:*:*:*:*:jenkins:*:*",
-      "catalogic-ecx": "cpe:2.3:a:jenkins:ecx_copy_data_management:*:*:*:*:*:jenkins:*:*",
-      "cavisson-ns-nd-integration": "cpe:2.3:a:jenkins:ns-nd_integration_performance_publisher:*:*:*:*:*:jenkins:*:*",
-      "cccc": "cpe:2.3:a:jenkins:cccc:*:*:*:*:*:jenkins:*:*",
-      "ccm": "cpe:2.3:a:jenkins:ccm:*:*:*:*:*:jenkins:*:*",
-      "chaos-monkey": "cpe:2.3:a:netflix:chaos_monkey:*:*:*:*:*:jenkins:*:*",
-      "checkmarx": "cpe:2.3:a:jenkins:checkmarx:*:*:*:*:*:jenkins:*:*",
-      "checkstyle": "cpe:2.3:a:jenkins:checkstyle:*:*:*:*:*:jenkins:*:*",
-      "chosen-views-tabbar": "cpe:2.3:a:jenkins:chosen-views-tabbar:*:*:*:*:*:jenkins:*:*",
-      "ci-with-toad-edge": "cpe:2.3:a:jenkins:continuous_integration_with_toad_edge:*:*:*:*:*:jenkins:*:*",
-      "cisco-spark": "cpe:2.3:a:jenkins:cisco_spark:*:*:*:*:*:jenkins:*:*",
-      "claim": "cpe:2.3:a:jenkins:claim:*:*:*:*:*:jenkins:*:*",
-      "clearcase-release": "cpe:2.3:a:jenkins:clearcase_release:*:*:*:*:*:jenkins:*:*",
-      "clif-performance-testing": "cpe:2.3:a:jenkins:clif_performance_testing:*:*:*:*:*:jenkins:*:*",
-      "cloud-stats": "cpe:2.3:a:jenkins:cloud_statistics:*:*:*:*:*:jenkins:*:*",
-      "cloudbees-bitbucket-branch-source": "cpe:2.3:a:jenkins:bitbucket_branch_source:*:*:*:*:*:jenkins:*:*",
-      "cloudbees-folder": "cpe:2.3:a:jenkins:folders:*:*:*:*:*:jenkins:*:*",
-      "cloudbees-jenkins-advisor": "cpe:2.3:a:jenkins:health_advisor_by_cloudbees:*:*:*:*:*:jenkins:*:*",
-      "cloudcoreo-deploytime": "cpe:2.3:a:jenkins:cloudcoreo_deploytime:*:*:*:*:*:jenkins:*:*",
-      "cloudfoundry": "cpe:2.3:a:jenkins:cloud_foundry:*:*:*:*:*:jenkins:*:*",
-      "cloudshare-docker": "cpe:2.3:a:jenkins:cloudshare_docker-machine:*:*:*:*:*:jenkins:*:*",
-      "cloudtest": "cpe:2.3:a:jenkins:soasta_cloudtest:*:*:*:*:*:jenkins:*:*",
-      "cobertura": "cpe:2.3:a:jenkins:cobertura:*:*:*:*:*:jenkins:*:*",
-      "code-coverage-api": "cpe:2.3:a:jenkins:code_coverage_api:*:*:*:*:*:jenkins:*:*",
-      "codefresh": "cpe:2.3:a:jenkins:codefresh_integration:*:*:*:*:*:jenkins:*:*",
-      "codescan": "cpe:2.3:a:jenkins:codescan:*:*:*:*:*:jenkins:*:*",
-      "collabnet": "cpe:2.3:a:jenkins:collabnet:*:*:*:*:*:jenkins:*:*",
-      "compact-columns": "cpe:2.3:a:jenkins:compact_columns:*:*:*:*:*:jenkins:*:*",
-      "compatibility-action-storage": "cpe:2.3:a:praqma:compatibility_action_storage:*:*:*:*:*:jenkins:*:*",
-      "computer-queue": "cpe:2.3:a:jenkins:computer_queue:*:*:*:*:*:jenkins:*:*",
-      "compuware-common-configuration": "cpe:2.3:a:jenkins:compuware_common_configuration:*:*:*:*:*:jenkins:*:*",
-      "compuware-ispw-operations": "cpe:2.3:a:jenkins:compuware_ispw_operations:*:*:*:*:*:jenkins:*:*",
-      "compuware-topaz-for-total-test": "cpe:2.3:a:jenkins:compuware_topaz_for_total_test:*:*:*:*:*:jenkins:*:*",
-      "compuware-topaz-utilities": "cpe:2.3:a:jenkins:compuware_topaz_utilities:*:*:*:*:*:jenkins:*:*",
-      "compuware-xpediter-code-coverage": "cpe:2.3:a:jenkins:compuware_xpediter_code_coverage:*:*:*:*:*:jenkins:*:*",
-      "config-file-provider": "cpe:2.3:a:jenkins:config_file_provider:*:*:*:*:*:jenkins:*:*",
-      "configuration-as-code": "cpe:2.3:a:jenkins:configuration_as_code:*:*:*:*:*:jenkins:*:*",
-      "configurationslicing": "cpe:2.3:a:jenkins:configuration_slicing:*:*:*:*:*:jenkins:*:*",
-      "confluence-publisher": "cpe:2.3:a:jenkins:confluence_publisher:*:*:*:*:*:jenkins:*:*",
-      "conjur-credentials": "cpe:2.3:a:jenkins:conjur_secrets:*:*:*:*:*:jenkins:*:*",
-      "cons3rt": "cpe:2.3:a:jenkins:cons3rt:*:*:*:*:*:jenkins:*:*",
-      "consul-kv-builder": "cpe:2.3:a:jenkins:consul_kv_builder:*:*:*:*:*:jenkins:*:*",
-      "contrast-continuous-application-security": "cpe:2.3:a:jenkins:contrast_continuous_application_security:*:*:*:*:*:jenkins:*:*",
-      "convert-to-pipeline": "cpe:2.3:a:jenkins:convert_to_pipeline:*:*:*:*:*:jenkins:*:*",
-      "convertigo-mobile-platform": "cpe:2.3:a:jenkins:convertigo_mobile_platform:*:*:*:*:*:jenkins:*:*",
-      "copr": "cpe:2.3:a:jenkins:copr:*:*:*:*:*:jenkins:*:*",
-      "copy-data-to-workspace": "cpe:2.3:a:jenkins:copy_data_to_workspace:*:*:*:*:*:jenkins:*:*",
-      "copy-data-to-workspace-plugin": "cpe:2.3:a:jenkins:copy_data_to_workspace:*:*:*:*:*:jenkins:*:*",
-      "copy-to-slave": "cpe:2.3:a:jenkins:copy_to_slave:*:*:*:*:*:jenkins:*:*",
-      "copyartifact": "cpe:2.3:a:jenkins:copy_artifact:*:*:*:*:*:jenkins:*:*",
-      "couchdb-statistics": "cpe:2.3:a:jenkins:couchdb-statistics:*:*:*:*:*:jenkins:*:*",
-      "covcomplplot": "cpe:2.3:a:jenkins:coverage\\/complexity_scatter_plot:*:*:*:*:*:jenkins:*:*",
-      "coverity": "cpe:2.3:a:jenkins:coverity:*:*:*:*:*:jenkins:*:*",
-      "cppcheck": "cpe:2.3:a:jenkins:cppcheck:*:*:*:*:*:jenkins:*:*",
-      "cppncss": "cpe:2.3:a:jenkins:cppncss:*:*:*:*:*:jenkins:*:*",
-      "crap4j": "cpe:2.3:a:jenkins:crap4j:*:*:*:*:*:jenkins:*:*",
-      "credentials": "cpe:2.3:a:jenkins:credentials:*:*:*:*:*:jenkins:*:*",
-      "credentials-binding": "cpe:2.3:a:jenkins:credentials_binding:*:*:*:*:*:jenkins:*:*",
-      "crittercism-dsym": "cpe:2.3:a:jenkins:crittercism-dsym:*:*:*:*:*:jenkins:*:*",
-      "crowd": "cpe:2.3:a:jenkins:crowd_integration:*:*:*:*:*:jenkins:*:*",
-      "crowd2": "cpe:2.3:a:jenkins:crowd_integration:*:*:*:*:*:jenkins:*:*",
-      "crx-content-package-deployer": "cpe:2.3:a:jenkins:crx_content_package_deployer:*:*:*:*:*:jenkins:*:*",
-      "cryptomove": "cpe:2.3:a:jenkins:cryptomove:*:*:*:*:*:jenkins:*:*",
-      "cucumber-living-documentation": "cpe:2.3:a:jenkins:cucumber_living_documentation:*:*:*:*:*:jenkins:*:*",
-      "custom-build-properties": "cpe:2.3:a:jenkins:custom_build_properties:*:*:*:*:*:jenkins:*:*",
-      "custom-checkbox-parameter": "cpe:2.3:a:jenkins:custom_checkbox_parameter:*:*:*:*:*:jenkins:*:*",
-      "custom-job-icon": "cpe:2.3:a:jenkins:custom_job_icon:*:*:*:*:*:jenkins:*:*",
-      "cvs": "cpe:2.3:a:jenkins:cvs:*:*:*:*:*:jenkins:*:*",
-      "dashboard-view": "cpe:2.3:a:jenkins:dashboard_view:*:*:*:*:*:jenkins:*:*",
-      "database": "cpe:2.3:a:jenkins:database:*:*:*:*:*:jenkins:*:*",
-      "datadog": "cpe:2.3:a:jenkins:datadog:*:*:*:*:*:jenkins:*:*",
-      "date-parameter": "cpe:2.3:a:jenkins:date_parameter:*:*:*:*:*:jenkins:*:*",
-      "dbCharts": "cpe:2.3:a:jenkins:dbcharts:*:*:*:*:*:jenkins:*:*",
-      "debian-package-builder": "cpe:2.3:a:jenkins:debian_package_builder:*:*:*:*:*:jenkins:*:*",
-      "delivery-pipeline-plugin": "cpe:2.3:a:jenkins:delivery_pipeline:*:*:*:*:*:jenkins:*:*",
-      "delphix": "cpe:2.3:a:jenkins:delphix:*:*:*:*:*:jenkins:*:*",
-      "dependency-check": "cpe:2.3:a:jenkins:owasp_dependency-check:*:*:*:*:*:jenkins:*:*",
-      "dependency-check-jenkins-plugin": "cpe:2.3:a:jenkins:owasp_dependency-check:*:*:*:*:*:jenkins:*:*",
-      "dependency-track": "cpe:2.3:a:jenkins:owasp_dependency-track:*:*:*:*:*:jenkins:*:*",
-      "depgraph-view": "cpe:2.3:a:jenkins:dependency_graph_viewer:*:*:*:*:*:jenkins:*:*",
-      "deploy": "cpe:2.3:a:jenkins:deploy:*:*:*:*:*:jenkins:*:*",
-      "deployer-framework": "cpe:2.3:a:jenkins:deployer_framework:*:*:*:*:*:jenkins:*:*",
-      "deployhub": "cpe:2.3:a:jenkins:deployhub:*:*:*:*:*:jenkins:*:*",
-      "deployit-plugin": "cpe:2.3:a:jenkins:xebialabs_xl_deploy:*:*:*:*:*:jenkins:*:*",
-      "description-column": "cpe:2.3:a:jenkins:description_column:*:*:*:*:*:jenkins:*:*",
-      "description-column-plugin": "cpe:2.3:a:jenkins:description_column:*:*:*:*:*:jenkins:*:*",
-      "diawi-upload": "cpe:2.3:a:jenkins:diawi_upload:*:*:*:*:*:jenkins:*:*",
-      "digitalocean": "cpe:2.3:a:jenkins:digitalocean:*:*:*:*:*:jenkins:*:*",
-      "digitalocean-plugin": "cpe:2.3:a:jenkins:digitalocean:*:*:*:*:*:jenkins:*:*",
-      "dimensionsscm": "cpe:2.3:a:microfocus:dimensions_cm:*:*:*:*:*:jenkins:*:*",
-      "dingding-json-pusher": "cpe:2.3:a:jenkins:dingding_json_pusher:*:*:*:*:*:jenkins:*:*",
-      "dingding-notifications": "cpe:2.3:a:jenkins:dingding:*:*:*:*:*:jenkins:*:*",
-      "distfork": "cpe:2.3:a:jenkins:distributed_fork:*:*:*:*:*:jenkins:*:*",
-      "docker": "cpe:2.3:a:jenkins:docker:*:*:*:*:*:jenkins:*:*",
-      "docker-commons": "cpe:2.3:a:jenkins:docker_commons:*:*:*:*:*:jenkins:*:*",
-      "docker-swarm": "cpe:2.3:a:jenkins:docker_swarm:*:*:*:*:*:jenkins:*:*",
-      "doktor": "cpe:2.3:a:jenkins:doktor:*:*:*:*:*:jenkins:*:*",
-      "dry": "cpe:2.3:a:jenkins:dry:*:*:*:*:*:jenkins:*:*",
-      "dynamic-extended-choice-parameter": "cpe:2.3:a:jenkins:dynamic_extended_choice_parameter:*:*:*:*:*:jenkins:*:*",
-      "dynamic_extended_choice_parameter": "cpe:2.3:a:jenkins:dynamic_extended_choice_parameter:*:*:*:*:*:jenkins:*:*",
-      "dynatrace": "cpe:2.3:a:jenkins:dynatrace_application_monitoring:*:*:*:*:*:jenkins:*:*",
-      "dynatrace-dashboard": "cpe:2.3:a:jenkins:dynatrace_application_monitoring:*:*:*:*:*:jenkins:*:*",
-      "eagle-tester": "cpe:2.3:a:jenkins:eagle_tester:*:*:*:*:*:jenkins:*:*",
-      "ease-plugin": "cpe:2.3:a:jenkins:digital.ai_app_management_publisher:*:*:*:*:*:jenkins:*:*",
-      "easyqa": "cpe:2.3:a:jenkins:easyqa:*:*:*:*:*:jenkins:*:*",
-      "ec2": "cpe:2.3:a:jenkins:ec2:*:*:*:*:*:jenkins:*:*",
-      "ec2-deployment-dashboard": "cpe:2.3:a:jenkins:deployment_dashboard:*:*:*:*:*:jenkins:*:*",
-      "echarts-api": "cpe:2.3:a:jenkins:echarts_api:*:*:*:*:*:jenkins:*:*",
-      "ecs-publisher": "cpe:2.3:a:trustsource:ecs_publisher:*:*:*:*:*:jenkins:*:*",
-      "ecutest": "cpe:2.3:a:jenkins:tracetronic_ecu-test:*:*:*:*:*:jenkins:*:*",
-      "eggplant": "cpe:2.3:a:jenkins:eggplant:*:*:*:*:*:jenkins:*:*",
-      "elastest": "cpe:2.3:a:jenkins:elastest:*:*:*:*:*:jenkins:*:*",
-      "elasticbox": "cpe:2.3:a:jenkins:elasticbox_ci:*:*:*:*:*:jenkins:*:*",
-      "elasticsearch-query": "cpe:2.3:a:jenkins:elasticsearch_query:*:*:*:*:*:jenkins:*:*",
-      "electricflow": "cpe:2.3:a:jenkins:electricflow:*:*:*:*:*:jenkins:*:*",
-      "eloyente": "cpe:2.3:a:jenkins:eloyente:*:*:*:*:*:jenkins:*:*",
-      "email-ext": "cpe:2.3:a:jenkins:email_extension:*:*:*:*:*:jenkins:*:*",
-      "emailext-template": "cpe:2.3:a:jenkins:email_extension_template:*:*:*:*:*:jenkins:*:*",
-      "embeddable-build-status": "cpe:2.3:a:jenkins:embeddable_build_status:*:*:*:*:*:jenkins:*:*",
-      "embotics-vcommander": "cpe:2.3:a:jenkins:snow_commander:*:*:*:*:*:jenkins:*:*",
-      "environment-dashboard": "cpe:2.3:a:jenkins:environment_dashboard:*:*:*:*:*:jenkins:*:*",
-      "environment-manager": "cpe:2.3:a:jenkins:parasoft_environment_manager:*:*:*:*:*:jenkins:*:*",
-      "environment-manager-tools": "cpe:2.3:a:jenkins:parasoft_environment_manager:*:*:*:*:*:jenkins:*:*",
-      "extended-choice-parameter": "cpe:2.3:a:jenkins:extended_choice_parameter:*:*:*:*:*:jenkins:*:*",
-      "extensivetesting": "cpe:2.3:a:jenkins:extensive_testing:*:*:*:*:*:jenkins:*:*",
-      "external-monitor-job": "cpe:2.3:a:jenkins:external_monitor_job_type:*:*:*:*:*:jenkins:*:*",
-      "extra-columns": "cpe:2.3:a:jenkins:extra_columns:*:*:*:*:*:jenkins:*:*",
-      "extreme-feedback": "cpe:2.3:a:jenkins:extreme-feedback:*:*:*:*:*:jenkins:*:*",
-      "fabric-beta-publisher": "cpe:2.3:a:jenkins:fabric_beta_publisher:*:*:*:*:*:jenkins:*:*",
-      "failedJobDeactivator": "cpe:2.3:a:jenkins:failed_job_deactivator:*:*:*:*:*:jenkins:*:*",
-      "favorite": "cpe:2.3:a:jenkins:favorite_plugin:*:*:*:*:*:jenkins:*:*",
-      "files-found-trigger": "cpe:2.3:a:jenkins:files_found_trigger:*:*:*:*:*:jenkins:*:*",
-      "filesystem-list-parameter-plugin": "cpe:2.3:a:jenkins:filesystem_list_parameter:*:*:*:*:*:jenkins:*:*",
-      "filesystem_scm": "cpe:2.3:a:jenkins:file_system_scm:*:*:*:*:*:jenkins:*:*",
-      "findbugs": "cpe:2.3:a:jenkins:findbugs:*:*:*:*:*:jenkins:*:*",
-      "fireline": "cpe:2.3:a:jenkins:360_fireline:*:*:*:*:*:jenkins:*:*",
-      "fitnesse": "cpe:2.3:a:jenkins:fitnesse:*:*:*:*:*:jenkins:*:*",
-      "flaky-test-handler": "cpe:2.3:a:jenkins:flaky_test_handler:*:*:*:*:*:jenkins:*:*",
-      "fogbugz": "cpe:2.3:a:jenkins:fogbugz:*:*:*:*:*:jenkins:*:*",
-      "folder-auth": "cpe:2.3:a:jenkins:folder-based_authorization_strategy:*:*:*:*:*:jenkins:*:*",
-      "fortify": "cpe:2.3:a:jenkins:fortify:*:*:*:*:*:jenkins:*:*",
-      "fortify-cloudscan": "cpe:2.3:a:jenkins:fortify_cloudscan:*:*:*:*:*:jenkins:*:.",
-      "fortify-cloudscan-jenkins-plugin": "cpe:2.3:a:jenkins:fortify_cloudscan:*:*:*:*:*:jenkins:*:.",
-      "fortify-on-demand-uploader": "cpe:2.3:a:jenkins:fortify_on_demand_uploader:*:*:*:*:*:jenkins:*:*",
-      "frugal-testing": "cpe:2.3:a:jenkins:frugal_testing:*:*:*:*:*:jenkins:*:*",
-      "fstrigger": "cpe:2.3:a:jenkins:filesystem_trigger:*:*:*:*:*:jenkins:*:*",
-      "ftppublisher": "cpe:2.3:a:jenkins:ftp_publisher:*:*:*:*:*:jenkins:*:*",
-      "gatling": "cpe:2.3:a:jenkins:gatling:*:*:*:*:*:jenkins:*:*",
-      "gcm-notification": "cpe:2.3:a:google:cloud_messaging_notification:*:*:*:*:*:jenkins:*:*",
-      "gearman-plugin": "cpe:2.3:a:jenkins:gearman:*:*:*:*:*:jenkins:*:*",
-      "gem-publisher": "cpe:2.3:a:jenkins:gem_publisher:*:*:*:*:*:jenkins:*:*",
-      "generic-webhook-trigger": "cpe:2.3:a:jenkins:generic_webhook_trigger:*:*:*:*:*:jenkins:*:*",
-      "gerrit-trigger": "cpe:2.3:a:jenkins:gerrit_trigger:*:*:*:*:*:jenkins:*:*",
-      "ghprb": "cpe:2.3:a:jenkins:github_pull_request_builder:*:*:*:*:*:jenkins:*:*",
-      "git": "cpe:2.3:a:jenkins:git:*:*:*:*:*:jenkins:*:*",
-      "git-changelog": "cpe:2.3:a:jenkins:git_changelog:*:*:*:*:*:jenkins:*:*",
-      "git-client": "cpe:2.3:a:jenkins:git_client:*:*:*:*:*:jenkins:*:*",
-      "git-parameter": "cpe:2.3:a:jenkins:git_parameter:*:*:*:*:*:jenkins:*:*",
-      "git-server": "cpe:2.3:a:jenkins:git_server:*:*:*:*:*:jenkins:*:*",
-      "gitea": "cpe:2.3:a:gitea:gitea:*:*:*:*:*:jenkins:*:*",
-      "github": "cpe:2.3:a:jenkins:github:*:*:*:*:*:jenkins:*:*",
-      "github-branch-source": "cpe:2.3:a:jenkins:github_branch_source:*:*:*:*:*:jenkins:*:*",
-      "github-coverage-reporter": "cpe:2.3:a:jenkins:github_coverage_reporter:*:*:*:*:*:jenkins:*:*",
-      "github-oauth": "cpe:2.3:a:jenkins:github_oauth:*:*:*:*:*:jenkins:*:*",
-      "github-pr-coverage-status": "cpe:2.3:a:jenkins:github_pull_request_coverage_status:*:*:*:*:*:jenkins:*:*",
-      "gitlab": "cpe:2.3:a:jenkins:gitlab:*:*:*:*:*:jenkins:*:*",
-      "gitlab-hook": "cpe:2.3:a:jenkins:gitlab_hook:*:*:*:*:*:jenkins:*:*",
-      "gitlab-oauth": "cpe:2.3:a:jenkins:gitlab_oauth:*:*:*:*:*:jenkins:*:*",
-      "gitlab-plugin": "cpe:2.3:a:jenkins:gitlab:*:*:*:*:*:jenkins:*:*",
-      "global-build-stats": "cpe:2.3:a:jenkins:global-build-stats:*:*:*:*:*:jenkins:*:*",
-      "global-post-script": "cpe:2.3:a:jenkins:global_post_script:*:*:*:*:*:jenkins:*:*",
-      "global-variable-string-parameter": "cpe:2.3:a:jenkins:global_variable_string_parameter:*:*:*:*:*:jenkins:*:*",
-      "gogs-webhook": "cpe:2.3:a:jenkins:gogs:*:*:*:*:*:jenkins:*:*",
-      "google-compute-engine": "cpe:2.3:a:jenkins:google_compute_engine:*:*:*:*:*:jenkins:*:*",
-      "google-kubernetes-engine": "cpe:2.3:a:jenkins:google_kubernetes_engine:*:*:*:*:*:jenkins:*:*",
-      "google-login": "cpe:2.3:a:jenkins:google_login:*:*:*:*:*:jenkins:*:*",
-      "google-oauth": "cpe:2.3:a:jenkins:google_oauth_credentials:*:*:*:*:*:jenkins:*:*",
-      "google-play-android-publisher": "cpe:2.3:a:jenkins:google-play-android-publisher:*:*:*:*:*:jenkins:*:*",
-      "gradle": "cpe:2.3:a:jenkins:gradle:*:*:*:*:*:jenkins:*:*",
-      "groovy": "cpe:2.3:a:jenkins:groovy:*:*:*:*:*:jenkins:*:*",
-      "groovy-postbuild": "cpe:2.3:a:jenkins:groovy_postbuild:*:*:*:*:*:jenkins:*:*",
-      "harvest": "cpe:2.3:a:jenkins:harvest_scm:*:*:*:*:*:jenkins:*:*",
-      "hashicorp-vault-plugin": "cpe:2.3:a:jenkins:hashicorp_vault:*:*:*:*:*:jenkins:*:*",
-      "hidden-parameter": "cpe:2.3:a:jenkins:hidden_parameter:*:*:*:*:*:jenkins:*:*",
-      "hipchat": "cpe:2.3:a:atlassian:hipchat:*:*:*:*:*:jenkins:*:*",
-      "hockeyapp": "cpe:2.3:a:jenkins:hockeyapp:*:*:*:*:*:jenkins:*:*",
-      "hp-application-automation-tools-plugin": "cpe:2.3:a:microfocus:application_automation_tools:*:*:*:*:*:jenkins:*:*",
-      "hp-quality-center": "cpe:2.3:a:hp_application_lifecycle_management_quality_center_project:hp_application_lifecycle_management_quality_center:*:*:*:*:*:jenkins:*:*",
-      "hpe-network-virtualization": "cpe:2.3:a:jenkins:hpe_network_virtualization:*:*:*:*:*:jenkins:*:*",
-      "htmlpublisher": "cpe:2.3:a:jenkins:html_publisher:*:*:*:*:*:jenkins:*:*",
-      "htmlresource": "cpe:2.3:a:jenkins:html_resource:*:*:*:*:*:*:*:*",
-      "http-request": "cpe:2.3:a:jenkins:http_request:*:*:*:*:*:jenkins:*:*",
-      "http_request": "cpe:2.3:a:jenkins:http_request:*:*:*:*:*:jenkins:*:*",
-      "hyper-commons": "cpe:2.3:a:jenkins:hyper.sh_commons:*:*:*:*:*:jenkins:*:*",
-      "ibm-application-security": "cpe:2.3:a:jenkins:ibm_application_security_on_cloud:*:*:*:*:*:jenkins:*:*",
-      "ibm-asoc": "cpe:2.3:a:jenkins:ibm_application_security_on_cloud:*:*:*:*:*:jenkins:*:*",
-      "icescrum": "cpe:2.3:a:jenkins:icescrum:*:*:*:*:*:jenkins:*:*",
-      "image-gallery": "cpe:2.3:a:jenkins:image_gallery:*:*:*:*:*:jenkins:*:*",
-      "image-tag-parameter": "cpe:2.3:a:jenkins:image_tag_parameter:*:*:*:*:*:jenkins:*:*",
-      "implied-labels": "cpe:2.3:a:jenkins:implied_labels:*:*:*:*:*:jenkins:*:*",
-      "incapptic-connect-uploader": "cpe:2.3:a:jenkins:incapptic_connect_uploader:*:*:*:*:*:jenkins:*:*",
-      "inedo-buildmaster": "cpe:2.3:a:jenkins:inedo_buildmaster:*:*:*:*:*:jenkins:*:*",
-      "inedo-proget": "cpe:2.3:a:jenkins:inedo_proget:*:*:*:*:*:jenkins:*:*",
-      "influxdb": "cpe:2.3:a:eficode:influxdb:*:*:*:*:*:jenkins:*:*",
-      "instant-messaging": "cpe:2.3:a:jenkins:instant-messaging:*:*:*:*:*:jenkins:*:*",
-      "ircbot": "cpe:2.3:a:jenkins:irc:*:*:*:*:*:jenkins:*:*",
-      "ivy": "cpe:2.3:a:jenkins:ivy:*:*:*:*:*:jenkins:*:*",
-      "jabber": "cpe:2.3:a:jenkins:jabber_\\(xmpp\\)_notifier_and_control:*:*:*:*:*:jenkins:*:*",
-      "jabber-server-plugin": "cpe:2.3:a:jenkins:jabber_server:*:*:*:*:*:jenkins:*:*",
-      "jacoco": "cpe:2.3:a:jenkins:jacoco:*:*:*:*:*:jenkins:*:*",
-      "jclouds": "cpe:2.3:a:jenkins:jclouds:*:*:*:*:*:jenkins:*:*",
-      "jenkins-cloudformation": "cpe:2.3:a:jenkins:jenkins-cloudformation-plugin:*:*:*:*:*:jenkins:*:*",
-      "jenkins-multijob-plugin": "cpe:2.3:a:jenkins:multijob:*:*:*:*:*:jenkins:*:*",
-      "jenkins-reviewbot": "cpe:2.3:a:jenkins:jenkins-reviewbot:*:*:*:*:*:jenkins:*:*",
-      "jenkinsci-appspider-plugin": "cpe:2.3:a:jenkins:appspider:*:*:*:*:*:jenkins:*:*",
-      "jianliao": "cpe:2.3:a:jenkins:jianliao_notification:*:*:*:*:*:jenkins:*:*",
-      "jigomerge": "cpe:2.3:a:jenkins:jigomerge:*:*:*:*:*:jenkins:*:*",
-      "jira": "cpe:2.3:a:jenkins:jira:*:*:*:*:*:jenkins:*:*",
-      "jira-ext": "cpe:2.3:a:jenkins:jira-ext:*:*:*:*:*:jenkins:*:*",
-      "jira-issue-updater": "cpe:2.3:a:jenkins:jira_issue_updater:*:*:*:*:*:jenkins:*:*",
-      "jira-steps": "cpe:2.3:a:jenkins:jira_pipeline_steps:*:*:*:*:*:jenkins:*:*",
-      "jms-messaging": "cpe:2.3:a:jenkins:jms_messaging:*:*:*:*:*:jenkins:*:*",
-      "job-dsl": "cpe:2.3:a:jenkins:job_dsl:*:*:*:*:*:jenkins:*:*",
-      "job-import": "cpe:2.3:a:jenkins:job_import:*:*:*:*:*:jenkins:*:*",
-      "job-import-plugin": "cpe:2.3:a:jenkins:job_import:*:*:*:*:*:jenkins:*:*",
-      "jobConfigHistory": "cpe:2.3:a:jobconfighistory_project:jobconfighistory:*:*:*:*:*:jenkins:*:*",
-      "jobgenerator": "cpe:2.3:a:jenkins:job_generator:*:*:*:*:*:jenkins:*:*",
-      "jsgames": "cpe:2.3:a:jenkins:jsgames:*:*:*:*:*:jenkins:*:*",
-      "junit": "cpe:2.3:a:jenkins:junit:*:*:*:*:*:jenkins:*:*",
-      "jx-resources": "cpe:2.3:a:jenkins:jx_resources:*:*:*:*:*:jenkins:*:*",
-      "kanboard": "cpe:2.3:a:jenkins:kanboard:*:*:*:*:*:jenkins:*:*",
-      "katalon": "cpe:2.3:a:jenkins:katalon:*:*:*:*:*:jenkins:*:*",
-      "kiuwanJenkinsPlugin": "cpe:2.3:a:jenkins:kiuwan:*:*:*:*:*:jenkins:*:*",
-      "klaros-testmanagement": "cpe:2.3:a:jenkins:klaros-testmanagement:*:*:*:*:*:jenkins:*:*",
-      "klocwork": "cpe:2.3:a:jenkins:klocwork_analysis:*:*:*:*:*:jenkins:*:*",
-      "kmap": "cpe:2.3:a:jenkins:kmap:*:*:*:*:*:jenkins:*:*",
-      "kmap-jenkins": "cpe:2.3:a:jenkins:kmap:*:*:*:*:*:jenkins:*:*",
-      "koji": "cpe:2.3:a:jenkins:koji:*:*:*:*:*:jenkins:*:*",
-      "kubernetes": "cpe:2.3:a:jenkins:kubernetes:*:*:*:*:*:jenkins:*:*",
-      "kubernetes-cd": "cpe:2.3:a:jenkins:kubernetes_continuous_deploy:*:*:*:*:*:jenkins:*:*",
-      "kubernetes-ci": "cpe:2.3:a:jenkins:kubernetes_ci:*:*:*:*:*:jenkins:*:*",
-      "kubernetes-credentials-provider": "cpe:2.3:a:jenkins:kubernetes_credentials_provider:*:*:*:*:*:jenkins:*:*",
-      "kubernetes-pipeline": "cpe:2.3:a:jenkins:kubernetes_pipeline:*:*:*:*:*:jenkins:*:*",
-      "labmanager": "cpe:2.3:a:jenkins:vmware_lab_manager_slaves:*:*:*:*:*:jenkins:*:*",
-      "lambdatest-automation": "cpe:2.3:a:jenkins:lambdatest-automation:*:*:*:*:*:jenkins:*:*",
-      "libvirt-slave": "cpe:2.3:a:jenkins:libvirt_slaves:*:*:*:*:*:jenkins:*:*",
-      "link-column": "cpe:2.3:a:jenkins:link_column:*:*:*:*:*:jenkins:*:*",
-      "liquibase-runner": "cpe:2.3:a:jenkins:liquibase_runner:*:*:*:*:*:jenkins:*:*",
-      "list-git-branches-parameter": "cpe:2.3:a:jenkins:list_git_branches_parameter:*:*:*:*:*:jenkins:*:*",
-      "literate": "cpe:2.3:a:jenkins:literate:*:*:*:*:*:jenkins:*:*",
-      "lockable-resources": "cpe:2.3:a:jenkins:lockable_resources:*:*:*:*:*:jenkins:*:*",
-      "locked-files-report": "cpe:2.3:a:jenkins:locked_files_report:*:*:*:*:*:jenkins:*:*",
-      "log-parser": "cpe:2.3:a:jenkins:log_parser:*:*:*:*:*:jenkins:*:*",
-      "logstash": "cpe:2.3:a:jenkins:logstash:*:*:*:*:*:jenkins:*:*",
-      "lucene-search": "cpe:2.3:a:jenkins:lucene-search:*:*:*:*:*:jenkins:*:*",
-      "m2release": "cpe:2.3:a:jenkins:m2release:*:*:*:*:*:jenkins:*:*",
-      "mabl-integration": "cpe:2.3:a:jenkins:mabl:*:*:*:*:*:jenkins:*:*",
-      "mac": "cpe:2.3:a:jenkins:mac:*:*:*:*:*:jenkins:*:*",
-      "macstadium-orka": "cpe:2.3:a:jenkins:orka_by_macstadium:*:*:*:*:*:jenkins:*:*",
-      "mail-commander": "cpe:2.3:a:jenkins:mail_commander:*:*:*:*:*:jenkins:*:*",
-      "mailcommander": "cpe:2.3:a:jenkins:mail_commander:*:*:*:*:*:jenkins:*:*",
-      "mailer": "cpe:2.3:a:jenkins:mailer:*:*:*:*:*:jenkins:*:*",
-      "mantis": "cpe:2.3:a:jenkins:mantis:*:*:*:*:*:jenkins:*:*",
-      "markdown-formatter": "cpe:2.3:a:jenkins:markdown_formatter:*:*:*:*:*:jenkins:*:*",
-      "mashup-portlets": "cpe:2.3:a:jenkins:mashup_portlets:*:*:*:*:*:jenkins:*:*",
-      "mask-passwords": "cpe:2.3:a:jenkins:mask_passwords:*:*:*:*:*:jenkins:*:*",
-      "mathworks-polyspace": "cpe:2.3:a:jenkins:mathworks_polyspace:*:*:*:*:*:jenkins:*:*",
-      "matlab": "cpe:2.3:a:jenkins:matlab:*:*:*:*:*:jenkins:*:*",
-      "matrix-auth": "cpe:2.3:a:jenkins:matrix_authorization_strategy:*:*:*:*:*:jenkins:*:*",
-      "matrix-project": "cpe:2.3:a:jenkins:matrix_project:*:*:*:*:*:jenkins:*:*",
-      "matrix-reloaded": "cpe:2.3:a:jenkins:matrix_reloaded:*:*:*:*:*:jenkins:*:*",
-      "mattermost": "cpe:2.3:a:jenkins:mattermost_notification:*:*:*:*:*:jenkins:*:*",
-      "maven": "cpe:2.3:a:jenkins:maven:*:*:*:*:*:jenkins:*:*",
-      "maven-artifact-choicelistprovider": "cpe:2.3:a:jenkins:maven_artifact_choicelistprovider_\\(nexus\\):*:*:*:*:*:jenkins:*:*",
-      "maven-metadata-plugin": "cpe:2.3:a:jenkins:maven_metadata:*:*:*:*:*:jenkins:*:*",
-      "maven-release-cascade": "cpe:2.3:a:barchart:maven_cascade_release:*:*:*:*:*:jenkins:*:*",
-      "meliora-testlab": "cpe:2.3:a:melioratestlab:melioratestlab:*:*:*:*:*:jenkins:*:*",
-      "mercurial": "cpe:2.3:a:jenkins:mercurial:*:*:*:*:*:jenkins:*:*",
-      "mesos": "cpe:2.3:a:apache:mesos:*:*:*:*:*:jenkins:*:*",
-      "metrics": "cpe:2.3:a:jenkins:metrics:*:*:*:*:*:jenkins:*:*",
-      "minio-storage": "cpe:2.3:a:jenkins:minio_storage:*:*:*:*:*:jenkins:*:*",
-      "miniorange-saml-sp": "cpe:2.3:a:jenkins:saml_single_sign_on:*:*:*:*:*:jenkins:*:*",
-      "mongodb": "cpe:2.3:a:jenkins:mongodb:*:*:*:*:*:jenkins:*:*",
-      "monitoring": "cpe:2.3:a:jenkins:monitoring:*:*:*:*:*:jenkins:*:*",
-      "mstest": "cpe:2.3:a:jenkins:mstest:*:*:*:*:*:jenkins:*:*",
-      "neoload": "cpe:2.3:a:jenkins:neoload:*:*:*:*:*:jenkins:*:*",
-      "nerrvana": "cpe:2.3:a:jenkins:nerrvana:*:*:*:*:*:jenkins:*:*",
-      "nested-view": "cpe:2.3:a:jenkins:nested_view:*:*:*:*:*:jenkins:*:*",
-      "netsparker-cloud-scan": "cpe:2.3:a:jenkins:netsparker_cloud_scan:*:*:*:*:*:jenkins:*:*",
-      "neuvector-vulnerability-scanner": "cpe:2.3:a:jenkins:neuvector_vulnerability_scanner:*:*:*:*:*:jenkins:*:*",
-      "nexus-platform": "cpe:2.3:a:jenkins:nexus_platform:*:*:*:*:*:jenkins:*:*",
-      "nodejs": "cpe:2.3:a:jenkins:nodejs:*:*:*:*:*:jenkins:*:*",
-      "nodelabelparameter": "cpe:2.3:a:jenkins:node_and_label_parameter:*:*:*:*:*:jenkins:*:*",
-      "nomad": "cpe:2.3:a:jenkins:nomad:*:*:*:*:*:jenkins:*:*",
-      "nuget": "cpe:2.3:a:jenkins:nuget:*:*:*:*:*:jenkins:*:*",
-      "nunit": "cpe:2.3:a:jenkins:nunit:*:*:*:*:*:jenkins:*:*",
-      "octoperf": "cpe:2.3:a:jenkins:octoperf_load_testing:*:*:*:*:*:jenkins:*:*",
-      "oic-auth": "cpe:2.3:a:jenkins:openid_connect_authentication:*:*:*:*:*:jenkins:*:*",
-      "ontrack": "cpe:2.3:a:jenkins:ontrack:*:*:*:*:*:jenkins:*:*",
-      "open-stf": "cpe:2.3:a:jenkins:open_stf:*:*:*:*:*:jenkins:*:*",
-      "openid": "cpe:2.3:a:jenkins:openid:*:*:*:*:*:jenkins:*:*",
-      "openshift-deployer": "cpe:2.3:a:jenkins:openshift_deployer:*:*:*:*:*:jenkins:*:*",
-      "openshift-login": "cpe:2.3:a:jenkins:openshift_login:*:*:*:*:*:jenkins:*:*",
-      "openshift-pipeline": "cpe:2.3:a:jenkins:openshift_pipeline:*:*:*:*:*:jenkins:*:*",
-      "openstack-cloud": "cpe:2.3:a:jenkins:openstack_cloud:*:*:*:*:*:jenkins:*:*",
-      "opsgenie": "cpe:2.3:a:jenkins:opsgenie:*:*:*:*:*:jenkins:*:*",
-      "oracle-cloud-infrastructure-compute-classic": "cpe:2.3:a:jenkins:oracle_cloud_infrastructure_compute_classic:*:*:*:*:*:jenkins:*:*",
-      "ownership": "cpe:2.3:a:jenkins:job_and_node_ownership:*:*:*:*:*:jenkins:*:*",
-      "p4": "cpe:2.3:a:jenkins:p4:*:*:*:*:*:jenkins:*:*",
-      "packageversion": "cpe:2.3:a:jenkins:package_version:*:*:*:*:*:jenkins:*:*",
-      "pam-auth": "cpe:2.3:a:jenkins:pluggable_authentication_module:*:*:*:*:*:jenkins:*:*",
-      "pangolin-testrail-connector": "cpe:2.3:a:agiletestware:pangolin_connector_for_testrail:*:*:*:*:*:jenkins:*:*",
-      "parameterized-remote-trigger": "cpe:2.3:a:jenkins:parameterized_remote_trigger:*:*:*:*:*:jenkins:*:*",
-      "parameterized-trigger": "cpe:2.3:a:jenkins:parameterized_trigger:*:*:*:*:*:jenkins:*:*",
-      "parasoft-findings": "cpe:2.3:a:jenkins:parasoft_findings:*:*:*:*:*:jenkins:*:*",
-      "pegdown-formatter": "cpe:2.3:a:jenkins:pegdown_formatter:*:*:*:*:*:jenkins:*:*",
-      "perfecto": "cpe:2.3:a:jenkins:perfecto:*:*:*:*:*:jenkins:*:*",
-      "perfectomobile": "cpe:2.3:a:jenkins:perfecto_mobile:*:*:*:*:*:jenkins:*:*",
-      "perforce": "cpe:2.3:a:jenkins:perforce:*:*:*:*:*:jenkins:*:*",
-      "performance": "cpe:2.3:a:jenkins:performance:*:*:*:*:*:jenkins:*:*",
-      "perfpublisher": "cpe:2.3:a:jenkins:performance_publisher:*:*:*:*:*:jenkins:*:*",
-      "periodicbackup": "cpe:2.3:a:jenkins:periodic_backup:*:*:*:*:*:jenkins:*:*",
-      "persona": "cpe:2.3:a:jenkins:persona:*:*:*:*:*:jenkins:*:*",
-      "phabricator-plugin": "cpe:2.3:a:jenkins:phabricator_differential:*:*:*:*:*:jenkins:*:*",
-      "phoenix-autotest": "cpe:2.3:a:jenkins:pipeline\\:_phoenix_autotest:*:*:*:*:*:jenkins:*:*",
-      "pipeline-aggregator-view": "cpe:2.3:a:jenkins:pipeline_aggregator_view:*:*:*:*:*:jenkins:*:*",
-      "pipeline-aws": "cpe:2.3:a:jenkins:pipeline\\:_aws_steps:*:*:*:*:*:jenkins:*:*",
-      "pipeline-build-step": "cpe:2.3:a:jenkins:pipeline\\:_build_step:*:*:*:*:*:jenkins:*:*",
-      "pipeline-githubnotify-step": "cpe:2.3:a:jenkins:pipeline_github_notify_step:*:*:*:*:*:jenkins:*:*",
-      "pipeline-input-step": "cpe:2.3:a:jenkins:pipeline\\:input_step:*:*:*:*:*:jenkins:*:*",
-      "pipeline-maven": "cpe:2.3:a:jenkins:pipeline_maven_integration:*:*:*:*:*:jenkins:*:*",
-      "pipeline-model-definition": "cpe:2.3:a:jenkins:pipeline\\:_declarative:*:*:*:*:*:jenkins:*:*",
-      "pipeline-restful-api": "cpe:2.3:a:jenkins:pipeline_restful_api:*:*:*:*:*:jenkins:*:*",
-      "pipeline-stage-view": "cpe:2.3:a:jenkins:stage_view:*:*:*:*:*:jenkins:*:*",
-      "play": "cpe:2.3:a:jenkins:play_framework:*:*:*:*:*:jenkins:*:*",
-      "plot": "cpe:2.3:a:jenkins:plot:*:*:*:*:*:jenkins:*:*",
-      "pmd": "cpe:2.3:a:jenkins:pmd:*:*:*:*:*:jenkins:*:*",
-      "pollscm": "cpe:2.3:a:jenkins:poll_scm:*:*:*:*:*:jenkins:*:*",
-      "pom2config": "cpe:2.3:a:jenkins:pom2config:*:*:*:*:*:jenkins:*:*",
-      "port-allocator": "cpe:2.3:a:jenkins:port_allocator:*:*:*:*:*:jenkins:*:*",
-      "project-inheritance": "cpe:2.3:a:jenkins:project_inheritance:*:*:*:*:*:jenkins:*:*",
-      "promoted-builds": "cpe:2.3:a:jenkins:promoted_builds:*:*:*:*:*:jenkins:*:*",
-      "promoted-builds-simple": "cpe:2.3:a:jenkins:promoted_builds_\\(simple\\):*:*:*:*:*:jenkins:*:*",
-      "proxmox": "cpe:2.3:a:jenkins:proxmox:*:*:*:*:*:jenkins:*:*",
-      "prqa": "cpe:2.3:a:jenkins:prqa:*:*:*:*:*:jenkins:*:*",
-      "prqa-plugin": "cpe:2.3:a:jenkins:prqa:*:*:*:*:*:jenkins:*:*",
-      "publish-over-cifs": "cpe:2.3:a:jenkins:publish_over_cifs:*:*:*:*:*:jenkins:*:*",
-      "publish-over-ftp": "cpe:2.3:a:jenkins:publish_over_ftp:*:*:*:*:*:jenkins:*:*",
-      "publish-over-ssh": "cpe:2.3:a:jenkins:publish_over_ssh:*:*:*:*:*:jenkins:*:*",
-      "puppet-enterprise-pipeline": "cpe:2.3:a:jenkins:puppet_enterprise_pipeline:*:*:*:*:*:jenkins:*:*",
-      "pwauth": "cpe:2.3:a:jenkins:pwauth_security_realm:*:*:*:*:*:jenkins:*:*",
-      "quality-gates": "cpe:2.3:a:jenkins:quality_gates:*:*:*:*:*:jenkins:*:*",
-      "quayio-trigger": "cpe:2.3:a:jenkins:quay.io_trigger:*:*:*:*:*:jenkins:*:*",
-      "queue-cleanup": "cpe:2.3:a:jenkins:queue_cleanup:*:*:*:*:*:jenkins:*:*",
-      "rabbitmq-consumer": "cpe:2.3:a:jenkins:rabbitmq_consumer:*:*:*:*:*:jenkins:*:*",
-      "radargun": "cpe:2.3:a:jenkins:radargun:*:*:*:*:*:jenkins:*:*",
-      "radiatorview": "cpe:2.3:a:jenkins:radiator_view:*:*:*:*:*:jenkins:*:*",
-      "radiatorviewplugin": "cpe:2.3:a:jenkins:radiator_view:*:*:*:*:*:jenkins:*:*",
-      "random-string-parameter": "cpe:2.3:a:jenkins:random_string_parameter:*:*:*:*:*:jenkins:*:*",
-      "rapiddeploy": "cpe:2.3:a:jenkins:rapiddeploy:*:*:*:*:*:jenkins:*:*",
-      "rapiddeploy-jenkins": "cpe:2.3:a:jenkins:rapiddeploy:*:*:*:*:*:jenkins:*:*",
-      "rebuild": "cpe:2.3:a:rebuild_project:rebuild:*:*:*:*:*:jenkins:*:*",
-      "recipe": "cpe:2.3:a:jenkins:recipe:*:*:*:*:*:jenkins:*:*",
-      "redgate-sql-ci": "cpe:2.3:a:jenkins:redgate_sql_change_automation:*:*:*:*:*:jenkins:*:*",
-      "redhat-dependency-analytics": "cpe:2.3:a:jenkins:red_hat_dependency_analytics:*:*:*:*:*:jenkins:*:*",
-      "release-helper": "cpe:2.3:a:jenkins:release_helper:*:*:*:*:*:jenkins:*:*",
-      "relution-publisher": "cpe:2.3:a:jenkins:relution_enterprise_appstore_publisher:*:*:*:*:*:jenkins:*:*",
-      "remote-jobs-view": "cpe:2.3:a:jenkins:remote-jobs-view:*:*:*:*:*:jenkins:*:*",
-      "repo": "cpe:2.3:a:jenkins:repo:*:*:*:*:*:jenkins:*:*",
-      "reportportal": "cpe:2.3:a:jenkins:report_portal:*:*:*:*:*:jenkins:*:*",
-      "repository-connector": "cpe:2.3:a:jenkins:repository_connector:*:*:*:*:*:jenkins:*:*",
-      "requests": "cpe:2.3:a:jenkins:requests:*:*:*:*:*:jenkins:*:*",
-      "resource-disposer": "cpe:2.3:a:jenkins:resource_disposer:*:*:*:*:*:jenkins:*:*",
-      "rest-list-parameter": "cpe:2.3:a:jenkins:rest_list_parameter:*:*:*:*:*:jenkins:*:*",
-      "reverse-proxy-auth": "cpe:2.3:a:jenkins:reverse_proxy_auth:*:*:*:*:*:jenkins:*:*",
-      "reverse-proxy-auth-plugin": "cpe:2.3:a:jenkins:reverse_proxy_auth:*:*:*:*:*:jenkins:*:*",
-      "rhnpush-plugin": "cpe:2.3:a:jenkins:rhnpush-plugin:*:*:*:*:*:jenkins:*:*",
-      "rich-text-publisher-plugin": "cpe:2.3:a:jenkins:rich_text_publisher:*:*:*:*:*:jenkins:*:*",
-      "robot": "cpe:2.3:a:jenkins:robot_framework:*:*:*:*:*:jenkins:*:*",
-      "rocketchatnotifier": "cpe:2.3:a:jenkins:rocketchat_notifier:*:*:*:*:*:jenkins:*:*",
-      "role-strategy": "cpe:2.3:a:jenkins:role-based_authorization_strategy:*:*:*:*:*:jenkins:*:*",
-      "rpmsign": "cpe:2.3:a:jenkins:rpmsign-plugin:*:*:*:*:*:jenkins:*:*",
-      "rpmsign-plugin": "cpe:2.3:a:jenkins:rpmsign-plugin:*:*:*:*:*:jenkins:*:*",
-      "rqm-plugin": "cpe:2.3:a:jenkins:rqm:*:*:*:*:*:jenkins:*:*",
-      "rrod": "cpe:2.3:a:jenkins:request_rename_or_delete:*:*:*:*:*:jenkins:*:*",
-      "rundeck": "cpe:2.3:a:jenkins:rundeck:*:*:*:*:*:jenkins:*:*",
-      "s3": "cpe:2.3:a:jenkins:s3_publisher:*:*:*:*:*:jenkins:*:*",
-      "s3explorer": "cpe:2.3:a:jenkins:s3_explorer:*:*:*:*:*:jenkins:*:*",
-      "saltstack": "cpe:2.3:a:jenkins:saltstack:*:*:*:*:*:jenkins:*:*",
-      "sametime": "cpe:2.3:a:jenkins:sametime:*:*:*:*:*:jenkins:*:*",
-      "saml": "cpe:2.3:a:jenkins:saml:*:*:*:*:*:jenkins:*:*",
-      "sauce-ondemand": "cpe:2.3:a:jenkins:sauce_ondemand:*:*:*:*:*:jenkins:*:*",
-      "scm-filter-jervis": "cpe:2.3:a:jenkins:source_code_management_filter_jervis:*:*:*:*:*:jenkins:*:*",
-      "scm-httpclient": "cpe:2.3:a:jenkins:scm_httpclient:*:*:*:*:*:jenkins:*:*",
-      "scp": "cpe:2.3:a:jenkins:scp_publisher:*:*:*:*:*:jenkins:*:*",
-      "script-security": "cpe:2.3:a:jenkins:script_security:*:*:*:*:*:jenkins:*:*",
-      "scriptler": "cpe:2.3:a:jenkins:scriptler:*:*:*:*:*:jenkins:*:*",
-      "security-inspector": "cpe:2.3:a:jenkins:security_inspector:*:*:*:*:*:jenkins:*:*",
-      "selected-tests-executor": "cpe:2.3:a:jenkins:tests_selector:*:*:*:*:*:jenkins:*:*",
-      "selection-tasks": "cpe:2.3:a:jenkins:selection_tasks:*:*:*:*:*:jenkins:*:*",
-      "selection-tasks-plugin": "cpe:2.3:a:jenkins:selection_tasks:*:*:*:*:*:jenkins:*:*",
-      "selenium": "cpe:2.3:a:jenkins:selenium:*:*:*:*:*:jenkins:*:*",
-      "seleniumhtmlreport": "cpe:2.3:a:jenkins:selenium_html_report:*:*:*:*:*:jenkins:*:*",
-      "semantic-versioning": "cpe:2.3:a:jenkins:semantic_versioning:*:*:*:*:*:jenkins:*:*",
-      "semantic-versioning-plugin": "cpe:2.3:a:jenkins:semantic_versioning:*:*:*:*:*:jenkins:*:*",
-      "servicenow-devops": "cpe:2.3:a:jenkins:servicenow_devops:*:*:*:*:*:jenkins:*:*",
-      "shared-objects": "cpe:2.3:a:jenkins:shared_objects:*:*:*:*:*:jenkins:*:*",
-      "shelve-project": "cpe:2.3:a:jenkins:shelve_project:*:*:*:*:*:jenkins:*:*",
-      "shelve-project-plugin": "cpe:2.3:a:jenkins:shelve_project:*:*:*:*:*:jenkins:*:*",
-      "shortcut-job": "cpe:2.3:a:jenkins:shortcut_job:*:*:*:*:*:jenkins:*:*",
-      "sidebar-link": "cpe:2.3:a:jenkins:sidebar_link:*:*:*:*:*:jenkins:*:*",
-      "simple-travis-runner": "cpe:2.3:a:jenkins:simple_travis_pipeline_runner:*:*:*:*:*:jenkins:*:*",
-      "sinatra-chef-builder": "cpe:2.3:a:jenkins:chef_sinatra:*:*:*:*:*:jenkins:*:*",
-      "sitemonitor": "cpe:2.3:a:jenkins:sitemonitor:*:*:*:*:*:jenkins:*:*",
-      "skype-notifier": "cpe:2.3:a:jenkins:skype_notifier:*:*:*:*:*:jenkins:*:*",
-      "skytap-cloud": "cpe:2.3:a:jenkins:skytap_cloud_ci:*:*:*:*:*:jenkins:*:*",
-      "slack": "cpe:2.3:a:jenkins:slack_notification:*:*:*:*:*:jenkins:*:*",
-      "slack-uploader": "cpe:2.3:a:jenkins:slack_upload:*:*:*:*:*:jenkins:*:*",
-      "smalltest": "cpe:2.3:a:jenkins:smalltest:*:*:*:*:*:jenkins:*:*",
-      "sms": "cpe:2.3:a:jenkins:sms_notification:*:*:*:*:*:jenkins:*:*",
-      "snsnotify": "cpe:2.3:a:jenkins:amazon_sns_build_notifier:*:*:*:*:*:jenkins:*:*",
-      "soapui-pro-functional-testing": "cpe:2.3:a:jenkins:soapui_pro_functional_testing:*:*:*:*:*:jenkins:*:*",
-      "sofy-ai": "cpe:2.3:a:jenkins:sofy.ai:*:*:*:*:*:jenkins:*:*",
-      "sonar-gerrit": "cpe:2.3:a:jenkins:sonar_gerrit:*:*:*:*:*:jenkins:*:*",
-      "sonar-quality-gates": "cpe:2.3:a:jenkins:sonar_quality_gates:*:*:*:*:*:jenkins:*:*",
-      "sonargraph-integration": "cpe:2.3:a:jenkins:sonargraph_integration:*:*:*:*:*:jenkins:*:*",
-      "sonarqube": "cpe:2.3:a:sonarsource:sonarqube_scanner:*:*:*:*:*:jenkins:*:*",
-      "sounds": "cpe:2.3:a:jenkins:sounds:*:*:*:*:*:jenkins:*:*",
-      "speaks": "cpe:2.3:a:jenkins:speaks\\!:*:*:*:*:*:jenkins:*:*",
-      "splunk-devops": "cpe:2.3:a:jenkins:splunk:*:*:*:*:*:jenkins:*:*",
-      "spoonscript": "cpe:2.3:a:jenkins:turboscript:*:*:*:*:*:jenkins:*:*",
-      "sqlplus-script-runner": "cpe:2.3:a:jenkins:sqlplus_script_runner:*:*:*:*:*:jenkins:*:*",
-      "sra-deploy": "cpe:2.3:a:jenkins:serena_sra_deploy:*:*:*:*:*:jenkins:*:*",
-      "ssh": "cpe:2.3:a:jenkins:ssh:*:*:*:*:*:jenkins:*:*",
-      "ssh-agent": "cpe:2.3:a:jenkins:ssh_agent:*:*:*:*:*:jenkins:*:*",
-      "ssh-credentials": "cpe:2.3:a:jenkins:ssh_credentials:*:*:*:*:*:jenkins:*:*",
-      "ssh-slaves": "cpe:2.3:a:jenkins:ssh_slaves:*:*:*:*:*:jenkins:*:*",
-      "ssh2easy": "cpe:2.3:a:jenkins:ssh2_easy:*:*:*:*:*:jenkins:*:*",
-      "starteam": "cpe:2.3:a:jenkins:starteam:*:*:*:*:*:jenkins:*:*",
-      "storable-configs": "cpe:2.3:a:jenkins:storable_configs:*:*:*:*:*:jenkins:*:*",
-      "storable-configs-plugin": "cpe:2.3:a:jenkins:storable_configs:*:*:*:*:*:jenkins:*:*",
-      "subversion": "cpe:2.3:a:jenkins-ci:subversion-plugin:*:*:*:*:*:*:*:*",
-      "sumologic-publisher": "cpe:2.3:a:jenkins:sumologic_publisher:*:*:*:*:*:jenkins:*:*",
-      "support-core": "cpe:2.3:a:jenkins:support_core:*:*:*:*:*:jenkins:*:*",
-      "svn-partial-release-mgr": "cpe:2.3:a:jenkins:subversion_partial_release_manager:*:*:*:*:*:jenkins:*:*",
-      "svn-release-mgr": "cpe:2.3:a:jenkins:subversion_release_manager:*:*:*:*:*:jenkins:*:*",
-      "swamp": "cpe:2.3:a:jenkins:swamp:*:*:*:*:*:jenkins:*:*",
-      "swarm": "cpe:2.3:a:jenkins:swarm:*:*:*:*:*:jenkins:*:*",
-      "synopsys-coverity": "cpe:2.3:a:jenkins:synopsys_coverity:*:*:*:*:*:jenkins:*:*",
-      "tap": "cpe:2.3:a:jenkins:tap:*:*:*:*:*:jenkins:*:*",
-      "team-views": "cpe:2.3:a:jenkins:team_views:*:*:*:*:*:jenkins:*:*",
-      "teams-webhook-trigger": "cpe:2.3:a:jenkins:msteams_webhook_trigger:*:*:*:*:*:jenkins:*:*",
-      "template-workflows": "cpe:2.3:a:jenkins:template_workflows:*:*:*:*:*:jenkins:*:*",
-      "templating-engine": "cpe:2.3:a:jenkins:templating_engine:*:*:*:*:*:jenkins:*:*",
-      "test-results-aggregator": "cpe:2.3:a:jenkins:test_results_aggregator:*:*:*:*:*:jenkins:*:*",
-      "testcomplete": "cpe:2.3:a:jenkins:testcomplete_support:*:*:*:*:*:jenkins:*:*",
-      "testfairy": "cpe:2.3:a:jenkins:testfairy:*:*:*:*:*:jenkins:*:*",
-      "testlink": "cpe:2.3:a:jenkins:testlink:*:*:*:*:*:jenkins:*:*",
-      "testng-plugin": "cpe:2.3:a:jenkins:testng_results:*:*:*:*:*:jenkins:*:*",
-      "testquality-updater": "cpe:2.3:a:jenkins:testquality_updater:*:*:*:*:*:jenkins:*:*",
-      "tfs": "cpe:2.3:a:jenkins:team_foundation_server:*:*:*:*:*:jenkins:*:*",
-      "threadfix": "cpe:2.3:a:jenkins:threadfix:*:*:*:*:*:jenkins:*:*",
-      "thycotic-devops-secrets-vault": "cpe:2.3:a:jenkins:thycotic_devops_secrets_vault:*:*:*:*:*:jenkins:*:*",
-      "thycotic-secret-server": "cpe:2.3:a:jenkins:thycotic_secret_server:*:*:*:*:*:jenkins:*:*",
-      "tics": "cpe:2.3:a:jenkins:tics:*:*:*:*:*:jenkins:*:*",
-      "tikal-multijob": "cpe:2.3:a:jenkins:multijob:*:*:*:*:*:jenkins:*:*",
-      "timestamper": "cpe:2.3:a:jenkins:timestamper:*:*:*:*:*:jenkins:*:*",
-      "tinfoil-scan": "cpe:2.3:a:jenkins:tinfoil_security:*:*:*:*:*:jenkins:*:*",
-      "token-macro": "cpe:2.3:a:jenkins:token_macro:*:*:*:*:*:jenkins:*:*",
-      "trac-publisher-plugin": "cpe:2.3:a:jenkins:trac_publisher:*:*:*:*:*:jenkins:*:*",
-      "translation": "cpe:2.3:a:jenkins:translation_assistance:*:*:*:*:*:jenkins:*:*",
-      "tuleap-git-branch-source": "cpe:2.3:a:jenkins:tuleap_git_branch_source:*:*:*:*:*:jenkins:*:*",
-      "tuleap-oauth": "cpe:2.3:a:jenkins:tuleap_authentication:*:*:*:*:*:jenkins:*:*",
-      "twitter": "cpe:2.3:a:jenkins:twitter:*:*:*:*:*:jenkins:*:*",
-      "uno-choice": "cpe:2.3:a:jenkins:active_choices:*:*:*:*:*:jenkins:*:*",
-      "upload-pgyer": "cpe:2.3:a:jenkins:upload_to_pgyer:*:*:*:*:*:jenkins:*:*",
-      "urltrigger": "cpe:2.3:a:jenkins:urltrigger:*:*:*:*:*:jenkins:*:*",
-      "usemango-runner": "cpe:2.3:a:jenkins:usemango_runner:*:*:*:*:*:jenkins:*:*",
-      "valgrind": "cpe:2.3:a:jenkins:valgrind:*:*:*:*:*:jenkins:*:*",
-      "validating-email-parameter": "cpe:2.3:a:jenkins:validating_email_parameter:*:*:*:*:*:jenkins:*:*",
-      "validating-string-parameter": "cpe:2.3:a:jenkins:validating_string_parameter:*:*:*:*:*:jenkins:*:*",
-      "vault-scm-plugin": "cpe:2.3:a:jenkins:sourcegear_vault:*:*:*:*:*:jenkins:*:*",
-      "vboxwrapper": "cpe:2.3:a:jenkins:vboxwrapper:*:*:*:*:*:jenkins:*:*",
-      "veracode-scanner": "cpe:2.3:a:jenkins:veracode-scanner:*:*:*:*:*:jenkins:*:*",
-      "view-cloner": "cpe:2.3:a:jenkins:view-cloner:*:*:*:*:*:jenkins:*:*",
-      "view26": "cpe:2.3:a:jenkins:view26_test-reporting:*:*:*:*:*:jenkins:*:*",
-      "violation-comments-to-gitlab": "cpe:2.3:a:jenkins:violation_comments_to_gitlab:*:*:*:*:*:jenkins:*:*",
-      "visualexpert": "cpe:2.3:a:jenkins:visualexpert:*:*:*:*:*:jenkins:*:*",
-      "visualworks-store": "cpe:2.3:a:jenkins:visualworks_store:*:*:*:*:*:jenkins:*:*",
-      "vmanager": "cpe:2.3:a:jenkins:cadence_vmanager:*:*:*:*:*:jenkins:*:*",
-      "vmanager-plugin": "cpe:2.3:a:jenkins:cadence_vmanager:*:*:*:*:*:jenkins:*:*",
-      "vmware-vrealize-automation-plugin": "cpe:2.3:a:jenkins:vmware_vrealize_automation:*:*:*:*:*:jenkins:*:*",
-      "vmware-vrealize-orchestrator": "cpe:2.3:a:jenkins:vrealize_orchestrator:*:*:*:*:*:jenkins:*:*",
-      "vncrecorder": "cpe:2.3:a:jenkins:vncrecorder:*:*:*:*:*:jenkins:*:*",
-      "vncviewer": "cpe:2.3:a:jenkins:vncviewer:*:*:*:*:*:jenkins:*:*",
-      "vs-code-metrics": "cpe:2.3:a:jenkins:visual_studio_code_metrics:*:*:*:*:*:jenkins:*:*",
-      "vsphere-cloud": "cpe:2.3:a:jenkins:vsphere:*:*:*:*:*:jenkins:*:*",
-      "vsts-cd": "cpe:2.3:a:jenkins:vs_team_services_continuous_deployment:*:*:*:*:*:jenkins:*:*",
-      "walldisplay": "cpe:2.3:a:jenkins:wall_display:*:*:*:*:*:jenkins:*:*",
-      "walti": "cpe:2.3:a:jenkins:walti:*:*:*:*:*:jenkins:*:*",
-      "warnings": "cpe:2.3:a:jenkins:warnings:*:*:*:*:*:jenkins:*:*",
-      "warnings-ng": "cpe:2.3:a:jenkins:warnings_next_generation:*:*:*:*:*:jenkins:*:*",
-      "weblogic-deployer": "cpe:2.3:a:jenkins:deploy_weblogic:*:*:*:*:*:jenkins:*:*",
-      "weblogic-deployer-plugin": "cpe:2.3:a:jenkins:deploy_weblogic:*:*:*:*:*:jenkins:*:*",
-      "websphere-deployer": "cpe:2.3:a:jenkins:websphere_deployer:*:*:*:*:*:jenkins:*:*",
-      "whitesource": "cpe:2.3:a:jenkins:white_source:*:*:*:*:*:jenkins:*:*",
-      "wildfly-deployer": "cpe:2.3:a:jenkins:wildfly_deployer:*:*:*:*:*:jenkins:*:*",
-      "windows-slaves": "cpe:2.3:a:jenkins:wmi_windows_agents:*:*:*:*:*:jenkins:*:*",
-      "workflow-cps": "cpe:2.3:a:jenkins:pipeline\\:_groovy:*:*:*:*:*:jenkins:*:*",
-      "workflow-cps-global-lib": "cpe:2.3:a:jenkins:pipeline\\:shared_groovy_libraries:*:*:*:*:*:jenkins:*:*",
-      "workflow-multibranch": "cpe:2.3:a:jenkins:pipeline\\:_multibranch:*:*:*:*:*:jenkins:*:*",
-      "workflow-remote-loader": "cpe:2.3:a:jenkins:pipeline_remote_loader:*:*:*:*:*:jenkins:*:*",
-      "workflow-support": "cpe:2.3:a:jenkins:pipeline_supporting_apis:*:*:*:*:*:jenkins:*:*",
-      "ws-execution-manager": "cpe:2.3:a:jenkins:worksoft_execution_manager:*:*:*:*:*:jenkins:*:*",
-      "wso2id-oauth": "cpe:2.3:a:jenkins:wso2_oauth:*:*:*:*:*:jenkins:*:*",
-      "xcode": "cpe:2.3:a:jenkins:xcode_integration:*:*:*:*:*:jenkins:*:*",
-      "xfpanel": "cpe:2.3:a:jenkins:extreme_feedback_panel:*:*:*:*:*:jenkins:*:*",
-      "xldeploy": "cpe:2.3:a:jenkins:xebialabs_xl_deploy:*:*:*:*:*:jenkins:*:*",
-      "xlrelease-plugin": "cpe:2.3:a:jenkins:xebialabs_xl_release:*:*:*:*:*:jenkins:*:*",
-      "xltestview": "cpe:2.3:a:jenkins:xl_testviews:*:*:*:*:*:jenkins:*:*",
-      "xpath-config-viewer": "cpe:2.3:a:jenkins:xpath_configuration_viewer:*:*:*:*:*:jenkins:*:*",
-      "xray-connector": "cpe:2.3:a:jenkins:xray_-_test_management_for_jira:*:*:*:*:*:jenkins:*:*",
-      "xunit": "cpe:2.3:a:jenkins:xunit:*:*:*:*:*:jenkins:*:*",
-      "yaml-axis": "cpe:2.3:a:jenkins:yaml_axis:*:*:*:*:*:jenkins:*:*",
-      "yet-another-build-visualizer": "cpe:2.3:a:jenkins:yet_another_build_visualizer:*:*:*:*:*:*:*:*",
-      "youtrack": "cpe:2.3:a:jenkins:youtrack-plugin:*:*:*:*:*:jenkins:*:*",
-      "zap": "cpe:2.3:a:jenkins:official_owasp_zap:*:*:*:*:*:jenkins:*:*",
-      "zap-pipeline": "cpe:2.3:a:jenkins:zap_pipeline:*:*:*:*:*:jenkins:*:*",
-      "zephyr-enterprise-test-management": "cpe:2.3:a:jenkins:zephyr_enterprise_test_management:*:*:*:*:*:jenkins:*:*",
-      "zephyr-for-jira-test-management": "cpe:2.3:a:jenkins:zephyr_for_jira_test_management:*:*:*:*:*:jenkins:*:*",
-      "zos-connector": "cpe:2.3:a:jenkins:z\\/os_connector:*:*:*:*:*:jenkins:*:*",
-      "zulip": "cpe:2.3:a:jenkins:zulip:*:*:*:*:*:jenkins:*:*"
+      "DotCi": [
+        "cpe:2.3:a:jenkins:dotci:*:*:*:*:*:jenkins:*:*"
+      ],
+      "JDK_Parameter_Plugin": [
+        "cpe:2.3:a:jenkins:jdk_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "JiraTestResultReporter": [
+        "cpe:2.3:a:jenkins:jiratestresultreporter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "Parameterized-Remote-Trigger": [
+        "cpe:2.3:a:jenkins:parameterized_remote_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "TestComplete": [
+        "cpe:2.3:a:jenkins:testcomplete_support:*:*:*:*:*:jenkins:*:*"
+      ],
+      "TestFairy": [
+        "cpe:2.3:a:jenkins:testfairy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "absint-a3": [
+        "cpe:2.3:a:jenkins:absint_a3:*:*:*:*:*:jenkins:*:*"
+      ],
+      "absint-astree": [
+        "cpe:2.3:a:jenkins:absint_astree:*:*:*:*:*:jenkins:*:*"
+      ],
+      "accurev": [
+        "cpe:2.3:a:jenkins:accurev:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:microfocus:accurev:*:*:*:*:*:jenkins:*:*"
+      ],
+      "active-choices": [
+        "cpe:2.3:a:jenkins:active_choices:*:*:*:*:*:jenkins:*:*"
+      ],
+      "active-directory": [
+        "cpe:2.3:a:jenkins:active_directory:*:*:*:*:*:jenkins:*:*"
+      ],
+      "agent-server-parameter": [
+        "cpe:2.3:a:jenkins:agent_server_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "alauda-kubernetes-support": [
+        "cpe:2.3:a:jenkins:alauda_kubernetes_support:*:*:*:*:*:jenkins:*:*"
+      ],
+      "analysis-core": [
+        "cpe:2.3:a:jenkins:static_analysis_utilities:*:*:*:*:*:jenkins:*:*"
+      ],
+      "anchore-container-scanner": [
+        "cpe:2.3:a:anchore:container_image_scanner:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:anchore_container_image_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "android-lint": [
+        "cpe:2.3:a:jenkins:android_lint:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ansible": [
+        "cpe:2.3:a:jenkins:ansible:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ansible-tower": [
+        "cpe:2.3:a:jenkins:ansible_tower:*:*:*:*:*:jenkins:*:*"
+      ],
+      "app-detector": [
+        "cpe:2.3:a:jenkins:application_detector:*:*:*:*:*:jenkins:*:*"
+      ],
+      "appdynamics": [
+        "cpe:2.3:a:jenkins:appdynamics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "applatix": [
+        "cpe:2.3:a:jenkins:applatix:*:*:*:*:*:jenkins:*:*"
+      ],
+      "apprenda": [
+        "cpe:2.3:a:jenkins:apprenda:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aqua-microscanner": [
+        "cpe:2.3:a:jenkins:aqua_microscanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aqua-security-scanner": [
+        "cpe:2.3:a:jenkins:aqua_security_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aqua-serverless": [
+        "cpe:2.3:a:jenkins:aqua_security_severless_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "artifact-repository-parameter": [
+        "cpe:2.3:a:jenkins:artifact_repository_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "assembla": [
+        "cpe:2.3:a:jenkins:assembla:*:*:*:*:*:jenkins:*:*"
+      ],
+      "assembla-auth": [
+        "cpe:2.3:a:jenkins:assembla_auth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "assembla-merge-request-builder": [
+        "cpe:2.3:a:jenkins:assembla_merge_request_builder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "atlassian-bitbucket-server-integration": [
+        "cpe:2.3:a:jenkins:bitbucket_server_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "audit-trail": [
+        "cpe:2.3:a:jenkins:audit_trail:*:*:*:*:*:jenkins:*:*"
+      ],
+      "audit2db": [
+        "cpe:2.3:a:jenkins:audit_to_database:*:*:*:*:*:jenkins:*:*"
+      ],
+      "autocomplete-parameter": [
+        "cpe:2.3:a:jenkins:autocomplete_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "autonomiq": [
+        "cpe:2.3:a:jenkins:autonomiq:*:*:*:*:*:jenkins:*:*"
+      ],
+      "avatar": [
+        "cpe:2.3:a:jenkins:avatar:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-beanstalk-publisher": [
+        "cpe:2.3:a:jenkins:aws_elastic_beanstalk_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-beanstalk-publisher-plugin": [
+        "cpe:2.3:a:jenkins:aws_elastic_beanstalk_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-cloudwatch-logs-publisher": [
+        "cpe:2.3:a:jenkins:aws_cloudwatch_logs_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-codebuild": [
+        "cpe:2.3:a:jenkins:aws_codebuild:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-codecommit-trigger": [
+        "cpe:2.3:a:jenkins:aws_codecommit_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-codedeploy": [
+        "cpe:2.3:a:jenkins:aws_codedeploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-codepipeline": [
+        "cpe:2.3:a:jenkins:aws_codepipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-credentials": [
+        "cpe:2.3:a:jenkins:cloudbees_aws_credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-device-farm": [
+        "cpe:2.3:a:jenkins:aws-device-farm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-global-configuration": [
+        "cpe:2.3:a:jenkins:aws_global_configuration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "aws-sam": [
+        "cpe:2.3:a:jenkins:amazon_web_services_serverless_application_model:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:amazon_web_services_service_application_model:*:*:*:*:*:jenkins:*:*"
+      ],
+      "awseb-deployment": [
+        "cpe:2.3:a:jenkins:awseb_deployment:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-acs": [
+        "cpe:2.3:a:jenkins:azure_container_service:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-ad": [
+        "cpe:2.3:a:jenkins:azure_ad:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-container-agents": [
+        "cpe:2.3:a:jenkins:azure_container_service:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-credentials": [
+        "cpe:2.3:a:jenkins:azure_credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-keyvault": [
+        "cpe:2.3:a:jenkins:azure_key_vault:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-publishersettings-credentials": [
+        "cpe:2.3:a:jenkins:azure_publishersettings_credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "azure-vm-agents": [
+        "cpe:2.3:a:jenkins:azure_vm_agents:*:*:*:*:*:jenkins:*:*"
+      ],
+      "backlog": [
+        "cpe:2.3:a:jenkins:backlog:*:*:*:*:*:jenkins:*:*"
+      ],
+      "badge": [
+        "cpe:2.3:a:jenkins:badge:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bart": [
+        "cpe:2.3:a:jenkins:bart:*:*:*:*:*:jenkins:*:*"
+      ],
+      "batch-task": [
+        "cpe:2.3:a:jenkins:batch_task:*:*:*:*:*:jenkins:*:*"
+      ],
+      "beaker-builder": [
+        "cpe:2.3:a:jenkins:beaker_builder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bearychat": [
+        "cpe:2.3:a:jenkins:bearychat:*:*:*:*:*:jenkins:*:*"
+      ],
+      "benchmark-evaluator": [
+        "cpe:2.3:a:jenkins:benchmark_evaluator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bigpanda-jenkins": [
+        "cpe:2.3:a:jenkins:bigpanda_notifier:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bitbucket-approve": [
+        "cpe:2.3:a:jenkins:bitbucket_approve:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bitbucket-branch-source": [
+        "cpe:2.3:a:jenkins:bitbucket_branch_source:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bitbucket-oauth": [
+        "cpe:2.3:a:jenkins:bitbucket_oauth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bitbucket-push-and-pull-request": [
+        "cpe:2.3:a:jenkins:bitbucket_push_and_pull_request:*:*:*:*:*:jenkins:*:*"
+      ],
+      "blackduck-detect": [
+        "cpe:2.3:a:jenkins:synopsys_detect:*:*:*:*:*:jenkins:*:*"
+      ],
+      "blackduck-hub": [
+        "cpe:2.3:a:jenkins:black_duck_hub:*:*:*:*:*:jenkins:*:*"
+      ],
+      "blueocean": [
+        "cpe:2.3:a:jenkins:blue_ocean:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bmc-rpd": [
+        "cpe:2.3:a:jenkins:bmc_release_package_and_deployment:*:*:*:*:*:jenkins:*:*"
+      ],
+      "brakeman": [
+        "cpe:2.3:a:jenkins:brakeman:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bugzilla": [
+        "cpe:2.3:a:jenkins:bugzilla:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:bugzilla_plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-failure-analyzer": [
+        "cpe:2.3:a:jenkins:build_failure_analyzer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-metrics": [
+        "cpe:2.3:a:jenkins:build-metrics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-notifications": [
+        "cpe:2.3:a:jenkins:build_notifications:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-pipeline": [
+        "cpe:2.3:a:jenkins:build_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-publisher": [
+        "cpe:2.3:a:jenkins:build-publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "build-with-parameters": [
+        "cpe:2.3:a:jenkins:build_with_parameters:*:*:*:*:*:jenkins:*:*"
+      ],
+      "buildgraph-view": [
+        "cpe:2.3:a:jenkins:buildgraph-view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "bumblebee": [
+        "cpe:2.3:a:jenkins:bumblebee_hp_alm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cas": [
+        "cpe:2.3:a:jenkins:cas:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cas-plugin": [
+        "cpe:2.3:a:jenkins:cas:*:*:*:*:*:jenkins:*:*"
+      ],
+      "catalogic-ecx": [
+        "cpe:2.3:a:jenkins:ecx_copy_data_management:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cavisson-ns-nd-integration": [
+        "cpe:2.3:a:jenkins:ns-nd_integration_performance_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cccc": [
+        "cpe:2.3:a:jenkins:cccc:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ccm": [
+        "cpe:2.3:a:jenkins:ccm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "chaos-monkey": [
+        "cpe:2.3:a:netflix:chaos_monkey:*:*:*:*:*:jenkins:*:*"
+      ],
+      "checkmarx": [
+        "cpe:2.3:a:jenkins:checkmarx:*:*:*:*:*:jenkins:*:*"
+      ],
+      "checkstyle": [
+        "cpe:2.3:a:jenkins:checkstyle:*:*:*:*:*:jenkins:*:*"
+      ],
+      "chosen-views-tabbar": [
+        "cpe:2.3:a:jenkins:chosen-views-tabbar:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ci-with-toad-edge": [
+        "cpe:2.3:a:jenkins:continuous_integration_with_toad_edge:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cisco-spark": [
+        "cpe:2.3:a:jenkins:cisco_spark:*:*:*:*:*:jenkins:*:*"
+      ],
+      "claim": [
+        "cpe:2.3:a:jenkins:claim:*:*:*:*:*:jenkins:*:*"
+      ],
+      "clearcase-release": [
+        "cpe:2.3:a:jenkins:clearcase_release:*:*:*:*:*:jenkins:*:*"
+      ],
+      "clif-performance-testing": [
+        "cpe:2.3:a:jenkins:clif_performance_testing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloud-stats": [
+        "cpe:2.3:a:jenkins:cloud_statistics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudbees-bitbucket-branch-source": [
+        "cpe:2.3:a:jenkins:bitbucket_branch_source:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudbees-folder": [
+        "cpe:2.3:a:jenkins:folders:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudbees-jenkins-advisor": [
+        "cpe:2.3:a:jenkins:health_advisor_by_cloudbees:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudcoreo-deploytime": [
+        "cpe:2.3:a:jenkins:cloudcoreo_deploytime:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudfoundry": [
+        "cpe:2.3:a:jenkins:cloud_foundry:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudshare-docker": [
+        "cpe:2.3:a:jenkins:cloudshare_docker-machine:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cloudtest": [
+        "cpe:2.3:a:jenkins:soasta_cloudtest:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cobertura": [
+        "cpe:2.3:a:jenkins:cobertura:*:*:*:*:*:jenkins:*:*"
+      ],
+      "code-coverage-api": [
+        "cpe:2.3:a:jenkins:code_coverage_api:*:*:*:*:*:jenkins:*:*"
+      ],
+      "codefresh": [
+        "cpe:2.3:a:jenkins:codefresh_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "codescan": [
+        "cpe:2.3:a:jenkins:codescan:*:*:*:*:*:jenkins:*:*"
+      ],
+      "collabnet": [
+        "cpe:2.3:a:jenkins:collabnet:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compact-columns": [
+        "cpe:2.3:a:jenkins:compact_columns:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compatibility-action-storage": [
+        "cpe:2.3:a:praqma:compatibility_action_storage:*:*:*:*:*:jenkins:*:*"
+      ],
+      "computer-queue": [
+        "cpe:2.3:a:jenkins:computer_queue:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compuware-common-configuration": [
+        "cpe:2.3:a:jenkins:compuware_common_configuration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compuware-ispw-operations": [
+        "cpe:2.3:a:jenkins:compuware_ispw_operations:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compuware-topaz-for-total-test": [
+        "cpe:2.3:a:jenkins:compuware_topaz_for_total_test:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compuware-topaz-utilities": [
+        "cpe:2.3:a:jenkins:compuware_topaz_utilities:*:*:*:*:*:jenkins:*:*"
+      ],
+      "compuware-xpediter-code-coverage": [
+        "cpe:2.3:a:jenkins:compuware_xpediter_code_coverage:*:*:*:*:*:jenkins:*:*"
+      ],
+      "config-file-provider": [
+        "cpe:2.3:a:jenkins:config_file_provider:*:*:*:*:*:jenkins:*:*"
+      ],
+      "configuration-as-code": [
+        "cpe:2.3:a:jenkins:configuration_as_code:*:*:*:*:*:jenkins:*:*"
+      ],
+      "configurationslicing": [
+        "cpe:2.3:a:jenkins:configuration_slicing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "confluence-publisher": [
+        "cpe:2.3:a:jenkins:confluence_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "conjur-credentials": [
+        "cpe:2.3:a:jenkins:conjur_secrets:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cons3rt": [
+        "cpe:2.3:a:jenkins:cons3rt:*:*:*:*:*:jenkins:*:*"
+      ],
+      "consul-kv-builder": [
+        "cpe:2.3:a:jenkins:consul_kv_builder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "contrast-continuous-application-security": [
+        "cpe:2.3:a:jenkins:contrast_continuous_application_security:*:*:*:*:*:jenkins:*:*"
+      ],
+      "convert-to-pipeline": [
+        "cpe:2.3:a:jenkins:convert_to_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "convertigo-mobile-platform": [
+        "cpe:2.3:a:jenkins:convertigo_mobile_platform:*:*:*:*:*:jenkins:*:*"
+      ],
+      "copr": [
+        "cpe:2.3:a:jenkins:copr:*:*:*:*:*:jenkins:*:*"
+      ],
+      "copy-data-to-workspace": [
+        "cpe:2.3:a:jenkins:copy_data_to_workspace:*:*:*:*:*:jenkins:*:*"
+      ],
+      "copy-data-to-workspace-plugin": [
+        "cpe:2.3:a:jenkins:copy_data_to_workspace:*:*:*:*:*:jenkins:*:*"
+      ],
+      "copy-to-slave": [
+        "cpe:2.3:a:jenkins:copy_to_slave:*:*:*:*:*:jenkins:*:*"
+      ],
+      "copyartifact": [
+        "cpe:2.3:a:jenkins:copy_artifact:*:*:*:*:*:jenkins:*:*"
+      ],
+      "couchdb-statistics": [
+        "cpe:2.3:a:jenkins:couchdb-statistics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "covcomplplot": [
+        "cpe:2.3:a:jenkins:coverage\\/complexity_scatter_plot:*:*:*:*:*:jenkins:*:*"
+      ],
+      "coverity": [
+        "cpe:2.3:a:jenkins:coverity:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cppcheck": [
+        "cpe:2.3:a:jenkins:cppcheck:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cppncss": [
+        "cpe:2.3:a:jenkins:cppncss:*:*:*:*:*:jenkins:*:*"
+      ],
+      "crap4j": [
+        "cpe:2.3:a:jenkins:crap4j:*:*:*:*:*:jenkins:*:*"
+      ],
+      "credentials": [
+        "cpe:2.3:a:jenkins:credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "credentials-binding": [
+        "cpe:2.3:a:jenkins:credentials_binding:*:*:*:*:*:jenkins:*:*"
+      ],
+      "crittercism-dsym": [
+        "cpe:2.3:a:jenkins:crittercism-dsym:*:*:*:*:*:jenkins:*:*"
+      ],
+      "crowd": [
+        "cpe:2.3:a:jenkins:crowd_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "crowd2": [
+        "cpe:2.3:a:atlassian:crowd2:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:crowd_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "crx-content-package-deployer": [
+        "cpe:2.3:a:jenkins:crx_content_package_deployer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cryptomove": [
+        "cpe:2.3:a:jenkins:cryptomove:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cucumber-living-documentation": [
+        "cpe:2.3:a:jenkins:cucumber_living_documentation:*:*:*:*:*:jenkins:*:*"
+      ],
+      "custom-build-properties": [
+        "cpe:2.3:a:jenkins:custom_build_properties:*:*:*:*:*:jenkins:*:*"
+      ],
+      "custom-checkbox-parameter": [
+        "cpe:2.3:a:jenkins:custom_checkbox_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "custom-job-icon": [
+        "cpe:2.3:a:jenkins:custom_job_icon:*:*:*:*:*:jenkins:*:*"
+      ],
+      "cvs": [
+        "cpe:2.3:a:jenkins:current_versions_systems:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:cvs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dashboard-view": [
+        "cpe:2.3:a:jenkins:dashboard_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "database": [
+        "cpe:2.3:a:jenkins:database:*:*:*:*:*:jenkins:*:*"
+      ],
+      "datadog": [
+        "cpe:2.3:a:jenkins:datadog:*:*:*:*:*:jenkins:*:*"
+      ],
+      "date-parameter": [
+        "cpe:2.3:a:jenkins:date_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dbCharts": [
+        "cpe:2.3:a:jenkins:dbcharts:*:*:*:*:*:jenkins:*:*"
+      ],
+      "debian-package-builder": [
+        "cpe:2.3:a:jenkins:debian_package_builder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "delivery-pipeline-plugin": [
+        "cpe:2.3:a:jenkins:delivery_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "delphix": [
+        "cpe:2.3:a:jenkins:delphix:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dependency-check": [
+        "cpe:2.3:a:jenkins:owasp_dependency-check:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dependency-check-jenkins-plugin": [
+        "cpe:2.3:a:jenkins:owasp_dependency-check:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dependency-track": [
+        "cpe:2.3:a:jenkins:owasp_dependency-track:*:*:*:*:*:jenkins:*:*"
+      ],
+      "depgraph-view": [
+        "cpe:2.3:a:jenkins:dependency_graph_viewer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "deploy": [
+        "cpe:2.3:a:jenkins:deploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "deployer-framework": [
+        "cpe:2.3:a:jenkins:deployer_framework:*:*:*:*:*:jenkins:*:*"
+      ],
+      "deployhub": [
+        "cpe:2.3:a:jenkins:deployhub:*:*:*:*:*:jenkins:*:*"
+      ],
+      "deployit-plugin": [
+        "cpe:2.3:a:jenkins:xebialabs_xl_deploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "description-column": [
+        "cpe:2.3:a:jenkins:description_column:*:*:*:*:*:jenkins:*:*"
+      ],
+      "description-column-plugin": [
+        "cpe:2.3:a:jenkins:description_column:*:*:*:*:*:jenkins:*:*"
+      ],
+      "diawi-upload": [
+        "cpe:2.3:a:jenkins:diawi_upload:*:*:*:*:*:jenkins:*:*"
+      ],
+      "digitalocean": [
+        "cpe:2.3:a:jenkins:digitalocean:*:*:*:*:*:jenkins:*:*"
+      ],
+      "digitalocean-plugin": [
+        "cpe:2.3:a:jenkins:digitalocean:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dimensionsscm": [
+        "cpe:2.3:a:microfocus:dimensions_cm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dingding-json-pusher": [
+        "cpe:2.3:a:jenkins:dingding_json_pusher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dingding-notifications": [
+        "cpe:2.3:a:jenkins:dingding:*:*:*:*:*:jenkins:*:*"
+      ],
+      "distfork": [
+        "cpe:2.3:a:jenkins:distributed_fork:*:*:*:*:*:jenkins:*:*"
+      ],
+      "docker": [
+        "cpe:2.3:a:jenkins:docker:*:*:*:*:*:jenkins:*:*"
+      ],
+      "docker-commons": [
+        "cpe:2.3:a:jenkins:docker_commons:*:*:*:*:*:jenkins:*:*"
+      ],
+      "docker-swarm": [
+        "cpe:2.3:a:jenkins:docker_swarm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "doktor": [
+        "cpe:2.3:a:jenkins:doktor:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dry": [
+        "cpe:2.3:a:jenkins:dry:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dynamic-extended-choice-parameter": [
+        "cpe:2.3:a:jenkins:dynamic_extended_choice_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dynamic_extended_choice_parameter": [
+        "cpe:2.3:a:jenkins:dynamic_extended_choice_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dynatrace": [
+        "cpe:2.3:a:jenkins:dynatrace_application_monitoring:*:*:*:*:*:jenkins:*:*"
+      ],
+      "dynatrace-dashboard": [
+        "cpe:2.3:a:jenkins:dynatrace_application_monitoring:*:*:*:*:*:jenkins:*:*"
+      ],
+      "eagle-tester": [
+        "cpe:2.3:a:jenkins:eagle_tester:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ease-plugin": [
+        "cpe:2.3:a:jenkins:digital.ai_app_management_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "easyqa": [
+        "cpe:2.3:a:jenkins:easyqa:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ec2": [
+        "cpe:2.3:a:jenkins:amazon_ec2:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:ec2:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ec2-deployment-dashboard": [
+        "cpe:2.3:a:jenkins:deployment_dashboard:*:*:*:*:*:jenkins:*:*"
+      ],
+      "echarts-api": [
+        "cpe:2.3:a:jenkins:echarts_api:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ecs-publisher": [
+        "cpe:2.3:a:trustsource:ecs_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ecutest": [
+        "cpe:2.3:a:jenkins:tracetronic_ecu-test:*:*:*:*:*:jenkins:*:*"
+      ],
+      "eggplant": [
+        "cpe:2.3:a:jenkins:eggplant:*:*:*:*:*:jenkins:*:*"
+      ],
+      "elastest": [
+        "cpe:2.3:a:jenkins:elastest:*:*:*:*:*:jenkins:*:*"
+      ],
+      "elasticbox": [
+        "cpe:2.3:a:jenkins:elasticbox_ci:*:*:*:*:*:jenkins:*:*"
+      ],
+      "elasticsearch-query": [
+        "cpe:2.3:a:jenkins:elasticsearch_query:*:*:*:*:*:jenkins:*:*"
+      ],
+      "electricflow": [
+        "cpe:2.3:a:jenkins:cloudbees_cd:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:electricflow:*:*:*:*:*:jenkins:*:*"
+      ],
+      "eloyente": [
+        "cpe:2.3:a:jenkins:eloyente:*:*:*:*:*:jenkins:*:*"
+      ],
+      "email-ext": [
+        "cpe:2.3:a:jenkins:email_extension:*:*:*:*:*:jenkins:*:*"
+      ],
+      "emailext-template": [
+        "cpe:2.3:a:jenkins:email_extension_template:*:*:*:*:*:jenkins:*:*"
+      ],
+      "embeddable-build-status": [
+        "cpe:2.3:a:jenkins:embeddable_build_status:*:*:*:*:*:jenkins:*:*"
+      ],
+      "embotics-vcommander": [
+        "cpe:2.3:a:jenkins:snow_commander:*:*:*:*:*:jenkins:*:*"
+      ],
+      "environment-dashboard": [
+        "cpe:2.3:a:jenkins:environment_dashboard:*:*:*:*:*:jenkins:*:*"
+      ],
+      "environment-manager": [
+        "cpe:2.3:a:jenkins:parasoft_environment_manager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "environment-manager-tools": [
+        "cpe:2.3:a:jenkins:parasoft_environment_manager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "extended-choice-parameter": [
+        "cpe:2.3:a:jenkins:extended_choice_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "extensivetesting": [
+        "cpe:2.3:a:jenkins:extensive_testing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "external-monitor-job": [
+        "cpe:2.3:a:jenkins:external_monitor_job_type:*:*:*:*:*:jenkins:*:*"
+      ],
+      "extra-columns": [
+        "cpe:2.3:a:jenkins:extra_columns:*:*:*:*:*:jenkins:*:*"
+      ],
+      "extreme-feedback": [
+        "cpe:2.3:a:jenkins:extreme-feedback:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fabric-beta-publisher": [
+        "cpe:2.3:a:jenkins:fabric_beta_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "failedJobDeactivator": [
+        "cpe:2.3:a:jenkins:failed_job_deactivator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "favorite": [
+        "cpe:2.3:a:jenkins:favorite:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:favorite_plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "files-found-trigger": [
+        "cpe:2.3:a:jenkins:files_found_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "filesystem-list-parameter-plugin": [
+        "cpe:2.3:a:jenkins:filesystem_list_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "filesystem_scm": [
+        "cpe:2.3:a:jenkins:file_system_scm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "findbugs": [
+        "cpe:2.3:a:jenkins:findbugs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fireline": [
+        "cpe:2.3:a:jenkins:360_fireline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fitnesse": [
+        "cpe:2.3:a:jenkins:fitnesse:*:*:*:*:*:jenkins:*:*"
+      ],
+      "flaky-test-handler": [
+        "cpe:2.3:a:jenkins:flaky_test_handler:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:jenkins:flaky_test_handler:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fogbugz": [
+        "cpe:2.3:a:jenkins:fogbugz:*:*:*:*:*:jenkins:*:*"
+      ],
+      "folder-auth": [
+        "cpe:2.3:a:jenkins:folder-based_authorization_strategy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fortify": [
+        "cpe:2.3:a:jenkins:fortify:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fortify-cloudscan": [
+        "cpe:2.3:a:jenkins:fortify_cloudscan:*:*:*:*:*:jenkins:*:."
+      ],
+      "fortify-cloudscan-jenkins-plugin": [
+        "cpe:2.3:a:jenkins:fortify_cloudscan:*:*:*:*:*:jenkins:*:."
+      ],
+      "fortify-on-demand-uploader": [
+        "cpe:2.3:a:jenkins:fortify_on_demand:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:fortify_on_demand:*:*:*:*:*:jenkins:*:.",
+        "cpe:2.3:a:jenkins:fortify_on_demand_uploader:*:*:*:*:*:jenkins:*:*"
+      ],
+      "frugal-testing": [
+        "cpe:2.3:a:jenkins:frugal_testing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fstrigger": [
+        "cpe:2.3:a:jenkins:filesystem_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ftppublisher": [
+        "cpe:2.3:a:jenkins:ftp_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gatling": [
+        "cpe:2.3:a:jenkins:gatling:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gcm-notification": [
+        "cpe:2.3:a:google:cloud_messaging_notification:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gearman-plugin": [
+        "cpe:2.3:a:jenkins:gearman:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gem-publisher": [
+        "cpe:2.3:a:jenkins:gem_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "generic-webhook-trigger": [
+        "cpe:2.3:a:jenkins:generic_webhook_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gerrit-trigger": [
+        "cpe:2.3:a:jenkins:gerrit_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ghprb": [
+        "cpe:2.3:a:jenkins:github_pull_request_builder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "git": [
+        "cpe:2.3:a:jenkins:git:*:*:*:*:*:jenkins:*:*"
+      ],
+      "git-changelog": [
+        "cpe:2.3:a:jenkins:git_changelog:*:*:*:*:*:jenkins:*:*"
+      ],
+      "git-client": [
+        "cpe:2.3:a:jenkins:git_client:*:*:*:*:*:jenkins:*:*"
+      ],
+      "git-parameter": [
+        "cpe:2.3:a:jenkins:git_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "git-server": [
+        "cpe:2.3:a:jenkins:git_server:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gitea": [
+        "cpe:2.3:a:gitea:gitea:*:*:*:*:*:jenkins:*:*"
+      ],
+      "github": [
+        "cpe:2.3:a:jenkins:github:*:*:*:*:*:jenkins:*:*"
+      ],
+      "github-branch-source": [
+        "cpe:2.3:a:jenkins:github_branch_source:*:*:*:*:*:jenkins:*:*"
+      ],
+      "github-coverage-reporter": [
+        "cpe:2.3:a:jenkins:github_coverage_reporter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "github-oauth": [
+        "cpe:2.3:a:jenkins:github_authentication:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:github_oauth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "github-pr-coverage-status": [
+        "cpe:2.3:a:jenkins:github_pull_request_coverage_status:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gitlab": [
+        "cpe:2.3:a:jenkins:gitlab:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gitlab-hook": [
+        "cpe:2.3:a:jenkins:gitlab_hook:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gitlab-oauth": [
+        "cpe:2.3:a:jenkins:gitlab_authentication:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:gitlab_oauth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gitlab-plugin": [
+        "cpe:2.3:a:jenkins:gitlab:*:*:*:*:*:jenkins:*:*"
+      ],
+      "global-build-stats": [
+        "cpe:2.3:a:jenkins:global-build-stats:*:*:*:*:*:jenkins:*:*"
+      ],
+      "global-post-script": [
+        "cpe:2.3:a:jenkins:global_post_script:*:*:*:*:*:jenkins:*:*"
+      ],
+      "global-variable-string-parameter": [
+        "cpe:2.3:a:jenkins:global_variable_string_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gogs-webhook": [
+        "cpe:2.3:a:jenkins:gogs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "google-compute-engine": [
+        "cpe:2.3:a:jenkins:google_compute_engine:*:*:*:*:*:jenkins:*:*"
+      ],
+      "google-kubernetes-engine": [
+        "cpe:2.3:a:google:kubernetes_engine:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:google_kubernetes_engine:*:*:*:*:*:jenkins:*:*"
+      ],
+      "google-login": [
+        "cpe:2.3:a:jenkins:google_login:*:*:*:*:*:jenkins:*:*"
+      ],
+      "google-oauth": [
+        "cpe:2.3:a:jenkins:google_oauth_credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "google-play-android-publisher": [
+        "cpe:2.3:a:jenkins:google-play-android-publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "gradle": [
+        "cpe:2.3:a:jenkins:gradle:*:*:*:*:*:jenkins:*:*"
+      ],
+      "groovy": [
+        "cpe:2.3:a:jenkins:groovy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "groovy-postbuild": [
+        "cpe:2.3:a:jenkins:groovy_postbuild:*:*:*:*:*:jenkins:*:*"
+      ],
+      "harvest": [
+        "cpe:2.3:a:jenkins:harvest_scm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hashicorp-vault-plugin": [
+        "cpe:2.3:a:jenkins:hashicorp_vault:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hidden-parameter": [
+        "cpe:2.3:a:jenkins:hidden_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hipchat": [
+        "cpe:2.3:a:atlassian:hipchat:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hockeyapp": [
+        "cpe:2.3:a:jenkins:hockeyapp:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hp-application-automation-tools-plugin": [
+        "cpe:2.3:a:microfocus:application_automation_tools:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hp-quality-center": [
+        "cpe:2.3:a:hp_application_lifecycle_management_quality_center_project:hp_application_lifecycle_management_quality_center:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hpe-network-virtualization": [
+        "cpe:2.3:a:jenkins:hpe_network_virtualization:*:*:*:*:*:jenkins:*:*"
+      ],
+      "htmlpublisher": [
+        "cpe:2.3:a:jenkins:html_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "htmlresource": [
+        "cpe:2.3:a:jenkins:html_resource:*:*:*:*:*:*:*:*"
+      ],
+      "http-request": [
+        "cpe:2.3:a:jenkins:http_request:*:*:*:*:*:jenkins:*:*"
+      ],
+      "http_request": [
+        "cpe:2.3:a:jenkins:http_request:*:*:*:*:*:jenkins:*:*"
+      ],
+      "hyper-commons": [
+        "cpe:2.3:a:jenkins:hyper.sh_commons:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ibm-application-security": [
+        "cpe:2.3:a:jenkins:ibm_application_security_on_cloud:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ibm-asoc": [
+        "cpe:2.3:a:jenkins:ibm_application_security_on_cloud:*:*:*:*:*:jenkins:*:*"
+      ],
+      "icescrum": [
+        "cpe:2.3:a:jenkins:icescrum:*:*:*:*:*:jenkins:*:*"
+      ],
+      "image-gallery": [
+        "cpe:2.3:a:jenkins:image_gallery:*:*:*:*:*:jenkins:*:*"
+      ],
+      "image-tag-parameter": [
+        "cpe:2.3:a:jenkins:image_tag_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "implied-labels": [
+        "cpe:2.3:a:jenkins:implied_labels:*:*:*:*:*:jenkins:*:*"
+      ],
+      "incapptic-connect-uploader": [
+        "cpe:2.3:a:jenkins:incapptic_connect_uploader:*:*:*:*:*:jenkins:*:*"
+      ],
+      "inedo-buildmaster": [
+        "cpe:2.3:a:jenkins:inedo_buildmaster:*:*:*:*:*:jenkins:*:*"
+      ],
+      "inedo-proget": [
+        "cpe:2.3:a:jenkins:inedo_proget:*:*:*:*:*:jenkins:*:*"
+      ],
+      "influxdb": [
+        "cpe:2.3:a:eficode:influxdb:*:*:*:*:*:jenkins:*:*"
+      ],
+      "instant-messaging": [
+        "cpe:2.3:a:jenkins:instant-messaging:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ircbot": [
+        "cpe:2.3:a:jenkins:irc:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ivy": [
+        "cpe:2.3:a:jenkins:ivy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jabber": [
+        "cpe:2.3:a:jenkins:jabber_\\(xmpp\\)_notifier_and_control:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jabber-server-plugin": [
+        "cpe:2.3:a:jenkins:jabber_server:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jacoco": [
+        "cpe:2.3:a:jenkins:jacoco:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jclouds": [
+        "cpe:2.3:a:jenkins:jclouds:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jenkins-cloudformation": [
+        "cpe:2.3:a:jenkins:jenkins-cloudformation-plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jenkins-multijob-plugin": [
+        "cpe:2.3:a:jenkins:multijob:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jenkins-reviewbot": [
+        "cpe:2.3:a:jenkins:jenkins-reviewbot:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jenkinsci-appspider-plugin": [
+        "cpe:2.3:a:jenkins:appspider:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jianliao": [
+        "cpe:2.3:a:jenkins:jianliao_notification:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jigomerge": [
+        "cpe:2.3:a:jenkins:jigomerge:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jira": [
+        "cpe:2.3:a:jenkins:jira:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:jenkins:jira:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jira-ext": [
+        "cpe:2.3:a:jenkins:jira-ext:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jira-issue-updater": [
+        "cpe:2.3:a:jenkins:jira_issue_updater:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jira-steps": [
+        "cpe:2.3:a:jenkins:jira_pipeline_steps:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jms-messaging": [
+        "cpe:2.3:a:jenkins:jms_messaging:*:*:*:*:*:jenkins:*:*"
+      ],
+      "job-dsl": [
+        "cpe:2.3:a:jenkins:job_dsl:*:*:*:*:*:jenkins:*:*"
+      ],
+      "job-import": [
+        "cpe:2.3:a:jenkins:job_import:*:*:*:*:*:jenkins:*:*"
+      ],
+      "job-import-plugin": [
+        "cpe:2.3:a:jenkins:job_import:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jobConfigHistory": [
+        "cpe:2.3:a:jenkins:job_configuration_history:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jobconfighistory_project:jobconfighistory:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jobgenerator": [
+        "cpe:2.3:a:jenkins:job_generator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jsgames": [
+        "cpe:2.3:a:jenkins:jsgames:*:*:*:*:*:jenkins:*:*"
+      ],
+      "junit": [
+        "cpe:2.3:a:jenkins:junit:*:*:*:*:*:jenkins:*:*"
+      ],
+      "jx-resources": [
+        "cpe:2.3:a:jenkins:jx_resources:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kanboard": [
+        "cpe:2.3:a:jenkins:kanboard:*:*:*:*:*:jenkins:*:*"
+      ],
+      "katalon": [
+        "cpe:2.3:a:jenkins:katalon:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kiuwanJenkinsPlugin": [
+        "cpe:2.3:a:jenkins:kiuwan:*:*:*:*:*:jenkins:*:*"
+      ],
+      "klaros-testmanagement": [
+        "cpe:2.3:a:jenkins:klaros-testmanagement:*:*:*:*:*:jenkins:*:*"
+      ],
+      "klocwork": [
+        "cpe:2.3:a:jenkins:klocwork_analysis:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kmap": [
+        "cpe:2.3:a:jenkins:kmap:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kmap-jenkins": [
+        "cpe:2.3:a:jenkins:kmap:*:*:*:*:*:jenkins:*:*"
+      ],
+      "koji": [
+        "cpe:2.3:a:jenkins:koji:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kubernetes": [
+        "cpe:2.3:a:jenkins:kubernetes:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kubernetes-cd": [
+        "cpe:2.3:a:jenkins:kubernetes_continuous_deploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kubernetes-ci": [
+        "cpe:2.3:a:jenkins:kubernetes_ci:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kubernetes-credentials-provider": [
+        "cpe:2.3:a:jenkins:kubernetes_credentials_provider:*:*:*:*:*:jenkins:*:*"
+      ],
+      "kubernetes-pipeline": [
+        "cpe:2.3:a:jenkins:kubernetes_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "labmanager": [
+        "cpe:2.3:a:jenkins:vmware_lab_manager_slaves:*:*:*:*:*:jenkins:*:*"
+      ],
+      "lambdatest-automation": [
+        "cpe:2.3:a:jenkins:lambdatest-automation:*:*:*:*:*:jenkins:*:*"
+      ],
+      "libvirt-slave": [
+        "cpe:2.3:a:jenkins:libvirt_agents:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:libvirt_slaves:*:*:*:*:*:jenkins:*:*"
+      ],
+      "link-column": [
+        "cpe:2.3:a:jenkins:link_column:*:*:*:*:*:jenkins:*:*"
+      ],
+      "liquibase-runner": [
+        "cpe:2.3:a:jenkins:liquibase_runner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "list-git-branches-parameter": [
+        "cpe:2.3:a:jenkins:list_git_branches_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "literate": [
+        "cpe:2.3:a:jenkins:literate:*:*:*:*:*:jenkins:*:*"
+      ],
+      "lockable-resources": [
+        "cpe:2.3:a:jenkins:lockable_resources:*:*:*:*:*:jenkins:*:*"
+      ],
+      "locked-files-report": [
+        "cpe:2.3:a:jenkins:locked_files_report:*:*:*:*:*:jenkins:*:*"
+      ],
+      "log-parser": [
+        "cpe:2.3:a:jenkins:log_parser:*:*:*:*:*:jenkins:*:*"
+      ],
+      "logstash": [
+        "cpe:2.3:a:jenkins:logstash:*:*:*:*:*:jenkins:*:*"
+      ],
+      "lucene-search": [
+        "cpe:2.3:a:jenkins:lucene-search:*:*:*:*:*:jenkins:*:*"
+      ],
+      "m2release": [
+        "cpe:2.3:a:jenkins:m2_release:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:m2release:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mabl-integration": [
+        "cpe:2.3:a:jenkins:mabl:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mac": [
+        "cpe:2.3:a:jenkins:mac:*:*:*:*:*:jenkins:*:*"
+      ],
+      "macstadium-orka": [
+        "cpe:2.3:a:jenkins:orka_by_macstadium:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mail-commander": [
+        "cpe:2.3:a:jenkins:mail_commander:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mailcommander": [
+        "cpe:2.3:a:jenkins:mail_commander:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mailer": [
+        "cpe:2.3:a:jenkins:mailer:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:jenkins:mailer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mantis": [
+        "cpe:2.3:a:jenkins:mantis:*:*:*:*:*:jenkins:*:*"
+      ],
+      "markdown-formatter": [
+        "cpe:2.3:a:jenkins:markdown_formatter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mashup-portlets": [
+        "cpe:2.3:a:jenkins:mashup_portlets:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mask-passwords": [
+        "cpe:2.3:a:jenkins:mask_passwords:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mathworks-polyspace": [
+        "cpe:2.3:a:jenkins:mathworks_polyspace:*:*:*:*:*:jenkins:*:*"
+      ],
+      "matlab": [
+        "cpe:2.3:a:jenkins:matlab:*:*:*:*:*:jenkins:*:*"
+      ],
+      "matrix-auth": [
+        "cpe:2.3:a:jenkins:matrix_authorization_strategy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "matrix-project": [
+        "cpe:2.3:a:jenkins:matrix_project:*:*:*:*:*:jenkins:*:*"
+      ],
+      "matrix-reloaded": [
+        "cpe:2.3:a:jenkins:matrix_reloaded:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mattermost": [
+        "cpe:2.3:a:jenkins:mattermost:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:mattermost_notification:*:*:*:*:*:jenkins:*:*"
+      ],
+      "maven": [
+        "cpe:2.3:a:jenkins:maven:*:*:*:*:*:jenkins:*:*"
+      ],
+      "maven-artifact-choicelistprovider": [
+        "cpe:2.3:a:jenkins:maven_artifact_choicelistprovider_\\(nexus\\):*:*:*:*:*:jenkins:*:*"
+      ],
+      "maven-metadata-plugin": [
+        "cpe:2.3:a:jenkins:maven_metadata:*:*:*:*:*:jenkins:*:*"
+      ],
+      "maven-release-cascade": [
+        "cpe:2.3:a:barchart:maven_cascade_release:*:*:*:*:*:jenkins:*:*"
+      ],
+      "meliora-testlab": [
+        "cpe:2.3:a:jenkins:meliora_testlab:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:melioratestlab:melioratestlab:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mercurial": [
+        "cpe:2.3:a:jenkins:mercurial:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mesos": [
+        "cpe:2.3:a:apache:mesos:*:*:*:*:*:jenkins:*:*"
+      ],
+      "metrics": [
+        "cpe:2.3:a:jenkins:metrics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "minio-storage": [
+        "cpe:2.3:a:jenkins:minio_storage:*:*:*:*:*:jenkins:*:*"
+      ],
+      "miniorange-saml-sp": [
+        "cpe:2.3:a:jenkins:saml_single_sign_on:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mongodb": [
+        "cpe:2.3:a:jenkins:mongodb:*:*:*:*:*:jenkins:*:*"
+      ],
+      "monitoring": [
+        "cpe:2.3:a:jenkins:monitoring:*:*:*:*:*:jenkins:*:*"
+      ],
+      "mstest": [
+        "cpe:2.3:a:jenkins:mstest:*:*:*:*:*:jenkins:*:*"
+      ],
+      "neoload": [
+        "cpe:2.3:a:jenkins:neoload:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nerrvana": [
+        "cpe:2.3:a:jenkins:nerrvana:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nested-view": [
+        "cpe:2.3:a:jenkins:nested_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "netsparker-cloud-scan": [
+        "cpe:2.3:a:jenkins:netsparker_cloud_scan:*:*:*:*:*:jenkins:*:*"
+      ],
+      "neuvector-vulnerability-scanner": [
+        "cpe:2.3:a:jenkins:neuvector_vulnerability_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nexus-platform": [
+        "cpe:2.3:a:jenkins:nexus_platform:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nodejs": [
+        "cpe:2.3:a:jenkins:nodejs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nodelabelparameter": [
+        "cpe:2.3:a:jenkins:node_and_label_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nomad": [
+        "cpe:2.3:a:jenkins:nomad:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nuget": [
+        "cpe:2.3:a:jenkins:nuget:*:*:*:*:*:jenkins:*:*"
+      ],
+      "nunit": [
+        "cpe:2.3:a:jenkins:nunit:*:*:*:*:*:jenkins:*:*"
+      ],
+      "octoperf": [
+        "cpe:2.3:a:jenkins:octoperf_load_testing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "oic-auth": [
+        "cpe:2.3:a:jenkins:openid:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:openid_connect_authentication:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ontrack": [
+        "cpe:2.3:a:jenkins:ontrack:*:*:*:*:*:jenkins:*:*"
+      ],
+      "open-stf": [
+        "cpe:2.3:a:jenkins:open_stf:*:*:*:*:*:jenkins:*:*"
+      ],
+      "openid": [
+        "cpe:2.3:a:jenkins:openid:*:*:*:*:*:jenkins:*:*"
+      ],
+      "openshift-deployer": [
+        "cpe:2.3:a:jenkins:openshift_deployer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "openshift-login": [
+        "cpe:2.3:a:jenkins:openshift_login:*:*:*:*:*:jenkins:*:*"
+      ],
+      "openshift-pipeline": [
+        "cpe:2.3:a:jenkins:openshift_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "openstack-cloud": [
+        "cpe:2.3:a:jenkins:openstack_cloud:*:*:*:*:*:jenkins:*:*"
+      ],
+      "opsgenie": [
+        "cpe:2.3:a:jenkins:opsgenie:*:*:*:*:*:jenkins:*:*"
+      ],
+      "oracle-cloud-infrastructure-compute-classic": [
+        "cpe:2.3:a:jenkins:oracle_cloud_infrastructure_compute_classic:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ownership": [
+        "cpe:2.3:a:jenkins:job_and_node_ownership:*:*:*:*:*:jenkins:*:*"
+      ],
+      "p4": [
+        "cpe:2.3:a:jenkins:p4:*:*:*:*:*:jenkins:*:*"
+      ],
+      "packageversion": [
+        "cpe:2.3:a:jenkins:package_version:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pam-auth": [
+        "cpe:2.3:a:jenkins:pluggable_authentication_module:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pangolin-testrail-connector": [
+        "cpe:2.3:a:agiletestware:pangolin_connector_for_testrail:*:*:*:*:*:jenkins:*:*"
+      ],
+      "parameterized-remote-trigger": [
+        "cpe:2.3:a:jenkins:parameterized_remote_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "parameterized-trigger": [
+        "cpe:2.3:a:jenkins:parameterized_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "parasoft-findings": [
+        "cpe:2.3:a:jenkins:parasoft_findings:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pegdown-formatter": [
+        "cpe:2.3:a:jenkins:pegdown_formatter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "perfecto": [
+        "cpe:2.3:a:jenkins:perfecto:*:*:*:*:*:jenkins:*:*"
+      ],
+      "perfectomobile": [
+        "cpe:2.3:a:jenkins:perfecto_mobile:*:*:*:*:*:jenkins:*:*"
+      ],
+      "perforce": [
+        "cpe:2.3:a:jenkins:perforce:*:*:*:*:*:jenkins:*:*"
+      ],
+      "performance": [
+        "cpe:2.3:a:jenkins:performance:*:*:*:*:*:jenkins:*:*"
+      ],
+      "perfpublisher": [
+        "cpe:2.3:a:jenkins:performance_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "periodicbackup": [
+        "cpe:2.3:a:jenkins:periodic_backup:*:*:*:*:*:jenkins:*:*"
+      ],
+      "persona": [
+        "cpe:2.3:a:jenkins:persona:*:*:*:*:*:jenkins:*:*"
+      ],
+      "phabricator-plugin": [
+        "cpe:2.3:a:jenkins:phabricator_differential:*:*:*:*:*:jenkins:*:*"
+      ],
+      "phoenix-autotest": [
+        "cpe:2.3:a:jenkins:pipeline\\:_phoenix_autotest:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-aggregator-view": [
+        "cpe:2.3:a:jenkins:pipeline_aggregator_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-aws": [
+        "cpe:2.3:a:jenkins:pipeline\\:_aws_steps:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-build-step": [
+        "cpe:2.3:a:jenkins:pipeline\\:_build_step:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-githubnotify-step": [
+        "cpe:2.3:a:jenkins:pipeline_github_notify_step:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-input-step": [
+        "cpe:2.3:a:jenkins:pipeline\\:_input_step:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:pipeline\\:input_step:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-maven": [
+        "cpe:2.3:a:jenkins:pipeline_maven_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-model-definition": [
+        "cpe:2.3:a:jenkins:pipeline\\:_declarative:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-restful-api": [
+        "cpe:2.3:a:jenkins:pipeline_restful_api:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pipeline-stage-view": [
+        "cpe:2.3:a:jenkins:pipeline\\:stage_view:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:stage_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "play": [
+        "cpe:2.3:a:jenkins:play_framework:*:*:*:*:*:jenkins:*:*"
+      ],
+      "plot": [
+        "cpe:2.3:a:jenkins:plot:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pmd": [
+        "cpe:2.3:a:jenkins:pmd:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pollscm": [
+        "cpe:2.3:a:jenkins:poll_scm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pom2config": [
+        "cpe:2.3:a:jenkins:pom2config:*:*:*:*:*:jenkins:*:*"
+      ],
+      "port-allocator": [
+        "cpe:2.3:a:jenkins:port_allocator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "project-inheritance": [
+        "cpe:2.3:a:jenkins:project_inheritance:*:*:*:*:*:jenkins:*:*"
+      ],
+      "promoted-builds": [
+        "cpe:2.3:a:jenkins:promoted_builds:*:*:*:*:*:jenkins:*:*"
+      ],
+      "promoted-builds-simple": [
+        "cpe:2.3:a:jenkins:promoted_builds_\\(simple\\):*:*:*:*:*:jenkins:*:*"
+      ],
+      "proxmox": [
+        "cpe:2.3:a:jenkins:proxmox:*:*:*:*:*:jenkins:*:*"
+      ],
+      "prqa": [
+        "cpe:2.3:a:jenkins:prqa:*:*:*:*:*:jenkins:*:*"
+      ],
+      "prqa-plugin": [
+        "cpe:2.3:a:jenkins:prqa:*:*:*:*:*:jenkins:*:*"
+      ],
+      "publish-over-cifs": [
+        "cpe:2.3:a:jenkins:publish_over_cifs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "publish-over-ftp": [
+        "cpe:2.3:a:jenkins:publish_over_ftp:*:*:*:*:*:jenkins:*:*"
+      ],
+      "publish-over-ssh": [
+        "cpe:2.3:a:jenkins:publish_over_ssh:*:*:*:*:*:jenkins:*:*"
+      ],
+      "puppet-enterprise-pipeline": [
+        "cpe:2.3:a:jenkins:puppet_enterprise_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "pwauth": [
+        "cpe:2.3:a:jenkins:pwauth_security_realm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "quality-gates": [
+        "cpe:2.3:a:jenkins:quality_gates:*:*:*:*:*:jenkins:*:*"
+      ],
+      "quayio-trigger": [
+        "cpe:2.3:a:jenkins:quay.io_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "queue-cleanup": [
+        "cpe:2.3:a:jenkins:queue_cleanup:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rabbitmq-consumer": [
+        "cpe:2.3:a:jenkins:rabbitmq_consumer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "radargun": [
+        "cpe:2.3:a:jenkins:radargun:*:*:*:*:*:jenkins:*:*"
+      ],
+      "radiatorview": [
+        "cpe:2.3:a:jenkins:radiator_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "radiatorviewplugin": [
+        "cpe:2.3:a:jenkins:radiator_view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "random-string-parameter": [
+        "cpe:2.3:a:jenkins:random_string_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rapiddeploy": [
+        "cpe:2.3:a:jenkins:rapiddeploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rapiddeploy-jenkins": [
+        "cpe:2.3:a:jenkins:rapiddeploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rebuild": [
+        "cpe:2.3:a:rebuild_project:rebuild:*:*:*:*:*:jenkins:*:*"
+      ],
+      "recipe": [
+        "cpe:2.3:a:jenkins:recipe:*:*:*:*:*:jenkins:*:*"
+      ],
+      "redgate-sql-ci": [
+        "cpe:2.3:a:jenkins:redgate_sql_change_automation:*:*:*:*:*:jenkins:*:*"
+      ],
+      "redhat-dependency-analytics": [
+        "cpe:2.3:a:jenkins:red_hat_dependency_analytics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "release-helper": [
+        "cpe:2.3:a:jenkins:release_helper:*:*:*:*:*:jenkins:*:*"
+      ],
+      "relution-publisher": [
+        "cpe:2.3:a:jenkins:relution_enterprise_appstore_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "remote-jobs-view": [
+        "cpe:2.3:a:jenkins:remote-jobs-view:*:*:*:*:*:jenkins:*:*"
+      ],
+      "repo": [
+        "cpe:2.3:a:jenkins:repo:*:*:*:*:*:jenkins:*:*"
+      ],
+      "reportportal": [
+        "cpe:2.3:a:jenkins:report_portal:*:*:*:*:*:jenkins:*:*"
+      ],
+      "repository-connector": [
+        "cpe:2.3:a:jenkins:repository_connector:*:*:*:*:*:jenkins:*:*"
+      ],
+      "requests": [
+        "cpe:2.3:a:jenkins:requests:*:*:*:*:*:jenkins:*:*"
+      ],
+      "resource-disposer": [
+        "cpe:2.3:a:jenkins:resource_disposer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rest-list-parameter": [
+        "cpe:2.3:a:jenkins:rest_list_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "reverse-proxy-auth": [
+        "cpe:2.3:a:jenkins:reverse_proxy_auth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "reverse-proxy-auth-plugin": [
+        "cpe:2.3:a:jenkins:reverse_proxy_auth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rhnpush-plugin": [
+        "cpe:2.3:a:jenkins:rhnpush-plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rich-text-publisher-plugin": [
+        "cpe:2.3:a:jenkins:rich_text_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "robot": [
+        "cpe:2.3:a:jenkins:robot_framework:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rocketchatnotifier": [
+        "cpe:2.3:a:jenkins:rocketchat_notifier:*:*:*:*:*:jenkins:*:*"
+      ],
+      "role-strategy": [
+        "cpe:2.3:a:jenkins:role-based_authorization_strategy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rpmsign": [
+        "cpe:2.3:a:jenkins:rpmsign-plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rpmsign-plugin": [
+        "cpe:2.3:a:jenkins:rpmsign-plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rqm-plugin": [
+        "cpe:2.3:a:jenkins:rqm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rrod": [
+        "cpe:2.3:a:jenkins:request_rename_or_delete:*:*:*:*:*:jenkins:*:*"
+      ],
+      "rundeck": [
+        "cpe:2.3:a:jenkins:rundeck:*:*:*:*:*:jenkins:*:*"
+      ],
+      "s3": [
+        "cpe:2.3:a:jenkins:s3_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "s3explorer": [
+        "cpe:2.3:a:jenkins:s3_explorer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "saltstack": [
+        "cpe:2.3:a:jenkins:saltstack:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sametime": [
+        "cpe:2.3:a:jenkins:sametime:*:*:*:*:*:jenkins:*:*"
+      ],
+      "saml": [
+        "cpe:2.3:a:jenkins:saml:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sauce-ondemand": [
+        "cpe:2.3:a:jenkins:sauce_ondemand:*:*:*:*:*:jenkins:*:*"
+      ],
+      "scm-filter-jervis": [
+        "cpe:2.3:a:jenkins:source_code_management_filter_jervis:*:*:*:*:*:jenkins:*:*"
+      ],
+      "scm-httpclient": [
+        "cpe:2.3:a:jenkins:scm_httpclient:*:*:*:*:*:jenkins:*:*"
+      ],
+      "scp": [
+        "cpe:2.3:a:jenkins:scp_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "script-security": [
+        "cpe:2.3:a:jenkins:script_security:*:*:*:*:*:jenkins:*:*"
+      ],
+      "scriptler": [
+        "cpe:2.3:a:jenkins:scriptler:*:*:*:*:*:jenkins:*:*"
+      ],
+      "security-inspector": [
+        "cpe:2.3:a:jenkins:security_inspector:*:*:*:*:*:jenkins:*:*"
+      ],
+      "selected-tests-executor": [
+        "cpe:2.3:a:jenkins:tests_selector:*:*:*:*:*:jenkins:*:*"
+      ],
+      "selection-tasks": [
+        "cpe:2.3:a:jenkins:selection_tasks:*:*:*:*:*:jenkins:*:*"
+      ],
+      "selection-tasks-plugin": [
+        "cpe:2.3:a:jenkins:selection_tasks:*:*:*:*:*:jenkins:*:*"
+      ],
+      "selenium": [
+        "cpe:2.3:a:jenkins:selenium:*:*:*:*:*:jenkins:*:*"
+      ],
+      "seleniumhtmlreport": [
+        "cpe:2.3:a:jenkins:selenium_html_report:*:*:*:*:*:jenkins:*:*"
+      ],
+      "semantic-versioning": [
+        "cpe:2.3:a:jenkins:semantic_versioning:*:*:*:*:*:jenkins:*:*"
+      ],
+      "semantic-versioning-plugin": [
+        "cpe:2.3:a:jenkins:semantic_versioning:*:*:*:*:*:jenkins:*:*"
+      ],
+      "servicenow-devops": [
+        "cpe:2.3:a:jenkins:servicenow_devops:*:*:*:*:*:jenkins:*:*"
+      ],
+      "shared-objects": [
+        "cpe:2.3:a:jenkins:shared_objects:*:*:*:*:*:jenkins:*:*"
+      ],
+      "shelve-project": [
+        "cpe:2.3:a:jenkins:shelve_project:*:*:*:*:*:jenkins:*:*"
+      ],
+      "shelve-project-plugin": [
+        "cpe:2.3:a:jenkins:shelve_project:*:*:*:*:*:jenkins:*:*"
+      ],
+      "shortcut-job": [
+        "cpe:2.3:a:jenkins:shortcut_job:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sidebar-link": [
+        "cpe:2.3:a:jenkins:sidebar_link:*:*:*:*:*:jenkins:*:*"
+      ],
+      "simple-travis-runner": [
+        "cpe:2.3:a:jenkins:simple_travis_pipeline_runner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sinatra-chef-builder": [
+        "cpe:2.3:a:jenkins:chef_sinatra:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sitemonitor": [
+        "cpe:2.3:a:jenkins:sitemonitor:*:*:*:*:*:jenkins:*:*"
+      ],
+      "skype-notifier": [
+        "cpe:2.3:a:jenkins:skype_notifier:*:*:*:*:*:jenkins:*:*"
+      ],
+      "skytap-cloud": [
+        "cpe:2.3:a:jenkins:skytap_cloud_ci:*:*:*:*:*:jenkins:*:*"
+      ],
+      "slack": [
+        "cpe:2.3:a:jenkins:slack:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:slack_notification:*:*:*:*:*:jenkins:*:*"
+      ],
+      "slack-uploader": [
+        "cpe:2.3:a:jenkins:slack_upload:*:*:*:*:*:jenkins:*:*"
+      ],
+      "smalltest": [
+        "cpe:2.3:a:jenkins:smalltest:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sms": [
+        "cpe:2.3:a:jenkins:sms_notification:*:*:*:*:*:jenkins:*:*"
+      ],
+      "snsnotify": [
+        "cpe:2.3:a:jenkins:amazon_sns_build_notifier:*:*:*:*:*:jenkins:*:*"
+      ],
+      "soapui-pro-functional-testing": [
+        "cpe:2.3:a:jenkins:soapui_pro_functional_testing:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sofy-ai": [
+        "cpe:2.3:a:jenkins:sofy.ai:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sonar-gerrit": [
+        "cpe:2.3:a:jenkins:sonar_gerrit:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sonar-quality-gates": [
+        "cpe:2.3:a:jenkins:sonar_quality_gates:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sonargraph-integration": [
+        "cpe:2.3:a:jenkins:sonargraph_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sonarqube": [
+        "cpe:2.3:a:sonarsource:sonarqube_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sounds": [
+        "cpe:2.3:a:jenkins:sounds:*:*:*:*:*:jenkins:*:*"
+      ],
+      "speaks": [
+        "cpe:2.3:a:jenkins:speaks\\!:*:*:*:*:*:jenkins:*:*"
+      ],
+      "splunk-devops": [
+        "cpe:2.3:a:jenkins:splunk:*:*:*:*:*:jenkins:*:*"
+      ],
+      "spoonscript": [
+        "cpe:2.3:a:jenkins:turboscript:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sqlplus-script-runner": [
+        "cpe:2.3:a:jenkins:sqlplus_script_runner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sra-deploy": [
+        "cpe:2.3:a:jenkins:serena_sra_deploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ssh": [
+        "cpe:2.3:a:jenkins:ssh:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ssh-agent": [
+        "cpe:2.3:a:jenkins:ssh_agent:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ssh-credentials": [
+        "cpe:2.3:a:jenkins:ssh_credentials:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ssh-slaves": [
+        "cpe:2.3:a:jenkins:ssh_slaves:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ssh2easy": [
+        "cpe:2.3:a:jenkins:ssh2_easy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "starteam": [
+        "cpe:2.3:a:jenkins:starteam:*:*:*:*:*:jenkins:*:*"
+      ],
+      "storable-configs": [
+        "cpe:2.3:a:jenkins:storable_configs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "storable-configs-plugin": [
+        "cpe:2.3:a:jenkins:storable_configs:*:*:*:*:*:jenkins:*:*"
+      ],
+      "subversion": [
+        "cpe:2.3:a:jenkins-ci:subversion-plugin:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:jenkins:subversion:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sumologic-publisher": [
+        "cpe:2.3:a:jenkins:sumologic_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "support-core": [
+        "cpe:2.3:a:jenkins:support_core:*:*:*:*:*:jenkins:*:*"
+      ],
+      "svn-partial-release-mgr": [
+        "cpe:2.3:a:jenkins:subversion_partial_release_manager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "svn-release-mgr": [
+        "cpe:2.3:a:jenkins:subversion_release_manager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "swamp": [
+        "cpe:2.3:a:jenkins:swamp:*:*:*:*:*:jenkins:*:*"
+      ],
+      "swarm": [
+        "cpe:2.3:a:jenkins:self-organizing_swarm_modules:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:swarm:*:*:*:*:*:jenkins:*:*"
+      ],
+      "synopsys-coverity": [
+        "cpe:2.3:a:jenkins:synopsys_coverity:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tap": [
+        "cpe:2.3:a:jenkins:tap:*:*:*:*:*:jenkins:*:*"
+      ],
+      "team-views": [
+        "cpe:2.3:a:jenkins:team_views:*:*:*:*:*:jenkins:*:*"
+      ],
+      "teams-webhook-trigger": [
+        "cpe:2.3:a:jenkins:msteams_webhook_trigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "template-workflows": [
+        "cpe:2.3:a:jenkins:template_workflows:*:*:*:*:*:jenkins:*:*"
+      ],
+      "templating-engine": [
+        "cpe:2.3:a:jenkins:templating_engine:*:*:*:*:*:jenkins:*:*"
+      ],
+      "test-results-aggregator": [
+        "cpe:2.3:a:jenkins:test_results_aggregator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "testcomplete": [
+        "cpe:2.3:a:jenkins:testcomplete_support:*:*:*:*:*:jenkins:*:*"
+      ],
+      "testfairy": [
+        "cpe:2.3:a:jenkins:testfairy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "testlink": [
+        "cpe:2.3:a:jenkins:testlink:*:*:*:*:*:jenkins:*:*"
+      ],
+      "testng-plugin": [
+        "cpe:2.3:a:jenkins:testng_results:*:*:*:*:*:jenkins:*:*"
+      ],
+      "testquality-updater": [
+        "cpe:2.3:a:jenkins:testquality_updater:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tfs": [
+        "cpe:2.3:a:jenkins:team_foundation_server:*:*:*:*:*:jenkins:*:*"
+      ],
+      "threadfix": [
+        "cpe:2.3:a:jenkins:threadfix:*:*:*:*:*:jenkins:*:*"
+      ],
+      "thycotic-devops-secrets-vault": [
+        "cpe:2.3:a:jenkins:thycotic_devops_secrets_vault:*:*:*:*:*:jenkins:*:*"
+      ],
+      "thycotic-secret-server": [
+        "cpe:2.3:a:jenkins:thycotic_secret_server:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tics": [
+        "cpe:2.3:a:jenkins:tics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tikal-multijob": [
+        "cpe:2.3:a:jenkins:multijob:*:*:*:*:*:jenkins:*:*"
+      ],
+      "timestamper": [
+        "cpe:2.3:a:jenkins:timestamper:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tinfoil-scan": [
+        "cpe:2.3:a:jenkins:tinfoil_security:*:*:*:*:*:jenkins:*:*"
+      ],
+      "token-macro": [
+        "cpe:2.3:a:jenkins:token_macro:*:*:*:*:*:jenkins:*:*"
+      ],
+      "trac-publisher-plugin": [
+        "cpe:2.3:a:jenkins:trac_publisher:*:*:*:*:*:jenkins:*:*"
+      ],
+      "translation": [
+        "cpe:2.3:a:jenkins:translation_assistance:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tuleap-git-branch-source": [
+        "cpe:2.3:a:jenkins:tuleap_git_branch_source:*:*:*:*:*:jenkins:*:*"
+      ],
+      "tuleap-oauth": [
+        "cpe:2.3:a:jenkins:tuleap_authentication:*:*:*:*:*:jenkins:*:*"
+      ],
+      "twitter": [
+        "cpe:2.3:a:jenkins:twitter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "uno-choice": [
+        "cpe:2.3:a:jenkins:active_choices:*:*:*:*:*:jenkins:*:*"
+      ],
+      "upload-pgyer": [
+        "cpe:2.3:a:jenkins:upload_to_pgyer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "urltrigger": [
+        "cpe:2.3:a:jenkins:urltrigger:*:*:*:*:*:jenkins:*:*"
+      ],
+      "usemango-runner": [
+        "cpe:2.3:a:jenkins:usemango_runner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "valgrind": [
+        "cpe:2.3:a:jenkins:valgrind:*:*:*:*:*:jenkins:*:*"
+      ],
+      "validating-email-parameter": [
+        "cpe:2.3:a:jenkins:validating_email_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "validating-string-parameter": [
+        "cpe:2.3:a:jenkins:validating_string_parameter:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vault-scm-plugin": [
+        "cpe:2.3:a:jenkins:sourcegear_vault:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vboxwrapper": [
+        "cpe:2.3:a:jenkins:vboxwrapper:*:*:*:*:*:jenkins:*:*"
+      ],
+      "veracode-scanner": [
+        "cpe:2.3:a:jenkins:veracode-scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "view-cloner": [
+        "cpe:2.3:a:jenkins:view-cloner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "view26": [
+        "cpe:2.3:a:jenkins:view26_test-reporting:*:*:*:*:*:jenkins:*:*"
+      ],
+      "violation-comments-to-gitlab": [
+        "cpe:2.3:a:jenkins:violation_comments_to_gitlab:*:*:*:*:*:jenkins:*:*"
+      ],
+      "visualexpert": [
+        "cpe:2.3:a:jenkins:visualexpert:*:*:*:*:*:jenkins:*:*"
+      ],
+      "visualworks-store": [
+        "cpe:2.3:a:jenkins:visualworks_store:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vmanager": [
+        "cpe:2.3:a:jenkins:cadence_vmanager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vmanager-plugin": [
+        "cpe:2.3:a:jenkins:cadence_vmanager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vmware-vrealize-automation-plugin": [
+        "cpe:2.3:a:jenkins:vmware_vrealize_automation:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vmware-vrealize-orchestrator": [
+        "cpe:2.3:a:jenkins:vrealize_orchestrator:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vncrecorder": [
+        "cpe:2.3:a:jenkins:vncrecorder:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vncviewer": [
+        "cpe:2.3:a:jenkins:vncviewer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vs-code-metrics": [
+        "cpe:2.3:a:jenkins:visual_studio_code_metrics:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vsphere-cloud": [
+        "cpe:2.3:a:jenkins:vsphere:*:*:*:*:*:jenkins:*:*"
+      ],
+      "vsts-cd": [
+        "cpe:2.3:a:jenkins:vs_team_services_continuous_deployment:*:*:*:*:*:jenkins:*:*"
+      ],
+      "walldisplay": [
+        "cpe:2.3:a:jenkins:wall_display:*:*:*:*:*:jenkins:*:*"
+      ],
+      "walti": [
+        "cpe:2.3:a:jenkins:walti:*:*:*:*:*:jenkins:*:*"
+      ],
+      "warnings": [
+        "cpe:2.3:a:jenkins:warnings:*:*:*:*:*:jenkins:*:*"
+      ],
+      "warnings-ng": [
+        "cpe:2.3:a:jenkins:warnings_next_generation:*:*:*:*:*:jenkins:*:*"
+      ],
+      "weblogic-deployer": [
+        "cpe:2.3:a:jenkins:deploy_weblogic:*:*:*:*:*:jenkins:*:*"
+      ],
+      "weblogic-deployer-plugin": [
+        "cpe:2.3:a:jenkins:deploy_weblogic:*:*:*:*:*:jenkins:*:*"
+      ],
+      "websphere-deployer": [
+        "cpe:2.3:a:jenkins:websphere_deployer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "whitesource": [
+        "cpe:2.3:a:jenkins:white_source:*:*:*:*:*:jenkins:*:*"
+      ],
+      "wildfly-deployer": [
+        "cpe:2.3:a:jenkins:wildfly_deployer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "windows-slaves": [
+        "cpe:2.3:a:jenkins:wmi_windows_agents:*:*:*:*:*:jenkins:*:*"
+      ],
+      "workflow-cps": [
+        "cpe:2.3:a:jenkins:pipeline\\:_groovy:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:jenkins:pipeline\\:_groovy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "workflow-cps-global-lib": [
+        "cpe:2.3:a:jenkins:pipeline\\:_shared_groovy_libraries:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:pipeline\\:shared_groovy_libraries:*:*:*:*:*:jenkins:*:*"
+      ],
+      "workflow-multibranch": [
+        "cpe:2.3:a:jenkins:pipeline\\:_multibranch:*:*:*:*:*:jenkins:*:*"
+      ],
+      "workflow-remote-loader": [
+        "cpe:2.3:a:jenkins:pipeline_remote_loader:*:*:*:*:*:jenkins:*:*"
+      ],
+      "workflow-support": [
+        "cpe:2.3:a:jenkins:pipeline\\:_supporting_apis:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:pipeline_supporting_apis:*:*:*:*:*:jenkins:*:*"
+      ],
+      "ws-execution-manager": [
+        "cpe:2.3:a:jenkins:worksoft_execution_manager:*:*:*:*:*:jenkins:*:*"
+      ],
+      "wso2id-oauth": [
+        "cpe:2.3:a:jenkins:wso2_oauth:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xcode": [
+        "cpe:2.3:a:jenkins:xcode_integration:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xfpanel": [
+        "cpe:2.3:a:jenkins:extreme_feedback_panel:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xldeploy": [
+        "cpe:2.3:a:jenkins:xebialabs_xl_deploy:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xlrelease-plugin": [
+        "cpe:2.3:a:jenkins:xebialabs_xl_release:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xltestview": [
+        "cpe:2.3:a:jenkins:xl_testview:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:xl_testviews:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xpath-config-viewer": [
+        "cpe:2.3:a:jenkins:xpath_configuration_viewer:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xray-connector": [
+        "cpe:2.3:a:jenkins:xray_-_test_management_for_jira:*:*:*:*:*:jenkins:*:*"
+      ],
+      "xunit": [
+        "cpe:2.3:a:jenkins:xunit:*:*:*:*:*:jenkins:*:*"
+      ],
+      "yaml-axis": [
+        "cpe:2.3:a:jenkins:yaml_axis:*:*:*:*:*:jenkins:*:*"
+      ],
+      "yet-another-build-visualizer": [
+        "cpe:2.3:a:jenkins:yet_another_build_visualizer:*:*:*:*:*:*:*:*"
+      ],
+      "youtrack": [
+        "cpe:2.3:a:jenkins:youtrack-plugin:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zap": [
+        "cpe:2.3:a:jenkins:official_owasp_zap:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zap-pipeline": [
+        "cpe:2.3:a:jenkins:zap_pipeline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zephyr-enterprise-test-management": [
+        "cpe:2.3:a:jenkins:zephyr_enterprise_test_management:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zephyr-for-jira-test-management": [
+        "cpe:2.3:a:jenkins:zephyr_for_jira_test_management:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zos-connector": [
+        "cpe:2.3:a:jenkins:z\\/os_connector:*:*:*:*:*:jenkins:*:*"
+      ],
+      "zulip": [
+        "cpe:2.3:a:jenkins:zulip:*:*:*:*:*:jenkins:*:*"
+      ]
     },
     "npm": {
-      "%40perfood/couch-auth": "cpe:2.3:a:perfood:couchauth:*:*:*:*:*:node.js:*:*",
-      "11xiaoli": "cpe:2.3:a:11xiaoli_project:11xiaoli:*:*:*:*:*:node.js:*:*",
-      "22lixian": "cpe:2.3:a:22lixian_project:22lixian:*:*:*:*:*:node.js:*:*",
-      "360class.jansenhm": "cpe:2.3:a:360class.jansenhm_project:360class.jansenhm:*:*:*:*:*:node.js:*:*",
-      "626": "cpe:2.3:a:626_project:626:*:*:*:*:*:node.js:*:*",
-      "@actions/core": "cpe:2.3:a:toolkit_project:toolkit:*:*:*:*:*:node.js:*:*",
-      "@adobe/css-tools": "cpe:2.3:a:adobe:css-tools:*:*:*:*:*:node.js:*:*",
-      "@aedart/js-service-provider": "cpe:2.3:a:aedart:ion:*:*:*:*:*:node.js:*:*",
-      "@angular/core": "cpe:2.3:a:angular:angular:*:*:*:*:*:node.js:*:*",
-      "@antfu/utils": "cpe:2.3:a:antfu:utils:*:*:*:*:*:node.js:*:*",
-      "@apollosproject/data-connector-rock": "cpe:2.3:a:apollosapp:data-connector-rock:*:*:*:*:*:node.js:*:*",
-      "@asyncapi/java-spring-cloud-stream-template": "cpe:2.3:a:asyncapi:java-spring-cloud-stream-template:*:*:*:*:*:node.js:*:*",
-      "@asyncapi/modelina": "cpe:2.3:a:lfprojects:modelina:*:*:*:*:*:node.js:*:*",
-      "@atlaskit/editor-core": "cpe:2.3:a:atlassian:editor-core:*:*:*:*:*:node.js:*:*",
-      "@auth0/nextjs-auth0": "cpe:2.3:a:auth0:nextjs-auth0:*:*:*:*:*:node.js:*:*",
-      "@awsui/components-react": "cpe:2.3:a:amazon:awsui\\/components-react:*:*:*:*:*:node.js:*:*",
-      "@azure/ms-rest-nodeauth": "cpe:2.3:a:microsoft:ms-rest-nodeauth:*:*:*:*:*:node.js:*:*",
-      "@backstage/plugin-auth-backend": "cpe:2.3:a:linuxfoundation:auth_backend:*:*:*:*:*:node.js:*:*",
-      "@backstage/plugin-techdocs": "cpe:2.3:a:linuxfoundation:\\@backstage\\/plugin-techdocs:*:*:*:*:*:node.js:*:*",
-      "@backstage/techdocs-common": "cpe:2.3:a:linuxfoundation:\\@backstage\\/techdocs-common:*:*:*:*:*:node.js:*:*",
-      "@braintree/sanitize-url": "cpe:2.3:a:paypal:braintree\\/sanitize-url:*:*:*:*:*:node.js:*:*",
-      "@chainsafe/libp2p-noise": "cpe:2.3:a:chainsafe:js-libp2p-noise:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-engine": "cpe:2.3:a:ckeditor:ckeditor5-engine:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-font": "cpe:2.3:a:ckeditor:ckeditor5-font:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-image": "cpe:2.3:a:ckeditor:ckeditor5-image:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-list": "cpe:2.3:a:ckeditor:ckeditor5-list:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-markdown-gfm": "cpe:2.3:a:ckeditor:ckeditor5-markdown-gfm:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-media-embed": "cpe:2.3:a:ckeditor:ckeditor5-media-embed:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-paste-from-office": "cpe:2.3:a:ckeditor:ckeditor5-paste-from-office:*:*:*:*:*:node.js:*:*",
-      "@ckeditor/ckeditor5-widget": "cpe:2.3:a:ckeditor:ckeditor5-widget:*:*:*:*:*:node.js:*:*",
-      "@cookiex/deep": "cpe:2.3:a:cookiex-deep_project:cookiex-deep:*:*:*:*:*:node.js:*:*",
-      "@cubejs-backend/api-gateway": "cpe:2.3:a:cube:cube.js:*:*:*:*:*:node.js:*:*",
-      "@curveball/a12n-server": "cpe:2.3:a:curveballjs:a12n-server:*:*:*:*:*:node.js:*:*",
-      "@diez/generation": "cpe:2.3:a:haikuforteams:diez:*:*:*:*:*:node.js:*:*",
-      "@evershop/evershop": "cpe:2.3:a:evershop:evershop:*:*:*:*:*:node.js:*:*",
-      "@fastly/js-compute": "cpe:2.3:a:fastly:js-compute:*:*:*:*:*:node.js:*:*",
-      "@finastra/ssr-pages": "cpe:2.3:a:finastra:ssr-pages:*:*:*:*:*:node.js:*:*",
-      "@firebase/util": "cpe:2.3:a:google:firebase\\/util:*:*:*:*:*:node.js:*:*",
-      "@github/paste-markdown": "cpe:2.3:a:paste-markdown_project:paste-markdown:*:*:*:*:*:node.js:*:*",
-      "@google-cloud/firestore": "cpe:2.3:a:google:cloud_firestore:*:*:*:*:*:node.js:*:*",
-      "@grpc/grpc-js": "cpe:2.3:a:grpc:grpc:*:*:*:*:*:node.js:*:*",
-      "@hapi/crumb": "cpe:2.3:a:sideway:hapi_crumb:*:*:*:*:*:node.js:*:*",
-      "@irrelon/path": "cpe:2.3:a:irrelon:\\@irrelon\\/path:*:*:*:*:*:node.js:*:*",
-      "@joeattardi/emoji-button": "cpe:2.3:a:emoji_button_project:emoji_button:*:*:*:*:*:node.js:*:*",
-      "@keystonejs/keystone": "cpe:2.3:a:keystonejs:keystone:*:*:*:*:*:node.js:*:*",
-      "@knight-lab/timelinejs": "cpe:2.3:a:northwestern:timelinejs:*:*:*:*:*:*:*:*",
-      "@lionello/secp256k1-js": "cpe:2.3:a:secp256k1-js_project:secp256k1-js:*:*:*:*:*:node.js:*:*",
-      "@mattkrick/sanitize-svg": "cpe:2.3:a:sanitize-svg_project:sanitize-svg:*:*:*:*:*:node.js:*:*",
-      "@nestjs/core": "cpe:2.3:a:nestjs:nest:*:*:*:*:*:node.js:*:*",
-      "@nextcloud/dialogs": "cpe:2.3:a:nextcloud\\/dialogs_project:nextcloud\\/dialogs:*:*:*:*:*:node.js:*:*",
-      "@node-saml/node-saml": "cpe:2.3:a:node_saml_project:node_saml:*:*:*:*:*:node.js:*:*",
-      "@npmcli/arborist": "cpe:2.3:a:npmjs:arborist:*:*:*:*:*:node.js:*:*",
-      "@nubosoftware/node-static": "cpe:2.3:a:\\@nubosoftware\\/node-static_project:\\@nubosoftware\\/node-static:*:*:*:*:*:node.js:*:*",
-      "@nuxt/devalue": "cpe:2.3:a:nuxtjs:\\@nuxt\\/devalue:*:*:*:*:*:node.js:*:*",
-      "@octokit/webhooks": "cpe:2.3:a:octokit:webhooks:*:*:*:*:*:node.js:*:*",
-      "@openzeppelin/contracts": "cpe:2.3:a:openzeppelin:contracts:*:*:*:*:*:node.js:*:*",
-      "@openzeppelin/contracts-upgradeable": "cpe:2.3:a:openzeppelin:contracts_upgradeable:*:*:*:*:*:node.js:*:*",
-      "@parse/push-adapter": "cpe:2.3:a:parseplatform:parse_server_push_adapter:*:*:*:*:*:node.js:*:*",
-      "@podium/layout": "cpe:2.3:a:finn:podium_proxy:*:*:*:*:*:node.js:*:*",
-      "@progfay/scrapbox-parser": "cpe:2.3:a:scrapbox-parser_project:scrapbox-parser:*:*:*:*:*:node.js:*:*",
-      "@rkesters/gnuplot": "cpe:2.3:a:gnuplot_project:gnuplot:*:*:*:*:*:node.js:*:*",
-      "@sap/xssec": "cpe:2.3:a:sap:\\@sap\\/xssec:*:*:*:*:*:node.js:*:*",
-      "@scandipwa/magento-scripts": "cpe:2.3:a:scandipwa:magento-scripts:*:*:*:*:*:node.js:*:*",
-      "@sentry/astro": "cpe:2.3:a:sentry:astro:*:*:*:*:*:node.js:*:*",
-      "@shopify/hydrogen": "cpe:2.3:a:shopify:hydrogen:*:*:*:*:*:node.js:*:*",
-      "@simonsmith/cypress-image-snapshot": "cpe:2.3:a:simonsmith:cypress_image_snapshot:*:*:*:*:*:node.js:*:*",
-      "@soketi/soketi": "cpe:2.3:a:soketi_project:soketi:*:*:*:*:*:node.js:*:*",
-      "@solana/pay": "cpe:2.3:a:solanalabs:pay:*:*:*:*:*:*:*:*",
-      "@strikeentco/set": "cpe:2.3:a:set_project:set:*:*:*:*:*:node.js:*:*",
-      "@sveltejs/adapter-node": "cpe:2.3:a:svelte:adapter-node:*:*:*:*:*:node.js:*:*",
-      "@sveltejs/kit": "cpe:2.3:a:svelte:kit:*:*:*:*:*:node.js:*:*",
-      "@tarojs/taro": "cpe:2.3:a:taro:taro:*:*:*:*:*:node.js:*:*",
-      "@thi.ng/egf": "cpe:2.3:a:\\@thi.ng\\/egf_project:\\@thi.ng\\/egf:*:*:*:*:*:node.js:*:*",
-      "@vue/devtools": "cpe:2.3:a:vuejs:devtools:*:*:*:*:*:node.js:*:*",
-      "@web3-react/coinbase-wallet": "cpe:2.3:a:uniswap:web3-react_coinbase-wallet:*:*:*:*:*:node.js:*:*",
-      "@web3-react/eip1193": "cpe:2.3:a:uniswap:web3-react_eip1193:*:*:*:*:*:node.js:*:*",
-      "@web3-react/metamask": "cpe:2.3:a:uniswap:web3-react_metamask:*:*:*:*:*:node.js:*:*",
-      "@web3-react/walletconnect": "cpe:2.3:a:uniswap:web3-react_walletconnect:*:*:*:*:*:node.js:*:*",
-      "@zxcvbn-ts/core": "cpe:2.3:a:zxcvbn-ts_project:zxcvbn-ts:*:*:*:*:*:node.js:*:*",
-      "Proto": "cpe:2.3:a:proto_project:proto:*:*:*:*:*:node.js:*:*",
-      "Templ8": "cpe:2.3:a:templ8_project:templ8:*:*:*:*:*:node.js:*:*",
-      "aaptjs": "cpe:2.3:a:aaptjs_project:aaptjs:*:*:*:*:*:node.js:*:*",
-      "abacus-ext-cmdline": "cpe:2.3:a:abacus-ext-cmdline_project:abacus-ext-cmdline:*:*:*:*:*:node.js:*:*",
-      "access-policy": "cpe:2.3:a:access-policy_project:access-policy:*:*:*:*:*:node.js:*:*",
-      "accesslog": "cpe:2.3:a:accesslog_project:accesslog:*:*:*:*:*:node.js:*:*",
-      "adamvr-geoip-lite": "cpe:2.3:a:adamvr-geoip-lite_project:adamvr-geoip-lite:*:*:*:*:*:node.js:*:*",
-      "adb-driver": "cpe:2.3:a:adb-driver_project:adb-driver:*:*:*:*:*:node.js:*:*",
-      "adm-zip": "cpe:2.3:a:adm-zip_project:adm-zip:*:*:*:*:*:node.js:*:*",
-      "aegir": "cpe:2.3:a:aegir_project:aegir:*:*:*:*:*:node.js:*:*",
-      "air-sdk": "cpe:2.3:a:air-sdk_project:air-sdk:*:*:*:*:*:node.js:*:*",
-      "airbrake": "cpe:2.3:a:airbrake:airbrake:*:*:*:*:*:node.js:*:*",
-      "airtable": "cpe:2.3:a:airtable:airtable:*:*:*:*:*:node.js:*:*",
-      "algoliasearch-helper": "cpe:2.3:a:algolia:algoliasearch-helper:*:*:*:*:*:node.js:*:*",
-      "alto-saxophone": "cpe:2.3:a:alto-saxophone_project:alto-saxophone:*:*:*:*:*:node.js:*:*",
-      "anchorme": "cpe:2.3:a:anchorme_project:anchorme:*:*:*:*:*:node.js:*:*",
-      "angular": "cpe:2.3:a:angularjs:angular:*:*:*:*:*:node.js:*:*",
-      "angular-expressions": "cpe:2.3:a:peerigon:angular-expressions:*:*:*:*:*:node.js:*:*",
-      "angular-http-server": "cpe:2.3:a:angular-http-server_project:angular-http-server:*:*:*:*:*:node.js:*:*",
-      "ansi-html": "cpe:2.3:a:ansi-html_project:ansi-html:*:*:*:*:*:node.js:*:*",
-      "ansi-regex": "cpe:2.3:a:ansi-regex_project:ansi-regex:*:*:*:*:*:node.js:*:*",
-      "ansi2html": "cpe:2.3:a:ansi2html_project:ansi2html:*:*:*:*:*:node.js:*:*",
-      "ansi_up": "cpe:2.3:a:ansi_up_project:ansi_up:*:*:*:*:*:node.js:*:*",
-      "apex-publish-static-files": "cpe:2.3:a:apex-publish-static-files_project:apex-publish-static-files:*:*:*:*:*:node.js:*:*",
-      "apexcharts": "cpe:2.3:a:fusioncharts:apexcharts:*:*:*:*:*:node.js:*:*",
-      "apiconnect-cli-plugins": "cpe:2.3:a:apiconnect-cli-plugins_project:apiconnect-cli-plugins:*:*:*:*:*:node.js:*:*",
-      "apk-parser": "cpe:2.3:a:apk-parser_project:apk-parser:*:*:*:*:*:node.js:*:*",
-      "apk-parser2": "cpe:2.3:a:apk-parser2_project:apk-parser2:*:*:*:*:*:node.js:*:*",
-      "apk-parser3": "cpe:2.3:a:apk-parser3_project:apk-parser3:*:*:*:*:*:node.js:*:*",
-      "appium-chromedriver": "cpe:2.3:a:appium:appium-chromedriver:*:*:*:*:*:node.js:*:*",
-      "arcanist": "cpe:2.3:a:hujiang:arcanist:*:*:*:*:*:node.js:*:*",
-      "argencoders-notevil": "cpe:2.3:a:argencoders-notevil_project:argencoders-notevil:*:*:*:*:*:node.js:*:*",
-      "arr-flatten-unflatten": "cpe:2.3:a:arr-flatten-unflatten_project:arr-flatten-unflatten:*:*:*:*:*:node.js:*:*",
-      "arrayfire-js": "cpe:2.3:a:arrayfire-js_project:arrayfire-js:*:*:*:*:*:node.js:*:*",
-      "asciitable.js": "cpe:2.3:a:asciitable.js_project:asciitable.js:*:*:*:*:*:node.js:*:*",
-      "assign-deep": "cpe:2.3:a:assign-deep_project:assign-deep:*:*:*:*:*:node.js:*:*",
-      "async-git": "cpe:2.3:a:async-git_project:async-git:*:*:*:*:*:node.js:*:*",
-      "atlassian-connect-express": "cpe:2.3:a:atlassian:connect_express:*:*:*:*:*:node.js:*:*",
-      "atob": "cpe:2.3:a:atob_project:atob:*:*:*:*:*:node.js:*:*",
-      "atom-node-module-installer": "cpe:2.3:a:atom-node-module-installer_project:atom-node-module-installer:*:*:*:*:*:node.js:*:*",
-      "augustine": "cpe:2.3:a:augustine_project:augustine:*:*:*:*:*:node.js:*:*",
-      "aurelia-path": "cpe:2.3:a:bluespire:aurelia-path:*:*:*:*:*:node.js:*:*",
-      "auth0-js": "cpe:2.3:a:auth0:auth0.js:*:*:*:*:*:node.js:*:*",
-      "aws-lambda-multipart-parser": "cpe:2.3:a:aws-lambda-multipart-parser_project:aws-lambda-multipart-parser:*:*:*:*:*:node.js:*:*",
-      "aws-sdk": "cpe:2.3:a:amazon:aws_sdk_for_javascipt:*:*:*:*:*:node.js:*:*",
-      "axios": "cpe:2.3:a:axios:axios:*:*:*:*:*:node.js:*:*",
-      "babelcli": "cpe:2.3:a:babelcli_project:babelcli:*:*:*:*:*:node.js:*:*",
-      "backbone": "cpe:2.3:a:backbone_project:backbone:*:*:*:*:*:node.js:*:*",
-      "badjs-sourcemap-server": "cpe:2.3:a:badjs-sourcemap-server_project:badjs-sourcemap-server:*:*:*:*:*:node.js:*:*",
-      "baryton-saxophone": "cpe:2.3:a:baryton-saxophone_project:baryton-saxophone:*:*:*:*:*:node.js:*:*",
-      "bassmaster": "cpe:2.3:a:bassmaster_project:bassmaster:*:*:*:*:*:*:*:*",
-      "bestzip": "cpe:2.3:a:bestzip_project:bestzip:*:*:*:*:*:node.js:*:*",
-      "bionode-sra": "cpe:2.3:a:bionode:bionode-sra:*:*:*:*:*:node.js:*:*",
-      "bittorrent-dht": "cpe:2.3:a:webtorrent:bittorrent-dht:*:*:*:*:*:node.js:*:*",
-      "bitty": "cpe:2.3:a:bitty_project:bitty:*:*:*:*:*:node.js:*:*",
-      "bkjs-wand": "cpe:2.3:a:bkjs-wand_project:bkjs-wand:*:*:*:*:*:node.js:*:*",
-      "blamer": "cpe:2.3:a:blamer_project:blamer:*:*:*:*:*:node.js:*:*",
-      "bmoor": "cpe:2.3:a:bmoor_project:bmoor:*:*:*:*:*:node.js:*:*",
-      "bodymen": "cpe:2.3:a:bodymen_project:bodymen:*:*:*:*:*:node.js:*:*",
-      "bootbox": "cpe:2.3:a:bootboxjs:bootbox:*:*:*:*:*:node.js:*:*",
-      "bootstrap-select": "cpe:2.3:a:snapappointments:bootstrap-select:*:*:*:*:*:node.js:*:*",
-      "botbait": "cpe:2.3:a:botbait_project:botbait:*:*:*:*:*:node.js:*:*",
-      "box2d-native": "cpe:2.3:a:box2d-native_project:box2d-native:*:*:*:*:*:node.js:*:*",
-      "braces": "cpe:2.3:a:braces_project:braces:*:*:*:*:*:node.js:*:*",
-      "bracket-template": "cpe:2.3:a:bracket-template_project:bracket-template:*:*:*:*:*:node.js:*:*",
-      "broccoli-closure": "cpe:2.3:a:broccoli-closure_project:broccoli-closure:*:*:*:*:*:node.js:*:*",
-      "broccoli-compass": "cpe:2.3:a:broccoli-compass_project:broccoli-compass:*:*:*:*:*:node.js:*:*",
-      "browserify-shim": "cpe:2.3:a:browserify-shim_project:browserify-shim:*:*:*:*:*:node.js:*:*",
-      "browserify-sign": "cpe:2.3:a:browserify:browserify-sign:*:*:*:*:*:node.js:*:*",
-      "browserless-chrome": "cpe:2.3:a:browserless:chrome:*:*:*:*:*:node.js:*:*",
-      "browserslist": "cpe:2.3:a:browserslist_project:browserslist:*:*:*:*:*:node.js:*:*",
-      "bson-objectid": "cpe:2.3:a:bson-objectid_project:bson-objectid:*:*:*:*:*:node.js:*:*",
-      "buns": "cpe:2.3:a:buns_project:buns:*:*:*:*:*:node.js:*:*",
-      "buttercms": "cpe:2.3:a:buttercms:buttercms:*:*:*:*:*:node.js:*:*",
-      "butterfly-button": "cpe:2.3:a:butterfly-button_project:butterfly-button:*:*:*:*:*:node.js:*:*",
-      "buttle": "cpe:2.3:a:buttle_project:buttle:*:*:*:*:*:node.js:*:*",
-      "byucslabsix": "cpe:2.3:a:byucslabsix_project:byucslabsix:*:*:*:*:*:node.js:*:*",
-      "cache-base": "cpe:2.3:a:cache-base_project:cache-base:*:*:*:*:*:node.js:*:*",
-      "cached-path-relative": "cpe:2.3:a:cached-path-relative_project:cached-path-relative:*:*:*:*:*:node.js:*:*",
-      "call": "cpe:2.3:a:call_project:call:*:*:*:*:*:node.js:*:*",
-      "calmquist.static-server": "cpe:2.3:a:calmquist.static-server_project:calmquist.static-server:*:*:*:*:*:node.js:*:*",
-      "canvas": "cpe:2.3:a:automattic:canvas:*:*:*:*:*:node.js:*:*",
-      "caolilinode": "cpe:2.3:a:caolilinode_project:caolilinode:*:*:*:*:*:node.js:*:*",
-      "cd-messenger": "cpe:2.3:a:cd-messenger_project:cd-messenger:*:*:*:*:*:node.js:*:*",
-      "ced": "cpe:2.3:a:ced_project:ced:*:*:*:*:*:node.js:*:*",
-      "censorify.tanisjr": "cpe:2.3:a:censorify.tanisjr_project:censorify.tanisjr:*:*:*:*:*:node.js:*:*",
-      "changeset": "cpe:2.3:a:changeset_project:changeset:*:*:*:*:*:node.js:*:*",
-      "charset": "cpe:2.3:a:charset_project:charset:*:*:*:*:*:node.js:*:*",
-      "chart.js": "cpe:2.3:a:chartjs:chart.js:*:*:*:*:*:node.js:*:*",
-      "chatbyvista": "cpe:2.3:a:chatbyvista_project:chatbyvista:*:*:*:*:*:node.js:*:*",
-      "chrome-launcher": "cpe:2.3:a:google:chrome-launcher:*:*:*:*:*:node.js:*:*",
-      "chromedriver": "cpe:2.3:a:chromedriver_project:chromedriver:*:*:*:*:*:node.js:*:*",
-      "chromedriver126": "cpe:2.3:a:chromedriver126_project:chromedriver126:*:*:*:*:*:node.js:*:*",
-      "chrono-node": "cpe:2.3:a:chrono-node_project:chrono-node:*:*:*:*:*:node.js:*:*",
-      "citypredict.whauwiller": "cpe:2.3:a:citypredict.whauwiller_project:citypredict.whauwiller:*:*:*:*:*:node.js:*:*",
-      "ckeditor-wordcount-plugin": "cpe:2.3:a:herbote-services:ckeditor-wordcount-plugin:*:*:*:*:*:node.js:*:*",
-      "clang-extra": "cpe:2.3:a:clang-extra_project:clang-extra:*:*:*:*:*:node.js:*:*",
-      "class-transformer": "cpe:2.3:a:class-transformer_project:class-transformer:*:*:*:*:*:node.js:*:*",
-      "cli": "cpe:2.3:a:cli_project:cli:*:*:*:*:*:node.js:*:*",
-      "closure-compiler-stream": "cpe:2.3:a:closure-compiler-stream_project:closure-compiler-stream:*:*:*:*:*:node.js:*:*",
-      "closure-util": "cpe:2.3:a:openlayers:closure-util:*:*:*:*:*:node.js:*:*",
-      "closurecompiler": "cpe:2.3:a:closurecompiler_project:closurecompiler:*:*:*:*:*:node.js:*:*",
-      "cloudpub-redis": "cpe:2.3:a:cloudpub-redis_project:cloudpub-redis:*:*:*:*:*:node.js:*:*",
-      "cmake": "cpe:2.3:a:cmake_project:cmake:*:*:*:*:*:node.js:*:*",
-      "co-cli-installer": "cpe:2.3:a:co-cli-installer_project:co-cli-installer:*:*:*:*:*:node.js:*:*",
-      "cobalt-cli": "cpe:2.3:a:cobalt-cli_project:cobalt-cli:*:*:*:*:*:node.js:*:*",
-      "codecov": "cpe:2.3:a:codecov:codecov:*:*:*:*:*:node.js:*:*",
-      "cofeescript": "cpe:2.3:a:cofeescript_project:cofeescript:*:*:*:*:*:node.js:*:*",
-      "collection.js": "cpe:2.3:a:collection.js_project:collection.js:*:*:*:*:*:node.js:*:*",
-      "color-string": "cpe:2.3:a:color-string_project:color-string:*:*:*:*:*:node.js:*:*",
-      "comb": "cpe:2.3:a:c2fo:comb:*:*:*:*:*:node.js:*:*",
-      "commentapp.stetsonwood": "cpe:2.3:a:commentapp.stetsonwood_project:commentapp.stetsonwood:*:*:*:*:*:node.js:*:*",
-      "compass-compile": "cpe:2.3:a:compass-compile_project:compass-compile:*:*:*:*:*:node.js:*:*",
-      "compile-sass": "cpe:2.3:a:compile-sass_project:compile-sass:*:*:*:*:*:*:*:*",
-      "component-flatten": "cpe:2.3:a:component-flatten_project:component-flatten:*:*:*:*:*:node.js:*:*",
-      "conf-cfg-ini": "cpe:2.3:a:conf-cfg-ini_project:conf-cfg-ini:*:*:*:*:*:node.js:*:*",
-      "confinit": "cpe:2.3:a:confinit_project:confinit:*:*:*:*:*:node.js:*:*",
-      "confucious": "cpe:2.3:a:realseriousgames:confucious:*:*:*:*:*:node.js:*:*",
-      "connect": "cpe:2.3:a:sencha:connect:*:*:*:*:*:node.js:*:*",
-      "connect-multiparty": "cpe:2.3:a:connect-multiparty_project:connect-multiparty:*:*:*:*:*:*:*:*",
-      "connect-pg-simple": "cpe:2.3:a:connect-pg-simple_project:connect-pg-simple:*:*:*:*:*:node.js:*:*",
-      "connection-tester": "cpe:2.3:a:connection-tester_project:connection-tester:*:*:*:*:*:node.js:*:*",
-      "console-io": "cpe:2.3:a:console-io_project:console-io:*:*:*:*:*:node.js:*:*",
-      "content": "cpe:2.3:a:content_project:content:*:*:*:*:*:node.js:*:*",
-      "controlled-merge": "cpe:2.3:a:controlled-merge_project:controlled-merge:*:*:*:*:*:node.js:*:*",
-      "convert-svg-core": "cpe:2.3:a:convert-svg-core_project:convert-svg-core:*:*:*:*:*:node.js:*:*",
-      "convict": "cpe:2.3:a:mozilla:convict:*:*:*:*:*:node.js:*:*",
-      "cookie-signature": "cpe:2.3:a:cookie-signature_project:cookie-signature:*:*:*:*:*:node.js:*:*",
-      "copy-props": "cpe:2.3:a:gulpjs:copy-props:*:*:*:*:*:node.js:*:*",
-      "cordova-plugin-file-transfer": "cpe:2.3:a:apache:cordova_file_transfer:*:*:*:*:*:android:*:*",
-      "corenlp-js-interface": "cpe:2.3:a:corenlp-js-interface_project:corenlp-js-interface:*:*:*:*:*:node.js:*:*",
-      "corenlp-js-prefab": "cpe:2.3:a:corenlp-js-prefab_project:corenlp-js-prefab:*:*:*:*:*:node.js:*:*",
-      "create-choo-app3": "cpe:2.3:a:create-choo-app3_project:create-choo-app3:*:*:*:*:*:node.js:*:*",
-      "create-choo-electron": "cpe:2.3:a:create-choo-electron_project:create-choo-electron:*:*:*:*:*:node.js:*:*",
-      "cross-env.js": "cpe:2.3:a:cross-env.js_project:cross-env.js:*:*:*:*:*:node.js:*:*",
-      "cross-fetch": "cpe:2.3:a:cross-fetch_project:cross-fetch:*:*:*:*:*:node.js:*:*",
-      "crossenv": "cpe:2.3:a:crossenv_project:crossenv:*:*:*:*:*:node.js:*:*",
-      "crud-file-server": "cpe:2.3:a:crud-file-server_project:crud-file-server:*:*:*:*:*:node.js:*:*",
-      "csrf-lite": "cpe:2.3:a:negotiator_project:negotiator:*:*:*:*:*:node.js:*:*",
-      "css-what": "cpe:2.3:a:css-what_project:css-what:*:*:*:*:*:node.js:*:*",
-      "csv-parse": "cpe:2.3:a:csv-parse_project:csv-parse:*:*:*:*:*:node.js:*:*",
-      "cuciuci": "cpe:2.3:a:cuciuci_project:cuciuci:*:*:*:*:*:node.js:*:*",
-      "cue-sdk-node": "cpe:2.3:a:cue-sdk-node_project:cue-sdk-node:*:*:*:*:*:node.js:*:*",
-      "cumulative-distribution-function": "cpe:2.3:a:cumulative-distribution-function_project:cumulative-distribution-function:*:*:*:*:*:node.js:*:*",
-      "curling": "cpe:2.3:a:curling_project:curling:*:*:*:*:*:node.js:*:*",
-      "curljs": "cpe:2.3:a:curljs_project:curljs:*:*:*:*:*:node.js:*:*",
-      "curlrequest": "cpe:2.3:a:curlrequest_project:curlrequest:*:*:*:*:*:node.js:*:*",
-      "curly-bracket-parser": "cpe:2.3:a:curly-bracket-parser_project:curly-bracket-parser:*:*:*:*:*:node.js:*:*",
-      "curses": "cpe:2.3:a:curses_project:curses:*:*:*:*:*:node.js:*:*",
-      "cyber-js": "cpe:2.3:a:cyber-js_project:cyber-js:*:*:*:*:*:node.js:*:*",
-      "cypserver": "cpe:2.3:a:cypserver_project:cypserver:*:*:*:*:*:node.js:*:*",
-      "d3.js": "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:node.js:*:*",
-      "dasafio": "cpe:2.3:a:dasafio_project:dasafio:*:*:*:*:*:node.js:*:*",
-      "datachannel-client": "cpe:2.3:a:datachannel-client_project:datachannel-client:*:*:*:*:*:node.js:*:*",
-      "datatables.net": "cpe:2.3:a:datatables:datatables.net:*:*:*:*:*:node.js:*:*",
-      "date-and-time": "cpe:2.3:a:date-and-time_project:date-and-time:*:*:*:*:*:node.js:*:*",
-      "dawnsparks-node-tesseract": "cpe:2.3:a:dawnsparks-node-tesseract_project:dawnsparks-node-tesseract:*:*:*:*:*:node.js:*:*",
-      "dcdcdcdcdc": "cpe:2.3:a:dcdcdcdcdc_project:dcdcdcdcdc:*:*:*:*:*:node.js:*:*",
-      "dcserver": "cpe:2.3:a:dcserver_project:dcserver:*:*:*:*:*:node.js:*:*",
-      "deap": "cpe:2.3:a:deap_project:deap:*:*:*:*:*:node.js:*:*",
-      "debug": "cpe:2.3:a:debug_project:debug:*:*:*:*:*:node.js:*:*",
-      "decal": "cpe:2.3:a:decal_project:decal:*:*:*:*:*:node.js:*:*",
-      "decode-uri-component": "cpe:2.3:a:decode-uri-component_project:decode-uri-component:*:*:*:*:*:node.js:*:*",
-      "decompress": "cpe:2.3:a:decompress_project:decompress:*:*:*:*:*:node.js:*:*",
-      "deep-defaults": "cpe:2.3:a:deep-defaults_project:deep-defaults:*:*:*:*:*:node.js:*:*",
-      "deep-extend": "cpe:2.3:a:deep_extend_project:deep_extend:*:*:*:*:*:node.js:*:*",
-      "deep-get-set": "cpe:2.3:a:deep-get-set_project:deep-get-set:*:*:*:*:*:node.js:*:*",
-      "deep-object-diff": "cpe:2.3:a:deep-object-diff_project:deep-object-diff:*:*:*:*:*:node.js:*:*",
-      "deep-parse-json": "cpe:2.3:a:deep-parse-json_project:deep-parse-json:*:*:*:*:*:node.js:*:*",
-      "deep-set": "cpe:2.3:a:deep-set_project:deep-set:*:*:*:*:*:node.js:*:*",
-      "deep.assign": "cpe:2.3:a:deep.assign_project:deep.assign:*:*:*:*:*:node.js:*:*",
-      "deephas": "cpe:2.3:a:deephas_project:deephas:*:*:*:*:*:node.js:*:*",
-      "deeply": "cpe:2.3:a:deeply_project:deeply:*:*:*:*:*:node.js:*:*",
-      "deepmergefn": "cpe:2.3:a:deepmergefn_project:deepmergefn:*:*:*:*:*:node.js:*:*",
-      "deepref": "cpe:2.3:a:deepref_project:deepref:*:*:*:*:*:node.js:*:*",
-      "deeps": "cpe:2.3:a:invertase:deeps:*:*:*:*:*:node.js:*:*",
-      "defaults-deep": "cpe:2.3:a:defaults-deep_project:defaults-deep:*:*:*:*:*:node.js:*:*",
-      "desafio": "cpe:2.3:a:desafio_project:desafio:*:*:*:*:*:node.js:*:*",
-      "devcert": "cpe:2.3:a:devcert_project:devcert:*:*:*:*:*:node.js:*:*",
-      "dexie": "cpe:2.3:a:dexie:dexie:*:*:*:*:*:*:*:*",
-      "dgard8.lab6": "cpe:2.3:a:dgard8.lab6_project:dgard8.lab6:*:*:*:*:*:node.js:*:*",
-      "dicer": "cpe:2.3:a:dicer_project:dicer:*:*:*:*:*:node.js:*:*",
-      "directus": "cpe:2.3:a:monospace:directus:*:*:*:*:*:node.js:*:*",
-      "discordi.js": "cpe:2.3:a:discordi.js_project:discordi.js:*:*:*:*:*:node.js:*:*",
-      "diskusage-ng": "cpe:2.3:a:diskusage-ng_project:diskusage-ng:*:*:*:*:*:node.js:*:*",
-      "djv": "cpe:2.3:a:djv_project:djv:*:*:*:*:*:node.js:*:*",
-      "dmmcquay.lab6": "cpe:2.3:a:dmmcquay.lab6_project:dmmcquay.lab6:*:*:*:*:*:node.js:*:*",
-      "dns-packet": "cpe:2.3:a:dns-packet_project:dns-packet:*:*:*:*:*:node.js:*:*",
-      "dns-sync": "cpe:2.3:a:dns-sync_project:dns-sync:*:*:*:*:*:node.js:*:*",
-      "docker-cli-js": "cpe:2.3:a:quobject:docker-cli-js:*:*:*:*:*:node.js:*:*",
-      "docker-compose-remote-api": "cpe:2.3:a:docker-compose-remote-api_project:docker-compose-remote-api:*:*:*:*:*:node.js:*:*",
-      "docker-tester": "cpe:2.3:a:docker-tester_project:docker-tester:*:*:*:*:*:node.js:*:*",
-      "docsify": "cpe:2.3:a:docsifyjs:docsify:*:*:*:*:*:*:*:*",
-      "dojo": "cpe:2.3:a:linuxfoundation:dojo:*:*:*:*:*:node.js:*:*",
-      "dojox": "cpe:2.3:a:linuxfoundation:dojox:*:*:*:*:*:node.js:*:*",
-      "dot-lens": "cpe:2.3:a:dot-lens_project:dot-lens:*:*:*:*:*:node.js:*:*",
-      "dot-notes": "cpe:2.3:a:dot-notes_project:dot-notes:*:*:*:*:*:node.js:*:*",
-      "dot-object": "cpe:2.3:a:dot-object_project:dot-object:*:*:*:*:*:node.js:*:*",
-      "dot-prop": "cpe:2.3:a:dot-prop_project:dot-prop:*:*:*:*:*:node.js:*:*",
-      "dottie": "cpe:2.3:a:dottie_project:dottie:*:*:*:*:*:node.js:*:*",
-      "dotty": "cpe:2.3:a:dotty_project:dotty:*:*:*:*:*:*:*:*",
-      "droppy": "cpe:2.3:a:droppy_project:droppy:*:*:*:*:*:node.js:*:*",
-      "dwebp-bin": "cpe:2.3:a:dwebp-bin_project:dwebp-bin:*:*:*:*:*:node.js:*:*",
-      "dylmomo": "cpe:2.3:a:dylmomo_project:dylmomo:*:*:*:*:*:node.js:*:*",
-      "dynamoose": "cpe:2.3:a:dynamoosejs:dynamoose:*:*:*:*:*:node.js:*:*",
-      "earlybird": "cpe:2.3:a:earlybird_project:earlybird:*:*:*:*:*:node.js:*:*",
-      "easy-static-server": "cpe:2.3:a:easy-static-server_project:easy-static-server:*:*:*:*:*:node.js:*:*",
-      "easyquick": "cpe:2.3:a:easyquick_project:easyquick:*:*:*:*:*:node.js:*:*",
-      "ecdh": "cpe:2.3:a:ecdh_project:ecdh:*:*:*:*:*:node.js:*:*",
-      "ecstatic": "cpe:2.3:a:ecstatic_project:ecstatic:*:*:*:*:*:node.js:*:*",
-      "edge.js": "cpe:2.3:a:adonisjs:edge:*:*:*:*:*:node.js:*:*",
-      "effect": "cpe:2.3:a:effect_project:effect:*:*:*:*:*:node.js:*:*",
-      "egg-scripts": "cpe:2.3:a:eggjs:egg-scripts:*:*:*:*:*:node.js:*:*",
-      "ejs": "cpe:2.3:a:ejs:ejs:*:*:*:*:*:node.js:*:*",
-      "elding": "cpe:2.3:a:elding_project:elding:*:*:*:*:*:node.js:*:*",
-      "electron": "cpe:2.3:a:electronjs:electron:*:*:*:*:*:node.js:*:*",
-      "electron-packager": "cpe:2.3:a:electron-packager_project:electron-packager:*:*:*:*:*:node.js:*:*",
-      "elliptic": "cpe:2.3:a:elliptic_project:elliptic:*:*:*:*:*:node.js:*:*",
-      "embedza": "cpe:2.3:a:embedza_project:embedza:*:*:*:*:*:node.js:*:*",
-      "engine.io": "cpe:2.3:a:socket:engine.io:*:*:*:*:*:node.js:*:*",
-      "engine.io-client": "cpe:2.3:a:socket:engine.io-client:*:*:*:*:*:node.js:*:*",
-      "enserver": "cpe:2.3:a:enserver_project:enserver:*:*:*:*:*:node.js:*:*",
-      "es6-crawler-detect": "cpe:2.3:a:crawlerdetect_project:crawlerdetect:*:*:*:*:*:node.js:*:*",
-      "eslint-fixer": "cpe:2.3:a:eslint-fixer_project:eslint-fixer:*:*:*:*:*:node.js:*:*",
-      "eslint-utils": "cpe:2.3:a:eslint-utils_project:eslint-utils:*:*:*:*:*:node.js:*:*",
-      "ewgaddis.lab6": "cpe:2.3:a:ewgaddis.lab6_project:ewgaddis.lab6:*:*:*:*:*:node.js:*:*",
-      "exceljs": "cpe:2.3:a:exceljs_project:exceljs:*:*:*:*:*:node.js:*:*",
-      "exec-local-bin": "cpe:2.3:a:exec-local-bin_project:exec-local-bin:*:*:*:*:*:node.js:*:*",
-      "express": "cpe:2.3:a:openjsf:express:*:*:*:*:*:node.js:*:*",
-      "express-cart": "cpe:2.3:a:express-cart_project:express-cart:*:*:*:*:*:node.js:*:*",
-      "express-fileupload": "cpe:2.3:a:express-fileupload_project:express-fileupload:*:*:*:*:*:node.js:*:*",
-      "express-handlebars": "cpe:2.3:a:express_handlebars_project:express_handlebars:*:*:*:*:*:node.js:*:*",
-      "express-jwt": "cpe:2.3:a:auth0:express-jwt:*:*:*:*:*:node.js:*:*",
-      "express-openid-connect": "cpe:2.3:a:auth0:express_openid_connect:*:*:*:*:*:node.js:*:*",
-      "express-restify-mongoose": "cpe:2.3:a:express-restify-mongoose_project:express-restify-mongoose:*:*:*:*:*:node.js:*:*",
-      "express-validators": "cpe:2.3:a:express-validators_project:express-validators:*:*:*:*:*:node.js:*:*",
-      "express-xss-sanitizer": "cpe:2.3:a:express_xss_sanitizer_project:express_xss_sanitizer:*:*:*:*:*:node.js:*:*",
-      "extend": "cpe:2.3:a:extend_project:extend:*:*:*:*:*:node.js:*:*",
-      "extend2": "cpe:2.3:a:eggjs:extend2:*:*:*:*:*:node.js:*:*",
-      "external-svg-loader": "cpe:2.3:a:shubhamjain:svg_loader:*:*:*:*:*:node.js:*:*",
-      "exxxxxxxxxxx": "cpe:2.3:a:exxxxxxxxxxx_project:exxxxxxxxxxx:*:*:*:*:*:node.js:*:*",
-      "f2e-server": "cpe:2.3:a:f2e-server_project:f2e-server:*:*:*:*:*:node.js:*:*",
-      "fabric-js": "cpe:2.3:a:fabric-js_project:fabric-js:*:*:*:*:*:node.js:*:*",
-      "fancy-server": "cpe:2.3:a:fancy-server_project:fancy-server:*:*:*:*:*:node.js:*:*",
-      "fast-csv": "cpe:2.3:a:c2fo:fast-csv:*:*:*:*:*:node.js:*:*",
-      "fast-http": "cpe:2.3:a:fast-http_project:fast-http:*:*:*:*:*:node.js:*:*",
-      "fast-http-cli": "cpe:2.3:a:fast-http-cli_project:fast-http-cli:*:*:*:*:*:node.js:*:*",
-      "fast-string-search": "cpe:2.3:a:fast_string_search_project:fast_string_search:*:*:*:*:*:node.js:*:*",
-      "fast-xml-parser": "cpe:2.3:a:fast-xml-parser_project:fast-xml-parser:*:*:*:*:*:node.js:*:*",
-      "fastest-json-copy": "cpe:2.3:a:fastest-json-copy_project:fastest-json-copy:*:*:*:*:*:node.js:*:*",
-      "fastify": "cpe:2.3:a:fastify:fastify:*:*:*:*:*:node.js:*:*",
-      "fastify-csrf": "cpe:2.3:a:fastify:fastify-csrf:*:*:*:*:*:node.js:*:*",
-      "fastify-http-proxy": "cpe:2.3:a:fastify-http-proxy_project:fastify-http-proxy:*:*:*:*:*:node.js:*:*",
-      "fastify-reply-from": "cpe:2.3:a:fastify-reply-from_project:fastify-reply-from:*:*:*:*:*:node.js:*:*",
-      "faye": "cpe:2.3:a:faye_project:faye:*:*:*:*:*:node.js:*:*",
-      "fbr-client": "cpe:2.3:a:webrtc-experiment:fbr-client:*:*:*:*:*:node.js:*:*",
-      "feathers-sequelize": "cpe:2.3:a:feathersjs:feathers-sequelize:*:*:*:*:*:node.js:*:*",
-      "ffmepg": "cpe:2.3:a:ffmepg_project:ffmepg:*:*:*:*:*:node.js:*:*",
-      "ffmpegdotjs": "cpe:2.3:a:ffmpegdotjs_project:ffmpegdotjs:*:*:*:*:*:node.js:*:*",
-      "fibjs": "cpe:2.3:a:fibjs_project:fibjs:*:*:*:*:*:node.js:*:*",
-      "file-type": "cpe:2.3:a:file-type_project:file-type:*:*:*:*:*:node.js:*:*",
-      "file-upload-with-preview": "cpe:2.3:a:johndatserakis:file-upload-with-preview:*:*:*:*:*:node.js:*:*",
-      "fis-kernel": "cpe:2.3:a:baidu:fis-kernel:*:*:*:*:*:node.js:*:*",
-      "fis-parser-sass-bin": "cpe:2.3:a:fis-parser-sass-bin_project:fis-parser-sass-bin:*:*:*:*:*:node.js:*:*",
-      "fis-sass-all": "cpe:2.3:a:fis-sass-all_project:fis-sass-all:*:*:*:*:*:node.js:*:*",
-      "flattenizer": "cpe:2.3:a:flattenizer_project:flattenizer:*:*:*:*:*:node.js:*:*",
-      "fleetctl": "cpe:2.3:a:fleetdm:fleet:*:*:*:*:*:node.js:*:*",
-      "fluture-node": "cpe:2.3:a:fluture-node_project:fluture-node:*:*:*:*:*:node.js:*:*",
-      "follow-redirects": "cpe:2.3:a:follow-redirects:follow_redirects:*:*:*:*:*:node.js:*:*",
-      "forms": "cpe:2.3:a:forms_project:forms:*:*:*:*:*:node.js:*:*",
-      "forwarded": "cpe:2.3:a:forwarded_project:forwarded:*:*:*:*:*:node.js:*:*",
-      "frames-compiler": "cpe:2.3:a:frames-compiler_project:frames-compiler:*:*:*:*:*:node.js:*:*",
-      "freediskspace": "cpe:2.3:a:freediskspace_project:freediskproject:*:*:*:*:*:node.js:*:*",
-      "fresh": "cpe:2.3:a:fresh_project:fresh:*:*:*:*:*:node.js:*:*",
-      "frourio": "cpe:2.3:a:frourio:frourio:*:*:*:*:*:node.js:*:*",
-      "fs-path": "cpe:2.3:a:fs-path_project:fs-path:*:*:*:*:*:node.js:*:*",
-      "fsk-server": "cpe:2.3:a:fsk-server_project:fsk-server:*:*:*:*:*:node.js:*:*",
-      "ftp-srv": "cpe:2.3:a:ftp-srv_project:ftp-srv:*:*:*:*:*:node.js:*:*",
-      "fuseki": "cpe:2.3:a:fuseki_project:fuseki:*:*:*:*:*:node.js:*:*",
-      "galenframework-cli": "cpe:2.3:a:galenframework:galenframework-cli:*:*:*:*:*:node.js:*:*",
-      "gammautils": "cpe:2.3:a:gammautils_project:gammautils:*:*:*:*:*:node.js:*:*",
-      "gaoxiaotingtingting": "cpe:2.3:a:gaoxiaotingtingting_project:gaoxiaotingtingting:*:*:*:*:*:node.js:*:*",
-      "gaoxuyan": "cpe:2.3:a:gaoxuyan_project:gaoxuyan:*:*:*:*:*:*:*:*",
-      "gatsby-plugin-mdx": "cpe:2.3:a:gatsbyjs:gatsby:*:*:*:*:*:node.js:*:*",
-      "gatsby-source-wordpress": "cpe:2.3:a:gatsbyjs:gatsby-source-wordpress:*:*:*:*:*:node.js:*:*",
-      "gedi": "cpe:2.3:a:gedi_project:gedi:*:*:*:*:*:node.js:*:*",
-      "general-file-server": "cpe:2.3:a:general-file-server_project:general-file-server:*:*:*:*:*:node.js:*:*",
-      "generator-hottowel": "cpe:2.3:a:generator-hottowel_project:generator-hottowel:*:*:*:*:*:node.js:*:*",
-      "geoip-lite-country": "cpe:2.3:a:geoip-lite-country_project:geoip-lite-country:*:*:*:*:*:node.js:*:*",
-      "geojson2kml": "cpe:2.3:a:geojson2kml_project:geojson2kml:*:*:*:*:*:node.js:*:*",
-      "get-ip-range": "cpe:2.3:a:get-ip-range_project:get-ip-range:*:*:*:*:*:node.js:*:*",
-      "get-npm-package-version": "cpe:2.3:a:get-npm-package-version_project:get-npm-package-version:*:*:*:*:*:node.js:*:*",
-      "getcityapi.yoehoehne": "cpe:2.3:a:getcityapi.yoehoehne_project:getcityapi.yoehoehne:*:*:*:*:*:node.js:*:*",
-      "getobject": "cpe:2.3:a:getobject_project:getobject:*:*:*:*:*:node.js:*:*",
-      "gfe-sass": "cpe:2.3:a:gfe-sass_project:gfe-sass:*:*:*:*:*:node.js:*:*",
-      "ghost": "cpe:2.3:a:ghost:ghost:*:*:*:*:*:node.js:*:*",
-      "git": "cpe:2.3:a:git_project:git:*:*:*:*:*:node.js:*:*",
-      "git-add-remote": "cpe:2.3:a:git-add-remote_project:git-add-remote:*:*:*:*:*:node.js:*:*",
-      "git-archive": "cpe:2.3:a:git-archive_project:git-archive:*:*:*:*:*:node.js:*:*",
-      "git-dummy-commit": "cpe:2.3:a:git-dummy-commit_project:git-dummy-commit:*:*:*:*:*:node.js:*:*",
-      "git-parse": "cpe:2.3:a:wayfair:git-parse:*:*:*:*:*:node.js:*:*",
-      "git-promise": "cpe:2.3:a:git-promise_project:git-promise:*:*:*:*:*:node.js:*:*",
-      "git-pull-or-clone": "cpe:2.3:a:git-pull-or-clone_project:git-pull-or-clone:*:*:*:*:*:node.js:*:*",
-      "gitblame": "cpe:2.3:a:gitblame_project:gitblame:*:*:*:*:*:node.js:*:*",
-      "gitbook": "cpe:2.3:a:gitbook:gitbook:*:*:*:*:*:node.js:*:*",
-      "gitlabhook": "cpe:2.3:a:gitlabhook_project:gitlabhook:*:*:*:*:*:node.js:*:*",
-      "gitlog": "cpe:2.3:a:gitlog_project:gitlog:*:*:*:*:*:node.js:*:*",
-      "gitlogplus": "cpe:2.3:a:gitlogplus_project:gitlogplus:*:*:*:*:*:node.js:*:*",
-      "gitsome": "cpe:2.3:a:gitsome_project:gitsome:*:*:*:*:*:node.js:*:*",
-      "glob-parent": "cpe:2.3:a:gulpjs:glob-parent:*:*:*:*:*:node.js:*:*",
-      "go-ipfs-dep": "cpe:2.3:a:ipfs:go-ipfs-dep:*:*:*:*:*:node.js:*:*",
-      "gomeplus-h5-proxy": "cpe:2.3:a:gomeplus-h5-proxy_project:gomeplus-h5-proxy:*:*:*:*:*:node.js:*:*",
-      "google-closure-tools-latest": "cpe:2.3:a:google-closure-tools-latest_project:google-closure-tools-latest:*:*:*:*:*:node.js:*:*",
-      "google-it": "cpe:2.3:a:google-it_project:google-it:*:*:*:*:*:node.js:*:*",
-      "goserv": "cpe:2.3:a:goserv_project:goserv:*:*:*:*:*:node.js:*:*",
-      "grapesjs": "cpe:2.3:a:grapesjs:grapesjs:*:*:*:*:*:node.js:*:*",
-      "graphql": "cpe:2.3:a:graphql:graphql:*:*:*:*:*:node.js:*:*",
-      "graphql-playground-html": "cpe:2.3:a:prisma:graphql-playground-html:*:*:*:*:*:node.js:*:*",
-      "graphql-playground-middleware-express": "cpe:2.3:a:prisma:graphql-playground-middleware-express:*:*:*:*:*:node.js:*:*",
-      "graphql-playground-middleware-hapi": "cpe:2.3:a:prisma:graphql-playground-middleware-hapi:*:*:*:*:*:node.js:*:*",
-      "graphql-playground-middleware-koa": "cpe:2.3:a:prisma:graphql-playground-middleware-koa:*:*:*:*:*:node.js:*:*",
-      "graphql-playground-middleware-lambda": "cpe:2.3:a:prisma:graphql-playground-middleware-lambda:*:*:*:*:*:node.js:*:*",
-      "graphql-upload": "cpe:2.3:a:graphql-upload_project:graphql-upload:*:*:*:*:*:npmjs:*:*",
-      "growl": "cpe:2.3:a:growl_project:growl:*:*:*:*:*:node.js:*:*",
-      "grunt-ccompiler": "cpe:2.3:a:grunt-ccompiler_project:grunt-ccompiler:*:*:*:*:*:node.js:*:*",
-      "grunt-gh-pages": "cpe:2.3:a:grunt-gh-pages_project:grunt-gh-pages:*:*:*:*:*:node.js:*:*",
-      "grunt-images": "cpe:2.3:a:grunt-images_project:grunt-images:*:*:*:*:*:node.js:*:*",
-      "grunt-karma": "cpe:2.3:a:grunt-karma_project:grunt-karma:*:*:*:*:*:node.js:*:*",
-      "grunt-util-property": "cpe:2.3:a:grunt-util-property_project:grunt-util-property:*:*:*:*:*:node.js:*:*",
-      "grunt-webdriver-qunit": "cpe:2.3:a:grunt-webdriver-qunit_project:grunt-webdriver-qunit:*:*:*:*:*:node.js:*:*",
-      "gruntcli": "cpe:2.3:a:gruntcli_project:gruntcli:*:*:*:*:*:node.js:*:*",
-      "gry": "cpe:2.3:a:gry_project:gry:*:*:*:*:*:node.js:*:*",
-      "gsap": "cpe:2.3:a:greensock:greensock_animation_platform:*:*:*:*:*:node.js:*:*",
-      "gulp-styledocco": "cpe:2.3:a:gulp-styledocco_project:gulp-styledocco:*:*:*:*:*:node.js:*:*",
-      "gulp-tape": "cpe:2.3:a:gulp-tape_project:gulp-tape:*:*:*:*:*:node.js:*:*",
-      "haml-coffee": "cpe:2.3:a:haml-coffee_project:haml-coffee:*:*:*:*:*:node.js:*:*",
-      "handlebars": "cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:node.js:*:*",
-      "handsontable": "cpe:2.3:a:handsontable:handsontable:*:*:*:*:*:node.js:*:*",
-      "hapi": "cpe:2.3:a:hapijs:hapi:*:*:*:*:*:node.js:*:*",
-      "hapi-auth-jwt2": "cpe:2.3:a:hapi-auth-jwt2_project:hapi-auth-jwt2:*:*:*:*:*:node.js:*:*",
-      "harp": "cpe:2.3:a:npmjs:harp:*:*:*:*:*:*:*:*",
-      "haxe": "cpe:2.3:a:haxe:haxe:*:*:*:*:*:node.js:*:*",
-      "haxe-dev": "cpe:2.3:a:haxe:haxe-dev:*:*:*:*:*:node.js:*:*",
-      "haxe3": "cpe:2.3:a:haxe:haxe:*:*:*:*:*:node.js:*:*",
-      "haxeshim": "cpe:2.3:a:haxeshim_project:haxeshim:*:*:*:*:*:node.js:*:*",
-      "hbs": "cpe:2.3:a:hbs_project:hbs:*:*:*:*:*:node.js:*:*",
-      "hcbserver": "cpe:2.3:a:hcbserver_project:hcbserver:*:*:*:*:*:node.js:*:*",
-      "headless-browser-lite": "cpe:2.3:a:headless-browser-lite_project:headless-browser-lite:*:*:*:*:*:node.js:*:*",
-      "healthcenter": "cpe:2.3:a:healthcenter_project:healthcenter:*:*:*:*:*:node.js:*:*",
-      "hekto": "cpe:2.3:a:hekto_project:hekto:*:*:*:*:*:node.js:*:*",
-      "hello.js": "cpe:2.3:a:hello.js_project:hello.js:*:*:*:*:*:node.js:*:*",
-      "herbivore": "cpe:2.3:a:herbivore_project:herbivore:*:*:*:*:*:node.js:*:*",
-      "heroku-addonpool": "cpe:2.3:a:heroku-addonpool_project:heroku-addonpool:*:*:*:*:*:node.js:*:*",
-      "heroku-env": "cpe:2.3:a:heroku-env_project:heroku-env:*:*:*:*:*:node.js:*:*",
-      "hexo": "cpe:2.3:a:hexo:hexo:*:*:*:*:*:node.js:*:*",
-      "hftp": "cpe:2.3:a:hftp_project:hftp:*:*:*:*:*:node.js:*:*",
-      "highlight.js": "cpe:2.3:a:highlightjs:highlight.js:*:*:*:*:*:node.js:*:*",
-      "highlight.run": "cpe:2.3:a:highlight:highlight:*:*:*:*:*:node.js:*:*",
-      "home-assistant-js-websocket": "cpe:2.3:a:home-assistant:home-assistant-js-websocket:*:*:*:*:*:node.js:*:*",
-      "hono": "cpe:2.3:a:hono:hono:*:*:*:*:*:node.js:*:*",
-      "hostr": "cpe:2.3:a:hostr_project:hostr:*:*:*:*:*:node.js:*:*",
-      "hot-formula-parser": "cpe:2.3:a:hot-formula-parser_project:hot-formula-parser:*:*:*:*:*:node.js:*:*",
-      "html-janitor": "cpe:2.3:a:html-janitor_project:html-janitor:*:*:*:*:*:node.js:*:*",
-      "html-pages": "cpe:2.3:a:html-pages_project:html-pages:*:*:*:*:*:node.js:*:*",
-      "html-pdf": "cpe:2.3:a:html-pdf_project:html-pdf:*:*:*:*:*:node.js:*:*",
-      "http-cache-semantics": "cpe:2.3:a:http-cache-semantics_project:http-cache-semantics:*:*:*:*:*:node.js:*:*",
-      "http-client": "cpe:2.3:a:http-client_project:http-client:*:*:*:*:*:node.js:*:*",
-      "http-file-server": "cpe:2.3:a:http-file-server_project:http-file-server:*:*:*:*:*:node.js:*:*",
-      "http-live-simulator": "cpe:2.3:a:http-live-simulator_project:http-live-simulator:*:*:*:*:*:node.js:*:*",
-      "http-proxy": "cpe:2.3:a:http-proxy_project:http-proxy:*:*:*:*:*:node.js:*:*",
-      "http-proxy.js": "cpe:2.3:a:http-proxy.js_project:http-proxy.js:*:*:*:*:*:node.js:*:*",
-      "http-server-node": "cpe:2.3:a:http-server-node_project:http-server-node:*:*:*:*:*:node.js:*:*",
-      "http-signature": "cpe:2.3:a:joyent:http-signature:*:*:*:*:*:node.js:*:*",
-      "http_server": "cpe:2.3:a:http_server_project:http_server:*:*:*:*:*:node.js:*:*",
-      "http_static_simple": "cpe:2.3:a:http_static_simple_project:http_static_simple:*:*:*:*:*:node.js:*:*",
-      "https-proxy-agent": "cpe:2.3:a:https-proxy-agent_project:https-proxy-agent:*:*:*:*:*:node.js:*:*",
-      "httpster": "cpe:2.3:a:httpster_project:httpster:*:*:*:*:*:node.js:*:*",
-      "httpsync": "cpe:2.3:a:httpsync_project:httpsync:*:*:*:*:*:node.js:*:*",
-      "hubl-server": "cpe:2.3:a:hubspot:hubl-server:*:*:*:*:*:node.js:*:*",
-      "hummus": "cpe:2.3:a:hummus_project:hummus:*:*:*:*:*:node.js:*:*",
-      "i18n": "cpe:2.3:a:i18n_project:i18n:*:*:*:*:*:node.js:*:*",
-      "i18n-node-angular": "cpe:2.3:a:i18n-node-angular_project:i18n-node-angular:*:*:*:*:*:node.js:*:*",
-      "ibapi": "cpe:2.3:a:interactivebrokers:ibapi:*:*:*:*:*:node.js:*:*",
-      "ibm_db": "cpe:2.3:a:ibm:ibm_db:*:*:*:*:*:node.js:*:*",
-      "iedriver": "cpe:2.3:a:iedriver_project:iedriver:*:*:*:*:*:node.js:*:*",
-      "igniteui": "cpe:2.3:a:infragistics:igniteui:*:*:*:*:*:node.js:*:*",
-      "ikst": "cpe:2.3:a:ikst_project:ikst:*:*:*:*:*:node.js:*:*",
-      "image-tiler": "cpe:2.3:a:image-tiler_project:image-tiler:*:*:*:*:*:node.js:*:*",
-      "imageoptim": "cpe:2.3:a:imageoptim_project:imageoptim:*:*:*:*:*:node.js:*:*",
-      "immer": "cpe:2.3:a:immer_project:immer:*:*:*:*:*:node.js:*:*",
-      "import-in-the-middle": "cpe:2.3:a:datadoghq:import-in-the-middle:*:*:*:*:*:node.js:*:*",
-      "inert": "cpe:2.3:a:hapi:inert:*:*:*:*:*:node.js:*:*",
-      "infraserver": "cpe:2.3:a:infraserver_project:infraserver:*:*:*:*:*:node.js:*:*",
-      "ini": "cpe:2.3:a:ini_project:ini:*:*:*:*:*:node.js:*:*",
-      "ini-parser": "cpe:2.3:a:ini-parser_project:ini-parser:*:*:*:*:*:*:*:*",
-      "iniparserjs": "cpe:2.3:a:iniparserjs_project:iniparserjs:*:*:*:*:*:node.js:*:*",
-      "install-g-test": "cpe:2.3:a:install-g-test_project:install-g-test:*:*:*:*:*:node.js:*:*",
-      "install-package": "cpe:2.3:a:install-package_project:install-package:*:*:*:*:*:node.js:*:*",
-      "intsol-package": "cpe:2.3:a:intsol-package_project:intsol-package:*:*:*:*:*:node.js:*:*",
-      "iobroker.admin": "cpe:2.3:a:iobroker:iobroker.admin:*:*:*:*:*:node.js:*:*",
-      "iobroker.web": "cpe:2.3:a:iobroker:iobroker.web:*:*:*:*:*:node.js:*:*",
-      "ip": "cpe:2.3:a:fedorindutny:ip:*:*:*:*:*:node.js:*:*",
-      "ipip": "cpe:2.3:a:ipip_project:ipip:*:*:*:*:*:node.js:*:*",
-      "ipip-coffee": "cpe:2.3:a:ipip:ipip-coffee:*:*:*:*:*:node.js:*:*",
-      "irrelon-path": "cpe:2.3:a:irrelon:irrelon-path:*:*:*:*:*:node.js:*:*",
-      "is-email": "cpe:2.3:a:segment:is-email:*:*:*:*:*:node.js:*:*",
-      "is-http2": "cpe:2.3:a:is-http2_project:is-http2:*:*:*:*:*:node.js:*:*",
-      "is-my-json-valid": "cpe:2.3:a:is-my-json-valid_project:is-my-json-valid:*:*:*:*:*:node.js:*:*",
-      "is-user-valid": "cpe:2.3:a:is-user-valid_project:is-user-valid:*:*:*:*:*:node.js:*:*",
-      "isolated-vm": "cpe:2.3:a:isolated-vm_project:isolated-vm:*:*:*:*:*:node.js:*:*",
-      "iter-http": "cpe:2.3:a:iter-http_project:iter-http:*:*:*:*:*:node.js:*:*",
-      "iter-server": "cpe:2.3:a:iter-server_project:iter-server:*:*:*:*:*:node.js:*:*",
-      "jadedown": "cpe:2.3:a:jadedown_project:jadedown:*:*:*:*:*:node.js:*:*",
-      "jailed": "cpe:2.3:a:jailed_project:jailed:*:*:*:*:*:node.js:*:*",
-      "jansenstuffpleasework": "cpe:2.3:a:jansenstuffpleasework_project:jansenstuffpleasework:*:*:*:*:*:node.js:*:*",
-      "jdf-sass": "cpe:2.3:a:jdf-sass_project:jdf-sass:*:*:*:*:*:node.js:*:*",
-      "jikes": "cpe:2.3:a:jikes_project:jikes:*:*:*:*:*:node.js:*:*",
-      "jison": "cpe:2.3:a:jison_project:jison:*:*:*:*:*:node.js:*:*",
-      "jn_jj_server": "cpe:2.3:a:jn_jj_server_project:jn_jj_server:*:*:*:*:*:node.js:*:*",
-      "jointjs": "cpe:2.3:a:client:jointjs:*:*:*:*:*:node.js:*:*",
-      "joplin": "cpe:2.3:a:joplin_project:joplin:*:*:*:*:*:node.js:*:*",
-      "jose": "cpe:2.3:a:jose_project:jose:*:*:*:*:*:node.js:*:*",
-      "jpeg-js": "cpe:2.3:a:jpeg-js_project:jpeg-js:*:*:*:*:*:node.js:*:*",
-      "jpv": "cpe:2.3:a:json_pattern_validator_project:json_pattern_validator:*:*:*:*:*:node.js:*:*",
-      "jquery": "cpe:2.3:a:jquery:jquery:*:*:*:*:*:node.js:*:*",
-      "jquery-file-upload": "cpe:2.3:a:jquery_file_upload_project:jquery_file_upload:*:*:*:*:*:*:*:*",
-      "jquery-validation": "cpe:2.3:a:jqueryvalidation:jquery_validation:*:*:*:*:*:node.js:*:*",
-      "jquery.cookie": "cpe:2.3:a:jquery.cookie_project:jquery.cookie:*:*:*:*:*:node.js:*:*",
-      "jquery.js": "cpe:2.3:a:jquery.js_project:jquery.js:*:*:*:*:*:node.js:*:*",
-      "jquery.json-viewer": "cpe:2.3:a:jquery_json-viewer_project:jquery_json-viewer:*:*:*:*:*:node.js:*:*",
-      "jquery.terminal": "cpe:2.3:a:jquery.terminal_project:jquery.terminal:*:*:*:*:*:node.js:*:*",
-      "jquey": "cpe:2.3:a:jquey_project:jquey:*:*:*:*:*:node.js:*:*",
-      "js-given": "cpe:2.3:a:js-given_project:js-given:*:*:*:*:*:node.js:*:*",
-      "jscover": "cpe:2.3:a:jscover_project:jscover:*:*:*:*:*:node.js:*:*",
-      "jsen": "cpe:2.3:a:jsen_project:jsen:*:*:*:*:*:node.js:*:*",
-      "jser-stat": "cpe:2.3:a:jser-stat_project:jser-stat:*:*:*:*:*:node.js:*:*",
-      "jshamcrest": "cpe:2.3:a:jshamcrest_project:jshamcrest:*:*:*:*:*:node.js:*:*",
-      "json": "cpe:2.3:a:joyent:json:*:*:*:*:*:node.js:*:*",
-      "json-bigint": "cpe:2.3:a:json-bigint_project:json-bigint:*:*:*:*:*:node.js:*:*",
-      "json-pointer": "cpe:2.3:a:smallpdf:json-pointer:*:*:*:*:*:node.js:*:*",
-      "json-web-token": "cpe:2.3:a:joaquimserafim:json_web_token:*:*:*:*:*:node.js:*:*",
-      "json5": "cpe:2.3:a:json5:json5:*:*:*:*:*:node.js:*:*",
-      "json8-merge-patch": "cpe:2.3:a:json8-merge-patch_project:json8-merge-patch:*:*:*:*:*:node.js:*:*",
-      "jsonpointer": "cpe:2.3:a:jsonpointer_project:jsonpointer:*:*:*:*:*:node.js:*:*",
-      "jsonwebtoken": "cpe:2.3:a:auth0:jsonwebtoken:*:*:*:*:*:node.js:*:*",
-      "jspdf": "cpe:2.3:a:parall:jspdf:*:*:*:*:*:node.js:*:*",
-      "jsreport": "cpe:2.3:a:jsreport:jsreport:*:*:*:*:*:node.js:*:*",
-      "jsrsasign": "cpe:2.3:a:jsrsasign_project:jsrsasign:*:*:*:*:*:node.js:*:*",
-      "jstestdriver": "cpe:2.3:a:jstestdriver_project:jstestdriver:*:*:*:*:*:node.js:*:*",
-      "jsx-slack": "cpe:2.3:a:jsx-slack_project:jsx-slack:*:*:*:*:*:node.js:*:*",
-      "jszip": "cpe:2.3:a:jszip_project:jszip:*:*:*:*:*:node.js:*:*",
-      "just-extend": "cpe:2.3:a:just-extend_project:just-extend:*:*:*:*:*:node.js:*:*",
-      "just-safe-set": "cpe:2.3:a:just-safe-set_project:just-safe-set:*:*:*:*:*:node.js:*:*",
-      "jvminstall": "cpe:2.3:a:jvminstall_project:jvminstall:*:*:*:*:*:node.js:*:*",
-      "jwt-simple": "cpe:2.3:a:jwt-simple_project:jwt-simple:*:*:*:*:*:node.js:*:*",
-      "karma": "cpe:2.3:a:karma_project:karma:*:*:*:*:*:node.js:*:*",
-      "karma-mojo": "cpe:2.3:a:karma-mojo_project:karma-mojo:*:*:*:*:*:node.js:*:*",
-      "kerberos": "cpe:2.3:a:kerberos_project:kerberos:*:*:*:*:*:node.js:*:*",
-      "keyget": "cpe:2.3:a:keyget_project:keyget:*:*:*:*:*:node.js:*:*",
-      "keystone": "cpe:2.3:a:keystonejs:keystone:*:*:*:*:*:node.js:*:*",
-      "kill-by-port": "cpe:2.3:a:kill-by-port_project:kill-by-port:*:*:*:*:*:node.js:*:*",
-      "kill-port": "cpe:2.3:a:kill-port_project:kill-port:*:*:*:*:*:node.js:*:*",
-      "kill-port-process": "cpe:2.3:a:kill-port-process_project:kill-port-process:*:*:*:*:*:node.js:*:*",
-      "kill-process-by-name": "cpe:2.3:a:kill-process-by-name_project:kill-process-by-name:*:*:*:*:*:node.js:*:*",
-      "kill-process-on-port": "cpe:2.3:a:kill-process-on-port_project:kill-process-on-port:*:*:*:*:*:node.js:*:*",
-      "killing": "cpe:2.3:a:killing_project:killing:*:*:*:*:*:node.js:*:*",
-      "killport": "cpe:2.3:a:killport_project:killport:*:*:*:*:*:node.js:*:*",
-      "kindlegen": "cpe:2.3:a:hakatashi:kindlegen:*:*:*:*:*:node.js:*:*",
-      "klona": "cpe:2.3:a:klona_project:klona:*:*:*:*:*:node.js:*:*",
-      "knightjs": "cpe:2.3:a:knight_project:knight:*:*:*:*:*:node.js:*:*",
-      "koa-remove-trailing-slashes": "cpe:2.3:a:koa-remove-trailing-slashes_project:koa-remove-trailing-slashes:*:*:*:*:*:node.js:*:*",
-      "lab6.brit95": "cpe:2.3:a:lab6.brit95_project:lab6.brit95:*:*:*:*:*:node.js:*:*",
-      "lab6drewfusbyu": "cpe:2.3:a:lab6drewfusbyu_project:lab6drewfusbyu:*:*:*:*:*:node.js:*:*",
-      "larvitbase-api": "cpe:2.3:a:larvit:larvitbase:*:*:*:*:*:node.js:*:*",
-      "launchpad": "cpe:2.3:a:bitovi:launchpad:*:*:*:*:*:node.js:*:*",
-      "less-openui5": "cpe:2.3:a:less-openui5_project:less-openui5:*:*:*:*:*:node.js:*:*",
-      "lessindex": "cpe:2.3:a:lessindex_project:lessindex:*:*:*:*:*:node.js:*:*",
-      "lettersanitizer": "cpe:2.3:a:lettersanitizer_project:lettersanitizer:*:*:*:*:*:node.js:*:*",
-      "libnested": "cpe:2.3:a:libnested_project:libnested:*:*:*:*:*:node.js:*:*",
-      "libnmap": "cpe:2.3:a:libnmap_project:libnmap:*:*:*:*:*:node.js:*:*",
-      "libp2p": "cpe:2.3:a:protocol:libp2p:*:*:*:*:*:node.js:*:*",
-      "libsbml": "cpe:2.3:a:libsbml_project:libsbml:*:*:*:*:*:node.js:*:*",
-      "libsbmlsim": "cpe:2.3:a:libsbmlsim_project:libsbmlsim:*:*:*:*:*:node.js:*:*",
-      "libxl": "cpe:2.3:a:libxl_project:libxl:*:*:*:*:*:node.js:*:*",
-      "lifion-verify-deps": "cpe:2.3:a:adp:lifion-verifiy-dependencies:*:*:*:*:*:node.js:*:*",
-      "limbus-buildgen": "cpe:2.3:a:limbus-buildgen_project:limbus-buildgen:*:*:*:*:*:node.js:*:*",
-      "limdu": "cpe:2.3:a:limdu_project:limdu:*:*:*:*:*:*:*:*",
-      "link-preview-js": "cpe:2.3:a:link-preview-js_project:link-preview-js:*:*:*:*:*:node.js:*:*",
-      "liquidjs": "cpe:2.3:a:liquidjs:liquidjs:*:*:*:*:*:node.js:*:*",
-      "list-n-stream": "cpe:2.3:a:list-n-stream_project:list-n-stream:*:*:*:*:*:node.js:*:*",
-      "lite-server": "cpe:2.3:a:lite-server_project:lite-server:*:*:*:*:*:node.js:*:*",
-      "lite-web-server": "cpe:2.3:a:lite-web-server_project:lite-web-server:*:*:*:*:*:node.js:*:*",
-      "litespeed.js": "cpe:2.3:a:litespeed.js_project:litespeed.js:*:*:*:*:*:node.js:*:*",
-      "liuyaserver": "cpe:2.3:a:liuyaserver_project:liuyaserver:*:*:*:*:*:node.js:*:*",
-      "liyujing": "cpe:2.3:a:liyujing_project:liyujing:*:*:*:*:*:node.js:*:*",
-      "localhost-now": "cpe:2.3:a:localhost-now_project:localhost-now:*:*:*:*:*:node.js:*:*",
-      "locutus": "cpe:2.3:a:locutus:locutus:*:*:*:*:*:node.js:*:*",
-      "lodahs": "cpe:2.3:a:lodahs_project:lodahs:*:*:*:*:*:node.js:*:*",
-      "lodash": "cpe:2.3:a:lodash:lodash:*:*:*:*:*:node.js:*:*",
-      "log4js": "cpe:2.3:a:log4js_project:log4js:*:*:*:*:*:node.js:*:*",
-      "logkitty": "cpe:2.3:a:logkitty_project:logkitty:*:*:*:*:*:*:*:*",
-      "loopback-connector-postgresql": "cpe:2.3:a:linuxfoundation:loopback-connector-postgresql:*:*:*:*:*:node.js:*:*",
-      "looppake": "cpe:2.3:a:looppake_project:looppake:*:*:*:*:*:node.js:*:*",
-      "lsof": "cpe:2.3:a:isof_project:isof:*:*:*:*:*:node.js:*:*",
-      "ltt": "cpe:2.3:a:ltt_project:ltt:*:*:*:*:*:node.js:*:*",
-      "lutils": "cpe:2.3:a:lutils_project:lutils:*:*:*:*:*:node.js:*:*",
-      "m-server": "cpe:2.3:a:npmjs:m-server:*:*:*:*:*:*:*:*",
-      "m.static": "cpe:2.3:a:m.static_project:m.static:*:*:*:*:*:node.js:*:*",
-      "macaca-chromedriver": "cpe:2.3:a:macacajs:macaca-chromedriver:*:*:*:*:*:node.js:*:*",
-      "macaca-chromedriver-zxa": "cpe:2.3:a:macaca-chromedriver-zxa_project:macaca-chromedriver-zxa:*:*:*:*:*:node.js:*:*",
-      "macfromip": "cpe:2.3:a:macfromip_project:macfromip:*:*:*:*:*:node.js:*:*",
-      "madge": "cpe:2.3:a:madge_project:madge:*:*:*:*:*:node.js:*:*",
-      "madlib-object-utils": "cpe:2.3:a:springtree:madlib-object-utils:*:*:*:*:*:node.js:*:*",
-      "mapbox.js": "cpe:2.3:a:mapbox:mapbox.js:*:*:*:*:*:node.js:*:*",
-      "mariadb": "cpe:2.3:a:mariadb:mariadb:*:*:*:*:*:node.js:*:*",
-      "marionette-socket-host": "cpe:2.3:a:marionette-socket-host_project:marionette-socket-host:*:*:*:*:*:node.js:*:*",
-      "markdown-it": "cpe:2.3:a:markdown-it_project:markdown-it:*:*:*:*:*:*:*:*",
-      "markdown-it-highlightjs": "cpe:2.3:a:markdown-it-highlightjs_project:markdown-it-highlightjs:*:*:*:*:*:node.js:*:*",
-      "markdown-link-extractor": "cpe:2.3:a:markdown-link-extractor_project:markdown-link-extractor:*:*:*:*:*:node.js:*:*",
-      "markdown-pdf": "cpe:2.3:a:markdown-pdf_project:markdown-pdf:*:*:*:*:*:node.js:*:*",
-      "marked": "cpe:2.3:a:marked_project:marked:*:*:*:*:*:node.js:*:*",
-      "marked-tree": "cpe:2.3:a:marked-tree_project:marked-tree:*:*:*:*:*:node.js:*:*",
-      "marscode": "cpe:2.3:a:indo-mars:marscode:*:*:*:*:*:node.js:*:*",
-      "massif": "cpe:2.3:a:massif_project:massif:*:*:*:*:*:node.js:*:*",
-      "materialize-css": "cpe:2.3:a:materializecss:materialize:*:*:*:*:*:*:node.js:*",
-      "matrix-appservice-bridge": "cpe:2.3:a:matrix:matrix-appservice-bridge:*:*:*:*:*:node.js:*:*",
-      "matrix-appservice-irc": "cpe:2.3:a:matrix:matrix_irc_bridge:*:*:*:*:*:node.js:*:*",
-      "matrix-react-sdk": "cpe:2.3:a:matrix-react-sdk_project:matrix-react-sdk:*:*:*:*:*:node.js:*:*",
-      "mc-kill-port": "cpe:2.3:a:mc-kill-port_project:mc-kill-port:*:*:*:*:*:node.js:*:*",
-      "mcstatic": "cpe:2.3:a:mcstatic_project:mcstatic:*:*:*:*:*:node.js:*:*",
-      "md-to-pdf": "cpe:2.3:a:markdown_to_pdf_project:markdown_to_pdf:*:*:*:*:*:node.js:*:*",
-      "mdx-mermaid": "cpe:2.3:a:mdx-mermaid_project:mdx-mermaid:*:*:*:*:*:*:*:*",
-      "memjs": "cpe:2.3:a:memcachier:memjs:*:*:*:*:*:node.js:*:*",
-      "mercurius": "cpe:2.3:a:mercurius_project:mercurius:*:*:*:*:*:node.js:*:*",
-      "merge": "cpe:2.3:a:merge_project:merge:*:*:*:*:*:node.js:*:*",
-      "merge-change": "cpe:2.3:a:merge-change_project:merge-change:*:*:*:*:*:node.js:*:*",
-      "merge-deep": "cpe:2.3:a:merge-deep_project:merge-deep:*:*:*:*:*:node.js:*:*",
-      "merge-object": "cpe:2.3:a:merge-object_project:merge-object:*:*:*:*:*:node.js:*:*",
-      "merge-options": "cpe:2.3:a:merge-options_project:merge-options:*:*:*:*:*:node.js:*:*",
-      "merge-recursive": "cpe:2.3:a:umbraengineering:merge-recursive:*:*:*:*:*:node.js:*:*",
-      "mermaid": "cpe:2.3:a:mermaid_project:mermaid:*:*:*:*:*:node.js:*:*",
-      "metascraper": "cpe:2.3:a:metascrape_project:metascrape:*:*:*:*:*:node.js:*:*",
-      "method-override": "cpe:2.3:a:expressjs:method-override:*:*:*:*:*:node.js:*:*",
-      "mfrserver": "cpe:2.3:a:mfrserver_project:mfrserver:*:*:*:*:*:node.js:*:*",
-      "mime": "cpe:2.3:a:mime_project:mime:*:*:*:*:*:node.js:*:*",
-      "min-http-server": "cpe:2.3:a:min-http-server_project:min-http-server:*:*:*:*:*:node.js:*:*",
-      "mind-elixir": "cpe:2.3:a:mind-elixir_project:mind-elixir:*:*:*:*:*:node.js:*:*",
-      "miniflare": "cpe:2.3:a:cloudflare:miniflare:*:*:*:*:*:node.js:*:*",
-      "minimatch": "cpe:2.3:a:minimatch_project:minimatch:*:*:*:*:*:node.js:*:*",
-      "mixin-deep": "cpe:2.3:a:mixin-deep_project:mixin-deep:*:*:*:*:*:node.js:*:*",
-      "mixme": "cpe:2.3:a:adaltas:mixme:*:*:*:*:*:node.js:*:*",
-      "mocha": "cpe:2.3:a:mochajs:mocha:*:*:*:*:*:node.js:*:*",
-      "mock2easy": "cpe:2.3:a:mock2easy_project:mock2easy:*:*:*:*:*:node.js:*:*",
-      "mockery": "cpe:2.3:a:mockery_project:mockery:*:*:*:*:*:node.js:*:*",
-      "mockjs": "cpe:2.3:a:mockjs:mock.js:*:*:*:*:*:node.js:*:*",
-      "mockserve": "cpe:2.3:a:mockserve_project:mockserve:*:*:*:*:*:node.js:*:*",
-      "modern-async": "cpe:2.3:a:modern-async_project:modern-async:*:*:*:*:*:node.js:*:*",
-      "moment": "cpe:2.3:a:momentjs:moment:*:*:*:*:*:node.js:*:*",
-      "mongo-express": "cpe:2.3:a:mongo-express_project:mongo-express:*:*:*:*:*:node.js:*:*",
-      "mongodb-client-encryption": "cpe:2.3:a:mongodb:libmongocrypt:*:*:*:*:*:node.js:*:*",
-      "mongodb-instance": "cpe:2.3:a:mongodb-instance_project:mongodb-instance:*:*:*:*:*:node.js:*:*",
-      "mongoose": "cpe:2.3:a:mongoosejs:mongoose:*:*:*:*:*:node.js:*:*",
-      "mongose": "cpe:2.3:a:mongose_project:mongose:*:*:*:*:*:node.js:*:*",
-      "monorepo-build": "cpe:2.3:a:monorepo-build_project:monorepo-build:*:*:*:*:*:node.js:*:*",
-      "mootools": "cpe:2.3:a:mootools_project:mootools:*:*:*:*:*:node.js:*:*",
-      "morgan": "cpe:2.3:a:morgan_project:morgan:*:*:*:*:*:node.js:*:*",
-      "morgan-json": "cpe:2.3:a:morgan-json_project:morgan-json:*:*:*:*:*:node.js:*:*",
-      "morris.js": "cpe:2.3:a:morris.js_project:morris.js:*:*:*:*:*:node.js:*:*",
-      "mout": "cpe:2.3:a:moutjs:mout:*:*:*:*:*:node.js:*:*",
-      "mpath": "cpe:2.3:a:mpath_project:mpath:*:*:*:*:*:node.js:*:*",
-      "mqtt-packet": "cpe:2.3:a:mqtt-packet_project:mqtt-packet:*:*:*:*:*:node.js:*:*",
-      "ms": "cpe:2.3:a:vercel:ms:*:*:*:*:*:node.js:*:*",
-      "msgpack": "cpe:2.3:a:msgpack:msgpack:*:*:*:*:*:node.js:*:*",
-      "msgpack5": "cpe:2.3:a:msgpack5_project:msgpack5:*:*:*:*:*:node.js:*:*",
-      "mssql-node": "cpe:2.3:a:mssql-node_project:mssql-node:*:*:*:*:*:node.js:*:*",
-      "mssql.js": "cpe:2.3:a:mssql.js_project:mssql.js:*:*:*:*:*:node.js:*:*",
-      "mt7688-wiscan": "cpe:2.3:a:mt7688-wiscan_project:mt7688-wiscan:*:*:*:*:*:node.js:*:*",
-      "muhammara": "cpe:2.3:a:muhammara_project:muhammara:*:*:*:*:*:node.js:*:*",
-      "multi-ini": "cpe:2.3:a:multi-ini_project:multi-ini:*:*:*:*:*:node.js:*:*",
-      "mversion": "cpe:2.3:a:mversion_project:mversion:*:*:*:*:*:*:*:*",
-      "myprolyz": "cpe:2.3:a:myprolyz_project:myprolyz:*:*:*:*:*:node.js:*:*",
-      "myserver.alexcthomas18": "cpe:2.3:a:myserver.alexcthomas18_project:myserver.alexcthomas18:*:*:*:*:*:node.js:*:*",
-      "mysql": "cpe:2.3:a:mysqljs:mysql:*:*:*:*:*:node.js:*:*",
-      "mysqljs": "cpe:2.3:a:mysqljs_project:mysqljs:*:*:*:*:*:node.js:*:*",
-      "mystem": "cpe:2.3:a:mystem_project:mystem:*:*:*:*:*:node.js:*:*",
-      "mystem-fix": "cpe:2.3:a:mystem-fix_project:mystem-fix:*:*:*:*:*:node.js:*:*",
-      "mystem-wrapper": "cpe:2.3:a:mystem-wrapper_project:mystem-wrapper:*:*:*:*:*:node.js:*:*",
-      "mystem3": "cpe:2.3:a:mystem3_project:mystem3:*:*:*:*:*:node.js:*:*",
-      "n8n": "cpe:2.3:a:n8n:n8n:*:*:*:*:*:node.js:*:*",
-      "nanoid": "cpe:2.3:a:nanoid_project:nanoid:*:*:*:*:*:node.js:*:*",
-      "native-opencv": "cpe:2.3:a:native-opencv_project:native-opencv:*:*:*:*:*:node.js:*:*",
-      "nats": "cpe:2.3:a:linuxfoundation:nats.js:*:*:*:*:*:node.js:*:*",
-      "nbdime": "cpe:2.3:a:jupyter:nbdime:*:*:*:*:*:node.js:*:*",
-      "nbdime-jupyterlab": "cpe:2.3:a:jupyter:nbdime-jupyterlab:*:*:*:*:*:node.js:*:*",
-      "nconf": "cpe:2.3:a:nconf_project:nconf:*:*:*:*:*:node.js:*:*",
-      "nconf-toml": "cpe:2.3:a:nconf-toml_project:nconf-toml:*:*:*:*:*:node.js:*:*",
-      "nedb": "cpe:2.3:a:nedb_project:nedb:*:*:*:*:*:node.js:*:*",
-      "nested-object-assign": "cpe:2.3:a:getadigital:nested-object-assign:*:*:*:*:*:node.js:*:*",
-      "nestie": "cpe:2.3:a:nestie_project:nestie:*:*:*:*:*:node.js:*:*",
-      "netmask": "cpe:2.3:a:netmask_project:netmask:*:*:*:*:*:node.js:*:*",
-      "network-manager": "cpe:2.3:a:network-manager_project:network-manager:*:*:*:*:*:node.js:*:*",
-      "next-auth": "cpe:2.3:a:nextauth.js:next-auth:*:*:*:*:*:node.js:*:*",
-      "nis-utils": "cpe:2.3:a:nis-utils_project:nis-utils:*:*:*:*:*:node.js:*:*",
-      "nitrado.js": "cpe:2.3:a:nitrado.js_project:nitrado.js:*:*:*:*:*:node.js:*:*",
-      "no-case": "cpe:2.3:a:no-case_project:no-case:*:*:*:*:*:node.js:*:*",
-      "node-air-sdk": "cpe:2.3:a:node-air-sdk_project:node-air-sdk:*:*:*:*:*:node.js:*:*",
-      "node-bluetooth": "cpe:2.3:a:node-bluetooth_project:node-bluetooth:*:*:*:*:*:node.js:*:*",
-      "node-bluetooth-serial-port": "cpe:2.3:a:node-bluetooth-serial-port_project:node-bluetooth-serial-port:*:*:*:*:*:node.js:*:*",
-      "node-browser": "cpe:2.3:a:node-browser_project:node-browser:*:*:*:*:*:node.js:*:*",
-      "node-bsdiff-android": "cpe:2.3:a:node-bsdiff-android_project:node-bsdiff-android:*:*:*:*:*:node.js:*:*",
-      "node-cli": "cpe:2.3:a:node-cli_project:node-cli:*:*:*:*:*:node.js:*:*",
-      "node-df": "cpe:2.3:a:node-df_project:node-df:*:*:*:*:*:node.js:*:*",
-      "node-etsy-client": "cpe:2.3:a:node-etsy-client_project:node-etsy-client:*:*:*:*:*:node.js:*:*",
-      "node-extend": "cpe:2.3:a:node-extend_project:node-extend:*:*:*:*:*:node.js:*:*",
-      "node-fetch": "cpe:2.3:a:node-fetch_project:node-fetch:*:*:*:*:*:node.js:*:*",
-      "node-forge": "cpe:2.3:a:digitalbazaar:forge:*:*:*:*:*:node.js:*:*",
-      "node-ipc": "cpe:2.3:a:node-ipc_project:node-ipc:*:*:*:*:*:node.js:*:*",
-      "node-jose": "cpe:2.3:a:cisco:node-jose:*:*:*:*:*:node.js:*:*",
-      "node-key-sender": "cpe:2.3:a:node-key-sender_project:node-key-sender:*:*:*:*:*:node.js:*:*",
-      "node-latex-pdf": "cpe:2.3:a:node-latex-pdf_project:node-latex-pdf:*:*:*:*:*:node.js:*:*",
-      "node-lmdb": "cpe:2.3:a:node-lmdb_project:node-lmdb:*:*:*:*:*:node.js:*:*",
-      "node-macaddress": "cpe:2.3:a:node-macaddress_project:node-macaddress:*:*:*:*:*:node.js:*:*",
-      "node-mpv": "cpe:2.3:a:node-mpv_project:node-mpv:*:*:*:*:*:node.js:*:*",
-      "node-mydomoathome": "cpe:2.3:a:romanes:mydomoathome:*:*:*:*:*:node.js:*:*",
-      "node-notifier": "cpe:2.3:a:node-notifier_project:node-notifier:*:*:*:*:*:node.js:*:*",
-      "node-oojs": "cpe:2.3:a:node-oojs_project:node-oojs:*:*:*:*:*:node.js:*:*",
-      "node-opcua": "cpe:2.3:a:node-opcua_project:node-opcua:*:*:*:*:*:node.js:*:*",
-      "node-opencv": "cpe:2.3:a:node-opencv_project:node-opencv:*:*:*:*:*:node.js:*:*",
-      "node-opensl": "cpe:2.3:a:node-opensl_project:node-opensl:*:*:*:*:*:node.js:*:*",
-      "node-openssl": "cpe:2.3:a:node-openssl_project:node-openssl:*:*:*:*:*:node.js:*:*",
-      "node-printer": "cpe:2.3:a:node-printer_project:node-printer:*:*:*:*:*:node.js:*:*",
-      "node-ps": "cpe:2.3:a:node-ps_project:node-ps:*:*:*:*:*:node.js:*:*",
-      "node-red-contrib-huemagic": "cpe:2.3:a:dgtl:huemagic:*:*:*:*:*:node.js:*:*",
-      "node-serialize": "cpe:2.3:a:node-serialize_project:node-serialize:*:*:*:*:*:node.js:*:*",
-      "node-server-forfront": "cpe:2.3:a:node-server-forfront_project:node-server-forfront:*:*:*:*:*:node.js:*:*",
-      "node-simple-router": "cpe:2.3:a:node-simple-router:node-simple-router:*:*:*:*:*:node.js:*:*",
-      "node-sqlite": "cpe:2.3:a:node-sqlite_project:node-sqlite:*:*:*:*:*:node.js:*:*",
-      "node-srv": "cpe:2.3:a:node-srv_project:node-srv:*:*:*:*:*:node.js:*:*",
-      "node-static": "cpe:2.3:a:node-static_project:node-static:*:*:*:*:*:node.js:*:*",
-      "node-thulac": "cpe:2.3:a:geohey:node-thulac:*:*:*:*:*:node.js:*:*",
-      "node-tkinter": "cpe:2.3:a:node-tkinter_project:node-tkinter:*:*:*:*:*:node.js:*:*",
-      "node-uuid": "cpe:2.3:a:node-uuid_project:node-uuid:*:*:*:*:*:node.js:*:*",
-      "node-windows": "cpe:2.3:a:node-windows_project:node-windows:*:*:*:*:*:node.js:*:*",
-      "node.extend": "cpe:2.3:a:dreamerslab:node.extend:*:*:*:*:*:node.js:*:*",
-      "nodeaaaaa": "cpe:2.3:a:nodeaaaaa_project:nodeaaaaa:*:*:*:*:*:node.js:*:*",
-      "nodebb-plugin-blog-comments": "cpe:2.3:a:nodebb:blog_comments:*:*:*:*:*:node.js:*:*",
-      "nodecaffe": "cpe:2.3:a:nodecaffe_project:nodecaffe:*:*:*:*:*:node.js:*:*",
-      "nodee-utils": "cpe:2.3:a:nodee-utils_project:nodee-utils:*:*:*:*:*:node.js:*:*",
-      "nodefabric": "cpe:2.3:a:nodefabric_project:nodefabric:*:*:*:*:*:node.js:*:*",
-      "nodeffmpeg": "cpe:2.3:a:nodeffmpeg_project:nodeffmpeg:*:*:*:*:*:node.js:*:*",
-      "nodemailer": "cpe:2.3:a:nodemailer:nodemailer:*:*:*:*:*:node.js:*:*",
-      "nodemailer-js": "cpe:2.3:a:nodemailer-js_project:nodemailer-js:*:*:*:*:*:node.js:*:*",
-      "nodemailer.js": "cpe:2.3:a:nodemailer.js_project:nodemailer.js:*:*:*:*:*:node.js:*:*",
-      "nodemssql": "cpe:2.3:a:nodemssql_project:nodemssql:*:*:*:*:*:node.js:*:*",
-      "nodepdf": "cpe:2.3:a:nodepdf_project:nodepdf:*:*:*:*:*:node.js:*:*",
-      "noderequest": "cpe:2.3:a:noderequest_project:noderequest:*:*:*:*:*:node.js:*:*",
-      "nodesass": "cpe:2.3:a:nodesass_project:nodesass:*:*:*:*:*:node.js:*:*",
-      "nodeschnaps": "cpe:2.3:a:nodeschnaps_project:nodeschnaps:*:*:*:*:*:node.js:*:*",
-      "nodesqlite": "cpe:2.3:a:nodesqlite_project:nodesqlite:*:*:*:*:*:node.js:*:*",
-      "nodewebkit": "cpe:2.3:a:nodewebkit_project:nodewebkit:*:*:*:*:*:node.js:*:*",
-      "normalize-url": "cpe:2.3:a:normalize-url_project:normalize-url:*:*:*:*:*:node.js:*:*",
-      "notevil": "cpe:2.3:a:notevil_project:notevil:*:*:*:*:*:node.js:*:*",
-      "npm": "cpe:2.3:a:node_packaged_modules_project:node_packaged_modules:*:*:*:*:*:node.js:*:*",
-      "npm-dependency-versions": "cpe:2.3:a:npm-dependency-versions_project:npm-dependency-versions:*:*:*:*:*:node.js:*:*",
-      "npm-lockfile": "cpe:2.3:a:npm-lockfile_project:npm-lockfile:*:*:*:*:*:node.js:*:*",
-      "npm-script-demo": "cpe:2.3:a:npm-script-demo_project:npm-script-demo:*:*:*:*:*:node.js:*:*",
-      "npm-test-sqlite3-trunk": "cpe:2.3:a:mapbox:npm-test-sqlite3-trunk:*:*:*:*:*:node.js:*:*",
-      "npos-tesseract": "cpe:2.3:a:npos-tesseract_project:npos-tesseract:*:*:*:*:*:node.js:*:*",
-      "nuxt-api-party": "cpe:2.3:a:johannschopplich:nuxt_api_party:*:*:*:*:*:node.js:*:*",
-      "nw": "cpe:2.3:a:nwjs:nw:*:*:*:*:*:node.js:*:*",
-      "nw-with-arm": "cpe:2.3:a:nw-with-arm_project:nw-with-arm:*:*:*:*:*:node.js:*:*",
-      "oauth2-server": "cpe:2.3:a:oauth2-server_project:oauth2-server:*:*:*:*:*:node.js:*:*",
-      "object-collider": "cpe:2.3:a:fireblink:object-collider:*:*:*:*:*:node.js:*:*",
-      "object-extend": "cpe:2.3:a:object-extend_project:object-extend:*:*:*:*:*:node.js:*:*",
-      "object-path": "cpe:2.3:a:object-path_project:object-path:*:*:*:*:*:node.js:*:*",
-      "objection": "cpe:2.3:a:objection_project:objection:*:*:*:*:*:node.js:*:*",
-      "octocat": "cpe:2.3:a:octocat_project:octocat:*:*:*:*:*:node.js:*:*",
-      "octokit": "cpe:2.3:a:octokit:octokit:*:*:*:*:*:node.js:*:*",
-      "onion-oled-js": "cpe:2.3:a:onion-oled-js_project:onion-oled-js:*:*:*:*:*:node.js:*:*",
-      "op-browser": "cpe:2.3:a:op-browser_project:op-browser:*:*:*:*:*:node.js:*:*",
-      "open-device": "cpe:2.3:a:open-device_project:open-device:*:*:*:*:*:node.js:*:*",
-      "open-graph": "cpe:2.3:a:open-graph_project:open-graph:*:*:*:*:*:node.js:*:*",
-      "opencv": "cpe:2.3:a:node-opencv_project:node-opencv:*:*:*:*:*:node.js:*:*",
-      "opencv.js": "cpe:2.3:a:opencv.js_project:opencv.js:*:*:*:*:*:node.js:*:*",
-      "openframe-ascii-image": "cpe:2.3:a:openframe-ascii-image_project:openframe-ascii-image:*:*:*:*:*:node.js:*:*",
-      "openframe-glslviewer": "cpe:2.3:a:openframe-glslviewer_project:openframe-glslviewer:*:*:*:*:*:node.js:*:*",
-      "openframe-image": "cpe:2.3:a:openframe-image_project:openframe-image:*:*:*:*:*:node.js:*:*",
-      "openssl.js": "cpe:2.3:a:openssl.js_project:openssl.js:*:*:*:*:*:node.js:*:*",
-      "openzeppelin-eth": "cpe:2.3:a:openzeppelin:openzeppelin-eth:*:*:*:*:*:node.js:*:*",
-      "openzeppelin-solidity": "cpe:2.3:a:openzeppelin:openzeppelin-solidity:*:*:*:*:*:node.js:*:*",
-      "operadriver": "cpe:2.3:a:cnpmjs:operadriver:*:*:*:*:*:node.js:*:*",
-      "osm-static-maps": "cpe:2.3:a:osm-static-maps_project:osm-static-maps:*:*:*:*:*:node.js:*:*",
-      "p4": "cpe:2.3:a:p4_project:p4:*:*:*:*:*:node.js:*:*",
-      "pac-resolver": "cpe:2.3:a:pac-resolver_project:pac-resolver:*:*:*:*:*:node.js:*:*",
-      "pandora-doomsday": "cpe:2.3:a:pandora-doomsday_project:pandora-doomsday:*:*:*:*:*:node.js:*:*",
-      "parse-link-header": "cpe:2.3:a:parse-link-header_project:parse-link-header:*:*:*:*:*:node.js:*:*",
-      "parse-server": "cpe:2.3:a:parseplatform:parse-server:*:*:*:*:*:node.js:*:*",
-      "parsejson": "cpe:2.3:a:parsejson_project:parsejson:*:*:*:*:*:node.js:*:*",
-      "passport": "cpe:2.3:a:passport_project:passport:*:*:*:*:*:node.js:*:*",
-      "passport-oauth2": "cpe:2.3:a:passportjs:passport-oauth2:*:*:*:*:*:node.js:*:*",
-      "passport-saml": "cpe:2.3:a:passport-saml_project:passport-saml:*:*:*:*:*:node.js:*:*",
-      "patchmerge": "cpe:2.3:a:patchmerge_project:patchmerge:*:*:*:*:*:node.js:*:*",
-      "path-parse": "cpe:2.3:a:path-parse_project:path-parse:*:*:*:*:*:node.js:*:*",
-      "pathval": "cpe:2.3:a:chaijis:pathval:*:*:*:*:*:node.js:*:*",
-      "payload": "cpe:2.3:a:payloadcms:payload:*:*:*:*:*:node.js:*:*",
-      "paypal-adaptive": "cpe:2.3:a:idea:paypal-adaptive:*:*:*:*:*:node.js:*:*",
-      "paypal-ipn": "cpe:2.3:a:paypal-ipn_project:paypal-ipn:*:*:*:*:*:node.js:*:*",
-      "pdf-image": "cpe:2.3:a:pdf-image_project:pdf-image:*:*:*:*:*:node.js:*:*",
-      "pdfinfojs": "cpe:2.3:a:pdfinfojs_project:pdfinfojs:*:*:*:*:*:node.js:*:*",
-      "peiserver": "cpe:2.3:a:peiserver_project:peiserver:*:*:*:*:*:node.js:*:*",
-      "pekeupload": "cpe:2.3:a:pekeupload_project:pekeupload:*:*:*:*:*:*:*:*",
-      "pennyworth": "cpe:2.3:a:pennyworth_project:pennyworth:*:*:*:*:*:node.js:*:*",
-      "pg": "cpe:2.3:a:node-postgres:pg:*:*:*:*:*:node.js:*:*",
-      "phantomjs-cheniu": "cpe:2.3:a:phantomjs-cheniu_project:phantomjs-cheniu:*:*:*:*:*:node.js:*:*",
-      "phantomjs-seo": "cpe:2.3:a:phantomjs-seo_project:phantomjs-seo:*:*:*:*:*:node.js:*:*",
-      "phpjs": "cpe:2.3:a:php.js_project:php.js:*:*:*:*:*:*:*:*",
-      "picard": "cpe:2.3:a:picard_project:picard:*:*:*:*:*:node.js:*:*",
-      "picotts": "cpe:2.3:a:picotts_project:picotts:*:*:*:*:*:node.js:*:*",
-      "pixl-class": "cpe:2.3:a:pixlcore:pixl-class:*:*:*:*:*:node.js:*:*",
-      "pk-app-wonderbox": "cpe:2.3:a:pk-app-wonderbox_project:pk-app-wonderbox:*:*:*:*:*:node.js:*:*",
-      "pkg": "cpe:2.3:a:vercel:pkg:*:*:*:*:*:node.js:*:*",
-      "plist": "cpe:2.3:a:plist_project:plist:*:*:*:*:*:node.js:*:*",
-      "plupload": "cpe:2.3:a:tiny:plupload:*:*:*:*:*:node.js:*:*",
-      "pm2-kafka": "cpe:2.3:a:pm2-kafka_project:pm2-kafka:*:*:*:*:*:node.js:*:*",
-      "pngcrush-installer": "cpe:2.3:a:pngcrush-installer_project:pngcrush-installer:*:*:*:*:*:node.js:*:*",
-      "pomelo-monitor": "cpe:2.3:a:netease:pomelo-monitor:*:*:*:*:*:node.js:*:*",
-      "pooledwebsocket": "cpe:2.3:a:pooledwebsocket_project:pooledwebsocket:*:*:*:*:*:node.js:*:*",
-      "port-killer": "cpe:2.3:a:port-killer_project:port-killer:*:*:*:*:*:node.js:*:*",
-      "portkiller": "cpe:2.3:a:portkiller_project:portkiller:*:*:*:*:*:node.js:*:*",
-      "portprocesses": "cpe:2.3:a:portprocesses_project:portprocesses:*:*:*:*:*:node.js:*:*",
-      "posix": "cpe:2.3:a:posix_project:posix:*:*:*:*:*:node.js:*:*",
-      "post-loader": "cpe:2.3:a:post-loader_project:post-loader:*:*:*:*:*:node.js:*:*",
-      "postcss": "cpe:2.3:a:postcss:postcss:*:*:*:*:*:node.js:*:*",
-      "pouchdb": "cpe:2.3:a:pouchdb:pouchdb:*:*:*:*:*:node.js:*:*",
-      "prebuild-lwip": "cpe:2.3:a:prebuild-lwip_project:prebuild-lwip:*:*:*:*:*:node.js:*:*",
-      "prince": "cpe:2.3:a:prince_project:prince:*:*:*:*:*:node.js:*:*",
-      "printf": "cpe:2.3:a:adaltas:printf:*:*:*:*:*:node.js:*:*",
-      "prismjs": "cpe:2.3:a:prismjs:prism:*:*:*:*:*:node.js:*:*",
-      "private-ip": "cpe:2.3:a:private-ip_project:private-ip:*:*:*:*:*:node.js:*:*",
-      "probot": "cpe:2.3:a:probot:probot:*:*:*:*:*:node.js:*:*",
-      "proctree": "cpe:2.3:a:proctree_project:proctree:*:*:*:*:*:*:*:*",
-      "product-monitor": "cpe:2.3:a:product-monitor_project:product-monitor:*:*:*:*:*:node.js:*:*",
-      "progressbar.js": "cpe:2.3:a:progressbar.js_project:progressbar.js:*:*:*:*:*:node.js:*:*",
-      "projen": "cpe:2.3:a:projen_project:projen:*:*:*:*:*:node.js:*:*",
-      "promise-probe": "cpe:2.3:a:promise-probe_project:promise-probe:*:*:*:*:*:node.js:*:*",
-      "promisehelpers": "cpe:2.3:a:yola:promisehelpers:*:*:*:*:*:node.js:*:*",
-      "property-expr": "cpe:2.3:a:property-expr_project:property-expr:*:*:*:*:*:node.js:*:*",
-      "protobufjs": "cpe:2.3:a:protobufjs_project:protobufjs:*:*:*:*:*:node.js:*:*",
-      "proxy": "cpe:2.3:a:proxy_project:proxy:*:*:*:*:*:node.js:*:*",
-      "proxy.js": "cpe:2.3:a:proxy.js_project:proxy.js:*:*:*:*:*:node.js:*:*",
-      "ps": "cpe:2.3:a:umbraengineering:ps:*:*:*:*:*:node.js:*:*",
-      "ps-kill": "cpe:2.3:a:ps-kill_project:ps-kill:*:*:*:*:*:node.js:*:*",
-      "ps-visitor": "cpe:2.3:a:ps-visitor_project:ps-visitor:*:*:*:*:*:node.js:*:*",
-      "psnode": "cpe:2.3:a:psnode_project:psnode:*:*:*:*:*:node.js:*:*",
-      "public": "cpe:2.3:a:public_project:public:*:*:*:*:*:node.js:*:*",
-      "pug": "cpe:2.3:a:pugjs:pug:*:*:*:*:*:node.js:*:*",
-      "pug-code-gen": "cpe:2.3:a:pugjs:pug-code-gen:*:*:*:*:*:node.js:*:*",
-      "pullit": "cpe:2.3:a:pull_it_project:pull_it:*:*:*:*:*:node.js:*:*",
-      "pulverizr": "cpe:2.3:a:pulverizr_project:pulverizr:*:*:*:*:*:node.js:*:*",
-      "push-dir": "cpe:2.3:a:push-dir_project:push-dir:*:*:*:*:*:node.js:*:*",
-      "putil-merge": "cpe:2.3:a:putil-merge_project:putil-merge:*:*:*:*:*:*:*:*",
-      "pytservce": "cpe:2.3:a:pytservce_project:pytservce:*:*:*:*:*:node.js:*:*",
-      "qbs": "cpe:2.3:a:qbs_project:qbs:*:*:*:*:*:node.js:*:*",
-      "qinserve": "cpe:2.3:a:qinserve_project:qinserve:*:*:*:*:*:node.js:*:*",
-      "qs": "cpe:2.3:a:qs_project:qs:*:*:*:*:*:node.js:*:*",
-      "query-mysql": "cpe:2.3:a:query-mysql_project:query-mysql:*:*:*:*:*:node.js:*:*",
-      "quickserver": "cpe:2.3:a:quickserver_project:quickserver:*:*:*:*:*:node.js:*:*",
-      "quill-mention": "cpe:2.3:a:quill-mention:quill_mention:*:*:*:*:*:node.js:*:*",
-      "ra-ui-materialui": "cpe:2.3:a:marmelab:ra-ui-materialui:*:*:*:*:*:node.js:*:*",
-      "randomatic": "cpe:2.3:a:randomatic_project:randomatic:*:*:*:*:*:node.js:*:*",
-      "raneto": "cpe:2.3:a:raneto_project:raneto:*:*:*:*:*:node.js:*:*",
-      "rdf-graph-array": "cpe:2.3:a:rdf-graph-array_project:rdf-graph-array:*:*:*:*:*:node.js:*:*",
-      "react-adal": "cpe:2.3:a:react-adal_project:react-adal:*:*:*:*:*:node.js:*:*",
-      "react-draft-wysiwyg": "cpe:2.3:a:react_draft_wysiwyg_project:react_draft_wysiwyg:*:*:*:*:*:node.js:*:*",
-      "react-native-baidu-voice-synthesizer": "cpe:2.3:a:react-native-baidu-voice-synthesizer_project:react-native-baidu-voice-synthesizer:*:*:*:*:*:node.js:*:*",
-      "react-native-mmkv": "cpe:2.3:a:mrousavy:react-native-mmkv:*:*:*:*:*:node.js:*:*",
-      "realms-shim": "cpe:2.3:a:agoric:realms-shim:*:*:*:*:*:node.js:*:*",
-      "record-like-deep-assign": "cpe:2.3:a:record-like-deep-assign_project:record-like-deep-assign:*:*:*:*:*:node.js:*:*",
-      "redis-srvr": "cpe:2.3:a:redis-srvr_project:redis-srvr:*:*:*:*:*:node.js:*:*",
-      "reduce-css-calc": "cpe:2.3:a:reduce-css-calc_project:reduce-css-calc:*:*:*:*:*:node.js:*:*",
-      "reecerver": "cpe:2.3:a:reecerver_project:reecerver:*:*:*:*:*:node.js:*:*",
-      "reg-keygen-git-hash-plugin": "cpe:2.3:a:reg-keygen-git-hash_project:reg-keygen-git-hash:*:*:*:*:*:reg-suit:*:*",
-      "regexfn": "cpe:2.3:a:regexfn_project:regexfn:*:*:*:*:*:node.js:*:*",
-      "remark-html": "cpe:2.3:a:remark:remark-html:*:*:*:*:*:node.js:*:*",
-      "remarkable": "cpe:2.3:a:remarkable_project:remarkable:*:*:*:*:*:node.js:*:*",
-      "repo-git-downloader": "cpe:2.3:a:repo-git-downloader_project:repo-git-downloader:*:*:*:*:*:node.js:*:*",
-      "request": "cpe:2.3:a:request_project:request:*:*:*:*:*:node.js:*:*",
-      "resolve-path": "cpe:2.3:a:resolve-path_project:resolve-path:*:*:*:*:*:node.js:*:*",
-      "resourcehacker": "cpe:2.3:a:resourcehacker_project:resourcehacker:*:*:*:*:*:node.js:*:*",
-      "restafary": "cpe:2.3:a:restafary_project:restafary:*:*:*:*:*:node.js:*:*",
-      "restify-paginate": "cpe:2.3:a:restify-paginate_project:restify-paginate:*:*:*:*:*:node.js:*:*",
-      "riot-compiler": "cpe:2.3:a:riot.js:riot-compiler:*:*:*:*:*:node.js:*:*",
-      "ritp": "cpe:2.3:a:ritp_project:ritp:*:*:*:*:*:node.js:*:*",
-      "roar-pidusage": "cpe:2.3:a:roar-pidusage_project:roar-pidusage:*:*:*:*:*:node.js:*:*",
-      "robot-js": "cpe:2.3:a:getrobot:robot-js:*:*:*:*:*:node.js:*:*",
-      "rollup-plugin-dev-server": "cpe:2.3:a:rollup-plugin-dev-server_project:rollup-plugin-dev-server:*:*:*:*:*:node.js:*:*",
-      "rollup-plugin-serve": "cpe:2.3:a:rollup-plugin-serve_project:rollup-plugin-serve:*:*:*:*:*:node.js:*:*",
-      "rollup-plugin-server": "cpe:2.3:a:rollup-plugin-server_project:rollup-plugin-server:*:*:*:*:*:node.js:*:*",
-      "rpi-gpio": "cpe:2.3:a:rpi_project:rpi:*:*:*:*:*:node.js:*:*",
-      "rs-brightcove": "cpe:2.3:a:rs-brightcove_project:rs-brightcove:*:*:*:*:*:node.js:*:*",
-      "rsshub": "cpe:2.3:a:rsshub:rsshub:*:*:*:*:*:node.js:*:*",
-      "rtcmulticonnection-client": "cpe:2.3:a:rtcmulticonnection-client_project:rtcmulticonnection-client:*:*:*:*:*:node.js:*:*",
-      "s3-uploader": "cpe:2.3:a:s3-uploader_project:s3-uploader:*:*:*:*:*:node.js:*:*",
-      "safe-eval": "cpe:2.3:a:safe-eval_project:safe-eval:*:*:*:*:*:node.js:*:*",
-      "safe-flat": "cpe:2.3:a:safe-flat_project:safe-flat:*:*:*:*:*:*:*:*",
-      "safe-object2": "cpe:2.3:a:safe-object2_project:safe-object2:*:*:*:*:*:node.js:*:*",
-      "safer-eval": "cpe:2.3:a:safer-eval_project:safer-eval:*:*:*:*:*:node.js:*:*",
-      "safetydance": "cpe:2.3:a:safetydance_project:safetydance:*:*:*:*:*:node.js:*:*",
-      "sails": "cpe:2.3:a:sailsjs:sails:*:*:*:*:*:node.js:*:*",
-      "samba-client": "cpe:2.3:a:samba-client_project:samba-client:*:*:*:*:*:node.js:*:*",
-      "sanitize-html": "cpe:2.3:a:punkave:sanitize-html:*:*:*:*:*:node.js:*:*",
-      "save-server": "cpe:2.3:a:save-server_project:save-server:*:*:*:*:*:node.js:*:*",
-      "scaffold-helper": "cpe:2.3:a:scaffold-helper_project:scaffold-helper:*:*:*:*:*:node.js:*:*",
-      "scalajs-standalone-bin": "cpe:2.3:a:scalajs-standalone-bin_project:scalajs-standalone-bin:*:*:*:*:*:node.js:*:*",
-      "scniro-validator": "cpe:2.3:a:scniro-validator_project:scniro-validator:*:*:*:*:*:node.js:*:*",
-      "scott-blanch-weather-app": "cpe:2.3:a:scott-blanch-weather-app_project:scott-blanch-weather-app:*:*:*:*:*:node.js:*:*",
-      "scratch-svg-renderer": "cpe:2.3:a:mit:scratch-svg-renderer:*:*:*:*:*:node.js:*:*",
-      "script-manager": "cpe:2.3:a:script-manager_project:script-manager:*:*:*:*:*:node.js:*:*",
-      "scss-tokenizer": "cpe:2.3:a:scss-tokenizer_project:scss-tokenizer:*:*:*:*:*:node.js:*:*",
-      "sds": "cpe:2.3:a:sds_project:sds:*:*:*:*:*:node.js:*:*",
-      "section2.madisonjbrooks12": "cpe:2.3:a:section2.madisonjbrooks12_project:section2.madisonjbrooks12:*:*:*:*:*:node.js:*:*",
-      "secure-compare": "cpe:2.3:a:secure-compare_project:secure-compare:*:*:*:*:*:node.js:*:*",
-      "seeftl": "cpe:2.3:a:seeftl_project:seeftl:*:*:*:*:*:node.js:*:*",
-      "selectize-plugin-a11y": "cpe:2.3:a:selectize-plugin-a11y_project:selectize-plugin-a11y:*:*:*:*:*:node.js:*:*",
-      "selenium-chromedriver": "cpe:2.3:a:selenium-chromedriver_project:selenium-chromedriver:*:*:*:*:*:node.js:*:*",
-      "selenium-standalone-painful": "cpe:2.3:a:selenium-standalone-painful_project:selenium-standalone-painful:*:*:*:*:*:node.js:*:*",
-      "selenium-wrapper": "cpe:2.3:a:selenium-wrapper_project:selenium-wrapper:*:*:*:*:*:node.js:*:*",
-      "semver": "cpe:2.3:a:npmjs:semver:*:*:*:*:*:node.js:*:*",
-      "semver-regex": "cpe:2.3:a:semver-regex_project:semver-regex:*:*:*:*:*:*:*:*",
-      "semver-tags": "cpe:2.3:a:semver-tags_project:semver-tags:*:*:*:*:*:node.js:*:*",
-      "sencisho": "cpe:2.3:a:sencisho_project:sencisho:*:*:*:*:*:node.js:*:*",
-      "send": "cpe:2.3:a:send_project:send:*:*:*:*:*:node.js:*:*",
-      "sequelize": "cpe:2.3:a:sequelizejs:sequelize:*:*:*:*:*:node.js:*:*",
-      "serc.js": "cpe:2.3:a:serc.js_project:serc.js:*:*:*:*:*:node.js:*:*",
-      "serialize-javascript": "cpe:2.3:a:verizon:serialize-javascript:*:*:*:*:*:node.js:*:*",
-      "serialize-to-js": "cpe:2.3:a:serialize-to-js_project:serialize-to-js:*:*:*:*:*:node.js:*:*",
-      "serve-here.js": "cpe:2.3:a:serve-here.js_project:serve-here.js:*:*:*:*:*:node.js:*:*",
-      "serve-lite": "cpe:2.3:a:serve-lite_project:serve-lite:*:*:*:*:*:node.js:*:*",
-      "serve46": "cpe:2.3:a:serve46_project:serve46:*:*:*:*:*:node.js:*:*",
-      "serverabc": "cpe:2.3:a:serverabc_project:serverabc:*:*:*:*:*:node.js:*:*",
-      "serverhuwenhui": "cpe:2.3:a:serverhuwenhui_project:serverhuwenhui:*:*:*:*:*:node.js:*:*",
-      "serverliujiayi1": "cpe:2.3:a:serverliujiayi1_project:serverliujiayi1:*:*:*:*:*:node.js:*:*",
-      "serverlyr": "cpe:2.3:a:serverlyr_project:serverlyr:*:*:*:*:*:node.js:*:*",
-      "serverwg": "cpe:2.3:a:serverwg_project:serverwg:*:*:*:*:*:node.js:*:*",
-      "serverwzl": "cpe:2.3:a:serverwzl_project:serverwzl:*:*:*:*:*:node.js:*:*",
-      "serverxxx": "cpe:2.3:a:serverxxx_project:serverxxx:*:*:*:*:*:node.js:*:*",
-      "serveryaozeyan": "cpe:2.3:a:serveryaozeyan_project:serveryaozeyan:*:*:*:*:*:node.js:*:*",
-      "serveryztyzt": "cpe:2.3:a:serveryztyzt_project:serveryztyzt:*:*:*:*:*:node.js:*:*",
-      "serverzyy": "cpe:2.3:a:serverzyy_project:serverzyy:*:*:*:*:*:node.js:*:*",
-      "servey": "cpe:2.3:a:servey_project:servey:*:*:*:*:*:node.js:*:*",
-      "ses": "cpe:2.3:a:agoric:ses:*:*:*:*:*:node.js:*:*",
-      "set-object-value": "cpe:2.3:a:set-object-value_project:set-object-value:*:*:*:*:*:node.js:*:*",
-      "set-or-get": "cpe:2.3:a:set-or-get_project:set-or-get:*:*:*:*:*:node.js:*:*",
-      "set-value": "cpe:2.3:a:set-value_project:set-value:*:*:*:*:*:node.js:*:*",
-      "sexstatic": "cpe:2.3:a:sexstatic_project:sexstatic:*:*:*:*:*:*:*:*",
-      "sey": "cpe:2.3:a:sey_project:sey:*:*:*:*:*:node.js:*:*",
-      "sfml": "cpe:2.3:a:sfml_project:sfml:*:*:*:*:*:node.js:*:*",
-      "sgqserve": "cpe:2.3:a:sgqserve_project:sgqserve:*:*:*:*:*:node.js:*:*",
-      "shadowsock": "cpe:2.3:a:shadowsock_project:shadowsock:*:*:*:*:*:node.js:*:*",
-      "sharp": "cpe:2.3:a:sharp_project:sharp:*:*:*:*:*:node.js:*:*",
-      "shell-quote": "cpe:2.3:a:shell-quote_project:shell-quote:*:*:*:*:*:node.js:*:*",
-      "shenliru": "cpe:2.3:a:shenliru_project:shenliru:*:*:*:*:*:node.js:*:*",
-      "shescape": "cpe:2.3:a:shescape_project:shescape:*:*:*:*:*:node.js:*:*",
-      "shit-server": "cpe:2.3:a:shit-server_project:shit-server:*:*:*:*:*:node.js:*:*",
-      "shout": "cpe:2.3:a:shout_project:shout:*:*:*:*:*:node.js:*:*",
-      "simple-get": "cpe:2.3:a:simple-get_project:simple-get:*:*:*:*:*:node.js:*:*",
-      "simple-git": "cpe:2.3:a:simple-git_project:simple-git:*:*:*:*:*:node.js:*:*",
-      "simple-markdown": "cpe:2.3:a:khanacademy:simple-markdown:*:*:*:*:*:node.js:*:*",
-      "simple-npm-registry": "cpe:2.3:a:simple-npm-registry_project:simple-npm-registry:*:*:*:*:*:node.js:*:*",
-      "simple-plist": "cpe:2.3:a:simple-plist_project:simple-plist:*:*:*:*:*:*:*:*",
-      "simplehttpserver": "cpe:2.3:a:simplehttpserver_project:simplehttpserver:*:*:*:*:*:node.js:*:*",
-      "skywalking-backend-js": "cpe:2.3:a:apache:skywalking:*:*:*:*:*:node.js:*:*",
-      "slashify": "cpe:2.3:a:google:slashify:*:*:*:*:*:node.js:*:*",
-      "slimerjs-edge": "cpe:2.3:a:slimerjs-edge_project:slimerjs-edge:*:*:*:*:*:node.js:*:*",
-      "slug": "cpe:2.3:a:slug_project:slug:*:*:*:*:*:node.js:*:*",
-      "sly07": "cpe:2.3:a:sly07_project:sly07:*:*:*:*:*:node.js:*:*",
-      "smb": "cpe:2.3:a:smb_project:smb:*:*:*:*:*:node.js:*:*",
-      "soci": "cpe:2.3:a:soci_project:soci:*:*:*:*:*:node.js:*:*",
-      "socket.io": "cpe:2.3:a:socket:socket.io:*:*:*:*:*:node.js:*:*",
-      "socket.io-file": "cpe:2.3:a:socket.io-file_project:socket.io-file:*:*:*:*:*:node.js:*:*",
-      "socket.io-parser": "cpe:2.3:a:socket:socket.io-parser:*:*:*:*:*:node.js:*:*",
-      "sockjs": "cpe:2.3:a:sockjs_project:sockjs:*:*:*:*:*:node.js:*:*",
-      "split-html-to-chars": "cpe:2.3:a:split-html-to-chars_project:split-html-to-chars:*:*:*:*:*:node.js:*:*",
-      "spritesheet-js": "cpe:2.3:a:spritesheet-js_project:spritesheet-js:*:*:*:*:*:node.js:*:*",
-      "sqlite.js": "cpe:2.3:a:sqlite.js_project:sqlite.js:*:*:*:*:*:node.js:*:*",
-      "sqlite3": "cpe:2.3:a:ghost:sqlite3:*:*:*:*:*:node.js:*:*",
-      "sqliter": "cpe:2.3:a:sqliter_project:sqliter:*:*:*:*:*:node.js:*:*",
-      "sqlserver": "cpe:2.3:a:sqlserver_project:sqlserver:*:*:*:*:*:node.js:*:*",
-      "squirrelly": "cpe:2.3:a:squirrelly:squirrelly:*:*:*:*:*:node.js:*:*",
-      "ssh2": "cpe:2.3:a:ssh2_project:ssh2:*:*:*:*:*:node.js:*:*",
-      "sshpk": "cpe:2.3:a:joyent:sshpk:*:*:*:*:*:node.js:*:*",
-      "ssl-utils": "cpe:2.3:a:ssl-utils_project:ssl-utils:*:*:*:*:*:node.js:*:*",
-      "sspa": "cpe:2.3:a:sspa_project:sspa:*:*:*:*:*:node.js:*:*",
-      "ssrf-agent": "cpe:2.3:a:ssrf-agent_project:ssrf-agent:*:*:*:*:*:node.js:*:*",
-      "ssri": "cpe:2.3:a:ssri_project:ssri:*:*:*:*:*:node.js:*:*",
-      "st": "cpe:2.3:a:st_project:st:*:*:*:*:*:node.js:*:*",
-      "startserver": "cpe:2.3:a:startserver_project:startserver:*:*:*:*:*:node.js:*:*",
-      "static-dev-server": "cpe:2.3:a:static-dev-server_project:static-dev-server:*:*:*:*:*:node.js:*:*",
-      "static-eval": "cpe:2.3:a:static-eval_project:static-eval:*:*:*:*:*:node.js:*:*",
-      "static-html-server": "cpe:2.3:a:static-html-server_project:static-html-server:*:*:*:*:*:node.js:*:*",
-      "static-resource-server": "cpe:2.3:a:static-resource-server_project:static-resource-server:*:*:*:*:*:node.js:*:*",
-      "static-server": "cpe:2.3:a:nbluis:static-server:*:*:*:*:*:node.js:*:*",
-      "statichttpserver": "cpe:2.3:a:statichttpserver_project:statichttpserver:*:*:*:*:*:node.js:*:*",
-      "statics-server": "cpe:2.3:a:statics-server_project:statics-server:*:*:*:*:*:node.js:*:*",
-      "stattic": "cpe:2.3:a:stattic_project:stattic:*:*:*:*:*:node.js:*:*",
-      "stimulsoft-dashboards-js": "cpe:2.3:a:stimulsoft:dashboard.js:*:*:*:*:*:node.js:*:*",
-      "strapi": "cpe:2.3:a:strapi:strapi:*:*:*:*:*:node.js:*:*",
-      "strider-sauce": "cpe:2.3:a:strider-sauce_project:strider-sauce:*:*:*:*:*:node.js:*:*",
-      "string": "cpe:2.3:a:string_project:string:*:*:*:*:*:node.js:*:*",
-      "string-kit": "cpe:2.3:a:string_kit_project:string_kit:*:*:*:*:*:node.js:*:*",
-      "striptags": "cpe:2.3:a:striptags_project:striptags:*:*:*:*:*:node.js:*:*",
-      "summit": "cpe:2.3:a:summit_project:summit:*:*:*:*:*:node.js:*:*",
-      "superagent": "cpe:2.3:a:superagent_project:superagent:*:*:*:*:*:node.js:*:*",
-      "superjson": "cpe:2.3:a:blitzjs:superjson:*:*:*:*:*:node.js:*:*",
-      "susu-sum": "cpe:2.3:a:susu-sum_project:susu-sum:*:*:*:*:*:node.js:*:*",
-      "svelecte": "cpe:2.3:a:mskocik:svelecte:*:*:*:*:*:node.js:*:*",
-      "svelte": "cpe:2.3:a:svelte:svelte:*:*:*:*:*:node.js:*:*",
-      "swagger-ui-dist": "cpe:2.3:a:smartbear:swagger-ui-dist:*:*:*:*:*:node.js:*:*",
-      "sync-exec": "cpe:2.3:a:sync-exec_project:sync-exec:*:*:*:*:*:node.js:*:*",
-      "systeminformation": "cpe:2.3:a:systeminformation:systeminformation:*:*:*:*:*:node.js:*:*",
-      "taffy": "cpe:2.3:a:taffydb:taffy:*:*:*:*:*:node.js:*:*",
-      "takeapeek": "cpe:2.3:a:takeapeek_project:takeapeek:*:*:*:*:*:node.js:*:*",
-      "tar": "cpe:2.3:a:tar_project:tar:*:*:*:*:*:node.js:*:*",
-      "teddy": "cpe:2.3:a:teddy_project:teddy:*:*:*:*:*:node.js:*:*",
-      "tencent-server": "cpe:2.3:a:tencent-server_project:tencent-server:*:*:*:*:*:node.js:*:*",
-      "terminal-kit": "cpe:2.3:a:terminal-kit_project:terminal-kit:*:*:*:*:*:node.js:*:*",
-      "terser": "cpe:2.3:a:terser:terser:*:*:*:*:*:node.js:*:*",
-      "that-value": "cpe:2.3:a:that-value_project:that-value:*:*:*:*:*:node.js:*:*",
-      "three": "cpe:2.3:a:three_project:three:*:*:*:*:*:node.js:*:*",
-      "tianma-static": "cpe:2.3:a:tianma-static_project:tianma-static:*:*:*:*:*:node.js:*:*",
-      "timespan": "cpe:2.3:a:timespan_project:timespan:*:*:*:*:*:node.js:*:*",
-      "tiny-conf": "cpe:2.3:a:tiny-conf_project:tiny-conf:*:*:*:*:*:node.js:*:*",
-      "tiny-csrf": "cpe:2.3:a:tiny-csrf_project:tiny-csrf:*:*:*:*:*:node.js:*:*",
-      "tiny-http": "cpe:2.3:a:tiny-http_project:tiny-http:*:*:*:*:*:node.js:*:*",
-      "tinyserver2": "cpe:2.3:a:tinyserver2_project:tinyserver2:*:*:*:*:*:node.js:*:*",
-      "tmock": "cpe:2.3:a:tmock_project:tmock:*:*:*:*:*:node.js:*:*",
-      "tmpl": "cpe:2.3:a:tmpl_project:tmpl:*:*:*:*:*:node.js:*:*",
-      "todo-regex": "cpe:2.3:a:todo-regex_project:todo-regex:*:*:*:*:*:node.js:*:*",
-      "tomita": "cpe:2.3:a:tomita_project:tomita:*:*:*:*:*:node.js:*:*",
-      "tomita-parser": "cpe:2.3:a:yandex:tomita-parser:*:*:*:*:*:node.js:*:*",
-      "total.js": "cpe:2.3:a:totaljs:total.js:*:*:*:*:*:node.js:*:*",
-      "total4": "cpe:2.3:a:totaljs:total4:*:*:*:*:*:node.js:*:*",
-      "tough-cookie": "cpe:2.3:a:salesforce:tough-cookie:*:*:*:*:*:node.js:*:*",
-      "traceroute": "cpe:2.3:a:traceroute_project:traceroute:*:*:*:*:*:node.js:*:*",
-      "trailing-slash": "cpe:2.3:a:trailing-slash_project:trailing-slash:*:*:*:*:*:node.js:*:*",
-      "transpile": "cpe:2.3:a:transpile_project:transpile:*:*:*:*:*:node.js:*:*",
-      "tree-kill": "cpe:2.3:a:tree-kill_project:tree-kill:*:*:*:*:*:node.js:*:*",
-      "treekill": "cpe:2.3:a:treekill_project:treekill:*:*:*:*:*:node.js:*:*",
-      "trim-newlines": "cpe:2.3:a:trim-newlines_project:trim-newlines:*:*:*:*:*:node.js:*:*",
-      "trim-off-newlines": "cpe:2.3:a:trim-off-newlines_project:trim-off-newlines:*:*:*:*:*:node.js:*:*",
-      "ts-deepmerge": "cpe:2.3:a:typescript_deep_merge_project:typescript_deep_merge:*:*:*:*:*:node.js:*:*",
-      "ts-nodash": "cpe:2.3:a:ts-nodash_project:ts-nodash:*:*:*:*:*:node.js:*:*",
-      "ts-process-promises": "cpe:2.3:a:ts-process-promises_project:ts-process-promises:*:*:*:*:*:node.js:*:*",
-      "ua-parser": "cpe:2.3:a:ua-parser_project:ua-parser:*:*:*:*:*:node.js:*:*",
-      "ua-parser-js": "cpe:2.3:a:ua-parser-js_project:ua-parser-js:*:*:*:*:*:node.js:*:*",
-      "uap-core": "cpe:2.3:a:uap-core_project:uap-core:*:*:*:*:*:node.js:*:*",
-      "uekw1511server": "cpe:2.3:a:uekw1511server_project:uekw1511server:*:*:*:*:*:node.js:*:*",
-      "uglify-js": "cpe:2.3:a:uglifyjs_project:uglifyjs:*:*:*:*:*:node.js:*:*",
-      "umount": "cpe:2.3:a:umount_project:umount:*:*:*:*:*:node.js:*:*",
-      "undefsafe": "cpe:2.3:a:undefsafe_project:undefsafe:*:*:*:*:*:node.js:*:*",
-      "underscore": "cpe:2.3:a:underscorejs:underscore:*:*:*:*:*:node.js:*:*",
-      "underscore-99xp": "cpe:2.3:a:underscore-99xp_project:underscore-99xp:*:*:*:*:*:node.js:*:*",
-      "underscore.deep": "cpe:2.3:a:clever:underscore.deep:*:*:*:*:*:node.js:*:*",
-      "undici": "cpe:2.3:a:nodejs:undici:*:*:*:*:*:node.js:*:*",
-      "ungit": "cpe:2.3:a:ungit_project:ungit:*:*:*:*:*:node.js:*:*",
-      "unicode": "cpe:2.3:a:unicode_project:unicode:*:*:*:*:*:node.js:*:*",
-      "unicode-json": "cpe:2.3:a:unicode:unicode-json:*:*:*:*:*:node.js:*:*",
-      "unicorn-list": "cpe:2.3:a:unicorn-list_project:unicorn-list:*:*:*:*:*:node.js:*:*",
-      "unzipper": "cpe:2.3:a:unzipper_project:unzipper:*:*:*:*:*:node.js:*:*",
-      "uppy": "cpe:2.3:a:transloadit:uppy:*:*:*:*:*:node.js:*:*",
-      "uri-js": "cpe:2.3:a:garycourt:uri-js:*:*:*:*:*:node.js:*:*",
-      "uri-template-lite": "cpe:2.3:a:litejs:uri-template-lite:*:*:*:*:*:node.js:*:*",
-      "urijs": "cpe:2.3:a:urijs_project:urijs:*:*:*:*:*:node.js:*:*",
-      "url-js": "cpe:2.3:a:url-js_project:url-js:*:*:*:*:*:node.js:*:*",
-      "url-parse": "cpe:2.3:a:url-parse_project:url-parse:*:*:*:*:*:node.js:*:*",
-      "useragent": "cpe:2.3:a:useragent_project:useragent:*:*:*:*:*:node.js:*:*",
-      "utahcityfinder": "cpe:2.3:a:utahcityfinder_project:utahcityfinder:*:*:*:*:*:node.js:*:*",
-      "utilities": "cpe:2.3:a:utilities_project:utilities:*:*:*:*:*:node.js:*:*",
-      "utils-extend": "cpe:2.3:a:utils-extend_project:utils-extend:*:*:*:*:*:node.js:*:*",
-      "uv-tj-demo": "cpe:2.3:a:uv-tj-demo_project:uv-tj-demo:*:*:*:*:*:node.js:*:*",
-      "uws": "cpe:2.3:a:uws_project:uws:*:*:*:*:*:node.js:*:*",
-      "valib": "cpe:2.3:a:sideralis:valib.js:*:*:*:*:*:node.js:*:*",
-      "validate-color": "cpe:2.3:a:validate_color_project:validate_color:*:*:*:*:*:node.js:*:*",
-      "validate-data": "cpe:2.3:a:validate_data_project:validate_data:*:*:*:*:*:node.js:*:*",
-      "validator": "cpe:2.3:a:validator_project:validator:*:*:*:*:*:node.js:*:*",
-      "vega": "cpe:2.3:a:vega_project:vega:*:*:*:*:*:node.js:*:*",
-      "vega-functions": "cpe:2.3:a:vega-functions_project:vega-functions:*:*:*:*:*:node.js:*:*",
-      "vite": "cpe:2.3:a:vitejs:vite:*:*:*:*:*:node.js:*:*",
-      "vm2": "cpe:2.3:a:vm2_project:vm2:*:*:*:*:*:node.js:*:*",
-      "vmd": "cpe:2.3:a:vmd_project:vmd:*:*:*:*:*:node.js:*:*",
-      "vuelidate": "cpe:2.3:a:vuelidate_project:vuelidate:*:*:*:*:*:node.js:*:*",
-      "w-zip": "cpe:2.3:a:w-zip_project:w-zip:*:*:*:*:*:node.js:*:*",
-      "wangguojing123": "cpe:2.3:a:wanggoujing123_project:wanggoujing123:*:*:*:*:*:node.js:*:*",
-      "wasdk": "cpe:2.3:a:wasdk_project:wasdk:*:*:*:*:*:node.js:*:*",
-      "waterline-sequel": "cpe:2.3:a:balderdash:waterline-sequel:*:*:*:*:*:node.js:*:*",
-      "wc-cmd": "cpe:2.3:a:wc-cmd_project:wc-cmd:*:*:*:*:*:node.js:*:*",
-      "weather.swlyons": "cpe:2.3:a:weather.swlyons_project:weather.swlyons:*:*:*:*:*:node.js:*:*",
-      "webdriver-launcher": "cpe:2.3:a:webdriver-launcher_project:webdriver-launcher:*:*:*:*:*:node.js:*:*",
-      "webdrvr": "cpe:2.3:a:webdrvr_project:webdrvr:*:*:*:*:*:node.js:*:*",
-      "webpack": "cpe:2.3:a:webpack.js:webpack:*:*:*:*:*:node.js:*:*",
-      "webpack-subresource-integrity": "cpe:2.3:a:webpack-subresource-integrity_project:webpack-subresource-integrity:*:*:*:*:*:node.js:*:*",
-      "webrtc-native": "cpe:2.3:a:webrtc:webrtc-native:*:*:*:*:*:node.js:*:*",
-      "websocket-extensions": "cpe:2.3:a:websocket-extensions_project:websocket-extensions:*:*:*:*:*:node.js:*:*",
-      "welcomyzt": "cpe:2.3:a:welcomyzt_project:welcomyzt:*:*:*:*:*:node.js:*:*",
-      "wffserve": "cpe:2.3:a:wffserve_project:wffserve:*:*:*:*:*:node.js:*:*",
-      "whereis": "cpe:2.3:a:whereis_project:whereis:*:*:*:*:*:node.js:*:*",
-      "whispercast": "cpe:2.3:a:whispercast_project:whispercast:*:*:*:*:*:node.js:*:*",
-      "whois": "cpe:2.3:a:furqansofware:node_whois:*:*:*:*:*:node.js:*:*",
-      "wifey": "cpe:2.3:a:wifey_project:wifey:*:*:*:*:*:node.js:*:*",
-      "wifiscanner": "cpe:2.3:a:thingssdk:wifiscanner:*:*:*:*:*:node.js:*:*",
-      "wincred": "cpe:2.3:a:wincred_project:wincred:*:*:*:*:*:*:*:*",
-      "wind-mvc": "cpe:2.3:a:wind-mvc_project:wind-mvc:*:*:*:*:*:node.js:*:*",
-      "windows-build-tools": "cpe:2.3:a:windows-build-tools_project:windows-build-tools:*:*:*:*:*:node.js:*:*",
-      "windows-iedriver": "cpe:2.3:a:windows-iedriver_project:windows-iedriver:*:*:*:*:*:node.js:*:*",
-      "windows-latestchromedriver": "cpe:2.3:a:windows-latestchromedriver_project:windows-latestchromedriver:*:*:*:*:*:node.js:*:*",
-      "windows-selenium-chromedriver": "cpe:2.3:a:windows-selenium-chromedriver_project:windows-selenium-chromedriver:*:*:*:*:*:node.js:*:*",
-      "windows-seleniumjar": "cpe:2.3:a:windows-seleniumjar_project:windows-seleniumjar:*:*:*:*:*:node.js:*:*",
-      "windows-seleniumjar-mirror": "cpe:2.3:a:windows-seleniumjar-mirror_project:windows-seleniumjar-mirror:*:*:*:*:*:node.js:*:*",
-      "wintiwebdev": "cpe:2.3:a:wintiwebdev_project:wintiwebdev:*:*:*:*:*:node.js:*:*",
-      "wixtoolset": "cpe:2.3:a:wixtoolset_project:wixtoolset:*:*:*:*:*:node.js:*:*",
-      "word-wrap": "cpe:2.3:a:word-wrap_project:word-wrap:*:*:*:*:*:node.js:*:*",
-      "worksmith": "cpe:2.3:a:guidesmiths:worksmith:*:*:*:*:*:node.js:*:*",
-      "wrangler": "cpe:2.3:a:cloudflare:wrangler:*:*:*:*:*:node.js:*:*",
-      "ws": "cpe:2.3:a:ws_project:ws:*:*:*:*:*:node.js:*:*",
-      "x-assign": "cpe:2.3:a:binaryops:x-assign:*:*:*:*:*:node.js:*:*",
-      "x-data-spreadsheet": "cpe:2.3:a:x-data-spreadsheet_project:x-data-spreadsheet:*:*:*:*:*:node.js:*:*",
-      "xd-testing": "cpe:2.3:a:xd-testing_project:xd-testing:*:*:*:*:*:node.js:*:*",
-      "xmldom": "cpe:2.3:a:xmldom_project:xmldom:*:*:*:*:*:node.js:*:*",
-      "xmlhttprequest": "cpe:2.3:a:xmlhttprequest_project:xmlhttprequest:*:*:*:*:*:node.js:*:*",
-      "xtalk": "cpe:2.3:a:xtalk_project:xtalk:*:*:*:*:*:node.js:*:*",
-      "y18n": "cpe:2.3:a:y18n_project:y18n:*:*:*:*:*:node.js:*:*",
-      "yargs-parser": "cpe:2.3:a:yargs:yargs-parser:*:*:*:*:*:node.js:*:*",
-      "yttivy": "cpe:2.3:a:yttivy_project:yttivy:*:*:*:*:*:node.js:*:*",
-      "yyooopack": "cpe:2.3:a:yyooopack_project:yyooopack:*:*:*:*:*:node.js:*:*",
-      "yzt": "cpe:2.3:a:yzt_project:yzt:*:*:*:*:*:node.js:*:*",
-      "zjjserver": "cpe:2.3:a:zjjserver_project:zjjserver:*:*:*:*:*:node.js:*:*",
-      "zwserver": "cpe:2.3:a:zwserver_project:zwserver:*:*:*:*:*:node.js:*:*"
+      "%40perfood/couch-auth": [
+        "cpe:2.3:a:perfood:couchauth:*:*:*:*:*:node.js:*:*"
+      ],
+      "11xiaoli": [
+        "cpe:2.3:a:11xiaoli_project:11xiaoli:*:*:*:*:*:node.js:*:*"
+      ],
+      "22lixian": [
+        "cpe:2.3:a:22lixian_project:22lixian:*:*:*:*:*:node.js:*:*"
+      ],
+      "360class.jansenhm": [
+        "cpe:2.3:a:360class.jansenhm_project:360class.jansenhm:*:*:*:*:*:node.js:*:*"
+      ],
+      "626": [
+        "cpe:2.3:a:626_project:626:*:*:*:*:*:node.js:*:*"
+      ],
+      "@actions/core": [
+        "cpe:2.3:a:github:toolkit:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:toolkit_project:toolkit:*:*:*:*:*:node.js:*:*"
+      ],
+      "@adobe/css-tools": [
+        "cpe:2.3:a:adobe:css-tools:*:*:*:*:*:node.js:*:*"
+      ],
+      "@aedart/js-service-provider": [
+        "cpe:2.3:a:aedart:ion:*:*:*:*:*:node.js:*:*"
+      ],
+      "@angular/core": [
+        "cpe:2.3:a:angular:angular:*:*:*:*:*:node.js:*:*"
+      ],
+      "@antfu/utils": [
+        "cpe:2.3:a:antfu:utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "@apollosproject/data-connector-rock": [
+        "cpe:2.3:a:apollosapp:data-connector-rock:*:*:*:*:*:node.js:*:*"
+      ],
+      "@asyncapi/java-spring-cloud-stream-template": [
+        "cpe:2.3:a:asyncapi:java-spring-cloud-stream-template:*:*:*:*:*:node.js:*:*"
+      ],
+      "@asyncapi/modelina": [
+        "cpe:2.3:a:lfprojects:modelina:*:*:*:*:*:node.js:*:*"
+      ],
+      "@atlaskit/editor-core": [
+        "cpe:2.3:a:atlassian:editor-core:*:*:*:*:*:node.js:*:*"
+      ],
+      "@auth0/nextjs-auth0": [
+        "cpe:2.3:a:auth0:nextjs-auth0:*:*:*:*:*:node.js:*:*"
+      ],
+      "@awsui/components-react": [
+        "cpe:2.3:a:amazon:awsui\\/components-react:*:*:*:*:*:node.js:*:*"
+      ],
+      "@azure/ms-rest-nodeauth": [
+        "cpe:2.3:a:microsoft:ms-rest-nodeauth:*:*:*:*:*:node.js:*:*"
+      ],
+      "@backstage/plugin-auth-backend": [
+        "cpe:2.3:a:linuxfoundation:auth_backend:*:*:*:*:*:node.js:*:*"
+      ],
+      "@backstage/plugin-techdocs": [
+        "cpe:2.3:a:linuxfoundation:\\@backstage\\/plugin-techdocs:*:*:*:*:*:node.js:*:*"
+      ],
+      "@backstage/techdocs-common": [
+        "cpe:2.3:a:linuxfoundation:\\@backstage\\/techdocs-common:*:*:*:*:*:node.js:*:*"
+      ],
+      "@braintree/sanitize-url": [
+        "cpe:2.3:a:paypal:braintree\\/sanitize-url:*:*:*:*:*:node.js:*:*"
+      ],
+      "@chainsafe/libp2p-noise": [
+        "cpe:2.3:a:chainsafe:js-libp2p-noise:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-engine": [
+        "cpe:2.3:a:ckeditor:ckeditor5-engine:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-font": [
+        "cpe:2.3:a:ckeditor:ckeditor5-font:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-image": [
+        "cpe:2.3:a:ckeditor:ckeditor5-image:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-list": [
+        "cpe:2.3:a:ckeditor:ckeditor5-list:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-markdown-gfm": [
+        "cpe:2.3:a:ckeditor:ckeditor5-markdown-gfm:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-media-embed": [
+        "cpe:2.3:a:ckeditor:ckeditor5-media-embed:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-paste-from-office": [
+        "cpe:2.3:a:ckeditor:ckeditor5-paste-from-office:*:*:*:*:*:node.js:*:*"
+      ],
+      "@ckeditor/ckeditor5-widget": [
+        "cpe:2.3:a:ckeditor:ckeditor5-widget:*:*:*:*:*:node.js:*:*"
+      ],
+      "@cookiex/deep": [
+        "cpe:2.3:a:cookiex-deep_project:cookiex-deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "@cubejs-backend/api-gateway": [
+        "cpe:2.3:a:cube:cube.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "@curveball/a12n-server": [
+        "cpe:2.3:a:curveballjs:a12n-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "@diez/generation": [
+        "cpe:2.3:a:haikuforteams:diez:*:*:*:*:*:node.js:*:*"
+      ],
+      "@evershop/evershop": [
+        "cpe:2.3:a:evershop:evershop:*:*:*:*:*:node.js:*:*"
+      ],
+      "@fastly/js-compute": [
+        "cpe:2.3:a:fastly:js-compute:*:*:*:*:*:node.js:*:*"
+      ],
+      "@finastra/ssr-pages": [
+        "cpe:2.3:a:finastra:ssr-pages:*:*:*:*:*:node.js:*:*"
+      ],
+      "@firebase/util": [
+        "cpe:2.3:a:google:firebase\\/util:*:*:*:*:*:node.js:*:*"
+      ],
+      "@github/paste-markdown": [
+        "cpe:2.3:a:paste-markdown_project:paste-markdown:*:*:*:*:*:node.js:*:*"
+      ],
+      "@google-cloud/firestore": [
+        "cpe:2.3:a:google:cloud_firestore:*:*:*:*:*:node.js:*:*"
+      ],
+      "@grpc/grpc-js": [
+        "cpe:2.3:a:grpc:grpc:*:*:*:*:*:node.js:*:*"
+      ],
+      "@hapi/crumb": [
+        "cpe:2.3:a:sideway:hapi_crumb:*:*:*:*:*:node.js:*:*"
+      ],
+      "@irrelon/path": [
+        "cpe:2.3:a:irrelon:\\@irrelon\\/path:*:*:*:*:*:node.js:*:*"
+      ],
+      "@joeattardi/emoji-button": [
+        "cpe:2.3:a:emoji_button_project:emoji_button:*:*:*:*:*:node.js:*:*"
+      ],
+      "@keystonejs/keystone": [
+        "cpe:2.3:a:keystonejs:keystone:*:*:*:*:*:node.js:*:*"
+      ],
+      "@knight-lab/timelinejs": [
+        "cpe:2.3:a:northwestern:timelinejs:*:*:*:*:*:*:*:*"
+      ],
+      "@lionello/secp256k1-js": [
+        "cpe:2.3:a:secp256k1-js_project:secp256k1-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "@mattkrick/sanitize-svg": [
+        "cpe:2.3:a:sanitize-svg_project:sanitize-svg:*:*:*:*:*:node.js:*:*"
+      ],
+      "@nestjs/core": [
+        "cpe:2.3:a:nestjs:nest:*:*:*:*:*:node.js:*:*"
+      ],
+      "@nextcloud/dialogs": [
+        "cpe:2.3:a:nextcloud\\/dialogs_project:nextcloud\\/dialogs:*:*:*:*:*:node.js:*:*"
+      ],
+      "@node-saml/node-saml": [
+        "cpe:2.3:a:node_saml_project:node_saml:*:*:*:*:*:node.js:*:*"
+      ],
+      "@npmcli/arborist": [
+        "cpe:2.3:a:npmjs:arborist:*:*:*:*:*:node.js:*:*"
+      ],
+      "@nubosoftware/node-static": [
+        "cpe:2.3:a:\\@nubosoftware\\/node-static_project:\\@nubosoftware\\/node-static:*:*:*:*:*:node.js:*:*"
+      ],
+      "@nuxt/devalue": [
+        "cpe:2.3:a:nuxtjs:\\@nuxt\\/devalue:*:*:*:*:*:node.js:*:*"
+      ],
+      "@octokit/webhooks": [
+        "cpe:2.3:a:octokit:webhooks:*:*:*:*:*:node.js:*:*"
+      ],
+      "@openzeppelin/contracts": [
+        "cpe:2.3:a:openzeppelin:contracts:*:*:*:*:*:node.js:*:*"
+      ],
+      "@openzeppelin/contracts-upgradeable": [
+        "cpe:2.3:a:openzeppelin:contracts_upgradeable:*:*:*:*:*:node.js:*:*"
+      ],
+      "@parse/push-adapter": [
+        "cpe:2.3:a:parseplatform:parse_server_push_adapter:*:*:*:*:*:node.js:*:*"
+      ],
+      "@podium/layout": [
+        "cpe:2.3:a:finn:podium_layout:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:finn:podium_proxy:*:*:*:*:*:node.js:*:*"
+      ],
+      "@progfay/scrapbox-parser": [
+        "cpe:2.3:a:scrapbox-parser_project:scrapbox-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "@rkesters/gnuplot": [
+        "cpe:2.3:a:gnuplot_project:gnuplot:*:*:*:*:*:node.js:*:*"
+      ],
+      "@sap/xssec": [
+        "cpe:2.3:a:sap:\\@sap\\/xssec:*:*:*:*:*:node.js:*:*"
+      ],
+      "@scandipwa/magento-scripts": [
+        "cpe:2.3:a:scandipwa:magento-scripts:*:*:*:*:*:node.js:*:*"
+      ],
+      "@sentry/astro": [
+        "cpe:2.3:a:sentry:astro:*:*:*:*:*:node.js:*:*"
+      ],
+      "@shopify/hydrogen": [
+        "cpe:2.3:a:shopify:hydrogen:*:*:*:*:*:node.js:*:*"
+      ],
+      "@simonsmith/cypress-image-snapshot": [
+        "cpe:2.3:a:simonsmith:cypress_image_snapshot:*:*:*:*:*:node.js:*:*"
+      ],
+      "@soketi/soketi": [
+        "cpe:2.3:a:soketi_project:soketi:*:*:*:*:*:node.js:*:*"
+      ],
+      "@solana/pay": [
+        "cpe:2.3:a:solanalabs:pay:*:*:*:*:*:*:*:*"
+      ],
+      "@strikeentco/set": [
+        "cpe:2.3:a:set_project:set:*:*:*:*:*:node.js:*:*"
+      ],
+      "@sveltejs/adapter-node": [
+        "cpe:2.3:a:svelte:adapter-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "@sveltejs/kit": [
+        "cpe:2.3:a:svelte:kit:*:*:*:*:*:node.js:*:*"
+      ],
+      "@tanstack/react-query-next-experimental": [
+        "cpe:2.3:a:tanstack:react-query-next-experimental:*:*:*:*:*:node.js:*:*"
+      ],
+      "@tarojs/taro": [
+        "cpe:2.3:a:taro:taro:*:*:*:*:*:node.js:*:*"
+      ],
+      "@thi.ng/egf": [
+        "cpe:2.3:a:\\@thi.ng\\/egf_project:\\@thi.ng\\/egf:*:*:*:*:*:node.js:*:*"
+      ],
+      "@vue/devtools": [
+        "cpe:2.3:a:vuejs:devtools:*:*:*:*:*:node.js:*:*"
+      ],
+      "@web3-react/coinbase-wallet": [
+        "cpe:2.3:a:uniswap:web3-react_coinbase-wallet:*:*:*:*:*:node.js:*:*"
+      ],
+      "@web3-react/eip1193": [
+        "cpe:2.3:a:uniswap:web3-react_eip1193:*:*:*:*:*:node.js:*:*"
+      ],
+      "@web3-react/metamask": [
+        "cpe:2.3:a:uniswap:web3-react_metamask:*:*:*:*:*:node.js:*:*"
+      ],
+      "@web3-react/walletconnect": [
+        "cpe:2.3:a:uniswap:web3-react_walletconnect:*:*:*:*:*:node.js:*:*"
+      ],
+      "@zxcvbn-ts/core": [
+        "cpe:2.3:a:zxcvbn-ts_project:zxcvbn-ts:*:*:*:*:*:node.js:*:*"
+      ],
+      "Proto": [
+        "cpe:2.3:a:proto_project:proto:*:*:*:*:*:node.js:*:*"
+      ],
+      "Templ8": [
+        "cpe:2.3:a:templ8_project:templ8:*:*:*:*:*:node.js:*:*"
+      ],
+      "aaptjs": [
+        "cpe:2.3:a:aaptjs_project:aaptjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "abacus-ext-cmdline": [
+        "cpe:2.3:a:abacus-ext-cmdline_project:abacus-ext-cmdline:*:*:*:*:*:node.js:*:*"
+      ],
+      "access-policy": [
+        "cpe:2.3:a:access-policy_project:access-policy:*:*:*:*:*:node.js:*:*"
+      ],
+      "accesslog": [
+        "cpe:2.3:a:accesslog_project:accesslog:*:*:*:*:*:node.js:*:*"
+      ],
+      "adamvr-geoip-lite": [
+        "cpe:2.3:a:adamvr-geoip-lite_project:adamvr-geoip-lite:*:*:*:*:*:node.js:*:*"
+      ],
+      "adb-driver": [
+        "cpe:2.3:a:adb-driver_project:adb-driver:*:*:*:*:*:node.js:*:*"
+      ],
+      "adm-zip": [
+        "cpe:2.3:a:adm-zip_project:adm-zip:*:*:*:*:*:node.js:*:*"
+      ],
+      "aegir": [
+        "cpe:2.3:a:aegir_project:aegir:*:*:*:*:*:node.js:*:*"
+      ],
+      "air-sdk": [
+        "cpe:2.3:a:air-sdk_project:air-sdk:*:*:*:*:*:node.js:*:*"
+      ],
+      "airbrake": [
+        "cpe:2.3:a:airbrake:airbrake:*:*:*:*:*:node.js:*:*"
+      ],
+      "airtable": [
+        "cpe:2.3:a:airtable:airtable:*:*:*:*:*:node.js:*:*"
+      ],
+      "algoliasearch-helper": [
+        "cpe:2.3:a:algolia:algoliasearch-helper:*:*:*:*:*:node.js:*:*"
+      ],
+      "alto-saxophone": [
+        "cpe:2.3:a:alto-saxophone_project:alto-saxophone:*:*:*:*:*:node.js:*:*"
+      ],
+      "anchorme": [
+        "cpe:2.3:a:anchorme_project:anchorme:*:*:*:*:*:node.js:*:*"
+      ],
+      "angular": [
+        "cpe:2.3:a:angularjs:angular:*:*:*:*:*:node.js:*:*"
+      ],
+      "angular-expressions": [
+        "cpe:2.3:a:peerigon:angular-expressions:*:*:*:*:*:node.js:*:*"
+      ],
+      "angular-http-server": [
+        "cpe:2.3:a:angular-http-server_project:angular-http-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "ansi-html": [
+        "cpe:2.3:a:ansi-html_project:ansi-html:*:*:*:*:*:node.js:*:*"
+      ],
+      "ansi-regex": [
+        "cpe:2.3:a:ansi-regex_project:ansi-regex:*:*:*:*:*:node.js:*:*"
+      ],
+      "ansi2html": [
+        "cpe:2.3:a:ansi2html_project:ansi2html:*:*:*:*:*:node.js:*:*"
+      ],
+      "ansi_up": [
+        "cpe:2.3:a:ansi_up_project:ansi_up:*:*:*:*:*:node.js:*:*"
+      ],
+      "apex-publish-static-files": [
+        "cpe:2.3:a:apex-publish-static-files_project:apex-publish-static-files:*:*:*:*:*:node.js:*:*"
+      ],
+      "apexcharts": [
+        "cpe:2.3:a:fusioncharts:apexcharts:*:*:*:*:*:node.js:*:*"
+      ],
+      "apiconnect-cli-plugins": [
+        "cpe:2.3:a:apiconnect-cli-plugins_project:apiconnect-cli-plugins:*:*:*:*:*:node.js:*:*"
+      ],
+      "apk-parser": [
+        "cpe:2.3:a:apk-parser_project:apk-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "apk-parser2": [
+        "cpe:2.3:a:apk-parser2_project:apk-parser2:*:*:*:*:*:node.js:*:*"
+      ],
+      "apk-parser3": [
+        "cpe:2.3:a:apk-parser3_project:apk-parser3:*:*:*:*:*:node.js:*:*"
+      ],
+      "appium-chromedriver": [
+        "cpe:2.3:a:appium:appium-chromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "arcanist": [
+        "cpe:2.3:a:hujiang:arcanist:*:*:*:*:*:node.js:*:*"
+      ],
+      "argencoders-notevil": [
+        "cpe:2.3:a:argencoders-notevil_project:argencoders-notevil:*:*:*:*:*:node.js:*:*"
+      ],
+      "arr-flatten-unflatten": [
+        "cpe:2.3:a:arr-flatten-unflatten_project:arr-flatten-unflatten:*:*:*:*:*:node.js:*:*"
+      ],
+      "arrayfire-js": [
+        "cpe:2.3:a:arrayfire-js_project:arrayfire-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "asciitable.js": [
+        "cpe:2.3:a:asciitable.js_project:asciitable.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "assign-deep": [
+        "cpe:2.3:a:assign-deep_project:assign-deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "async-git": [
+        "cpe:2.3:a:async-git_project:async-git:*:*:*:*:*:node.js:*:*"
+      ],
+      "atlassian-connect-express": [
+        "cpe:2.3:a:atlassian:connect_express:*:*:*:*:*:node.js:*:*"
+      ],
+      "atob": [
+        "cpe:2.3:a:atob_project:atob:*:*:*:*:*:node.js:*:*"
+      ],
+      "atom-node-module-installer": [
+        "cpe:2.3:a:atom-node-module-installer_project:atom-node-module-installer:*:*:*:*:*:node.js:*:*"
+      ],
+      "augustine": [
+        "cpe:2.3:a:augustine_project:augustine:*:*:*:*:*:node.js:*:*"
+      ],
+      "aurelia-path": [
+        "cpe:2.3:a:bluespire:aurelia-path:*:*:*:*:*:node.js:*:*"
+      ],
+      "auth0-js": [
+        "cpe:2.3:a:auth0:auth0.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "aws-lambda-multipart-parser": [
+        "cpe:2.3:a:aws-lambda-multipart-parser_project:aws-lambda-multipart-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "aws-sdk": [
+        "cpe:2.3:a:amazon:aws_sdk_for_javascipt:*:*:*:*:*:node.js:*:*"
+      ],
+      "axios": [
+        "cpe:2.3:a:axios:axios:*:*:*:*:*:node.js:*:*"
+      ],
+      "babelcli": [
+        "cpe:2.3:a:babelcli_project:babelcli:*:*:*:*:*:node.js:*:*"
+      ],
+      "backbone": [
+        "cpe:2.3:a:backbone_project:backbone:*:*:*:*:*:node.js:*:*"
+      ],
+      "badjs-sourcemap-server": [
+        "cpe:2.3:a:badjs-sourcemap-server_project:badjs-sourcemap-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "baryton-saxophone": [
+        "cpe:2.3:a:baryton-saxophone_project:baryton-saxophone:*:*:*:*:*:node.js:*:*"
+      ],
+      "bassmaster": [
+        "cpe:2.3:a:bassmaster_project:bassmaster:*:*:*:*:*:*:*:*"
+      ],
+      "bestzip": [
+        "cpe:2.3:a:bestzip_project:bestzip:*:*:*:*:*:node.js:*:*"
+      ],
+      "bionode-sra": [
+        "cpe:2.3:a:bionode:bionode-sra:*:*:*:*:*:node.js:*:*"
+      ],
+      "bittorrent-dht": [
+        "cpe:2.3:a:webtorrent:bittorrent-dht:*:*:*:*:*:node.js:*:*"
+      ],
+      "bitty": [
+        "cpe:2.3:a:bitty_project:bitty:*:*:*:*:*:node.js:*:*"
+      ],
+      "bkjs-wand": [
+        "cpe:2.3:a:bkjs-wand_project:bkjs-wand:*:*:*:*:*:node.js:*:*"
+      ],
+      "blamer": [
+        "cpe:2.3:a:blamer_project:blamer:*:*:*:*:*:node.js:*:*"
+      ],
+      "bmoor": [
+        "cpe:2.3:a:bmoor_project:bmoor:*:*:*:*:*:node.js:*:*"
+      ],
+      "bodymen": [
+        "cpe:2.3:a:bodymen_project:bodymen:*:*:*:*:*:node.js:*:*"
+      ],
+      "bootbox": [
+        "cpe:2.3:a:bootboxjs:bootbox:*:*:*:*:*:node.js:*:*"
+      ],
+      "bootstrap-select": [
+        "cpe:2.3:a:snapappointments:bootstrap-select:*:*:*:*:*:node.js:*:*"
+      ],
+      "botbait": [
+        "cpe:2.3:a:botbait_project:botbait:*:*:*:*:*:node.js:*:*"
+      ],
+      "box2d-native": [
+        "cpe:2.3:a:box2d-native_project:box2d-native:*:*:*:*:*:node.js:*:*"
+      ],
+      "braces": [
+        "cpe:2.3:a:braces_project:braces:*:*:*:*:*:node.js:*:*"
+      ],
+      "bracket-template": [
+        "cpe:2.3:a:bracket-template_project:bracket-template:*:*:*:*:*:node.js:*:*"
+      ],
+      "broccoli-closure": [
+        "cpe:2.3:a:broccoli-closure_project:broccoli-closure:*:*:*:*:*:node.js:*:*"
+      ],
+      "broccoli-compass": [
+        "cpe:2.3:a:broccoli-compass_project:broccoli-compass:*:*:*:*:*:node.js:*:*"
+      ],
+      "browserify-shim": [
+        "cpe:2.3:a:browserify-shim_project:browserify-shim:*:*:*:*:*:node.js:*:*"
+      ],
+      "browserify-sign": [
+        "cpe:2.3:a:browserify:browserify-sign:*:*:*:*:*:node.js:*:*"
+      ],
+      "browserless-chrome": [
+        "cpe:2.3:a:browserless:chrome:*:*:*:*:*:node.js:*:*"
+      ],
+      "browserslist": [
+        "cpe:2.3:a:browserslist_project:browserslist:*:*:*:*:*:node.js:*:*"
+      ],
+      "bson-objectid": [
+        "cpe:2.3:a:bson-objectid_project:bson-objectid:*:*:*:*:*:node.js:*:*"
+      ],
+      "buns": [
+        "cpe:2.3:a:buns_project:buns:*:*:*:*:*:node.js:*:*"
+      ],
+      "buttercms": [
+        "cpe:2.3:a:buttercms:buttercms:*:*:*:*:*:node.js:*:*"
+      ],
+      "butterfly-button": [
+        "cpe:2.3:a:butterfly-button_project:butterfly-button:*:*:*:*:*:node.js:*:*"
+      ],
+      "buttle": [
+        "cpe:2.3:a:buttle_project:buttle:*:*:*:*:*:node.js:*:*"
+      ],
+      "byucslabsix": [
+        "cpe:2.3:a:byucslabsix_project:byucslabsix:*:*:*:*:*:node.js:*:*"
+      ],
+      "cache-base": [
+        "cpe:2.3:a:cache-base_project:cache-base:*:*:*:*:*:node.js:*:*"
+      ],
+      "cached-path-relative": [
+        "cpe:2.3:a:cached-path-relative_project:cached-path-relative:*:*:*:*:*:node.js:*:*"
+      ],
+      "call": [
+        "cpe:2.3:a:call_project:call:*:*:*:*:*:node.js:*:*"
+      ],
+      "calmquist.static-server": [
+        "cpe:2.3:a:calmquist.static-server_project:calmquist.static-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "canvas": [
+        "cpe:2.3:a:automattic:canvas:*:*:*:*:*:node.js:*:*"
+      ],
+      "caolilinode": [
+        "cpe:2.3:a:caolilinode_project:caolilinode:*:*:*:*:*:node.js:*:*"
+      ],
+      "cd-messenger": [
+        "cpe:2.3:a:cd-messenger_project:cd-messenger:*:*:*:*:*:node.js:*:*"
+      ],
+      "ced": [
+        "cpe:2.3:a:ced_project:ced:*:*:*:*:*:node.js:*:*"
+      ],
+      "censorify.tanisjr": [
+        "cpe:2.3:a:censorify.tanisjr_project:censorify.tanisjr:*:*:*:*:*:node.js:*:*"
+      ],
+      "changeset": [
+        "cpe:2.3:a:changeset_project:changeset:*:*:*:*:*:node.js:*:*"
+      ],
+      "charset": [
+        "cpe:2.3:a:charset_project:charset:*:*:*:*:*:node.js:*:*"
+      ],
+      "chart.js": [
+        "cpe:2.3:a:chartjs:chart.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "chatbyvista": [
+        "cpe:2.3:a:chatbyvista_project:chatbyvista:*:*:*:*:*:node.js:*:*"
+      ],
+      "chrome-launcher": [
+        "cpe:2.3:a:google:chrome-launcher:*:*:*:*:*:node.js:*:*"
+      ],
+      "chromedriver": [
+        "cpe:2.3:a:chromedriver_project:chromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "chromedriver126": [
+        "cpe:2.3:a:chromedriver126_project:chromedriver126:*:*:*:*:*:node.js:*:*"
+      ],
+      "chrono-node": [
+        "cpe:2.3:a:chrono-node_project:chrono-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "citypredict.whauwiller": [
+        "cpe:2.3:a:citypredict.whauwiller_project:citypredict.whauwiller:*:*:*:*:*:node.js:*:*"
+      ],
+      "ckeditor-wordcount-plugin": [
+        "cpe:2.3:a:ckeditor-wordcount-plugin_project:ckeditor-wordcount-plugin:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:herbote-services:ckeditor-wordcount-plugin:*:*:*:*:*:node.js:*:*"
+      ],
+      "clang-extra": [
+        "cpe:2.3:a:clang-extra_project:clang-extra:*:*:*:*:*:node.js:*:*"
+      ],
+      "class-transformer": [
+        "cpe:2.3:a:class-transformer_project:class-transformer:*:*:*:*:*:node.js:*:*"
+      ],
+      "cli": [
+        "cpe:2.3:a:cli_project:cli:*:*:*:*:*:node.js:*:*"
+      ],
+      "closure-compiler-stream": [
+        "cpe:2.3:a:closure-compiler-stream_project:closure-compiler-stream:*:*:*:*:*:node.js:*:*"
+      ],
+      "closure-util": [
+        "cpe:2.3:a:openlayers:closure-util:*:*:*:*:*:node.js:*:*"
+      ],
+      "closurecompiler": [
+        "cpe:2.3:a:closurecompiler_project:closurecompiler:*:*:*:*:*:node.js:*:*"
+      ],
+      "cloudpub-redis": [
+        "cpe:2.3:a:cloudpub-redis_project:cloudpub-redis:*:*:*:*:*:node.js:*:*"
+      ],
+      "cmake": [
+        "cpe:2.3:a:cmake_project:cmake:*:*:*:*:*:node.js:*:*"
+      ],
+      "co-cli-installer": [
+        "cpe:2.3:a:co-cli-installer_project:co-cli-installer:*:*:*:*:*:node.js:*:*"
+      ],
+      "cobalt-cli": [
+        "cpe:2.3:a:cobalt-cli_project:cobalt-cli:*:*:*:*:*:node.js:*:*"
+      ],
+      "codecov": [
+        "cpe:2.3:a:codecov:codecov:*:*:*:*:*:node.js:*:*"
+      ],
+      "cofeescript": [
+        "cpe:2.3:a:cofeescript_project:cofeescript:*:*:*:*:*:node.js:*:*"
+      ],
+      "collection.js": [
+        "cpe:2.3:a:collection.js_project:collection.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "color-string": [
+        "cpe:2.3:a:color-string_project:color-string:*:*:*:*:*:node.js:*:*"
+      ],
+      "comb": [
+        "cpe:2.3:a:c2fo:comb:*:*:*:*:*:node.js:*:*"
+      ],
+      "commentapp.stetsonwood": [
+        "cpe:2.3:a:commentapp.stetsonwood_project:commentapp.stetsonwood:*:*:*:*:*:node.js:*:*"
+      ],
+      "compass-compile": [
+        "cpe:2.3:a:compass-compile_project:compass-compile:*:*:*:*:*:node.js:*:*"
+      ],
+      "compile-sass": [
+        "cpe:2.3:a:compile-sass_project:compile-sass:*:*:*:*:*:*:*:*"
+      ],
+      "component-flatten": [
+        "cpe:2.3:a:component-flatten_project:component-flatten:*:*:*:*:*:node.js:*:*"
+      ],
+      "conf-cfg-ini": [
+        "cpe:2.3:a:conf-cfg-ini_project:conf-cfg-ini:*:*:*:*:*:node.js:*:*"
+      ],
+      "confinit": [
+        "cpe:2.3:a:confinit_project:confinit:*:*:*:*:*:node.js:*:*"
+      ],
+      "confucious": [
+        "cpe:2.3:a:realseriousgames:confucious:*:*:*:*:*:node.js:*:*"
+      ],
+      "connect": [
+        "cpe:2.3:a:sencha:connect:*:*:*:*:*:node.js:*:*"
+      ],
+      "connect-multiparty": [
+        "cpe:2.3:a:connect-multiparty_project:connect-multiparty:*:*:*:*:*:*:*:*"
+      ],
+      "connect-pg-simple": [
+        "cpe:2.3:a:connect-pg-simple_project:connect-pg-simple:*:*:*:*:*:node.js:*:*"
+      ],
+      "connection-tester": [
+        "cpe:2.3:a:connection-tester_project:connection-tester:*:*:*:*:*:node.js:*:*"
+      ],
+      "console-io": [
+        "cpe:2.3:a:console-io_project:console-io:*:*:*:*:*:node.js:*:*"
+      ],
+      "content": [
+        "cpe:2.3:a:content_project:content:*:*:*:*:*:node.js:*:*"
+      ],
+      "controlled-merge": [
+        "cpe:2.3:a:controlled-merge_project:controlled-merge:*:*:*:*:*:node.js:*:*"
+      ],
+      "convert-svg-core": [
+        "cpe:2.3:a:convert-svg-core_project:convert-svg-core:*:*:*:*:*:node.js:*:*"
+      ],
+      "convict": [
+        "cpe:2.3:a:mozilla:convict:*:*:*:*:*:node.js:*:*"
+      ],
+      "cookie-signature": [
+        "cpe:2.3:a:cookie-signature_project:cookie-signature:*:*:*:*:*:node.js:*:*"
+      ],
+      "copy-props": [
+        "cpe:2.3:a:gulpjs:copy-props:*:*:*:*:*:node.js:*:*"
+      ],
+      "cordova-plugin-file-transfer": [
+        "cpe:2.3:a:apache:cordova_file_transfer:*:*:*:*:*:android:*:*"
+      ],
+      "corenlp-js-interface": [
+        "cpe:2.3:a:corenlp-js-interface_project:corenlp-js-interface:*:*:*:*:*:node.js:*:*"
+      ],
+      "corenlp-js-prefab": [
+        "cpe:2.3:a:corenlp-js-prefab_project:corenlp-js-prefab:*:*:*:*:*:node.js:*:*"
+      ],
+      "create-choo-app3": [
+        "cpe:2.3:a:create-choo-app3_project:create-choo-app3:*:*:*:*:*:node.js:*:*"
+      ],
+      "create-choo-electron": [
+        "cpe:2.3:a:create-choo-electron_project:create-choo-electron:*:*:*:*:*:node.js:*:*"
+      ],
+      "cross-env.js": [
+        "cpe:2.3:a:cross-env.js_project:cross-env.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "cross-fetch": [
+        "cpe:2.3:a:cross-fetch_project:cross-fetch:*:*:*:*:*:node.js:*:*"
+      ],
+      "crossenv": [
+        "cpe:2.3:a:crossenv_project:crossenv:*:*:*:*:*:node.js:*:*"
+      ],
+      "crud-file-server": [
+        "cpe:2.3:a:crud-file-server_project:crud-file-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "csrf-lite": [
+        "cpe:2.3:a:csrf-lite_project:csrf-lite:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:negotiator_project:negotiator:*:*:*:*:*:node.js:*:*"
+      ],
+      "css-what": [
+        "cpe:2.3:a:css-what_project:css-what:*:*:*:*:*:node.js:*:*"
+      ],
+      "csv-parse": [
+        "cpe:2.3:a:csv-parse_project:csv-parse:*:*:*:*:*:node.js:*:*"
+      ],
+      "cuciuci": [
+        "cpe:2.3:a:cuciuci_project:cuciuci:*:*:*:*:*:node.js:*:*"
+      ],
+      "cue-sdk-node": [
+        "cpe:2.3:a:cue-sdk-node_project:cue-sdk-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "cumulative-distribution-function": [
+        "cpe:2.3:a:cumulative-distribution-function_project:cumulative-distribution-function:*:*:*:*:*:node.js:*:*"
+      ],
+      "curling": [
+        "cpe:2.3:a:curling_project:curling:*:*:*:*:*:node.js:*:*"
+      ],
+      "curljs": [
+        "cpe:2.3:a:curljs_project:curljs:*:*:*:*:*:node.js:*:*"
+      ],
+      "curlrequest": [
+        "cpe:2.3:a:curlrequest_project:curlrequest:*:*:*:*:*:node.js:*:*"
+      ],
+      "curly-bracket-parser": [
+        "cpe:2.3:a:curly-bracket-parser_project:curly-bracket-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "curses": [
+        "cpe:2.3:a:curses_project:curses:*:*:*:*:*:node.js:*:*"
+      ],
+      "cyber-js": [
+        "cpe:2.3:a:cyber-js_project:cyber-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "cypserver": [
+        "cpe:2.3:a:cypserver_project:cypserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "d3.js": [
+        "cpe:2.3:a:d3.js_project:d3.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "dasafio": [
+        "cpe:2.3:a:dasafio_project:dasafio:*:*:*:*:*:node.js:*:*"
+      ],
+      "datachannel-client": [
+        "cpe:2.3:a:datachannel-client_project:datachannel-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "datatables.net": [
+        "cpe:2.3:a:datatables:datatables.net:*:*:*:*:*:node.js:*:*"
+      ],
+      "date-and-time": [
+        "cpe:2.3:a:date-and-time_project:date-and-time:*:*:*:*:*:node.js:*:*"
+      ],
+      "dawnsparks-node-tesseract": [
+        "cpe:2.3:a:dawnsparks-node-tesseract_project:dawnsparks-node-tesseract:*:*:*:*:*:node.js:*:*"
+      ],
+      "dcdcdcdcdc": [
+        "cpe:2.3:a:dcdcdcdcdc_project:dcdcdcdcdc:*:*:*:*:*:node.js:*:*"
+      ],
+      "dcserver": [
+        "cpe:2.3:a:dcserver_project:dcserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "deap": [
+        "cpe:2.3:a:deap_project:deap:*:*:*:*:*:node.js:*:*"
+      ],
+      "debug": [
+        "cpe:2.3:a:debug_project:debug:*:*:*:*:*:node.js:*:*"
+      ],
+      "decal": [
+        "cpe:2.3:a:decal_project:decal:*:*:*:*:*:node.js:*:*"
+      ],
+      "decode-uri-component": [
+        "cpe:2.3:a:decode-uri-component_project:decode-uri-component:*:*:*:*:*:node.js:*:*"
+      ],
+      "decompress": [
+        "cpe:2.3:a:decompress_project:decompress:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-defaults": [
+        "cpe:2.3:a:deep-defaults_project:deep-defaults:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-extend": [
+        "cpe:2.3:a:deep_extend_project:deep_extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-get-set": [
+        "cpe:2.3:a:deep-get-set_project:deep-get-set:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-object-diff": [
+        "cpe:2.3:a:deep-object-diff_project:deep-object-diff:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-parse-json": [
+        "cpe:2.3:a:deep-parse-json_project:deep-parse-json:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep-set": [
+        "cpe:2.3:a:deep-set_project:deep-set:*:*:*:*:*:node.js:*:*"
+      ],
+      "deep.assign": [
+        "cpe:2.3:a:deep.assign_project:deep.assign:*:*:*:*:*:node.js:*:*"
+      ],
+      "deephas": [
+        "cpe:2.3:a:deephas_project:deephas:*:*:*:*:*:node.js:*:*"
+      ],
+      "deeply": [
+        "cpe:2.3:a:deeply_project:deeply:*:*:*:*:*:node.js:*:*"
+      ],
+      "deepmergefn": [
+        "cpe:2.3:a:deepmergefn_project:deepmergefn:*:*:*:*:*:node.js:*:*"
+      ],
+      "deepref": [
+        "cpe:2.3:a:deepref_project:deepref:*:*:*:*:*:node.js:*:*"
+      ],
+      "deeps": [
+        "cpe:2.3:a:invertase:deeps:*:*:*:*:*:node.js:*:*"
+      ],
+      "defaults-deep": [
+        "cpe:2.3:a:defaults-deep_project:defaults-deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "desafio": [
+        "cpe:2.3:a:desafio_project:desafio:*:*:*:*:*:node.js:*:*"
+      ],
+      "devcert": [
+        "cpe:2.3:a:devcert_project:devcert:*:*:*:*:*:node.js:*:*"
+      ],
+      "dexie": [
+        "cpe:2.3:a:dexie:dexie:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:dexie:dexie:*:*:*:*:*:node.js:*:*"
+      ],
+      "dgard8.lab6": [
+        "cpe:2.3:a:dgard8.lab6_project:dgard8.lab6:*:*:*:*:*:node.js:*:*"
+      ],
+      "dicer": [
+        "cpe:2.3:a:dicer_project:dicer:*:*:*:*:*:node.js:*:*"
+      ],
+      "directus": [
+        "cpe:2.3:a:monospace:directus:*:*:*:*:*:node.js:*:*"
+      ],
+      "discordi.js": [
+        "cpe:2.3:a:discordi.js_project:discordi.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "diskusage-ng": [
+        "cpe:2.3:a:diskusage-ng_project:diskusage-ng:*:*:*:*:*:node.js:*:*"
+      ],
+      "djv": [
+        "cpe:2.3:a:djv_project:djv:*:*:*:*:*:node.js:*:*"
+      ],
+      "dmmcquay.lab6": [
+        "cpe:2.3:a:dmmcquay.lab6_project:dmmcquay.lab6:*:*:*:*:*:node.js:*:*"
+      ],
+      "dns-packet": [
+        "cpe:2.3:a:dns-packet_project:dns-packet:*:*:*:*:*:node.js:*:*"
+      ],
+      "dns-sync": [
+        "cpe:2.3:a:dns-sync_project:dns-sync:*:*:*:*:*:node.js:*:*"
+      ],
+      "docker-cli-js": [
+        "cpe:2.3:a:quobject:docker-cli-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "docker-compose-remote-api": [
+        "cpe:2.3:a:docker-compose-remote-api_project:docker-compose-remote-api:*:*:*:*:*:node.js:*:*"
+      ],
+      "docker-tester": [
+        "cpe:2.3:a:docker-tester_project:docker-tester:*:*:*:*:*:node.js:*:*"
+      ],
+      "docsify": [
+        "cpe:2.3:a:docsifyjs:docsify:*:*:*:*:*:*:*:*"
+      ],
+      "dojo": [
+        "cpe:2.3:a:linuxfoundation:dojo:*:*:*:*:*:node.js:*:*"
+      ],
+      "dojox": [
+        "cpe:2.3:a:linuxfoundation:dojox:*:*:*:*:*:node.js:*:*"
+      ],
+      "dot-lens": [
+        "cpe:2.3:a:dot-lens_project:dot-lens:*:*:*:*:*:node.js:*:*"
+      ],
+      "dot-notes": [
+        "cpe:2.3:a:dot-notes_project:dot-notes:*:*:*:*:*:node.js:*:*"
+      ],
+      "dot-object": [
+        "cpe:2.3:a:dot-object_project:dot-object:*:*:*:*:*:node.js:*:*"
+      ],
+      "dot-prop": [
+        "cpe:2.3:a:dot-prop_project:dot-prop:*:*:*:*:*:node.js:*:*"
+      ],
+      "dottie": [
+        "cpe:2.3:a:dottie_project:dottie:*:*:*:*:*:node.js:*:*"
+      ],
+      "dotty": [
+        "cpe:2.3:a:dotty_project:dotty:*:*:*:*:*:*:*:*"
+      ],
+      "droppy": [
+        "cpe:2.3:a:droppy_project:droppy:*:*:*:*:*:node.js:*:*"
+      ],
+      "dwebp-bin": [
+        "cpe:2.3:a:dwebp-bin_project:dwebp-bin:*:*:*:*:*:node.js:*:*"
+      ],
+      "dylmomo": [
+        "cpe:2.3:a:dylmomo_project:dylmomo:*:*:*:*:*:node.js:*:*"
+      ],
+      "dynamoose": [
+        "cpe:2.3:a:dynamoosejs:dynamoose:*:*:*:*:*:node.js:*:*"
+      ],
+      "earlybird": [
+        "cpe:2.3:a:earlybird_project:earlybird:*:*:*:*:*:node.js:*:*"
+      ],
+      "easy-static-server": [
+        "cpe:2.3:a:easy-static-server_project:easy-static-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "easyquick": [
+        "cpe:2.3:a:easyquick_project:easyquick:*:*:*:*:*:node.js:*:*"
+      ],
+      "ecdh": [
+        "cpe:2.3:a:ecdh_project:ecdh:*:*:*:*:*:node.js:*:*"
+      ],
+      "ecstatic": [
+        "cpe:2.3:a:ecstatic_project:ecstatic:*:*:*:*:*:node.js:*:*"
+      ],
+      "edge.js": [
+        "cpe:2.3:a:adonisjs:edge:*:*:*:*:*:node.js:*:*"
+      ],
+      "effect": [
+        "cpe:2.3:a:effect_project:effect:*:*:*:*:*:node.js:*:*"
+      ],
+      "egg-scripts": [
+        "cpe:2.3:a:eggjs:egg-scripts:*:*:*:*:*:node.js:*:*"
+      ],
+      "ejs": [
+        "cpe:2.3:a:ejs:ejs:*:*:*:*:*:node.js:*:*"
+      ],
+      "elding": [
+        "cpe:2.3:a:elding_project:elding:*:*:*:*:*:node.js:*:*"
+      ],
+      "electron": [
+        "cpe:2.3:a:electronjs:electron:*:*:*:*:*:node.js:*:*"
+      ],
+      "electron-packager": [
+        "cpe:2.3:a:electron-packager_project:electron-packager:*:*:*:*:*:node.js:*:*"
+      ],
+      "elliptic": [
+        "cpe:2.3:a:elliptic_project:elliptic:*:*:*:*:*:node.js:*:*"
+      ],
+      "embedza": [
+        "cpe:2.3:a:embedza_project:embedza:*:*:*:*:*:node.js:*:*"
+      ],
+      "engine.io": [
+        "cpe:2.3:a:socket:engine.io:*:*:*:*:*:node.js:*:*"
+      ],
+      "engine.io-client": [
+        "cpe:2.3:a:socket:engine.io-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "enserver": [
+        "cpe:2.3:a:enserver_project:enserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "es6-crawler-detect": [
+        "cpe:2.3:a:crawlerdetect_project:crawlerdetect:*:*:*:*:*:node.js:*:*"
+      ],
+      "eslint-fixer": [
+        "cpe:2.3:a:eslint-fixer_project:eslint-fixer:*:*:*:*:*:node.js:*:*"
+      ],
+      "eslint-utils": [
+        "cpe:2.3:a:eslint-utils_project:eslint-utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "ewgaddis.lab6": [
+        "cpe:2.3:a:ewgaddis.lab6_project:ewgaddis.lab6:*:*:*:*:*:node.js:*:*"
+      ],
+      "exceljs": [
+        "cpe:2.3:a:exceljs_project:exceljs:*:*:*:*:*:node.js:*:*"
+      ],
+      "exec-local-bin": [
+        "cpe:2.3:a:exec-local-bin_project:exec-local-bin:*:*:*:*:*:node.js:*:*"
+      ],
+      "express": [
+        "cpe:2.3:a:openjsf:express:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-cart": [
+        "cpe:2.3:a:express-cart_project:express-cart:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:expresscart_project:expresscart:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-fileupload": [
+        "cpe:2.3:a:express-fileupload_project:express-fileupload:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-handlebars": [
+        "cpe:2.3:a:express_handlebars_project:express_handlebars:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-jwt": [
+        "cpe:2.3:a:auth0:express-jwt:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-openid-connect": [
+        "cpe:2.3:a:auth0:express_openid_connect:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-restify-mongoose": [
+        "cpe:2.3:a:express-restify-mongoose_project:express-restify-mongoose:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-validators": [
+        "cpe:2.3:a:express-validators_project:express-validators:*:*:*:*:*:node.js:*:*"
+      ],
+      "express-xss-sanitizer": [
+        "cpe:2.3:a:express_xss_sanitizer_project:express_xss_sanitizer:*:*:*:*:*:node.js:*:*"
+      ],
+      "extend": [
+        "cpe:2.3:a:extend_project:extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "extend2": [
+        "cpe:2.3:a:eggjs:extend2:*:*:*:*:*:node.js:*:*"
+      ],
+      "external-svg-loader": [
+        "cpe:2.3:a:shubhamjain:svg_loader:*:*:*:*:*:node.js:*:*"
+      ],
+      "exxxxxxxxxxx": [
+        "cpe:2.3:a:exxxxxxxxxxx_project:exxxxxxxxxxx:*:*:*:*:*:node.js:*:*"
+      ],
+      "f2e-server": [
+        "cpe:2.3:a:f2e-server_project:f2e-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "fabric-js": [
+        "cpe:2.3:a:fabric-js_project:fabric-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "fancy-server": [
+        "cpe:2.3:a:fancy-server_project:fancy-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "fast-csv": [
+        "cpe:2.3:a:c2fo:fast-csv:*:*:*:*:*:node.js:*:*"
+      ],
+      "fast-http": [
+        "cpe:2.3:a:fast-http_project:fast-http:*:*:*:*:*:node.js:*:*"
+      ],
+      "fast-http-cli": [
+        "cpe:2.3:a:fast-http-cli_project:fast-http-cli:*:*:*:*:*:node.js:*:*"
+      ],
+      "fast-string-search": [
+        "cpe:2.3:a:fast_string_search_project:fast_string_search:*:*:*:*:*:node.js:*:*"
+      ],
+      "fast-xml-parser": [
+        "cpe:2.3:a:fast-xml-parser_project:fast-xml-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "fastest-json-copy": [
+        "cpe:2.3:a:fastest-json-copy_project:fastest-json-copy:*:*:*:*:*:node.js:*:*"
+      ],
+      "fastify": [
+        "cpe:2.3:a:fastify:fastify:*:*:*:*:*:node.js:*:*"
+      ],
+      "fastify-csrf": [
+        "cpe:2.3:a:fastify:fastify-csrf:*:*:*:*:*:node.js:*:*"
+      ],
+      "fastify-http-proxy": [
+        "cpe:2.3:a:fastify-http-proxy_project:fastify-http-proxy:*:*:*:*:*:node.js:*:*"
+      ],
+      "fastify-reply-from": [
+        "cpe:2.3:a:fastify-reply-from_project:fastify-reply-from:*:*:*:*:*:node.js:*:*"
+      ],
+      "faye": [
+        "cpe:2.3:a:faye_project:faye:*:*:*:*:*:node.js:*:*"
+      ],
+      "fbr-client": [
+        "cpe:2.3:a:webrtc-experiment:fbr-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "feathers-sequelize": [
+        "cpe:2.3:a:feathersjs:feathers-sequelize:*:*:*:*:*:node.js:*:*"
+      ],
+      "ffmepg": [
+        "cpe:2.3:a:ffmepg_project:ffmepg:*:*:*:*:*:node.js:*:*"
+      ],
+      "ffmpegdotjs": [
+        "cpe:2.3:a:ffmpegdotjs_project:ffmpegdotjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "fibjs": [
+        "cpe:2.3:a:fibjs_project:fibjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "file-type": [
+        "cpe:2.3:a:file-type_project:file-type:*:*:*:*:*:node.js:*:*"
+      ],
+      "file-upload-with-preview": [
+        "cpe:2.3:a:johndatserakis:file-upload-with-preview:*:*:*:*:*:node.js:*:*"
+      ],
+      "fis-kernel": [
+        "cpe:2.3:a:baidu:fis-kernel:*:*:*:*:*:node.js:*:*"
+      ],
+      "fis-parser-sass-bin": [
+        "cpe:2.3:a:fis-parser-sass-bin_project:fis-parser-sass-bin:*:*:*:*:*:node.js:*:*"
+      ],
+      "fis-sass-all": [
+        "cpe:2.3:a:fis-sass-all_project:fis-sass-all:*:*:*:*:*:node.js:*:*"
+      ],
+      "flattenizer": [
+        "cpe:2.3:a:flattenizer_project:flattenizer:*:*:*:*:*:node.js:*:*"
+      ],
+      "fleetctl": [
+        "cpe:2.3:a:fleetdm:fleet:*:*:*:*:*:node.js:*:*"
+      ],
+      "fluture-node": [
+        "cpe:2.3:a:fluture-node_project:fluture-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "follow-redirects": [
+        "cpe:2.3:a:follow-redirects:follow_redirects:*:*:*:*:*:node.js:*:*"
+      ],
+      "forms": [
+        "cpe:2.3:a:forms_project:forms:*:*:*:*:*:node.js:*:*"
+      ],
+      "forwarded": [
+        "cpe:2.3:a:forwarded_project:forwarded:*:*:*:*:*:node.js:*:*"
+      ],
+      "frames-compiler": [
+        "cpe:2.3:a:frames-compiler_project:frames-compiler:*:*:*:*:*:node.js:*:*"
+      ],
+      "freediskspace": [
+        "cpe:2.3:a:freediskspace_project:freediskproject:*:*:*:*:*:node.js:*:*"
+      ],
+      "fresh": [
+        "cpe:2.3:a:fresh_project:fresh:*:*:*:*:*:node.js:*:*"
+      ],
+      "frourio": [
+        "cpe:2.3:a:frourio:frourio:*:*:*:*:*:node.js:*:*"
+      ],
+      "fs-path": [
+        "cpe:2.3:a:fs-path_project:fs-path:*:*:*:*:*:node.js:*:*"
+      ],
+      "fsk-server": [
+        "cpe:2.3:a:fsk-server_project:fsk-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "ftp-srv": [
+        "cpe:2.3:a:ftp-srv_project:ftp-srv:*:*:*:*:*:node.js:*:*"
+      ],
+      "fuseki": [
+        "cpe:2.3:a:fuseki_project:fuseki:*:*:*:*:*:node.js:*:*"
+      ],
+      "galenframework-cli": [
+        "cpe:2.3:a:galenframework:galenframework-cli:*:*:*:*:*:node.js:*:*"
+      ],
+      "gammautils": [
+        "cpe:2.3:a:gammautils_project:gammautils:*:*:*:*:*:node.js:*:*"
+      ],
+      "gaoxiaotingtingting": [
+        "cpe:2.3:a:gaoxiaotingtingting_project:gaoxiaotingtingting:*:*:*:*:*:node.js:*:*"
+      ],
+      "gaoxuyan": [
+        "cpe:2.3:a:gaoxuyan_project:gaoxuyan:*:*:*:*:*:*:*:*"
+      ],
+      "gatsby-plugin-mdx": [
+        "cpe:2.3:a:gatsbyjs:gatsby:*:*:*:*:*:node.js:*:*"
+      ],
+      "gatsby-source-wordpress": [
+        "cpe:2.3:a:gatsbyjs:gatsby-source-wordpress:*:*:*:*:*:node.js:*:*"
+      ],
+      "gedi": [
+        "cpe:2.3:a:gedi_project:gedi:*:*:*:*:*:node.js:*:*"
+      ],
+      "general-file-server": [
+        "cpe:2.3:a:general-file-server_project:general-file-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "generator-hottowel": [
+        "cpe:2.3:a:generator-hottowel_project:generator-hottowel:*:*:*:*:*:node.js:*:*"
+      ],
+      "geoip-lite-country": [
+        "cpe:2.3:a:geoip-lite-country_project:geoip-lite-country:*:*:*:*:*:node.js:*:*"
+      ],
+      "geojson2kml": [
+        "cpe:2.3:a:geojson2kml_project:geojson2kml:*:*:*:*:*:node.js:*:*"
+      ],
+      "get-ip-range": [
+        "cpe:2.3:a:get-ip-range_project:get-ip-range:*:*:*:*:*:node.js:*:*"
+      ],
+      "get-npm-package-version": [
+        "cpe:2.3:a:get-npm-package-version_project:get-npm-package-version:*:*:*:*:*:node.js:*:*"
+      ],
+      "getcityapi.yoehoehne": [
+        "cpe:2.3:a:getcityapi.yoehoehne_project:getcityapi.yoehoehne:*:*:*:*:*:node.js:*:*"
+      ],
+      "getobject": [
+        "cpe:2.3:a:getobject_project:getobject:*:*:*:*:*:node.js:*:*"
+      ],
+      "gfe-sass": [
+        "cpe:2.3:a:gfe-sass_project:gfe-sass:*:*:*:*:*:node.js:*:*"
+      ],
+      "ghost": [
+        "cpe:2.3:a:ghost:ghost:*:*:*:*:*:node.js:*:*"
+      ],
+      "git": [
+        "cpe:2.3:a:git_project:git:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-add-remote": [
+        "cpe:2.3:a:git-add-remote_project:git-add-remote:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-archive": [
+        "cpe:2.3:a:git-archive_project:git-archive:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-dummy-commit": [
+        "cpe:2.3:a:git-dummy-commit_project:git-dummy-commit:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-parse": [
+        "cpe:2.3:a:wayfair:git-parse:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-promise": [
+        "cpe:2.3:a:git-promise_project:git-promise:*:*:*:*:*:node.js:*:*"
+      ],
+      "git-pull-or-clone": [
+        "cpe:2.3:a:git-pull-or-clone_project:git-pull-or-clone:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitblame": [
+        "cpe:2.3:a:gitblame_project:gitblame:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitbook": [
+        "cpe:2.3:a:gitbook:gitbook:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitlabhook": [
+        "cpe:2.3:a:gitlabhook_project:gitlabhook:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitlog": [
+        "cpe:2.3:a:gitlog_project:gitlog:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitlogplus": [
+        "cpe:2.3:a:gitlogplus_project:gitlogplus:*:*:*:*:*:node.js:*:*"
+      ],
+      "gitsome": [
+        "cpe:2.3:a:gitsome_project:gitsome:*:*:*:*:*:node.js:*:*"
+      ],
+      "glob-parent": [
+        "cpe:2.3:a:gulpjs:glob-parent:*:*:*:*:*:node.js:*:*"
+      ],
+      "go-ipfs-dep": [
+        "cpe:2.3:a:ipfs:go-ipfs-dep:*:*:*:*:*:node.js:*:*"
+      ],
+      "gomeplus-h5-proxy": [
+        "cpe:2.3:a:gomeplus-h5-proxy_project:gomeplus-h5-proxy:*:*:*:*:*:node.js:*:*"
+      ],
+      "google-closure-tools-latest": [
+        "cpe:2.3:a:google-closure-tools-latest_project:google-closure-tools-latest:*:*:*:*:*:node.js:*:*"
+      ],
+      "google-it": [
+        "cpe:2.3:a:google-it_project:google-it:*:*:*:*:*:node.js:*:*"
+      ],
+      "goserv": [
+        "cpe:2.3:a:goserv_project:goserv:*:*:*:*:*:node.js:*:*"
+      ],
+      "grapesjs": [
+        "cpe:2.3:a:grapesjs:grapesjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql": [
+        "cpe:2.3:a:graphql:graphql:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-playground-html": [
+        "cpe:2.3:a:prisma:graphql-playground-html:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-playground-middleware-express": [
+        "cpe:2.3:a:prisma:graphql-playground-middleware-express:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-playground-middleware-hapi": [
+        "cpe:2.3:a:prisma:graphql-playground-middleware-hapi:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-playground-middleware-koa": [
+        "cpe:2.3:a:prisma:graphql-playground-middleware-koa:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-playground-middleware-lambda": [
+        "cpe:2.3:a:prisma:graphql-playground-middleware-lambda:*:*:*:*:*:node.js:*:*"
+      ],
+      "graphql-upload": [
+        "cpe:2.3:a:graphql-upload_project:graphql-upload:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:graphql-upload_project:graphql-upload:*:*:*:*:*:npmjs:*:*"
+      ],
+      "growl": [
+        "cpe:2.3:a:growl_project:growl:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-ccompiler": [
+        "cpe:2.3:a:grunt-ccompiler_project:grunt-ccompiler:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-gh-pages": [
+        "cpe:2.3:a:grunt-gh-pages_project:grunt-gh-pages:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-images": [
+        "cpe:2.3:a:grunt-images_project:grunt-images:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-karma": [
+        "cpe:2.3:a:grunt-karma_project:grunt-karma:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-util-property": [
+        "cpe:2.3:a:grunt-util-property_project:grunt-util-property:*:*:*:*:*:node.js:*:*"
+      ],
+      "grunt-webdriver-qunit": [
+        "cpe:2.3:a:grunt-webdriver-qunit_project:grunt-webdriver-qunit:*:*:*:*:*:node.js:*:*"
+      ],
+      "gruntcli": [
+        "cpe:2.3:a:gruntcli_project:gruntcli:*:*:*:*:*:node.js:*:*"
+      ],
+      "gry": [
+        "cpe:2.3:a:gry_project:gry:*:*:*:*:*:node.js:*:*"
+      ],
+      "gsap": [
+        "cpe:2.3:a:greensock:greensock_animation_platform:*:*:*:*:*:node.js:*:*"
+      ],
+      "gulp-styledocco": [
+        "cpe:2.3:a:gulp-styledocco_project:gulp-styledocco:*:*:*:*:*:node.js:*:*"
+      ],
+      "gulp-tape": [
+        "cpe:2.3:a:gulp-tape_project:gulp-tape:*:*:*:*:*:node.js:*:*"
+      ],
+      "haml-coffee": [
+        "cpe:2.3:a:haml-coffee_project:haml-coffee:*:*:*:*:*:node.js:*:*"
+      ],
+      "handlebars": [
+        "cpe:2.3:a:handlebars.js_project:handlebars.js:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:handlebarsjs:handlebars:*:*:*:*:*:node.js:*:*"
+      ],
+      "handsontable": [
+        "cpe:2.3:a:handsontable:handsontable:*:*:*:*:*:node.js:*:*"
+      ],
+      "hapi": [
+        "cpe:2.3:a:hapijs:hapi:*:*:*:*:*:node.js:*:*"
+      ],
+      "hapi-auth-jwt2": [
+        "cpe:2.3:a:hapi-auth-jwt2_project:hapi-auth-jwt2:*:*:*:*:*:node.js:*:*"
+      ],
+      "harp": [
+        "cpe:2.3:a:npmjs:harp:*:*:*:*:*:*:*:*"
+      ],
+      "haxe": [
+        "cpe:2.3:a:haxe:haxe:*:*:*:*:*:node.js:*:*"
+      ],
+      "haxe-dev": [
+        "cpe:2.3:a:haxe:haxe-dev:*:*:*:*:*:node.js:*:*"
+      ],
+      "haxe3": [
+        "cpe:2.3:a:haxe:haxe:*:*:*:*:*:node.js:*:*"
+      ],
+      "haxeshim": [
+        "cpe:2.3:a:haxeshim_project:haxeshim:*:*:*:*:*:node.js:*:*"
+      ],
+      "hbs": [
+        "cpe:2.3:a:hbs_project:hbs:*:*:*:*:*:node.js:*:*"
+      ],
+      "hcbserver": [
+        "cpe:2.3:a:hcbserver_project:hcbserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "headless-browser-lite": [
+        "cpe:2.3:a:headless-browser-lite_project:headless-browser-lite:*:*:*:*:*:node.js:*:*"
+      ],
+      "healthcenter": [
+        "cpe:2.3:a:healthcenter_project:healthcenter:*:*:*:*:*:node.js:*:*"
+      ],
+      "hekto": [
+        "cpe:2.3:a:hekto_project:hekto:*:*:*:*:*:node.js:*:*"
+      ],
+      "hello.js": [
+        "cpe:2.3:a:hello.js_project:hello.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "herbivore": [
+        "cpe:2.3:a:herbivore_project:herbivore:*:*:*:*:*:node.js:*:*"
+      ],
+      "heroku-addonpool": [
+        "cpe:2.3:a:heroku-addonpool_project:heroku-addonpool:*:*:*:*:*:node.js:*:*"
+      ],
+      "heroku-env": [
+        "cpe:2.3:a:heroku-env_project:heroku-env:*:*:*:*:*:node.js:*:*"
+      ],
+      "hexo": [
+        "cpe:2.3:a:hexo:hexo:*:*:*:*:*:node.js:*:*"
+      ],
+      "hftp": [
+        "cpe:2.3:a:hftp_project:hftp:*:*:*:*:*:node.js:*:*"
+      ],
+      "highlight.js": [
+        "cpe:2.3:a:highlightjs:highlight.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "highlight.run": [
+        "cpe:2.3:a:highlight:highlight:*:*:*:*:*:node.js:*:*"
+      ],
+      "home-assistant-js-websocket": [
+        "cpe:2.3:a:home-assistant:home-assistant-js-websocket:*:*:*:*:*:node.js:*:*"
+      ],
+      "hono": [
+        "cpe:2.3:a:hono:hono:*:*:*:*:*:node.js:*:*"
+      ],
+      "hostr": [
+        "cpe:2.3:a:hostr_project:hostr:*:*:*:*:*:node.js:*:*"
+      ],
+      "hot-formula-parser": [
+        "cpe:2.3:a:hot-formula-parser_project:hot-formula-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "html-janitor": [
+        "cpe:2.3:a:html-janitor_project:html-janitor:*:*:*:*:*:node.js:*:*"
+      ],
+      "html-pages": [
+        "cpe:2.3:a:html-pages_project:html-pages:*:*:*:*:*:node.js:*:*"
+      ],
+      "html-pdf": [
+        "cpe:2.3:a:html-pdf_project:html-pdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-cache-semantics": [
+        "cpe:2.3:a:http-cache-semantics_project:http-cache-semantics:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-client": [
+        "cpe:2.3:a:http-client_project:http-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-file-server": [
+        "cpe:2.3:a:http-file-server_project:http-file-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-live-simulator": [
+        "cpe:2.3:a:http-live-simulator_project:http-live-simulator:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-proxy": [
+        "cpe:2.3:a:http-proxy_project:http-proxy:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-proxy.js": [
+        "cpe:2.3:a:http-proxy.js_project:http-proxy.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-server-node": [
+        "cpe:2.3:a:http-server-node_project:http-server-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "http-signature": [
+        "cpe:2.3:a:joyent:http-signature:*:*:*:*:*:node.js:*:*"
+      ],
+      "http_server": [
+        "cpe:2.3:a:http_server_project:http_server:*:*:*:*:*:node.js:*:*"
+      ],
+      "http_static_simple": [
+        "cpe:2.3:a:http_static_simple_project:http_static_simple:*:*:*:*:*:node.js:*:*"
+      ],
+      "https-proxy-agent": [
+        "cpe:2.3:a:https-proxy-agent_project:https-proxy-agent:*:*:*:*:*:node.js:*:*"
+      ],
+      "httpster": [
+        "cpe:2.3:a:httpster_project:httpster:*:*:*:*:*:node.js:*:*"
+      ],
+      "httpsync": [
+        "cpe:2.3:a:httpsync_project:httpsync:*:*:*:*:*:node.js:*:*"
+      ],
+      "hubl-server": [
+        "cpe:2.3:a:hubspot:hubl-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "hummus": [
+        "cpe:2.3:a:hummus_project:hummus:*:*:*:*:*:node.js:*:*"
+      ],
+      "i18n": [
+        "cpe:2.3:a:i18n_project:i18n:*:*:*:*:*:node.js:*:*"
+      ],
+      "i18n-node-angular": [
+        "cpe:2.3:a:i18n-node-angular_project:i18n-node-angular:*:*:*:*:*:node.js:*:*"
+      ],
+      "ibapi": [
+        "cpe:2.3:a:interactivebrokers:ibapi:*:*:*:*:*:node.js:*:*"
+      ],
+      "ibm_db": [
+        "cpe:2.3:a:ibm:ibm_db:*:*:*:*:*:node.js:*:*"
+      ],
+      "iedriver": [
+        "cpe:2.3:a:iedriver_project:iedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "igniteui": [
+        "cpe:2.3:a:infragistics:igniteui:*:*:*:*:*:node.js:*:*"
+      ],
+      "ikst": [
+        "cpe:2.3:a:ikst_project:ikst:*:*:*:*:*:node.js:*:*"
+      ],
+      "image-tiler": [
+        "cpe:2.3:a:image-tiler_project:image-tiler:*:*:*:*:*:node.js:*:*"
+      ],
+      "imageoptim": [
+        "cpe:2.3:a:imageoptim_project:imageoptim:*:*:*:*:*:node.js:*:*"
+      ],
+      "immer": [
+        "cpe:2.3:a:immer_project:immer:*:*:*:*:*:node.js:*:*"
+      ],
+      "import-in-the-middle": [
+        "cpe:2.3:a:datadoghq:import-in-the-middle:*:*:*:*:*:node.js:*:*"
+      ],
+      "inert": [
+        "cpe:2.3:a:hapi:inert:*:*:*:*:*:node.js:*:*"
+      ],
+      "infraserver": [
+        "cpe:2.3:a:infraserver_project:infraserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "ini": [
+        "cpe:2.3:a:ini_project:ini:*:*:*:*:*:node.js:*:*"
+      ],
+      "ini-parser": [
+        "cpe:2.3:a:ini-parser_project:ini-parser:*:*:*:*:*:*:*:*"
+      ],
+      "iniparserjs": [
+        "cpe:2.3:a:iniparserjs_project:iniparserjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "install-g-test": [
+        "cpe:2.3:a:install-g-test_project:install-g-test:*:*:*:*:*:node.js:*:*"
+      ],
+      "install-package": [
+        "cpe:2.3:a:install-package_project:install-package:*:*:*:*:*:node.js:*:*"
+      ],
+      "intsol-package": [
+        "cpe:2.3:a:intsol-package_project:intsol-package:*:*:*:*:*:node.js:*:*"
+      ],
+      "iobroker.admin": [
+        "cpe:2.3:a:iobroker:iobroker.admin:*:*:*:*:*:node.js:*:*"
+      ],
+      "iobroker.web": [
+        "cpe:2.3:a:iobroker:iobroker.web:*:*:*:*:*:node.js:*:*"
+      ],
+      "ip": [
+        "cpe:2.3:a:fedorindutny:ip:*:*:*:*:*:node.js:*:*"
+      ],
+      "ipip": [
+        "cpe:2.3:a:ipip_project:ipip:*:*:*:*:*:node.js:*:*"
+      ],
+      "ipip-coffee": [
+        "cpe:2.3:a:ipip:ipip-coffee:*:*:*:*:*:node.js:*:*"
+      ],
+      "irrelon-path": [
+        "cpe:2.3:a:irrelon:irrelon-path:*:*:*:*:*:node.js:*:*"
+      ],
+      "is-email": [
+        "cpe:2.3:a:segment:is-email:*:*:*:*:*:node.js:*:*"
+      ],
+      "is-http2": [
+        "cpe:2.3:a:is-http2_project:is-http2:*:*:*:*:*:node.js:*:*"
+      ],
+      "is-my-json-valid": [
+        "cpe:2.3:a:is-my-json-valid_project:is-my-json-valid:*:*:*:*:*:node.js:*:*"
+      ],
+      "is-user-valid": [
+        "cpe:2.3:a:is-user-valid_project:is-user-valid:*:*:*:*:*:node.js:*:*"
+      ],
+      "isolated-vm": [
+        "cpe:2.3:a:isolated-vm_project:isolated-vm:*:*:*:*:*:node.js:*:*"
+      ],
+      "iter-http": [
+        "cpe:2.3:a:iter-http_project:iter-http:*:*:*:*:*:node.js:*:*"
+      ],
+      "iter-server": [
+        "cpe:2.3:a:iter-server_project:iter-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "jadedown": [
+        "cpe:2.3:a:jadedown_project:jadedown:*:*:*:*:*:node.js:*:*"
+      ],
+      "jailed": [
+        "cpe:2.3:a:jailed_project:jailed:*:*:*:*:*:node.js:*:*"
+      ],
+      "jansenstuffpleasework": [
+        "cpe:2.3:a:jansenstuffpleasework_project:jansenstuffpleasework:*:*:*:*:*:node.js:*:*"
+      ],
+      "jdf-sass": [
+        "cpe:2.3:a:jdf-sass_project:jdf-sass:*:*:*:*:*:node.js:*:*"
+      ],
+      "jikes": [
+        "cpe:2.3:a:jikes_project:jikes:*:*:*:*:*:node.js:*:*"
+      ],
+      "jison": [
+        "cpe:2.3:a:jison_project:jison:*:*:*:*:*:node.js:*:*"
+      ],
+      "jn_jj_server": [
+        "cpe:2.3:a:jn_jj_server_project:jn_jj_server:*:*:*:*:*:node.js:*:*"
+      ],
+      "jointjs": [
+        "cpe:2.3:a:client:jointjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "joplin": [
+        "cpe:2.3:a:joplin_project:joplin:*:*:*:*:*:-:*:*",
+        "cpe:2.3:a:joplin_project:joplin:*:*:*:*:*:node.js:*:*"
+      ],
+      "jose": [
+        "cpe:2.3:a:jose_project:jose:*:*:*:*:*:node.js:*:*"
+      ],
+      "jpeg-js": [
+        "cpe:2.3:a:jpeg-js_project:jpeg-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "jpv": [
+        "cpe:2.3:a:json_pattern_validator_project:json_pattern_validator:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:json_pattern_validator_project:json_pattern_validator:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery": [
+        "cpe:2.3:a:jquery:jquery:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery-file-upload": [
+        "cpe:2.3:a:jquery_file_upload_project:jquery_file_upload:*:*:*:*:*:*:*:*"
+      ],
+      "jquery-validation": [
+        "cpe:2.3:a:jqueryvalidation:jquery_validation:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery.cookie": [
+        "cpe:2.3:a:jquery.cookie_project:jquery.cookie:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery.js": [
+        "cpe:2.3:a:jquery.js_project:jquery.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery.json-viewer": [
+        "cpe:2.3:a:jquery_json-viewer_project:jquery_json-viewer:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquery.terminal": [
+        "cpe:2.3:a:jquery.terminal_project:jquery.terminal:*:*:*:*:*:node.js:*:*"
+      ],
+      "jquey": [
+        "cpe:2.3:a:jquey_project:jquey:*:*:*:*:*:node.js:*:*"
+      ],
+      "js-given": [
+        "cpe:2.3:a:js-given_project:js-given:*:*:*:*:*:node.js:*:*"
+      ],
+      "jscover": [
+        "cpe:2.3:a:jscover_project:jscover:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsen": [
+        "cpe:2.3:a:jsen_project:jsen:*:*:*:*:*:node.js:*:*"
+      ],
+      "jser-stat": [
+        "cpe:2.3:a:jser-stat_project:jser-stat:*:*:*:*:*:node.js:*:*"
+      ],
+      "jshamcrest": [
+        "cpe:2.3:a:jshamcrest_project:jshamcrest:*:*:*:*:*:node.js:*:*"
+      ],
+      "json": [
+        "cpe:2.3:a:joyent:json:*:*:*:*:*:node.js:*:*"
+      ],
+      "json-bigint": [
+        "cpe:2.3:a:json-bigint_project:json-bigint:*:*:*:*:*:node.js:*:*"
+      ],
+      "json-pointer": [
+        "cpe:2.3:a:smallpdf:json-pointer:*:*:*:*:*:node.js:*:*"
+      ],
+      "json-web-token": [
+        "cpe:2.3:a:joaquimserafim:json_web_token:*:*:*:*:*:node.js:*:*"
+      ],
+      "json5": [
+        "cpe:2.3:a:json5:json5:*:*:*:*:*:node.js:*:*"
+      ],
+      "json8-merge-patch": [
+        "cpe:2.3:a:json8-merge-patch_project:json8-merge-patch:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsonpointer": [
+        "cpe:2.3:a:jsonpointer_project:jsonpointer:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsonwebtoken": [
+        "cpe:2.3:a:auth0:jsonwebtoken:*:*:*:*:*:node.js:*:*"
+      ],
+      "jspdf": [
+        "cpe:2.3:a:parall:jspdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsreport": [
+        "cpe:2.3:a:jsreport:jsreport:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsrsasign": [
+        "cpe:2.3:a:jsrsasign_project:jsrsasign:*:*:*:*:*:node.js:*:*"
+      ],
+      "jstestdriver": [
+        "cpe:2.3:a:jstestdriver_project:jstestdriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "jsx-slack": [
+        "cpe:2.3:a:jsx-slack_project:jsx-slack:*:*:*:*:*:node.js:*:*"
+      ],
+      "jszip": [
+        "cpe:2.3:a:jszip_project:jszip:*:*:*:*:*:node.js:*:*"
+      ],
+      "just-extend": [
+        "cpe:2.3:a:just-extend_project:just-extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "just-safe-set": [
+        "cpe:2.3:a:just-safe-set_project:just-safe-set:*:*:*:*:*:node.js:*:*"
+      ],
+      "jvminstall": [
+        "cpe:2.3:a:jvminstall_project:jvminstall:*:*:*:*:*:node.js:*:*"
+      ],
+      "jwt-simple": [
+        "cpe:2.3:a:jwt-simple_project:jwt-simple:*:*:*:*:*:node.js:*:*"
+      ],
+      "karma": [
+        "cpe:2.3:a:karma_project:karma:*:*:*:*:*:node.js:*:*"
+      ],
+      "karma-mojo": [
+        "cpe:2.3:a:karma-mojo_project:karma-mojo:*:*:*:*:*:node.js:*:*"
+      ],
+      "kerberos": [
+        "cpe:2.3:a:kerberos_project:kerberos:*:*:*:*:*:node.js:*:*"
+      ],
+      "keyget": [
+        "cpe:2.3:a:keyget_project:keyget:*:*:*:*:*:node.js:*:*"
+      ],
+      "keystone": [
+        "cpe:2.3:a:keystonejs:keystone:*:*:*:*:*:node.js:*:*"
+      ],
+      "kill-by-port": [
+        "cpe:2.3:a:kill-by-port_project:kill-by-port:*:*:*:*:*:node.js:*:*"
+      ],
+      "kill-port": [
+        "cpe:2.3:a:kill-port_project:kill-port:*:*:*:*:*:node.js:*:*"
+      ],
+      "kill-port-process": [
+        "cpe:2.3:a:kill-port-process_project:kill-port-process:*:*:*:*:*:node.js:*:*"
+      ],
+      "kill-process-by-name": [
+        "cpe:2.3:a:kill-process-by-name_project:kill-process-by-name:*:*:*:*:*:node.js:*:*"
+      ],
+      "kill-process-on-port": [
+        "cpe:2.3:a:kill-process-on-port_project:kill-process-on-port:*:*:*:*:*:node.js:*:*"
+      ],
+      "killing": [
+        "cpe:2.3:a:killing_project:killing:*:*:*:*:*:node.js:*:*"
+      ],
+      "killport": [
+        "cpe:2.3:a:killport_project:killport:*:*:*:*:*:node.js:*:*"
+      ],
+      "kindlegen": [
+        "cpe:2.3:a:hakatashi:kindlegen:*:*:*:*:*:node.js:*:*"
+      ],
+      "klona": [
+        "cpe:2.3:a:klona_project:klona:*:*:*:*:*:node.js:*:*"
+      ],
+      "knightjs": [
+        "cpe:2.3:a:knight_project:knight:*:*:*:*:*:node.js:*:*"
+      ],
+      "koa-remove-trailing-slashes": [
+        "cpe:2.3:a:koa-remove-trailing-slashes_project:koa-remove-trailing-slashes:*:*:*:*:*:node.js:*:*"
+      ],
+      "lab6.brit95": [
+        "cpe:2.3:a:lab6.brit95_project:lab6.brit95:*:*:*:*:*:node.js:*:*"
+      ],
+      "lab6drewfusbyu": [
+        "cpe:2.3:a:lab6drewfusbyu_project:lab6drewfusbyu:*:*:*:*:*:node.js:*:*"
+      ],
+      "larvitbase-api": [
+        "cpe:2.3:a:larvit:larvitbase:*:*:*:*:*:node.js:*:*"
+      ],
+      "launchpad": [
+        "cpe:2.3:a:bitovi:launchpad:*:*:*:*:*:node.js:*:*"
+      ],
+      "less-openui5": [
+        "cpe:2.3:a:less-openui5_project:less-openui5:*:*:*:*:*:node.js:*:*"
+      ],
+      "lessindex": [
+        "cpe:2.3:a:lessindex_project:lessindex:*:*:*:*:*:node.js:*:*"
+      ],
+      "lettersanitizer": [
+        "cpe:2.3:a:lettersanitizer_project:lettersanitizer:*:*:*:*:*:node.js:*:*"
+      ],
+      "libnested": [
+        "cpe:2.3:a:libnested_project:libnested:*:*:*:*:*:node.js:*:*"
+      ],
+      "libnmap": [
+        "cpe:2.3:a:libnmap_project:libnmap:*:*:*:*:*:node.js:*:*"
+      ],
+      "libp2p": [
+        "cpe:2.3:a:protocol:libp2p:*:*:*:*:*:node.js:*:*"
+      ],
+      "libsbml": [
+        "cpe:2.3:a:libsbml_project:libsbml:*:*:*:*:*:node.js:*:*"
+      ],
+      "libsbmlsim": [
+        "cpe:2.3:a:libsbmlsim_project:libsbmlsim:*:*:*:*:*:node.js:*:*"
+      ],
+      "libxl": [
+        "cpe:2.3:a:libxl_project:libxl:*:*:*:*:*:node.js:*:*"
+      ],
+      "lifion-verify-deps": [
+        "cpe:2.3:a:adp:lifion-verifiy-dependencies:*:*:*:*:*:node.js:*:*"
+      ],
+      "limbus-buildgen": [
+        "cpe:2.3:a:limbus-buildgen_project:limbus-buildgen:*:*:*:*:*:node.js:*:*"
+      ],
+      "limdu": [
+        "cpe:2.3:a:limdu_project:limdu:*:*:*:*:*:*:*:*"
+      ],
+      "link-preview-js": [
+        "cpe:2.3:a:link-preview-js_project:link-preview-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "liquidjs": [
+        "cpe:2.3:a:liquidjs:liquidjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "list-n-stream": [
+        "cpe:2.3:a:list-n-stream_project:list-n-stream:*:*:*:*:*:node.js:*:*"
+      ],
+      "lite-server": [
+        "cpe:2.3:a:lite-server_project:lite-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "lite-web-server": [
+        "cpe:2.3:a:lite-web-server_project:lite-web-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "litespeed.js": [
+        "cpe:2.3:a:litespeed.js_project:litespeed.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "liuyaserver": [
+        "cpe:2.3:a:liuyaserver_project:liuyaserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "liyujing": [
+        "cpe:2.3:a:liyujing_project:liyujing:*:*:*:*:*:node.js:*:*"
+      ],
+      "localhost-now": [
+        "cpe:2.3:a:localhost-now_project:localhost-now:*:*:*:*:*:node.js:*:*"
+      ],
+      "locutus": [
+        "cpe:2.3:a:locutus:locutus:*:*:*:*:*:node.js:*:*"
+      ],
+      "lodahs": [
+        "cpe:2.3:a:lodahs_project:lodahs:*:*:*:*:*:node.js:*:*"
+      ],
+      "lodash": [
+        "cpe:2.3:a:lodash:lodash:*:*:*:*:*:node.js:*:*"
+      ],
+      "log4js": [
+        "cpe:2.3:a:log4js_project:log4js:*:*:*:*:*:node.js:*:*"
+      ],
+      "logkitty": [
+        "cpe:2.3:a:logkitty_project:logkitty:*:*:*:*:*:*:*:*"
+      ],
+      "loopback-connector-postgresql": [
+        "cpe:2.3:a:linuxfoundation:loopback-connector-postgresql:*:*:*:*:*:node.js:*:*"
+      ],
+      "looppake": [
+        "cpe:2.3:a:looppake_project:looppake:*:*:*:*:*:node.js:*:*"
+      ],
+      "lsof": [
+        "cpe:2.3:a:isof_project:isof:*:*:*:*:*:node.js:*:*"
+      ],
+      "ltt": [
+        "cpe:2.3:a:ltt_project:ltt:*:*:*:*:*:node.js:*:*"
+      ],
+      "lutils": [
+        "cpe:2.3:a:lutils_project:lutils:*:*:*:*:*:node.js:*:*"
+      ],
+      "m-server": [
+        "cpe:2.3:a:m-server_project:m-server:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:npmjs:m-server:*:*:*:*:*:*:*:*"
+      ],
+      "m.static": [
+        "cpe:2.3:a:m.static_project:m.static:*:*:*:*:*:node.js:*:*"
+      ],
+      "macaca-chromedriver": [
+        "cpe:2.3:a:macacajs:macaca-chromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "macaca-chromedriver-zxa": [
+        "cpe:2.3:a:macaca-chromedriver-zxa_project:macaca-chromedriver-zxa:*:*:*:*:*:node.js:*:*"
+      ],
+      "macfromip": [
+        "cpe:2.3:a:macfromip_project:macfromip:*:*:*:*:*:node.js:*:*"
+      ],
+      "madge": [
+        "cpe:2.3:a:madge_project:madge:*:*:*:*:*:node.js:*:*"
+      ],
+      "madlib-object-utils": [
+        "cpe:2.3:a:springtree:madlib-object-utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "mapbox.js": [
+        "cpe:2.3:a:mapbox:mapbox.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "mariadb": [
+        "cpe:2.3:a:mariadb:mariadb:*:*:*:*:*:node.js:*:*"
+      ],
+      "marionette-socket-host": [
+        "cpe:2.3:a:marionette-socket-host_project:marionette-socket-host:*:*:*:*:*:node.js:*:*"
+      ],
+      "markdown-it": [
+        "cpe:2.3:a:markdown-it_project:markdown-it:*:*:*:*:*:*:*:*"
+      ],
+      "markdown-it-highlightjs": [
+        "cpe:2.3:a:markdown-it-highlightjs_project:markdown-it-highlightjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "markdown-link-extractor": [
+        "cpe:2.3:a:markdown-link-extractor_project:markdown-link-extractor:*:*:*:*:*:node.js:*:*"
+      ],
+      "markdown-pdf": [
+        "cpe:2.3:a:markdown-pdf_project:markdown-pdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "marked": [
+        "cpe:2.3:a:marked_project:marked:*:*:*:*:*:node.js:*:*"
+      ],
+      "marked-tree": [
+        "cpe:2.3:a:marked-tree_project:marked-tree:*:*:*:*:*:node.js:*:*"
+      ],
+      "marscode": [
+        "cpe:2.3:a:indo-mars:marscode:*:*:*:*:*:node.js:*:*"
+      ],
+      "massif": [
+        "cpe:2.3:a:massif_project:massif:*:*:*:*:*:node.js:*:*"
+      ],
+      "materialize-css": [
+        "cpe:2.3:a:materializecss:materialize:*:*:*:*:*:*:node.js:*"
+      ],
+      "matrix-appservice-bridge": [
+        "cpe:2.3:a:matrix:matrix-appservice-bridge:*:*:*:*:*:node.js:*:*"
+      ],
+      "matrix-appservice-irc": [
+        "cpe:2.3:a:matrix:matrix_irc_bridge:*:*:*:*:*:node.js:*:*"
+      ],
+      "matrix-react-sdk": [
+        "cpe:2.3:a:matrix-react-sdk_project:matrix-react-sdk:*:*:*:*:*:node.js:*:*"
+      ],
+      "mc-kill-port": [
+        "cpe:2.3:a:mc-kill-port_project:mc-kill-port:*:*:*:*:*:node.js:*:*"
+      ],
+      "mcstatic": [
+        "cpe:2.3:a:mcstatic_project:mcstatic:*:*:*:*:*:node.js:*:*"
+      ],
+      "md-to-pdf": [
+        "cpe:2.3:a:markdown_to_pdf_project:markdown_to_pdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "mdx-mermaid": [
+        "cpe:2.3:a:mdx-mermaid_project:mdx-mermaid:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:mdx-mermaid_project:mdx-mermaid:*:*:*:*:*:node.js:*:*"
+      ],
+      "memjs": [
+        "cpe:2.3:a:memcachier:memjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "mercurius": [
+        "cpe:2.3:a:mercurius_project:mercurius:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge": [
+        "cpe:2.3:a:merge_project:merge:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge-change": [
+        "cpe:2.3:a:merge-change_project:merge-change:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge-deep": [
+        "cpe:2.3:a:merge-deep_project:merge-deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge-object": [
+        "cpe:2.3:a:merge-object_project:merge-object:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge-options": [
+        "cpe:2.3:a:merge-options_project:merge-options:*:*:*:*:*:node.js:*:*"
+      ],
+      "merge-recursive": [
+        "cpe:2.3:a:umbraengineering:merge-recursive:*:*:*:*:*:node.js:*:*"
+      ],
+      "mermaid": [
+        "cpe:2.3:a:mermaid_project:mermaid:*:*:*:*:*:node.js:*:*"
+      ],
+      "metascraper": [
+        "cpe:2.3:a:metascrape_project:metascrape:*:*:*:*:*:node.js:*:*"
+      ],
+      "method-override": [
+        "cpe:2.3:a:expressjs:method-override:*:*:*:*:*:node.js:*:*"
+      ],
+      "mfrserver": [
+        "cpe:2.3:a:mfrserver_project:mfrserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "mime": [
+        "cpe:2.3:a:mime_project:mime:*:*:*:*:*:node.js:*:*"
+      ],
+      "min-http-server": [
+        "cpe:2.3:a:min-http-server_project:min-http-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "mind-elixir": [
+        "cpe:2.3:a:mind-elixir_project:mind-elixir:*:*:*:*:*:node.js:*:*"
+      ],
+      "miniflare": [
+        "cpe:2.3:a:cloudflare:miniflare:*:*:*:*:*:node.js:*:*"
+      ],
+      "minimatch": [
+        "cpe:2.3:a:minimatch_project:minimatch:*:*:*:*:*:node.js:*:*"
+      ],
+      "mixin-deep": [
+        "cpe:2.3:a:mixin-deep_project:mixin-deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "mixme": [
+        "cpe:2.3:a:adaltas:mixme:*:*:*:*:*:node.js:*:*"
+      ],
+      "mocha": [
+        "cpe:2.3:a:mochajs:mocha:*:*:*:*:*:node.js:*:*"
+      ],
+      "mock2easy": [
+        "cpe:2.3:a:mock2easy_project:mock2easy:*:*:*:*:*:node.js:*:*"
+      ],
+      "mockery": [
+        "cpe:2.3:a:mockery_project:mockery:*:*:*:*:*:node.js:*:*"
+      ],
+      "mockjs": [
+        "cpe:2.3:a:mockjs:mock.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "mockserve": [
+        "cpe:2.3:a:mockserve_project:mockserve:*:*:*:*:*:node.js:*:*"
+      ],
+      "modern-async": [
+        "cpe:2.3:a:modern-async_project:modern-async:*:*:*:*:*:node.js:*:*"
+      ],
+      "moment": [
+        "cpe:2.3:a:momentjs:moment:*:*:*:*:*:node.js:*:*"
+      ],
+      "mongo-express": [
+        "cpe:2.3:a:mongo-express_project:mongo-express:*:*:*:*:*:node.js:*:*"
+      ],
+      "mongodb-client-encryption": [
+        "cpe:2.3:a:mongodb:libmongocrypt:*:*:*:*:*:node.js:*:*"
+      ],
+      "mongodb-instance": [
+        "cpe:2.3:a:mongodb-instance_project:mongodb-instance:*:*:*:*:*:node.js:*:*"
+      ],
+      "mongoose": [
+        "cpe:2.3:a:mongoosejs:mongoose:*:*:*:*:*:node.js:*:*"
+      ],
+      "mongose": [
+        "cpe:2.3:a:mongose_project:mongose:*:*:*:*:*:node.js:*:*"
+      ],
+      "monorepo-build": [
+        "cpe:2.3:a:monorepo-build_project:monorepo-build:*:*:*:*:*:node.js:*:*"
+      ],
+      "mootools": [
+        "cpe:2.3:a:mootools_project:mootools:*:*:*:*:*:node.js:*:*"
+      ],
+      "morgan": [
+        "cpe:2.3:a:morgan_project:morgan:*:*:*:*:*:node.js:*:*"
+      ],
+      "morgan-json": [
+        "cpe:2.3:a:morgan-json_project:morgan-json:*:*:*:*:*:node.js:*:*"
+      ],
+      "morris.js": [
+        "cpe:2.3:a:morris.js_project:morris.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "mout": [
+        "cpe:2.3:a:moutjs:mout:*:*:*:*:*:node.js:*:*"
+      ],
+      "mpath": [
+        "cpe:2.3:a:mpath_project:mpath:*:*:*:*:*:node.js:*:*"
+      ],
+      "mqtt-packet": [
+        "cpe:2.3:a:mqtt-packet_project:mqtt-packet:*:*:*:*:*:node.js:*:*"
+      ],
+      "ms": [
+        "cpe:2.3:a:vercel:ms:*:*:*:*:*:node.js:*:*"
+      ],
+      "msgpack": [
+        "cpe:2.3:a:msgpack:msgpack:*:*:*:*:*:node.js:*:*"
+      ],
+      "msgpack5": [
+        "cpe:2.3:a:msgpack5_project:msgpack5:*:*:*:*:*:node.js:*:*"
+      ],
+      "mssql-node": [
+        "cpe:2.3:a:mssql-node_project:mssql-node:*:*:*:*:*:node.js:*:*"
+      ],
+      "mssql.js": [
+        "cpe:2.3:a:mssql.js_project:mssql.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "mt7688-wiscan": [
+        "cpe:2.3:a:mt7688-wiscan_project:mt7688-wiscan:*:*:*:*:*:node.js:*:*"
+      ],
+      "muhammara": [
+        "cpe:2.3:a:muhammara_project:muhammara:*:*:*:*:*:node.js:*:*"
+      ],
+      "multi-ini": [
+        "cpe:2.3:a:multi-ini_project:multi-ini:*:*:*:*:*:node.js:*:*"
+      ],
+      "mversion": [
+        "cpe:2.3:a:mversion_project:mversion:*:*:*:*:*:*:*:*"
+      ],
+      "myprolyz": [
+        "cpe:2.3:a:myprolyz_project:myprolyz:*:*:*:*:*:node.js:*:*"
+      ],
+      "myserver.alexcthomas18": [
+        "cpe:2.3:a:myserver.alexcthomas18_project:myserver.alexcthomas18:*:*:*:*:*:node.js:*:*"
+      ],
+      "mysql": [
+        "cpe:2.3:a:mysql_project:mysql:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:mysql_project:mysql:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:mysqljs:mysql:*:*:*:*:*:node.js:*:*"
+      ],
+      "mysqljs": [
+        "cpe:2.3:a:mysqljs_project:mysqljs:*:*:*:*:*:node.js:*:*"
+      ],
+      "mystem": [
+        "cpe:2.3:a:mystem_project:mystem:*:*:*:*:*:node.js:*:*"
+      ],
+      "mystem-fix": [
+        "cpe:2.3:a:mystem-fix_project:mystem-fix:*:*:*:*:*:node.js:*:*"
+      ],
+      "mystem-wrapper": [
+        "cpe:2.3:a:mystem-wrapper_project:mystem-wrapper:*:*:*:*:*:node.js:*:*"
+      ],
+      "mystem3": [
+        "cpe:2.3:a:mystem3_project:mystem3:*:*:*:*:*:node.js:*:*"
+      ],
+      "n8n": [
+        "cpe:2.3:a:n8n:n8n:*:*:*:*:*:node.js:*:*"
+      ],
+      "nanoid": [
+        "cpe:2.3:a:nanoid_project:nanoid:*:*:*:*:*:node.js:*:*"
+      ],
+      "native-opencv": [
+        "cpe:2.3:a:native-opencv_project:native-opencv:*:*:*:*:*:node.js:*:*"
+      ],
+      "nats": [
+        "cpe:2.3:a:linuxfoundation:nats.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "nbdime": [
+        "cpe:2.3:a:jupyter:nbdime:*:*:*:*:*:node.js:*:*"
+      ],
+      "nbdime-jupyterlab": [
+        "cpe:2.3:a:jupyter:nbdime-jupyterlab:*:*:*:*:*:node.js:*:*"
+      ],
+      "nconf": [
+        "cpe:2.3:a:nconf_project:nconf:*:*:*:*:*:node.js:*:*"
+      ],
+      "nconf-toml": [
+        "cpe:2.3:a:nconf-toml_project:nconf-toml:*:*:*:*:*:node.js:*:*"
+      ],
+      "nedb": [
+        "cpe:2.3:a:nedb_project:nedb:*:*:*:*:*:node.js:*:*"
+      ],
+      "nested-object-assign": [
+        "cpe:2.3:a:getadigital:nested-object-assign:*:*:*:*:*:node.js:*:*"
+      ],
+      "nestie": [
+        "cpe:2.3:a:nestie_project:nestie:*:*:*:*:*:node.js:*:*"
+      ],
+      "netmask": [
+        "cpe:2.3:a:netmask_project:netmask:*:*:*:*:*:node.js:*:*"
+      ],
+      "network-manager": [
+        "cpe:2.3:a:network-manager_project:network-manager:*:*:*:*:*:node.js:*:*"
+      ],
+      "next-auth": [
+        "cpe:2.3:a:nextauth.js:next-auth:*:*:*:*:*:node.js:*:*"
+      ],
+      "nis-utils": [
+        "cpe:2.3:a:nis-utils_project:nis-utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "nitrado.js": [
+        "cpe:2.3:a:nitrado.js_project:nitrado.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "no-case": [
+        "cpe:2.3:a:no-case_project:no-case:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-air-sdk": [
+        "cpe:2.3:a:node-air-sdk_project:node-air-sdk:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-bluetooth": [
+        "cpe:2.3:a:node-bluetooth_project:node-bluetooth:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-bluetooth-serial-port": [
+        "cpe:2.3:a:node-bluetooth-serial-port_project:node-bluetooth-serial-port:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-browser": [
+        "cpe:2.3:a:node-browser_project:node-browser:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-bsdiff-android": [
+        "cpe:2.3:a:node-bsdiff-android_project:node-bsdiff-android:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-cli": [
+        "cpe:2.3:a:node-cli_project:node-cli:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-df": [
+        "cpe:2.3:a:node-df_project:node-df:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-etsy-client": [
+        "cpe:2.3:a:node-etsy-client_project:node-etsy-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-extend": [
+        "cpe:2.3:a:node-extend_project:node-extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-fetch": [
+        "cpe:2.3:a:node-fetch_project:node-fetch:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-forge": [
+        "cpe:2.3:a:digitalbazaar:forge:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-ipc": [
+        "cpe:2.3:a:node-ipc_project:node-ipc:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-jose": [
+        "cpe:2.3:a:cisco:node-jose:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-key-sender": [
+        "cpe:2.3:a:node-key-sender_project:node-key-sender:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-latex-pdf": [
+        "cpe:2.3:a:node-latex-pdf_project:node-latex-pdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-lmdb": [
+        "cpe:2.3:a:node-lmdb_project:node-lmdb:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-macaddress": [
+        "cpe:2.3:a:node-macaddress_project:node-macaddress:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-mpv": [
+        "cpe:2.3:a:node-mpv_project:node-mpv:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-mydomoathome": [
+        "cpe:2.3:a:domoticz:mydomoathome:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:romanes:mydomoathome:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-notifier": [
+        "cpe:2.3:a:node-notifier_project:node-notifier:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-oojs": [
+        "cpe:2.3:a:node-oojs_project:node-oojs:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-opcua": [
+        "cpe:2.3:a:node-opcua_project:node-opcua:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-opencv": [
+        "cpe:2.3:a:node-opencv_project:node-opencv:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-opensl": [
+        "cpe:2.3:a:node-opensl_project:node-opensl:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-openssl": [
+        "cpe:2.3:a:node-openssl_project:node-openssl:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-printer": [
+        "cpe:2.3:a:node-printer_project:node-printer:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-ps": [
+        "cpe:2.3:a:node-ps_project:node-ps:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-red-contrib-huemagic": [
+        "cpe:2.3:a:dgtl:huemagic:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:node-red-contrib-huemagic_project:node-red-contrib-huemagic:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-serialize": [
+        "cpe:2.3:a:node-serialize_project:node-serialize:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-server-forfront": [
+        "cpe:2.3:a:node-server-forfront_project:node-server-forfront:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-simple-router": [
+        "cpe:2.3:a:node-simple-router:node-simple-router:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-sqlite": [
+        "cpe:2.3:a:node-sqlite_project:node-sqlite:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-srv": [
+        "cpe:2.3:a:node-srv_project:node-srv:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-static": [
+        "cpe:2.3:a:node-static_project:node-static:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-thulac": [
+        "cpe:2.3:a:geohey:node-thulac:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-tkinter": [
+        "cpe:2.3:a:node-tkinter_project:node-tkinter:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-uuid": [
+        "cpe:2.3:a:node-uuid_project:node-uuid:*:*:*:*:*:node.js:*:*"
+      ],
+      "node-windows": [
+        "cpe:2.3:a:node-windows_project:node-windows:*:*:*:*:*:node.js:*:*"
+      ],
+      "node.extend": [
+        "cpe:2.3:a:dreamerslab:node.extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodeaaaaa": [
+        "cpe:2.3:a:nodeaaaaa_project:nodeaaaaa:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodebb-plugin-blog-comments": [
+        "cpe:2.3:a:nodebb:blog_comments:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodecaffe": [
+        "cpe:2.3:a:nodecaffe_project:nodecaffe:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodee-utils": [
+        "cpe:2.3:a:nodee-utils_project:nodee-utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodefabric": [
+        "cpe:2.3:a:nodefabric_project:nodefabric:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodeffmpeg": [
+        "cpe:2.3:a:nodeffmpeg_project:nodeffmpeg:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodemailer": [
+        "cpe:2.3:a:nodemailer:nodemailer:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodemailer-js": [
+        "cpe:2.3:a:nodemailer-js_project:nodemailer-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodemailer.js": [
+        "cpe:2.3:a:nodemailer.js_project:nodemailer.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodemssql": [
+        "cpe:2.3:a:nodemssql_project:nodemssql:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodepdf": [
+        "cpe:2.3:a:nodepdf_project:nodepdf:*:*:*:*:*:node.js:*:*"
+      ],
+      "noderequest": [
+        "cpe:2.3:a:noderequest_project:noderequest:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodesass": [
+        "cpe:2.3:a:nodesass_project:nodesass:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodeschnaps": [
+        "cpe:2.3:a:nodeschnaps_project:nodeschnaps:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodesqlite": [
+        "cpe:2.3:a:nodesqlite_project:nodesqlite:*:*:*:*:*:node.js:*:*"
+      ],
+      "nodewebkit": [
+        "cpe:2.3:a:nodewebkit_project:nodewebkit:*:*:*:*:*:node.js:*:*"
+      ],
+      "normalize-url": [
+        "cpe:2.3:a:normalize-url_project:normalize-url:*:*:*:*:*:node.js:*:*"
+      ],
+      "notevil": [
+        "cpe:2.3:a:notevil_project:notevil:*:*:*:*:*:node.js:*:*"
+      ],
+      "npm": [
+        "cpe:2.3:a:node_packaged_modules_project:node_packaged_modules:*:*:*:*:*:node.js:*:*"
+      ],
+      "npm-dependency-versions": [
+        "cpe:2.3:a:npm-dependency-versions_project:npm-dependency-versions:*:*:*:*:*:node.js:*:*"
+      ],
+      "npm-lockfile": [
+        "cpe:2.3:a:npm-lockfile_project:npm-lockfile:*:*:*:*:*:node.js:*:*"
+      ],
+      "npm-script-demo": [
+        "cpe:2.3:a:npm-script-demo_project:npm-script-demo:*:*:*:*:*:node.js:*:*"
+      ],
+      "npm-test-sqlite3-trunk": [
+        "cpe:2.3:a:mapbox:npm-test-sqlite3-trunk:*:*:*:*:*:node.js:*:*"
+      ],
+      "npos-tesseract": [
+        "cpe:2.3:a:npos-tesseract_project:npos-tesseract:*:*:*:*:*:node.js:*:*"
+      ],
+      "nuxt-api-party": [
+        "cpe:2.3:a:johannschopplich:nuxt_api_party:*:*:*:*:*:node.js:*:*"
+      ],
+      "nw": [
+        "cpe:2.3:a:nwjs:nw:*:*:*:*:*:node.js:*:*"
+      ],
+      "nw-with-arm": [
+        "cpe:2.3:a:nw-with-arm_project:nw-with-arm:*:*:*:*:*:node.js:*:*"
+      ],
+      "oauth2-server": [
+        "cpe:2.3:a:oauth2-server_project:oauth2-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "object-collider": [
+        "cpe:2.3:a:fireblink:object-collider:*:*:*:*:*:node.js:*:*"
+      ],
+      "object-extend": [
+        "cpe:2.3:a:object-extend_project:object-extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "object-path": [
+        "cpe:2.3:a:object-path_project:object-path:*:*:*:*:*:node.js:*:*"
+      ],
+      "objection": [
+        "cpe:2.3:a:objection_project:objection:*:*:*:*:*:node.js:*:*"
+      ],
+      "octocat": [
+        "cpe:2.3:a:octocat_project:octocat:*:*:*:*:*:node.js:*:*"
+      ],
+      "octokit": [
+        "cpe:2.3:a:octokit:octokit:*:*:*:*:*:node.js:*:*"
+      ],
+      "onion-oled-js": [
+        "cpe:2.3:a:onion-oled-js_project:onion-oled-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "op-browser": [
+        "cpe:2.3:a:op-browser_project:op-browser:*:*:*:*:*:node.js:*:*"
+      ],
+      "open-device": [
+        "cpe:2.3:a:open-device_project:open-device:*:*:*:*:*:node.js:*:*"
+      ],
+      "open-graph": [
+        "cpe:2.3:a:open-graph_project:open-graph:*:*:*:*:*:node.js:*:*"
+      ],
+      "opencv": [
+        "cpe:2.3:a:node-opencv_project:node-opencv:*:*:*:*:*:node.js:*:*"
+      ],
+      "opencv.js": [
+        "cpe:2.3:a:opencv.js_project:opencv.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "openframe-ascii-image": [
+        "cpe:2.3:a:openframe-ascii-image_project:openframe-ascii-image:*:*:*:*:*:node.js:*:*"
+      ],
+      "openframe-glslviewer": [
+        "cpe:2.3:a:openframe-glslviewer_project:openframe-glslviewer:*:*:*:*:*:node.js:*:*"
+      ],
+      "openframe-image": [
+        "cpe:2.3:a:openframe-image_project:openframe-image:*:*:*:*:*:node.js:*:*"
+      ],
+      "openssl.js": [
+        "cpe:2.3:a:openssl.js_project:openssl.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "openzeppelin-eth": [
+        "cpe:2.3:a:openzeppelin:openzeppelin-eth:*:*:*:*:*:node.js:*:*"
+      ],
+      "openzeppelin-solidity": [
+        "cpe:2.3:a:openzeppelin:openzeppelin-solidity:*:*:*:*:*:node.js:*:*"
+      ],
+      "operadriver": [
+        "cpe:2.3:a:cnpmjs:operadriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "osm-static-maps": [
+        "cpe:2.3:a:osm-static-maps_project:osm-static-maps:*:*:*:*:*:node.js:*:*"
+      ],
+      "p4": [
+        "cpe:2.3:a:p4_project:p4:*:*:*:*:*:node.js:*:*"
+      ],
+      "pac-resolver": [
+        "cpe:2.3:a:pac-resolver_project:pac-resolver:*:*:*:*:*:node.js:*:*"
+      ],
+      "pandora-doomsday": [
+        "cpe:2.3:a:pandora-doomsday_project:pandora-doomsday:*:*:*:*:*:node.js:*:*"
+      ],
+      "parse-link-header": [
+        "cpe:2.3:a:parse-link-header_project:parse-link-header:*:*:*:*:*:node.js:*:*"
+      ],
+      "parse-server": [
+        "cpe:2.3:a:parseplatform:parse-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "parsejson": [
+        "cpe:2.3:a:parsejson_project:parsejson:*:*:*:*:*:node.js:*:*"
+      ],
+      "passport": [
+        "cpe:2.3:a:passport_project:passport:*:*:*:*:*:node.js:*:*"
+      ],
+      "passport-oauth2": [
+        "cpe:2.3:a:passportjs:passport-oauth2:*:*:*:*:*:node.js:*:*"
+      ],
+      "passport-saml": [
+        "cpe:2.3:a:passport-saml_project:passport-saml:*:*:*:*:*:node.js:*:*"
+      ],
+      "patchmerge": [
+        "cpe:2.3:a:patchmerge_project:patchmerge:*:*:*:*:*:node.js:*:*"
+      ],
+      "path-parse": [
+        "cpe:2.3:a:path-parse_project:path-parse:*:*:*:*:*:node.js:*:*"
+      ],
+      "pathval": [
+        "cpe:2.3:a:chaijis:pathval:*:*:*:*:*:node.js:*:*"
+      ],
+      "payload": [
+        "cpe:2.3:a:payloadcms:payload:*:*:*:*:*:node.js:*:*"
+      ],
+      "paypal-adaptive": [
+        "cpe:2.3:a:idea:paypal-adaptive:*:*:*:*:*:node.js:*:*"
+      ],
+      "paypal-ipn": [
+        "cpe:2.3:a:paypal-ipn_project:paypal-ipn:*:*:*:*:*:node.js:*:*"
+      ],
+      "pdf-image": [
+        "cpe:2.3:a:pdf-image_project:pdf-image:*:*:*:*:*:node.js:*:*"
+      ],
+      "pdfinfojs": [
+        "cpe:2.3:a:pdfinfojs_project:pdfinfojs:*:*:*:*:*:node.js:*:*"
+      ],
+      "peiserver": [
+        "cpe:2.3:a:peiserver_project:peiserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "pekeupload": [
+        "cpe:2.3:a:pekeupload_project:pekeupload:*:*:*:*:*:*:*:*"
+      ],
+      "pennyworth": [
+        "cpe:2.3:a:pennyworth_project:pennyworth:*:*:*:*:*:node.js:*:*"
+      ],
+      "pg": [
+        "cpe:2.3:a:node-postgres:pg:*:*:*:*:*:node.js:*:*"
+      ],
+      "phantomjs-cheniu": [
+        "cpe:2.3:a:phantomjs-cheniu_project:phantomjs-cheniu:*:*:*:*:*:node.js:*:*"
+      ],
+      "phantomjs-seo": [
+        "cpe:2.3:a:phantomjs-seo_project:phantomjs-seo:*:*:*:*:*:node.js:*:*"
+      ],
+      "phpjs": [
+        "cpe:2.3:a:php.js_project:php.js:*:*:*:*:*:*:*:*"
+      ],
+      "picard": [
+        "cpe:2.3:a:picard_project:picard:*:*:*:*:*:node.js:*:*"
+      ],
+      "picotts": [
+        "cpe:2.3:a:picotts_project:picotts:*:*:*:*:*:node.js:*:*"
+      ],
+      "pixl-class": [
+        "cpe:2.3:a:pixlcore:pixl-class:*:*:*:*:*:node.js:*:*"
+      ],
+      "pk-app-wonderbox": [
+        "cpe:2.3:a:pk-app-wonderbox_project:pk-app-wonderbox:*:*:*:*:*:node.js:*:*"
+      ],
+      "pkg": [
+        "cpe:2.3:a:vercel:pkg:*:*:*:*:*:node.js:*:*"
+      ],
+      "plist": [
+        "cpe:2.3:a:plist_project:plist:*:*:*:*:*:node.js:*:*"
+      ],
+      "plupload": [
+        "cpe:2.3:a:tiny:plupload:*:*:*:*:*:node.js:*:*"
+      ],
+      "pm2-kafka": [
+        "cpe:2.3:a:pm2-kafka_project:pm2-kafka:*:*:*:*:*:node.js:*:*"
+      ],
+      "pngcrush-installer": [
+        "cpe:2.3:a:pngcrush-installer_project:pngcrush-installer:*:*:*:*:*:node.js:*:*"
+      ],
+      "pomelo-monitor": [
+        "cpe:2.3:a:netease:pomelo-monitor:*:*:*:*:*:node.js:*:*"
+      ],
+      "pooledwebsocket": [
+        "cpe:2.3:a:pooledwebsocket_project:pooledwebsocket:*:*:*:*:*:node.js:*:*"
+      ],
+      "port-killer": [
+        "cpe:2.3:a:port-killer_project:port-killer:*:*:*:*:*:node.js:*:*"
+      ],
+      "portkiller": [
+        "cpe:2.3:a:portkiller_project:portkiller:*:*:*:*:*:node.js:*:*"
+      ],
+      "portprocesses": [
+        "cpe:2.3:a:portprocesses_project:portprocesses:*:*:*:*:*:node.js:*:*"
+      ],
+      "posix": [
+        "cpe:2.3:a:posix_project:posix:*:*:*:*:*:node.js:*:*"
+      ],
+      "post-loader": [
+        "cpe:2.3:a:post-loader_project:post-loader:*:*:*:*:*:node.js:*:*"
+      ],
+      "postcss": [
+        "cpe:2.3:a:postcss:postcss:*:*:*:*:*:node.js:*:*"
+      ],
+      "pouchdb": [
+        "cpe:2.3:a:pouchdb:pouchdb:*:*:*:*:*:node.js:*:*"
+      ],
+      "prebuild-lwip": [
+        "cpe:2.3:a:prebuild-lwip_project:prebuild-lwip:*:*:*:*:*:node.js:*:*"
+      ],
+      "prince": [
+        "cpe:2.3:a:prince_project:prince:*:*:*:*:*:node.js:*:*"
+      ],
+      "printf": [
+        "cpe:2.3:a:adaltas:printf:*:*:*:*:*:node.js:*:*"
+      ],
+      "prismjs": [
+        "cpe:2.3:a:prismjs:prism:*:*:*:*:*:node.js:*:*"
+      ],
+      "private-ip": [
+        "cpe:2.3:a:private-ip_project:private-ip:*:*:*:*:*:node.js:*:*"
+      ],
+      "probot": [
+        "cpe:2.3:a:probot:probot:*:*:*:*:*:node.js:*:*"
+      ],
+      "proctree": [
+        "cpe:2.3:a:proctree_project:proctree:*:*:*:*:*:*:*:*"
+      ],
+      "product-monitor": [
+        "cpe:2.3:a:product-monitor_project:product-monitor:*:*:*:*:*:node.js:*:*"
+      ],
+      "progressbar.js": [
+        "cpe:2.3:a:progressbar.js_project:progressbar.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "projen": [
+        "cpe:2.3:a:projen_project:projen:*:*:*:*:*:node.js:*:*"
+      ],
+      "promise-probe": [
+        "cpe:2.3:a:promise-probe_project:promise-probe:*:*:*:*:*:node.js:*:*"
+      ],
+      "promisehelpers": [
+        "cpe:2.3:a:yola:promisehelpers:*:*:*:*:*:node.js:*:*"
+      ],
+      "property-expr": [
+        "cpe:2.3:a:property-expr_project:property-expr:*:*:*:*:*:node.js:*:*"
+      ],
+      "protobufjs": [
+        "cpe:2.3:a:protobufjs_project:protobufjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "proxy": [
+        "cpe:2.3:a:proxy_project:proxy:*:*:*:*:*:node.js:*:*"
+      ],
+      "proxy.js": [
+        "cpe:2.3:a:proxy.js_project:proxy.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "ps": [
+        "cpe:2.3:a:umbraengineering:ps:*:*:*:*:*:node.js:*:*"
+      ],
+      "ps-kill": [
+        "cpe:2.3:a:ps-kill_project:ps-kill:*:*:*:*:*:node.js:*:*"
+      ],
+      "ps-visitor": [
+        "cpe:2.3:a:ps-visitor_project:ps-visitor:*:*:*:*:*:node.js:*:*"
+      ],
+      "psnode": [
+        "cpe:2.3:a:psnode_project:psnode:*:*:*:*:*:node.js:*:*"
+      ],
+      "public": [
+        "cpe:2.3:a:public.js_project:public.js:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:public_project:public:*:*:*:*:*:node.js:*:*"
+      ],
+      "pug": [
+        "cpe:2.3:a:pugjs:pug:*:*:*:*:*:node.js:*:*"
+      ],
+      "pug-code-gen": [
+        "cpe:2.3:a:pugjs:pug-code-gen:*:*:*:*:*:node.js:*:*"
+      ],
+      "pullit": [
+        "cpe:2.3:a:pull_it_project:pull_it:*:*:*:*:*:node.js:*:*"
+      ],
+      "pulverizr": [
+        "cpe:2.3:a:pulverizr_project:pulverizr:*:*:*:*:*:node.js:*:*"
+      ],
+      "push-dir": [
+        "cpe:2.3:a:push-dir_project:push-dir:*:*:*:*:*:node.js:*:*"
+      ],
+      "putil-merge": [
+        "cpe:2.3:a:putil-merge_project:putil-merge:*:*:*:*:*:*:*:*"
+      ],
+      "pytservce": [
+        "cpe:2.3:a:pytservce_project:pytservce:*:*:*:*:*:node.js:*:*"
+      ],
+      "qbs": [
+        "cpe:2.3:a:qbs_project:qbs:*:*:*:*:*:node.js:*:*"
+      ],
+      "qinserve": [
+        "cpe:2.3:a:qinserve_project:qinserve:*:*:*:*:*:node.js:*:*"
+      ],
+      "qs": [
+        "cpe:2.3:a:qs_project:qs:*:*:*:*:*:node.js:*:*"
+      ],
+      "query-mysql": [
+        "cpe:2.3:a:query-mysql_project:query-mysql:*:*:*:*:*:node.js:*:*"
+      ],
+      "quickserver": [
+        "cpe:2.3:a:quickserver_project:quickserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "quill-mention": [
+        "cpe:2.3:a:quill-mention:quill_mention:*:*:*:*:*:node.js:*:*"
+      ],
+      "ra-ui-materialui": [
+        "cpe:2.3:a:marmelab:ra-ui-materialui:*:*:*:*:*:node.js:*:*"
+      ],
+      "randomatic": [
+        "cpe:2.3:a:randomatic_project:randomatic:*:*:*:*:*:node.js:*:*"
+      ],
+      "raneto": [
+        "cpe:2.3:a:raneto_project:raneto:*:*:*:*:*:node.js:*:*"
+      ],
+      "rdf-graph-array": [
+        "cpe:2.3:a:rdf-graph-array_project:rdf-graph-array:*:*:*:*:*:node.js:*:*"
+      ],
+      "react-adal": [
+        "cpe:2.3:a:react-adal_project:react-adal:*:*:*:*:*:node.js:*:*"
+      ],
+      "react-draft-wysiwyg": [
+        "cpe:2.3:a:react_draft_wysiwyg_project:react_draft_wysiwyg:*:*:*:*:*:node.js:*:*"
+      ],
+      "react-native-baidu-voice-synthesizer": [
+        "cpe:2.3:a:react-native-baidu-voice-synthesizer_project:react-native-baidu-voice-synthesizer:*:*:*:*:*:node.js:*:*"
+      ],
+      "react-native-mmkv": [
+        "cpe:2.3:a:mrousavy:react-native-mmkv:*:*:*:*:*:node.js:*:*"
+      ],
+      "realms-shim": [
+        "cpe:2.3:a:agoric:realms-shim:*:*:*:*:*:node.js:*:*"
+      ],
+      "record-like-deep-assign": [
+        "cpe:2.3:a:record-like-deep-assign_project:record-like-deep-assign:*:*:*:*:*:node.js:*:*"
+      ],
+      "redis-srvr": [
+        "cpe:2.3:a:redis-srvr_project:redis-srvr:*:*:*:*:*:node.js:*:*"
+      ],
+      "reduce-css-calc": [
+        "cpe:2.3:a:reduce-css-calc_project:reduce-css-calc:*:*:*:*:*:node.js:*:*"
+      ],
+      "reecerver": [
+        "cpe:2.3:a:reecerver_project:reecerver:*:*:*:*:*:node.js:*:*"
+      ],
+      "reg-keygen-git-hash-plugin": [
+        "cpe:2.3:a:reg-keygen-git-hash_project:reg-keygen-git-hash:*:*:*:*:*:reg-suit:*:*"
+      ],
+      "regexfn": [
+        "cpe:2.3:a:regexfn_project:regexfn:*:*:*:*:*:node.js:*:*"
+      ],
+      "remark-html": [
+        "cpe:2.3:a:remark:remark-html:*:*:*:*:*:node.js:*:*"
+      ],
+      "remarkable": [
+        "cpe:2.3:a:remarkable_project:remarkable:*:*:*:*:*:node.js:*:*"
+      ],
+      "repo-git-downloader": [
+        "cpe:2.3:a:repo-git-downloader_project:repo-git-downloader:*:*:*:*:*:node.js:*:*"
+      ],
+      "request": [
+        "cpe:2.3:a:request_project:request:*:*:*:*:*:node.js:*:*"
+      ],
+      "resolve-path": [
+        "cpe:2.3:a:resolve-path_project:resolve-path:*:*:*:*:*:node.js:*:*"
+      ],
+      "resourcehacker": [
+        "cpe:2.3:a:resourcehacker_project:resourcehacker:*:*:*:*:*:node.js:*:*"
+      ],
+      "restafary": [
+        "cpe:2.3:a:restafary_project:restafary:*:*:*:*:*:node.js:*:*"
+      ],
+      "restify-paginate": [
+        "cpe:2.3:a:restify-paginate_project:restify-paginate:*:*:*:*:*:node.js:*:*"
+      ],
+      "riot-compiler": [
+        "cpe:2.3:a:riot.js:riot-compiler:*:*:*:*:*:node.js:*:*"
+      ],
+      "ritp": [
+        "cpe:2.3:a:ritp_project:ritp:*:*:*:*:*:node.js:*:*"
+      ],
+      "roar-pidusage": [
+        "cpe:2.3:a:roar-pidusage_project:roar-pidusage:*:*:*:*:*:node.js:*:*"
+      ],
+      "robot-js": [
+        "cpe:2.3:a:getrobot:robot-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "rollup-plugin-dev-server": [
+        "cpe:2.3:a:rollup-plugin-dev-server_project:rollup-plugin-dev-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "rollup-plugin-serve": [
+        "cpe:2.3:a:rollup-plugin-serve_project:rollup-plugin-serve:*:*:*:*:*:node.js:*:*"
+      ],
+      "rollup-plugin-server": [
+        "cpe:2.3:a:rollup-plugin-server_project:rollup-plugin-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "rpi-gpio": [
+        "cpe:2.3:a:rpi_project:rpi:*:*:*:*:*:node.js:*:*"
+      ],
+      "rs-brightcove": [
+        "cpe:2.3:a:rs-brightcove_project:rs-brightcove:*:*:*:*:*:node.js:*:*"
+      ],
+      "rsshub": [
+        "cpe:2.3:a:rsshub:rsshub:*:*:*:*:*:node.js:*:*"
+      ],
+      "rtcmulticonnection-client": [
+        "cpe:2.3:a:rtcmulticonnection-client_project:rtcmulticonnection-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "s3-uploader": [
+        "cpe:2.3:a:s3-uploader_project:s3-uploader:*:*:*:*:*:node.js:*:*"
+      ],
+      "safe-eval": [
+        "cpe:2.3:a:safe-eval_project:safe-eval:*:*:*:*:*:node.js:*:*"
+      ],
+      "safe-flat": [
+        "cpe:2.3:a:safe-flat_project:safe-flat:*:*:*:*:*:*:*:*"
+      ],
+      "safe-object2": [
+        "cpe:2.3:a:safe-object2_project:safe-object2:*:*:*:*:*:node.js:*:*"
+      ],
+      "safer-eval": [
+        "cpe:2.3:a:safer-eval_project:safer-eval:*:*:*:*:*:node.js:*:*"
+      ],
+      "safetydance": [
+        "cpe:2.3:a:safetydance_project:safetydance:*:*:*:*:*:node.js:*:*"
+      ],
+      "sails": [
+        "cpe:2.3:a:sailsjs:sails:*:*:*:*:*:node.js:*:*"
+      ],
+      "samba-client": [
+        "cpe:2.3:a:samba-client_project:samba-client:*:*:*:*:*:node.js:*:*"
+      ],
+      "sanitize-html": [
+        "cpe:2.3:a:apostrophecms:sanitize-html:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:punkave:sanitize-html:*:*:*:*:*:node.js:*:*"
+      ],
+      "save-server": [
+        "cpe:2.3:a:save-server_project:save-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "scaffold-helper": [
+        "cpe:2.3:a:scaffold-helper_project:scaffold-helper:*:*:*:*:*:node.js:*:*"
+      ],
+      "scalajs-standalone-bin": [
+        "cpe:2.3:a:scalajs-standalone-bin_project:scalajs-standalone-bin:*:*:*:*:*:node.js:*:*"
+      ],
+      "scniro-validator": [
+        "cpe:2.3:a:scniro-validator_project:scniro-validator:*:*:*:*:*:node.js:*:*"
+      ],
+      "scott-blanch-weather-app": [
+        "cpe:2.3:a:scott-blanch-weather-app_project:scott-blanch-weather-app:*:*:*:*:*:node.js:*:*"
+      ],
+      "scratch-svg-renderer": [
+        "cpe:2.3:a:mit:scratch-svg-renderer:*:*:*:*:*:node.js:*:*"
+      ],
+      "script-manager": [
+        "cpe:2.3:a:script-manager_project:script-manager:*:*:*:*:*:node.js:*:*"
+      ],
+      "scss-tokenizer": [
+        "cpe:2.3:a:scss-tokenizer_project:scss-tokenizer:*:*:*:*:*:node.js:*:*"
+      ],
+      "sds": [
+        "cpe:2.3:a:sds_project:sds:*:*:*:*:*:node.js:*:*"
+      ],
+      "section2.madisonjbrooks12": [
+        "cpe:2.3:a:section2.madisonjbrooks12_project:section2.madisonjbrooks12:*:*:*:*:*:node.js:*:*"
+      ],
+      "secure-compare": [
+        "cpe:2.3:a:secure-compare_project:secure-compare:*:*:*:*:*:node.js:*:*"
+      ],
+      "seeftl": [
+        "cpe:2.3:a:seeftl_project:seeftl:*:*:*:*:*:node.js:*:*"
+      ],
+      "selectize-plugin-a11y": [
+        "cpe:2.3:a:selectize-plugin-a11y_project:selectize-plugin-a11y:*:*:*:*:*:node.js:*:*"
+      ],
+      "selenium-chromedriver": [
+        "cpe:2.3:a:selenium-chromedriver_project:selenium-chromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "selenium-standalone-painful": [
+        "cpe:2.3:a:selenium-standalone-painful_project:selenium-standalone-painful:*:*:*:*:*:node.js:*:*"
+      ],
+      "selenium-wrapper": [
+        "cpe:2.3:a:selenium-wrapper_project:selenium-wrapper:*:*:*:*:*:node.js:*:*"
+      ],
+      "semver": [
+        "cpe:2.3:a:npmjs:semver:*:*:*:*:*:node.js:*:*"
+      ],
+      "semver-regex": [
+        "cpe:2.3:a:semver-regex_project:semver-regex:*:*:*:*:*:*:*:*"
+      ],
+      "semver-tags": [
+        "cpe:2.3:a:semver-tags_project:semver-tags:*:*:*:*:*:node.js:*:*"
+      ],
+      "sencisho": [
+        "cpe:2.3:a:sencisho_project:sencisho:*:*:*:*:*:node.js:*:*"
+      ],
+      "send": [
+        "cpe:2.3:a:send_project:send:*:*:*:*:*:node.js:*:*"
+      ],
+      "sequelize": [
+        "cpe:2.3:a:sequelizejs:sequelize:*:*:*:*:*:node.js:*:*"
+      ],
+      "serc.js": [
+        "cpe:2.3:a:serc.js_project:serc.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "serialize-javascript": [
+        "cpe:2.3:a:verizon:serialize-javascript:*:*:*:*:*:node.js:*:*"
+      ],
+      "serialize-to-js": [
+        "cpe:2.3:a:serialize-to-js_project:serialize-to-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "serve-here.js": [
+        "cpe:2.3:a:serve-here.js_project:serve-here.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "serve-lite": [
+        "cpe:2.3:a:serve-lite_project:serve-lite:*:*:*:*:*:node.js:*:*"
+      ],
+      "serve46": [
+        "cpe:2.3:a:serve46_project:serve46:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverabc": [
+        "cpe:2.3:a:serverabc_project:serverabc:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverhuwenhui": [
+        "cpe:2.3:a:serverhuwenhui_project:serverhuwenhui:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverliujiayi1": [
+        "cpe:2.3:a:serverliujiayi1_project:serverliujiayi1:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverlyr": [
+        "cpe:2.3:a:serverlyr_project:serverlyr:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverwg": [
+        "cpe:2.3:a:serverwg_project:serverwg:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverwzl": [
+        "cpe:2.3:a:serverwzl_project:serverwzl:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverxxx": [
+        "cpe:2.3:a:serverxxx_project:serverxxx:*:*:*:*:*:node.js:*:*"
+      ],
+      "serveryaozeyan": [
+        "cpe:2.3:a:serveryaozeyan_project:serveryaozeyan:*:*:*:*:*:node.js:*:*"
+      ],
+      "serveryztyzt": [
+        "cpe:2.3:a:serveryztyzt_project:serveryztyzt:*:*:*:*:*:node.js:*:*"
+      ],
+      "serverzyy": [
+        "cpe:2.3:a:serverzyy_project:serverzyy:*:*:*:*:*:node.js:*:*"
+      ],
+      "servey": [
+        "cpe:2.3:a:servey_project:servey:*:*:*:*:*:node.js:*:*"
+      ],
+      "ses": [
+        "cpe:2.3:a:agoric:ses:*:*:*:*:*:node.js:*:*"
+      ],
+      "set-object-value": [
+        "cpe:2.3:a:set-object-value_project:set-object-value:*:*:*:*:*:node.js:*:*"
+      ],
+      "set-or-get": [
+        "cpe:2.3:a:set-or-get_project:set-or-get:*:*:*:*:*:node.js:*:*"
+      ],
+      "set-value": [
+        "cpe:2.3:a:set-value_project:set-value:*:*:*:*:*:node.js:*:*"
+      ],
+      "sexstatic": [
+        "cpe:2.3:a:sexstatic_project:sexstatic:*:*:*:*:*:*:*:*"
+      ],
+      "sey": [
+        "cpe:2.3:a:sey_project:sey:*:*:*:*:*:node.js:*:*"
+      ],
+      "sfml": [
+        "cpe:2.3:a:sfml_project:sfml:*:*:*:*:*:node.js:*:*"
+      ],
+      "sgqserve": [
+        "cpe:2.3:a:sgqserve_project:sgqserve:*:*:*:*:*:node.js:*:*"
+      ],
+      "shadowsock": [
+        "cpe:2.3:a:shadowsock_project:shadowsock:*:*:*:*:*:node.js:*:*"
+      ],
+      "sharp": [
+        "cpe:2.3:a:sharp_project:sharp:*:*:*:*:*:node.js:*:*"
+      ],
+      "shell-quote": [
+        "cpe:2.3:a:shell-quote_project:shell-quote:*:*:*:*:*:node.js:*:*"
+      ],
+      "shenliru": [
+        "cpe:2.3:a:shenliru_project:shenliru:*:*:*:*:*:node.js:*:*"
+      ],
+      "shescape": [
+        "cpe:2.3:a:shescape_project:shescape:*:*:*:*:*:node.js:*:*"
+      ],
+      "shit-server": [
+        "cpe:2.3:a:shit-server_project:shit-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "shout": [
+        "cpe:2.3:a:shout_project:shout:*:*:*:*:*:node.js:*:*"
+      ],
+      "simple-get": [
+        "cpe:2.3:a:simple-get_project:simple-get:*:*:*:*:*:node.js:*:*"
+      ],
+      "simple-git": [
+        "cpe:2.3:a:simple-git_project:simple-git:*:*:*:*:*:node.js:*:*"
+      ],
+      "simple-markdown": [
+        "cpe:2.3:a:khanacademy:simple-markdown:*:*:*:*:*:node.js:*:*"
+      ],
+      "simple-npm-registry": [
+        "cpe:2.3:a:simple-npm-registry_project:simple-npm-registry:*:*:*:*:*:node.js:*:*"
+      ],
+      "simple-plist": [
+        "cpe:2.3:a:simple-plist_project:simple-plist:*:*:*:*:*:*:*:*"
+      ],
+      "simplehttpserver": [
+        "cpe:2.3:a:simplehttpserver_project:simplehttpserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "skywalking-backend-js": [
+        "cpe:2.3:a:apache:skywalking:*:*:*:*:*:node.js:*:*"
+      ],
+      "slashify": [
+        "cpe:2.3:a:google:slashify:*:*:*:*:*:node.js:*:*"
+      ],
+      "slimerjs-edge": [
+        "cpe:2.3:a:slimerjs-edge_project:slimerjs-edge:*:*:*:*:*:node.js:*:*"
+      ],
+      "slug": [
+        "cpe:2.3:a:slug_project:slug:*:*:*:*:*:node.js:*:*"
+      ],
+      "sly07": [
+        "cpe:2.3:a:sly07_project:sly07:*:*:*:*:*:node.js:*:*"
+      ],
+      "smb": [
+        "cpe:2.3:a:smb_project:smb:*:*:*:*:*:node.js:*:*"
+      ],
+      "soci": [
+        "cpe:2.3:a:soci_project:soci:*:*:*:*:*:node.js:*:*"
+      ],
+      "socket.io": [
+        "cpe:2.3:a:socket:socket.io:*:*:*:*:*:node.js:*:*"
+      ],
+      "socket.io-file": [
+        "cpe:2.3:a:socket.io-file_project:socket.io-file:*:*:*:*:*:node.js:*:*"
+      ],
+      "socket.io-parser": [
+        "cpe:2.3:a:socket:socket.io-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "sockjs": [
+        "cpe:2.3:a:sockjs_project:sockjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "split-html-to-chars": [
+        "cpe:2.3:a:split-html-to-chars_project:split-html-to-chars:*:*:*:*:*:node.js:*:*"
+      ],
+      "spritesheet-js": [
+        "cpe:2.3:a:spritesheet-js_project:spritesheet-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "sqlite.js": [
+        "cpe:2.3:a:sqlite.js_project:sqlite.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "sqlite3": [
+        "cpe:2.3:a:ghost:sqlite3:*:*:*:*:*:node.js:*:*"
+      ],
+      "sqliter": [
+        "cpe:2.3:a:sqliter_project:sqliter:*:*:*:*:*:node.js:*:*"
+      ],
+      "sqlserver": [
+        "cpe:2.3:a:sqlserver_project:sqlserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "squirrelly": [
+        "cpe:2.3:a:squirrelly:squirrelly:*:*:*:*:*:node.js:*:*"
+      ],
+      "ssh2": [
+        "cpe:2.3:a:ssh2_project:ssh2:*:*:*:*:*:node.js:*:*"
+      ],
+      "sshpk": [
+        "cpe:2.3:a:joyent:sshpk:*:*:*:*:*:node.js:*:*"
+      ],
+      "ssl-utils": [
+        "cpe:2.3:a:ssl-utils_project:ssl-utils:*:*:*:*:*:node.js:*:*"
+      ],
+      "sspa": [
+        "cpe:2.3:a:sspa_project:sspa:*:*:*:*:*:node.js:*:*"
+      ],
+      "ssrf-agent": [
+        "cpe:2.3:a:ssrf-agent_project:ssrf-agent:*:*:*:*:*:node.js:*:*"
+      ],
+      "ssri": [
+        "cpe:2.3:a:ssri_project:ssri:*:*:*:*:*:node.js:*:*"
+      ],
+      "st": [
+        "cpe:2.3:a:st_project:st:*:*:*:*:*:node.js:*:*"
+      ],
+      "startserver": [
+        "cpe:2.3:a:startserver_project:startserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-dev-server": [
+        "cpe:2.3:a:static-dev-server_project:static-dev-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-eval": [
+        "cpe:2.3:a:static-eval_project:static-eval:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-html-server": [
+        "cpe:2.3:a:static-html-server_project:static-html-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-resource-server": [
+        "cpe:2.3:a:static-resource-server_project:static-resource-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-server": [
+        "cpe:2.3:a:nbluis:static-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "statichttpserver": [
+        "cpe:2.3:a:statichttpserver_project:statichttpserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "statics-server": [
+        "cpe:2.3:a:statics-server_project:statics-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "stattic": [
+        "cpe:2.3:a:stattic_project:stattic:*:*:*:*:*:node.js:*:*"
+      ],
+      "stimulsoft-dashboards-js": [
+        "cpe:2.3:a:stimulsoft:dashboard.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "strapi": [
+        "cpe:2.3:a:strapi:strapi:*:*:*:*:*:node.js:*:*"
+      ],
+      "strider-sauce": [
+        "cpe:2.3:a:strider-sauce_project:strider-sauce:*:*:*:*:*:node.js:*:*"
+      ],
+      "string": [
+        "cpe:2.3:a:string_project:string:*:*:*:*:*:node.js:*:*"
+      ],
+      "string-kit": [
+        "cpe:2.3:a:string_kit_project:string_kit:*:*:*:*:*:node.js:*:*"
+      ],
+      "striptags": [
+        "cpe:2.3:a:striptags_project:striptags:*:*:*:*:*:node.js:*:*"
+      ],
+      "summit": [
+        "cpe:2.3:a:summit_project:summit:*:*:*:*:*:node.js:*:*"
+      ],
+      "superagent": [
+        "cpe:2.3:a:superagent_project:superagent:*:*:*:*:*:node.js:*:*"
+      ],
+      "superjson": [
+        "cpe:2.3:a:blitzjs:superjson:*:*:*:*:*:node.js:*:*"
+      ],
+      "susu-sum": [
+        "cpe:2.3:a:susu-sum_project:susu-sum:*:*:*:*:*:node.js:*:*"
+      ],
+      "svelecte": [
+        "cpe:2.3:a:mskocik:svelecte:*:*:*:*:*:node.js:*:*"
+      ],
+      "svelte": [
+        "cpe:2.3:a:svelte:svelte:*:*:*:*:*:node.js:*:*"
+      ],
+      "swagger-ui-dist": [
+        "cpe:2.3:a:smartbear:swagger-ui-dist:*:*:*:*:*:node.js:*:*"
+      ],
+      "sync-exec": [
+        "cpe:2.3:a:sync-exec_project:sync-exec:*:*:*:*:*:node.js:*:*"
+      ],
+      "systeminformation": [
+        "cpe:2.3:a:systeminformation:systeminformation:*:*:*:*:*:node.js:*:*"
+      ],
+      "taffy": [
+        "cpe:2.3:a:taffydb:taffy:*:*:*:*:*:node.js:*:*"
+      ],
+      "takeapeek": [
+        "cpe:2.3:a:takeapeek_project:takeapeek:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:takeapeek_project:takeapeek:*:*:*:*:*:node.js:*:*"
+      ],
+      "tar": [
+        "cpe:2.3:a:tar_project:tar:*:*:*:*:*:node.js:*:*"
+      ],
+      "teddy": [
+        "cpe:2.3:a:teddy_project:teddy:*:*:*:*:*:node.js:*:*"
+      ],
+      "tencent-server": [
+        "cpe:2.3:a:tencent-server_project:tencent-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "terminal-kit": [
+        "cpe:2.3:a:terminal-kit_project:terminal-kit:*:*:*:*:*:node.js:*:*"
+      ],
+      "terser": [
+        "cpe:2.3:a:terser:terser:*:*:*:*:*:node.js:*:*"
+      ],
+      "that-value": [
+        "cpe:2.3:a:that-value_project:that-value:*:*:*:*:*:node.js:*:*"
+      ],
+      "three": [
+        "cpe:2.3:a:three_project:three:*:*:*:*:*:node.js:*:*"
+      ],
+      "tianma-static": [
+        "cpe:2.3:a:tianma-static_project:tianma-static:*:*:*:*:*:node.js:*:*"
+      ],
+      "timespan": [
+        "cpe:2.3:a:timespan_project:timespan:*:*:*:*:*:node.js:*:*"
+      ],
+      "tiny-conf": [
+        "cpe:2.3:a:tiny-conf_project:tiny-conf:*:*:*:*:*:node.js:*:*"
+      ],
+      "tiny-csrf": [
+        "cpe:2.3:a:tiny-csrf_project:tiny-csrf:*:*:*:*:*:node.js:*:*"
+      ],
+      "tiny-http": [
+        "cpe:2.3:a:tiny-http_project:tiny-http:*:*:*:*:*:node.js:*:*"
+      ],
+      "tinyserver2": [
+        "cpe:2.3:a:tinyserver2_project:tinyserver2:*:*:*:*:*:node.js:*:*"
+      ],
+      "tmock": [
+        "cpe:2.3:a:tmock_project:tmock:*:*:*:*:*:node.js:*:*"
+      ],
+      "tmpl": [
+        "cpe:2.3:a:tmpl_project:tmpl:*:*:*:*:*:node.js:*:*"
+      ],
+      "todo-regex": [
+        "cpe:2.3:a:todo-regex_project:todo-regex:*:*:*:*:*:node.js:*:*"
+      ],
+      "tomita": [
+        "cpe:2.3:a:tomita_project:tomita:*:*:*:*:*:node.js:*:*"
+      ],
+      "tomita-parser": [
+        "cpe:2.3:a:yandex:tomita-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "total.js": [
+        "cpe:2.3:a:totaljs:total.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "total4": [
+        "cpe:2.3:a:totaljs:total4:*:*:*:*:*:node.js:*:*"
+      ],
+      "tough-cookie": [
+        "cpe:2.3:a:salesforce:tough-cookie:*:*:*:*:*:node.js:*:*"
+      ],
+      "traceroute": [
+        "cpe:2.3:a:traceroute_project:traceroute:*:*:*:*:*:node.js:*:*"
+      ],
+      "trailing-slash": [
+        "cpe:2.3:a:trailing-slash_project:trailing-slash:*:*:*:*:*:node.js:*:*"
+      ],
+      "transpile": [
+        "cpe:2.3:a:transpile_project:transpile:*:*:*:*:*:node.js:*:*"
+      ],
+      "tree-kill": [
+        "cpe:2.3:a:tree-kill_project:tree-kill:*:*:*:*:*:node.js:*:*"
+      ],
+      "treekill": [
+        "cpe:2.3:a:treekill_project:treekill:*:*:*:*:*:node.js:*:*"
+      ],
+      "trim-newlines": [
+        "cpe:2.3:a:trim-newlines_project:trim-newlines:*:*:*:*:*:node.js:*:*"
+      ],
+      "trim-off-newlines": [
+        "cpe:2.3:a:trim-off-newlines_project:trim-off-newlines:*:*:*:*:*:node.js:*:*"
+      ],
+      "ts-deepmerge": [
+        "cpe:2.3:a:typescript_deep_merge_project:typescript_deep_merge:*:*:*:*:*:node.js:*:*"
+      ],
+      "ts-nodash": [
+        "cpe:2.3:a:ts-nodash_project:ts-nodash:*:*:*:*:*:node.js:*:*"
+      ],
+      "ts-process-promises": [
+        "cpe:2.3:a:ts-process-promises_project:ts-process-promises:*:*:*:*:*:node.js:*:*"
+      ],
+      "ua-parser": [
+        "cpe:2.3:a:ua-parser_project:ua-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "ua-parser-js": [
+        "cpe:2.3:a:ua-parser-js_project:ua-parser-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "uap-core": [
+        "cpe:2.3:a:uap-core_project:uap-core:*:*:*:*:*:node.js:*:*"
+      ],
+      "uekw1511server": [
+        "cpe:2.3:a:uekw1511server_project:uekw1511server:*:*:*:*:*:node.js:*:*"
+      ],
+      "uglify-js": [
+        "cpe:2.3:a:uglifyjs_project:uglifyjs:*:*:*:*:*:node.js:*:*"
+      ],
+      "umount": [
+        "cpe:2.3:a:umount_project:umount:*:*:*:*:*:node.js:*:*"
+      ],
+      "undefsafe": [
+        "cpe:2.3:a:undefsafe_project:undefsafe:*:*:*:*:*:node.js:*:*"
+      ],
+      "underscore": [
+        "cpe:2.3:a:underscorejs:underscore:*:*:*:*:*:node.js:*:*"
+      ],
+      "underscore-99xp": [
+        "cpe:2.3:a:underscore-99xp_project:underscore-99xp:*:*:*:*:*:node.js:*:*"
+      ],
+      "underscore.deep": [
+        "cpe:2.3:a:clever:underscore.deep:*:*:*:*:*:node.js:*:*"
+      ],
+      "undici": [
+        "cpe:2.3:a:nodejs:undici:*:*:*:*:*:node.js:*:*"
+      ],
+      "ungit": [
+        "cpe:2.3:a:ungit_project:ungit:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicode": [
+        "cpe:2.3:a:unicode_project:unicode:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicode-json": [
+        "cpe:2.3:a:unicode:unicode-json:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicorn-list": [
+        "cpe:2.3:a:unicorn-list_project:unicorn-list:*:*:*:*:*:node.js:*:*"
+      ],
+      "unzipper": [
+        "cpe:2.3:a:unzipper_project:unzipper:*:*:*:*:*:node.js:*:*"
+      ],
+      "uppy": [
+        "cpe:2.3:a:transloadit:uppy:*:*:*:*:*:node.js:*:*"
+      ],
+      "uri-js": [
+        "cpe:2.3:a:garycourt:uri-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "uri-template-lite": [
+        "cpe:2.3:a:litejs:uri-template-lite:*:*:*:*:*:node.js:*:*"
+      ],
+      "urijs": [
+        "cpe:2.3:a:urijs_project:urijs:*:*:*:*:*:node.js:*:*"
+      ],
+      "url-js": [
+        "cpe:2.3:a:url-js_project:url-js:*:*:*:*:*:node.js:*:*"
+      ],
+      "url-parse": [
+        "cpe:2.3:a:url-parse_project:url-parse:*:*:*:*:*:node.js:*:*"
+      ],
+      "useragent": [
+        "cpe:2.3:a:useragent_project:useragent:*:*:*:*:*:node.js:*:*"
+      ],
+      "utahcityfinder": [
+        "cpe:2.3:a:utahcityfinder_project:utahcityfinder:*:*:*:*:*:node.js:*:*"
+      ],
+      "utilities": [
+        "cpe:2.3:a:utilities_project:utilities:*:*:*:*:*:node.js:*:*"
+      ],
+      "utils-extend": [
+        "cpe:2.3:a:utils-extend_project:utils-extend:*:*:*:*:*:node.js:*:*"
+      ],
+      "uv-tj-demo": [
+        "cpe:2.3:a:uv-tj-demo_project:uv-tj-demo:*:*:*:*:*:node.js:*:*"
+      ],
+      "uws": [
+        "cpe:2.3:a:uws_project:uws:*:*:*:*:*:node.js:*:*"
+      ],
+      "valib": [
+        "cpe:2.3:a:sideralis:valib.js:*:*:*:*:*:node.js:*:*"
+      ],
+      "validate-color": [
+        "cpe:2.3:a:validate_color_project:validate_color:*:*:*:*:*:node.js:*:*"
+      ],
+      "validate-data": [
+        "cpe:2.3:a:validate_data_project:validate_data:*:*:*:*:*:node.js:*:*"
+      ],
+      "validator": [
+        "cpe:2.3:a:validator_project:validator:*:*:*:*:*:node.js:*:*"
+      ],
+      "vega": [
+        "cpe:2.3:a:vega_project:vega:*:*:*:*:*:node.js:*:*"
+      ],
+      "vega-functions": [
+        "cpe:2.3:a:vega-functions_project:vega-functions:*:*:*:*:*:node.js:*:*"
+      ],
+      "vite": [
+        "cpe:2.3:a:vitejs:vite:*:*:*:*:*:node.js:*:*"
+      ],
+      "vm2": [
+        "cpe:2.3:a:vm2_project:vm2:*:*:*:*:*:node.js:*:*"
+      ],
+      "vmd": [
+        "cpe:2.3:a:vmd_project:vmd:*:*:*:*:*:node.js:*:*"
+      ],
+      "vuelidate": [
+        "cpe:2.3:a:vuelidate_project:vuelidate:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:vuelidate_project:vuelidate:*:*:*:*:*:node.js:*:*"
+      ],
+      "w-zip": [
+        "cpe:2.3:a:w-zip_project:w-zip:*:*:*:*:*:node.js:*:*"
+      ],
+      "wangguojing123": [
+        "cpe:2.3:a:wanggoujing123_project:wanggoujing123:*:*:*:*:*:node.js:*:*"
+      ],
+      "wasdk": [
+        "cpe:2.3:a:wasdk_project:wasdk:*:*:*:*:*:node.js:*:*"
+      ],
+      "waterline-sequel": [
+        "cpe:2.3:a:balderdash:waterline-sequel:*:*:*:*:*:node.js:*:*"
+      ],
+      "wc-cmd": [
+        "cpe:2.3:a:wc-cmd_project:wc-cmd:*:*:*:*:*:node.js:*:*"
+      ],
+      "weather.swlyons": [
+        "cpe:2.3:a:weather.swlyons_project:weather.swlyons:*:*:*:*:*:node.js:*:*"
+      ],
+      "webdriver-launcher": [
+        "cpe:2.3:a:webdriver-launcher_project:webdriver-launcher:*:*:*:*:*:node.js:*:*"
+      ],
+      "webdrvr": [
+        "cpe:2.3:a:webdrvr_project:webdrvr:*:*:*:*:*:node.js:*:*"
+      ],
+      "webpack": [
+        "cpe:2.3:a:webpack.js:webpack:*:*:*:*:*:node.js:*:*"
+      ],
+      "webpack-subresource-integrity": [
+        "cpe:2.3:a:webpack-subresource-integrity_project:webpack-subresource-integrity:*:*:*:*:*:node.js:*:*"
+      ],
+      "webrtc-native": [
+        "cpe:2.3:a:webrtc:webrtc-native:*:*:*:*:*:node.js:*:*"
+      ],
+      "websocket-extensions": [
+        "cpe:2.3:a:websocket-extensions_project:websocket-extensions:*:*:*:*:*:node.js:*:*"
+      ],
+      "welcomyzt": [
+        "cpe:2.3:a:welcomyzt_project:welcomyzt:*:*:*:*:*:node.js:*:*"
+      ],
+      "wffserve": [
+        "cpe:2.3:a:wffserve_project:wffserve:*:*:*:*:*:node.js:*:*"
+      ],
+      "whereis": [
+        "cpe:2.3:a:whereis_project:whereis:*:*:*:*:*:node.js:*:*"
+      ],
+      "whispercast": [
+        "cpe:2.3:a:whispercast_project:whispercast:*:*:*:*:*:node.js:*:*"
+      ],
+      "whois": [
+        "cpe:2.3:a:furqansofware:node_whois:*:*:*:*:*:node.js:*:*"
+      ],
+      "wifey": [
+        "cpe:2.3:a:wifey_project:wifey:*:*:*:*:*:node.js:*:*"
+      ],
+      "wifiscanner": [
+        "cpe:2.3:a:thingssdk:wifiscanner:*:*:*:*:*:node.js:*:*"
+      ],
+      "wincred": [
+        "cpe:2.3:a:wincred_project:wincred:*:*:*:*:*:*:*:*"
+      ],
+      "wind-mvc": [
+        "cpe:2.3:a:wind-mvc_project:wind-mvc:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-build-tools": [
+        "cpe:2.3:a:windows-build-tools_project:windows-build-tools:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-iedriver": [
+        "cpe:2.3:a:windows-iedriver_project:windows-iedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-latestchromedriver": [
+        "cpe:2.3:a:windows-latestchromedriver_project:windows-latestchromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-selenium-chromedriver": [
+        "cpe:2.3:a:windows-selenium-chromedriver_project:windows-selenium-chromedriver:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-seleniumjar": [
+        "cpe:2.3:a:windows-seleniumjar_project:windows-seleniumjar:*:*:*:*:*:node.js:*:*"
+      ],
+      "windows-seleniumjar-mirror": [
+        "cpe:2.3:a:windows-seleniumjar-mirror_project:windows-seleniumjar-mirror:*:*:*:*:*:node.js:*:*"
+      ],
+      "wintiwebdev": [
+        "cpe:2.3:a:wintiwebdev_project:wintiwebdev:*:*:*:*:*:node.js:*:*"
+      ],
+      "wixtoolset": [
+        "cpe:2.3:a:node-wixtoolset_project:node-wixtoolset:*:*:*:*:*:node.js:*:*",
+        "cpe:2.3:a:wixtoolset_project:wixtoolset:*:*:*:*:*:node.js:*:*"
+      ],
+      "word-wrap": [
+        "cpe:2.3:a:word-wrap_project:word-wrap:*:*:*:*:*:node.js:*:*"
+      ],
+      "worksmith": [
+        "cpe:2.3:a:guidesmiths:worksmith:*:*:*:*:*:node.js:*:*"
+      ],
+      "wrangler": [
+        "cpe:2.3:a:cloudflare:wrangler:*:*:*:*:*:node.js:*:*"
+      ],
+      "ws": [
+        "cpe:2.3:a:ws_project:ws:*:*:*:*:*:node.js:*:*"
+      ],
+      "x-assign": [
+        "cpe:2.3:a:binaryops:x-assign:*:*:*:*:*:node.js:*:*"
+      ],
+      "x-data-spreadsheet": [
+        "cpe:2.3:a:x-data-spreadsheet_project:x-data-spreadsheet:*:*:*:*:*:node.js:*:*"
+      ],
+      "xd-testing": [
+        "cpe:2.3:a:xd-testing_project:xd-testing:*:*:*:*:*:node.js:*:*"
+      ],
+      "xmldom": [
+        "cpe:2.3:a:xmldom_project:xmldom:*:*:*:*:*:node.js:*:*"
+      ],
+      "xmlhttprequest": [
+        "cpe:2.3:a:xmlhttprequest_project:xmlhttprequest:*:*:*:*:*:node.js:*:*"
+      ],
+      "xtalk": [
+        "cpe:2.3:a:xtalk_project:xtalk:*:*:*:*:*:node.js:*:*"
+      ],
+      "y18n": [
+        "cpe:2.3:a:y18n_project:y18n:*:*:*:*:*:node.js:*:*"
+      ],
+      "yargs-parser": [
+        "cpe:2.3:a:yargs:yargs-parser:*:*:*:*:*:node.js:*:*"
+      ],
+      "yttivy": [
+        "cpe:2.3:a:yttivy_project:yttivy:*:*:*:*:*:node.js:*:*"
+      ],
+      "yyooopack": [
+        "cpe:2.3:a:yyooopack_project:yyooopack:*:*:*:*:*:node.js:*:*"
+      ],
+      "yzt": [
+        "cpe:2.3:a:yzt_project:yzt:*:*:*:*:*:node.js:*:*"
+      ],
+      "zjjserver": [
+        "cpe:2.3:a:zjjserver_project:zjjserver:*:*:*:*:*:node.js:*:*"
+      ],
+      "zwserver": [
+        "cpe:2.3:a:zwserver_project:zwserver:*:*:*:*:*:node.js:*:*"
+      ]
     },
     "php_composer": {
-      "alfnru/password_recovery": "cpe:2.3:a:password_recovery_project:password_recovery:*:*:*:*:*:roundcube:*:*",
-      "fineuploader/php-traditional-server": "cpe:2.3:a:php-traditional-server_project:php-traditional-server:*:*:*:*:*:*:*:*",
-      "frappant/frp-form-answers": "cpe:2.3:a:frappant:forms_export:*:*:*:*:*:typo3:*:*",
-      "joomla/session": "cpe:2.3:a:joomla:session:*:*:*:*:*:*:*:*",
-      "mustache/mustache": "cpe:2.3:a:mustache_project:mustache:*:*:*:*:*:php:*:*",
-      "phpfastcache/phpfastcache": "cpe:2.3:a:phpfastcache:phpfastcache:*:*:*:*:*:*:*:*",
-      "shopware/shopware": "cpe:2.3:a:shopware:shopware:*:*:*:*:*:*:*:*",
-      "typo3/html-sanitizer": "cpe:2.3:a:typo3:html_sanitizer:*:*:*:*:*:*:*:*",
-      "typo3/phar-stream-wrapper": "cpe:2.3:a:typo3:pharstreamwrapper:*:*:*:*:*:*:*:*",
-      "yab/quarx": "cpe:2.3:a:quarx_cms_project:quarx_cms:*:*:*:*:*:*:*:*"
+      "alfnru/password_recovery": [
+        "cpe:2.3:a:password_recovery_project:password_recovery:*:*:*:*:*:roundcube:*:*"
+      ],
+      "fineuploader/php-traditional-server": [
+        "cpe:2.3:a:php-traditional-server_project:php-traditional-server:*:*:*:*:*:*:*:*"
+      ],
+      "frappant/frp-form-answers": [
+        "cpe:2.3:a:frappant:forms_export:*:*:*:*:*:typo3:*:*"
+      ],
+      "joomla/session": [
+        "cpe:2.3:a:joomla:session:*:*:*:*:*:*:*:*"
+      ],
+      "mustache/mustache": [
+        "cpe:2.3:a:mustache_project:mustache:*:*:*:*:*:php:*:*"
+      ],
+      "phpfastcache/phpfastcache": [
+        "cpe:2.3:a:phpfastcache:phpfastcache:*:*:*:*:*:*:*:*"
+      ],
+      "shopware/shopware": [
+        "cpe:2.3:a:shopware:shopware:*:*:*:*:*:*:*:*"
+      ],
+      "typo3/html-sanitizer": [
+        "cpe:2.3:a:typo3:html_sanitizer:*:*:*:*:*:*:*:*"
+      ],
+      "typo3/phar-stream-wrapper": [
+        "cpe:2.3:a:typo3:pharstreamwrapper:*:*:*:*:*:*:*:*"
+      ],
+      "yab/quarx": [
+        "cpe:2.3:a:quarx_cms_project:quarx_cms:*:*:*:*:*:*:*:*"
+      ]
     },
     "php_pear": {
-      "Archive_Tar": "cpe:2.3:a:php:pear_archive_tar:*:*:*:*:*:*:*:*",
-      "HTML_AJAX": "cpe:2.3:a:pear:html_ajax:*:*:*:*:*:*:*:*",
-      "HTML_QuickForm": "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*",
-      "PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
-      "XML_RPC": "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*",
-      "pearweb": "cpe:2.3:a:pear:pearweb:*:*:*:*:*:*:*:*"
+      "Archive_Tar": [
+        "cpe:2.3:a:php:archive_tar:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:php:pear_archive_tar:*:*:*:*:*:*:*:*"
+      ],
+      "HTML_AJAX": [
+        "cpe:2.3:a:pear:html_ajax:*:*:*:*:*:*:*:*"
+      ],
+      "HTML_QuickForm": [
+        "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*"
+      ],
+      "PEAR": [
+        "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*"
+      ],
+      "XML_RPC": [
+        "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*"
+      ],
+      "pearweb": [
+        "cpe:2.3:a:pear:pearweb:*:*:*:*:*:*:*:*"
+      ]
     },
     "php_pecl": {
-      "imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
-      "memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
-      "pecl_http": "cpe:2.3:a:php:pecl_http:*:*:*:*:*:*:*:*",
-      "xhprof": "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+      "imagick": [
+        "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*"
+      ],
+      "memcached": [
+        "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*"
+      ],
+      "pecl_http": [
+        "cpe:2.3:a:php:pecl_http:*:*:*:*:*:*:*:*"
+      ],
+      "xhprof": [
+        "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+      ]
     },
     "pypi": {
-      "0.0.1": "cpe:2.3:a:pypi:pypi:*:*:*:*:*:*:*:*",
-      "AAmiles": "cpe:2.3:a:pypi:aamiles:*:*:*:*:*:pypi:*:*",
-      "Beaker": "cpe:2.3:a:beakerbrowser:beaker:*:*:*:*:*:python:*:*",
-      "Flask": "cpe:2.3:a:palletsprojects:flask:*:*:*:*:*:*:*:*",
-      "Flask-Caching": "cpe:2.3:a:flask-caching_project:flask-caching:*:*:*:*:*:flask:*:*",
-      "Flask-Security-Too": "cpe:2.3:a:flask-security-too_project:flask-security-too:*:*:*:*:*:*:*:*",
-      "GitPython": "cpe:2.3:a:gitpython_project:gitpython:*:*:*:*:*:python:*:*",
-      "MechanicalSoup": "cpe:2.3:a:mechanicalsoup_project:mechanicalsoup:*:*:*:*:*:python:*:*",
-      "Pillow": "cpe:2.3:a:python:pillow:*:*:*:*:*:*:*:*",
-      "PyAMF": "cpe:2.3:a:pyamf:pyamf:*:*:*:*:*:*:*:*",
-      "PyPDF2": "cpe:2.3:a:pypdf2_project:pypdf2:*:*:*:*:*:*:*:*",
-      "PyXML": "cpe:2.3:a:python:pyxml:*:*:*:*:*:*:*:*",
-      "Red-Dashboard": "cpe:2.3:a:cogboard:red-dashboard:*:*:*:*:*:*:*:*",
-      "SilverCity": "cpe:2.3:a:silvercity_project:silvercity:*:*:*:*:*:*:*:*",
-      "TGCaptcha": "cpe:2.3:a:python:tgcaptcha2:*:*:*:*:*:*:*:*",
-      "XML2Dict": "cpe:2.3:a:xml2dict_project:xml2dict:*:*:*:*:*:python:*:*",
-      "aniso8601": "cpe:2.3:a:aniso8601_project:aniso8601:*:*:*:*:*:*:*:*",
-      "api-res-py": "cpe:2.3:a:api-res-py_project:api-res-py:*:*:*:*:*:python:*:*",
-      "aries-cloudagent": "cpe:2.3:a:hyperledger:aries_cloud_agent:*:*:*:*:*:python:*:*",
-      "asyncua": "cpe:2.3:a:freeopcua:opcua-asyncio:*:*:*:*:*:python:*:*",
-      "autobahn": "cpe:2.3:a:crossbar:autobahn:*:*:*:*:*:*:*:*",
-      "b2sdk": "cpe:2.3:a:backblaze:b2-sdk-python:*:*:*:*:*:*:*:*",
-      "blackduck": "cpe:2.3:a:synopsys:hub-rest-api-python:*:*:*:*:*:*:*:*",
-      "bottle": "cpe:2.3:a:bottlepy:bottle:*:*:*:*:*:*:*:*",
-      "case-utils": "cpe:2.3:a:lfprojects:case_python_utilities:*:*:*:*:*:python:*:*",
-      "cdo-local-uuid": "cpe:2.3:a:lfprojects:cdo_local_uuid_utility:*:*:*:*:*:python:*:*",
-      "celery": "cpe:2.3:a:celeryproject:celery:*:*:*:*:*:python:*:*",
-      "certifi": "cpe:2.3:a:kennethreitz:certifi:*:*:*:*:*:python:*:*",
-      "cleo": "cpe:2.3:a:python-poetry:cleo:*:*:*:*:*:*:*:*",
-      "cloudlabeling": "cpe:2.3:a:pypi:cloudlabeling:*:*:*:*:*:pypi:*:*",
-      "cloudtoken": "cpe:2.3:a:atlassian:cloudtoken:*:*:*:*:*:*:*:*",
-      "conference-scheduler-cli": "cpe:2.3:a:pyconuk:conference-scheduler-cli:*:*:*:*:*:*:*:*",
-      "cryptography": "cpe:2.3:a:python-cryptography_project:python-cryptography:*:*:*:*:*:*:*:*",
-      "cvxopt": "cpe:2.3:a:cvxopt_project:cvxopt:*:*:*:*:*:python:*:*",
-      "d8s-domains": "cpe:2.3:a:democritus_domains_project:democritus_domains:*:*:*:*:*:python:*:*",
-      "d8s-ip-addresses": "cpe:2.3:a:democritus_ip_addresses_project:democritus_ip_addresses:*:*:*:*:*:python:*:*",
-      "d8s-pdfs": "cpe:2.3:a:democritus_pdfs_project:democritus_pdfs:*:*:*:*:*:python:*:*",
-      "d8s-urls": "cpe:2.3:a:democritus_urls_project:democritus_urls:*:*:*:*:*:python:*:*",
-      "d8s-uuids": "cpe:2.3:a:democritus_uuids_project:democritus_uuids:*:*:*:*:*:python:*:*",
-      "decorator": "cpe:2.3:a:python:decorator:*:*:*:*:*:*:*:*",
-      "django-filter": "cpe:2.3:a:django-filter_project:django-filter:*:*:*:*:*:*:*:*",
-      "django-user-sessions": "cpe:2.3:a:django-user-sessions_project:django-user-sessions:*:*:*:*:*:*:*:*",
-      "drf-jwt": "cpe:2.3:a:styria:django-rest-framework-json_web_tokens:*:*:*:*:*:*:*:*",
-      "drxhello": "cpe:2.3:a:pypi:drxhello:*:*:*:*:*:pypi:*:*",
-      "easy-parse": "cpe:2.3:a:easy-parse_project:easy-parse:*:*:*:*:*:python:*:*",
-      "easy-xml": "cpe:2.3:a:easyxml_project:easyxml:*:*:*:*:*:python:*:*",
-      "ecdsa": "cpe:2.3:a:tlsfuzzer:ecdsa:*:*:*:*:*:python:*:*",
-      "enum34": "cpe:2.3:a:python:enum34:*:*:*:*:*:*:*:*",
-      "eth-account": "cpe:2.3:a:ethereum:eth-account:*:*:*:*:*:python:*:*",
-      "exotel": "cpe:2.3:a:exotel_project:exotel:*:*:*:*:*:python:*:*",
-      "feedgen": "cpe:2.3:a:feedgen_project:feedgen:*:*:*:*:*:python:*:*",
-      "flask-restx": "cpe:2.3:a:flask-restx_project:flask-restx:*:*:*:*:*:python:*:*",
-      "flower": "cpe:2.3:a:flower_project:flower:*:*:*:*:*:*:*:*",
-      "fonttools": "cpe:2.3:a:fonttools:fonttools:*:*:*:*:*:python:*:*",
-      "global-workqueue": "cpe:2.3:a:global-workqueue_project:global-workqueue:*:*:*:*:*:python:*:*",
-      "gradio": "cpe:2.3:a:gradio_project:gradio:*:*:*:*:*:python:*:*",
-      "hail": "cpe:2.3:a:hail:hail:*:*:*:*:*:python:*:*",
-      "horus": "cpe:2.3:a:pylonsproject:horus:*:*:*:*:*:pyramid:*:*",
-      "html-to-csv": "cpe:2.3:a:html-to-csv_project:html-to-csv:*:*:*:*:*:python:*:*",
-      "html2csv": "cpe:2.3:a:html2csv_project:html2csv:*:*:*:*:*:python:*:*",
-      "httplib2": "cpe:2.3:a:httplib2_project:httplib2:*:*:*:*:*:python:*:*",
-      "httpx": "cpe:2.3:a:encode:httpx:*:*:*:*:*:python:*:*",
-      "hyper-bump-it": "cpe:2.3:a:plannigan:hyper_bump_it:*:*:*:*:*:python:*:*",
-      "invenio-records": "cpe:2.3:a:inveniosoftware:invenio-records:*:*:*:*:*:*:*:*",
-      "jupyterhub-systemdspawner": "cpe:2.3:a:jupyterhub:systemdspawner:*:*:*:*:*:*:*:*",
-      "jw.util": "cpe:2.3:a:python:jw.util:*:*:*:*:*:python:*:*",
-      "keep": "cpe:2.3:a:keep_project:keep:*:*:*:*:*:*:*:*",
-      "keymaker": "cpe:2.3:a:keymaker_project:keymaker:*:*:*:*:*:*:*:*",
-      "ladon": "cpe:2.3:a:ladon_project:ladon:*:*:*:*:*:*:*:*",
-      "langchain-experimental": "cpe:2.3:a:langchain:langchain_experimental:*:*:*:*:*:python:*:*",
-      "loguru": "cpe:2.3:a:loguru_project:loguru:*:*:*:*:*:python:*:*",
-      "lxml": "cpe:2.3:a:lxml:lxml:*:*:*:*:*:*:*:*",
-      "mage-ai": "cpe:2.3:a:mage:mage-ai:*:*:*:*:*:python:*:*",
-      "marshmallow": "cpe:2.3:a:marshmallow_project:marshmallow:*:*:*:*:*:python:*:*",
-      "mltable": "cpe:2.3:a:microsoft:azure_machine_learning_software_development_kit:*:*:*:*:*:*:*:*",
-      "mpxj": "cpe:2.3:a:mpxj:mpxj:*:*:*:*:*:python:*:*",
-      "nbconvert": "cpe:2.3:a:jupyter:nbconvert:*:*:*:*:*:python:*:*",
-      "nbdime": "cpe:2.3:a:jupyter:nbdime:*:*:*:*:*:python:*:*",
-      "networkx": "cpe:2.3:a:python:networkx:*:*:*:*:*:*:*:*",
-      "novajoin": "cpe:2.3:a:python:novajoin:*:*:*:*:*:*:*:*",
-      "oncall": "cpe:2.3:a:linkedin:oncall:*:*:*:*:*:*:*:*",
-      "openapi-python-client": "cpe:2.3:a:openapi-python-client_project:openapi-python-client:*:*:*:*:*:*:*:*",
-      "openpyxl": "cpe:2.3:a:python:openpyxl:*:*:*:*:*:*:*:*",
-      "openssh-key-parser": "cpe:2.3:a:openssh_key_parser_project:openssh_key_parser:*:*:*:*:*:python:*:*",
-      "ovirt-engine-sdk-python": "cpe:2.3:a:ovirt-engine-sdk-python_project:ovirt-engine-sdk-python:*:*:*:*:*:*:*:*",
-      "pandasai": "cpe:2.3:a:gabrieleventuri:pandasai:*:*:*:*:*:python:*:*",
-      "passeo": "cpe:2.3:a:passeo_project:passeo:*:*:*:*:*:python:*:*",
-      "pdm": "cpe:2.3:a:frostming:pdm:*:*:*:*:*:python:*:*",
-      "pipreqs": "cpe:2.3:a:pipreqs_project:pipreqs:*:*:*:*:*:python:*:*",
-      "plone.namedfile": "cpe:2.3:a:plone:namedfile:*:*:*:*:*:*:*:*",
-      "poetry": "cpe:2.3:a:python-poetry:poetry:*:*:*:*:*:python:*:*",
-      "pretix": "cpe:2.3:a:rami:pretix:*:*:*:*:*:*:*:*",
-      "protobuf": "cpe:2.3:a:google:protobuf-python:*:*:*:*:*:*:*:*",
-      "proxy.py": "cpe:2.3:a:proxy.py_project:proxy.py:*:*:*:*:*:*:*:*",
-      "py-bcrypt": "cpe:2.3:a:python:py-bcrypt:*:*:*:*:*:*:*:*",
-      "py-xml": "cpe:2.3:a:py-xml_project:py-xml:*:*:*:*:*:python:*:*",
-      "py7zr": "cpe:2.3:a:py7zr_project:py7zr:*:*:*:*:*:python:*:*",
-      "pyRdfa3": "cpe:2.3:a:pyrdfa3_project:pyrdfa3:*:*:*:*:*:python:*:*",
-      "pyanxdns": "cpe:2.3:a:pyanxdns_project:pyanxdns:*:*:*:*:*:*:*:*",
-      "pyanyapi": "cpe:2.3:a:pyanyapi_project:pyanyapi:*:*:*:*:*:*:*:*",
-      "pybluemonday": "cpe:2.3:a:python:pybluemonday:*:*:*:*:*:*:*:*",
-      "pycryptodome": "cpe:2.3:a:pycryptodome:pycryptodome:*:*:*:*:*:python:*:*",
-      "pycryptodomex": "cpe:2.3:a:pycryptodome:pycryptodomex:*:*:*:*:*:python:*:*",
-      "pydash": "cpe:2.3:a:derrickgilland:pydash:*:*:*:*:*:python:*:*",
-      "pyesasky": "cpe:2.3:a:esa:pyesasky:*:*:*:*:*:python:*:*",
-      "pyload-ng": "cpe:2.3:a:pyload-ng_project:pyload-ng:*:*:*:*:*:python:*:*",
-      "pymatgen": "cpe:2.3:a:pymatgen:pymatgen:*:*:*:*:*:*:*:*",
-      "pyo": "cpe:2.3:a:pyo_project:pyo:*:*:*:*:*:*:*:*",
-      "pypdf": "cpe:2.3:a:pypdf_project:pypdf:*:*:*:*:*:*:*:*",
-      "pypiserver": "cpe:2.3:a:python:pypiserver:*:*:*:*:*:*:*:*",
-      "pypolicyd-spf": "cpe:2.3:a:pypolicyd-spf_project:pypolicyd-spf:*:*:*:*:*:*:*:*",
-      "python-gnupg": "cpe:2.3:a:python:python-gnupg:*:*:*:*:*:*:*:*",
-      "python-jwt": "cpe:2.3:a:python-jwt_project:python-jwt:*:*:*:*:*:*:*:*",
-      "python-libnmap": "cpe:2.3:a:python-libnmap_project:python-libnmap:*:*:*:*:*:python:*:*",
-      "python-scciclient": "cpe:2.3:a:python-scciclient_project:python-scciclient:*:*:*:*:*:python:*:*",
-      "pytorch-lightning": "cpe:2.3:a:pytorchlightning:pytorch_lightning:*:*:*:*:*:python:*:*",
-      "rencode": "cpe:2.3:a:rencode_project:rencode:*:*:*:*:*:python:*:*",
-      "reportlab": "cpe:2.3:a:reportlab:reportlab:*:*:*:*:*:*:*:*",
-      "reqmgr2": "cpe:2.3:a:reqmgr2_project:reqmgr2:*:*:*:*:*:python:*:*",
-      "reqmon": "cpe:2.3:a:reqmon_project:reqmon:*:*:*:*:*:python:*:*",
-      "requests": "cpe:2.3:a:python:requests:*:*:*:*:*:*:*:*",
-      "requests-xml": "cpe:2.3:a:requests-xml_project:requests-xml:*:*:*:*:*:python:*:*",
-      "rondolu-yt-concate": "cpe:2.3:a:rondolu-yt-concate_project:rondolu-yt-concate:*:*:*:*:*:pypi:*:*",
-      "rope": "cpe:2.3:a:rope_project:rope:*:*:*:*:*:python:*:*",
-      "rply": "cpe:2.3:a:rply_project:rply:*:*:*:*:*:*:*:*",
-      "rsa": "cpe:2.3:a:python:rsa:*:*:*:*:*:python:*:*",
-      "ruamel.yaml": "cpe:2.3:a:ruamel.yaml_project:ruamel.yaml:*:*:*:*:*:*:*:*",
-      "sap-xssec": "cpe:2.3:a:sap:sap-xssec:*:*:*:*:*:python:*:*",
-      "scoptrial": "cpe:2.3:a:scoptrial_project:scoptrial:*:*:*:*:*:pypi:*:*",
-      "sentry-sdk": "cpe:2.3:a:sentry:sentry_software_development_kit:*:*:*:*:*:python:*:*",
-      "setuptools": "cpe:2.3:a:python:setuptools:*:*:*:*:*:*:*:*",
-      "simiki": "cpe:2.3:a:simiki_project:simiki:*:*:*:*:*:*:*:*",
-      "sixfab-power-python-api": "cpe:2.3:a:sixfab-tool_project:sixfab-tool:*:*:*:*:*:pypi:*:*",
-      "slashify": "cpe:2.3:a:google:slashify:*:*:*:*:*:node.js:*:*",
-      "snowflake-connector-python": "cpe:2.3:a:snowflake:snowflake-connector-python:*:*:*:*:*:*:*:*",
-      "sockeye": "cpe:2.3:a:amazon:sockeye:*:*:*:*:*:python:*:*",
-      "sopel-plugins.channelmgnt": "cpe:2.3:a:mirahezebots:channelmgnt:*:*:*:*:*:sopel:*:*",
-      "spacy": "cpe:2.3:a:explosion:spacy:*:*:*:*:*:python:*:*",
-      "sqlparse": "cpe:2.3:a:sqlparse_project:sqlparse:*:*:*:*:*:python:*:*",
-      "starlette": "cpe:2.3:a:encode:starlette:*:*:*:*:*:python:*:*",
-      "tablib": "cpe:2.3:a:python:tablib:*:*:*:*:*:*:*:*",
-      "tkvideoplayer": "cpe:2.3:a:python:tkvideoplayer:*:*:*:*:*:*:*:*",
-      "togglee": "cpe:2.3:a:togglee:togglee:*:*:*:*:*:pypi:*:*",
-      "tuf": "cpe:2.3:a:linuxfoundation:the_update_framework:*:*:*:*:*:python:*:*",
-      "unearth": "cpe:2.3:a:frostming:unearth:*:*:*:*:*:python:*:*",
-      "untangle": "cpe:2.3:a:untangle_project:untangle:*:*:*:*:*:python:*:*",
-      "urllib3": "cpe:2.3:a:python:urllib3:*:*:*:*:*:*:*:*",
-      "validators": "cpe:2.3:a:validators_project:validators:*:*:*:*:*:python:*:*",
-      "vault-cli": "cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*",
-      "vyper": "cpe:2.3:a:vyperlang:vyper:*:*:*:*:*:python:*:*",
-      "wikifaces": "cpe:2.3:a:wikifaces_project:wikifaces:*:*:*:*:*:pypi:*:*",
-      "wmagent": "cpe:2.3:a:wmagent_project:wmagent:*:*:*:*:*:python:*:*",
-      "xmpp-http-upload": "cpe:2.3:a:xmpp-http-upload_project:xmpp-http-upload:*:*:*:*:*:*:*:*",
-      "zibalPlatform": "cpe:2.3:a:zibal_project:zibal:*:*:*:*:*:pypi:*:*"
+      "0.0.1": [
+        "cpe:2.3:a:pypi:pypi:*:*:*:*:*:*:*:*"
+      ],
+      "AAmiles": [
+        "cpe:2.3:a:pypi:aamiles:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:pypi:aamiles:*:*:*:*:*:pypi:*:*"
+      ],
+      "Beaker": [
+        "cpe:2.3:a:beakerbrowser:beaker:*:*:*:*:*:python:*:*"
+      ],
+      "Flask": [
+        "cpe:2.3:a:palletsprojects:flask:*:*:*:*:*:*:*:*"
+      ],
+      "Flask-Caching": [
+        "cpe:2.3:a:flask-caching_project:flask-caching:*:*:*:*:*:flask:*:*"
+      ],
+      "Flask-Security-Too": [
+        "cpe:2.3:a:flask-security-too_project:flask-security-too:*:*:*:*:*:*:*:*"
+      ],
+      "GitPython": [
+        "cpe:2.3:a:gitpython_project:gitpython:*:*:*:*:*:python:*:*"
+      ],
+      "MechanicalSoup": [
+        "cpe:2.3:a:mechanicalsoup_project:mechanicalsoup:*:*:*:*:*:python:*:*"
+      ],
+      "Pillow": [
+        "cpe:2.3:a:python:pillow:*:*:*:*:*:*:*:*"
+      ],
+      "PyAMF": [
+        "cpe:2.3:a:pyamf:pyamf:*:*:*:*:*:*:*:*"
+      ],
+      "PyPDF2": [
+        "cpe:2.3:a:pypdf2_project:pypdf2:*:*:*:*:*:*:*:*"
+      ],
+      "PyXML": [
+        "cpe:2.3:a:python:pyxml:*:*:*:*:*:*:*:*"
+      ],
+      "Red-Dashboard": [
+        "cpe:2.3:a:cogboard:red-dashboard:*:*:*:*:*:*:*:*"
+      ],
+      "SilverCity": [
+        "cpe:2.3:a:silvercity_project:silvercity:*:*:*:*:*:*:*:*"
+      ],
+      "TGCaptcha": [
+        "cpe:2.3:a:python:tgcaptcha2:*:*:*:*:*:*:*:*"
+      ],
+      "XML2Dict": [
+        "cpe:2.3:a:xml2dict_project:xml2dict:*:*:*:*:*:python:*:*"
+      ],
+      "aniso8601": [
+        "cpe:2.3:a:aniso8601_project:aniso8601:*:*:*:*:*:*:*:*"
+      ],
+      "api-res-py": [
+        "cpe:2.3:a:api-res-py_project:api-res-py:*:*:*:*:*:python:*:*"
+      ],
+      "aries-cloudagent": [
+        "cpe:2.3:a:hyperledger:aries_cloud_agent:*:*:*:*:*:python:*:*"
+      ],
+      "asyncua": [
+        "cpe:2.3:a:freeopcua:opcua-asyncio:*:*:*:*:*:python:*:*"
+      ],
+      "autobahn": [
+        "cpe:2.3:a:crossbar:autobahn:*:*:*:*:*:*:*:*"
+      ],
+      "b2sdk": [
+        "cpe:2.3:a:backblaze:b2-sdk-python:*:*:*:*:*:*:*:*"
+      ],
+      "blackduck": [
+        "cpe:2.3:a:synopsys:hub-rest-api-python:*:*:*:*:*:*:*:*"
+      ],
+      "bottle": [
+        "cpe:2.3:a:bottlepy:bottle:*:*:*:*:*:*:*:*"
+      ],
+      "case-utils": [
+        "cpe:2.3:a:lfprojects:case_python_utilities:*:*:*:*:*:python:*:*"
+      ],
+      "cdo-local-uuid": [
+        "cpe:2.3:a:lfprojects:cdo_local_uuid_utility:*:*:*:*:*:python:*:*"
+      ],
+      "celery": [
+        "cpe:2.3:a:celeryproject:celery:*:*:*:*:*:python:*:*"
+      ],
+      "certifi": [
+        "cpe:2.3:a:kennethreitz:certifi:*:*:*:*:*:python:*:*"
+      ],
+      "cleo": [
+        "cpe:2.3:a:python-poetry:cleo:*:*:*:*:*:*:*:*"
+      ],
+      "cloudlabeling": [
+        "cpe:2.3:a:pypi:cloudlabeling:*:*:*:*:*:pypi:*:*"
+      ],
+      "cloudtoken": [
+        "cpe:2.3:a:atlassian:cloudtoken:*:*:*:*:*:*:*:*"
+      ],
+      "conference-scheduler-cli": [
+        "cpe:2.3:a:pyconuk:conference-scheduler-cli:*:*:*:*:*:*:*:*"
+      ],
+      "cryptography": [
+        "cpe:2.3:a:cryptography_project:cryptography:*:*:*:*:*:python:*:*",
+        "cpe:2.3:a:python-cryptography_project:python-cryptography:*:*:*:*:*:*:*:*"
+      ],
+      "cvxopt": [
+        "cpe:2.3:a:cvxopt_project:cvxopt:*:*:*:*:*:python:*:*"
+      ],
+      "d8s-domains": [
+        "cpe:2.3:a:democritus_domains_project:democritus_domains:*:*:*:*:*:python:*:*"
+      ],
+      "d8s-ip-addresses": [
+        "cpe:2.3:a:democritus_ip_addresses_project:democritus_ip_addresses:*:*:*:*:*:python:*:*"
+      ],
+      "d8s-pdfs": [
+        "cpe:2.3:a:democritus_pdfs_project:democritus_pdfs:*:*:*:*:*:python:*:*"
+      ],
+      "d8s-urls": [
+        "cpe:2.3:a:democritus_urls_project:democritus_urls:*:*:*:*:*:python:*:*"
+      ],
+      "d8s-uuids": [
+        "cpe:2.3:a:democritus_uuids_project:democritus_uuids:*:*:*:*:*:python:*:*"
+      ],
+      "decorator": [
+        "cpe:2.3:a:python:decorator:*:*:*:*:*:*:*:*"
+      ],
+      "django-filter": [
+        "cpe:2.3:a:django-filter_project:django-filter:*:*:*:*:*:*:*:*"
+      ],
+      "django-user-sessions": [
+        "cpe:2.3:a:django-user-sessions_project:django-user-sessions:*:*:*:*:*:*:*:*"
+      ],
+      "drf-jwt": [
+        "cpe:2.3:a:styria:django-rest-framework-json_web_tokens:*:*:*:*:*:*:*:*"
+      ],
+      "drxhello": [
+        "cpe:2.3:a:pypi:aamiles:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:pypi:cloudlabeling:*:*:*:*:*:pypi:*:*",
+        "cpe:2.3:a:pypi:dr-web-engine:*:*:*:*:*:pypi:*:*",
+        "cpe:2.3:a:pypi:drxhello:*:*:*:*:*:pypi:*:*"
+      ],
+      "easy-parse": [
+        "cpe:2.3:a:easy-parse_project:easy-parse:*:*:*:*:*:python:*:*"
+      ],
+      "easy-xml": [
+        "cpe:2.3:a:easyxml_project:easyxml:*:*:*:*:*:python:*:*"
+      ],
+      "ecdsa": [
+        "cpe:2.3:a:tlsfuzzer:ecdsa:*:*:*:*:*:python:*:*"
+      ],
+      "enum34": [
+        "cpe:2.3:a:python:enum34:*:*:*:*:*:*:*:*"
+      ],
+      "eth-account": [
+        "cpe:2.3:a:ethereum:eth-account:*:*:*:*:*:python:*:*"
+      ],
+      "exotel": [
+        "cpe:2.3:a:exotel_project:exotel:*:*:*:*:*:python:*:*"
+      ],
+      "feedgen": [
+        "cpe:2.3:a:feedgen_project:feedgen:*:*:*:*:*:python:*:*"
+      ],
+      "flask-restx": [
+        "cpe:2.3:a:flask-restx_project:flask-restx:*:*:*:*:*:python:*:*"
+      ],
+      "flower": [
+        "cpe:2.3:a:flower_project:flower:*:*:*:*:*:*:*:*"
+      ],
+      "fonttools": [
+        "cpe:2.3:a:fonttools:fonttools:*:*:*:*:*:python:*:*"
+      ],
+      "global-workqueue": [
+        "cpe:2.3:a:global-workqueue_project:global-workqueue:*:*:*:*:*:python:*:*"
+      ],
+      "gradio": [
+        "cpe:2.3:a:gradio_project:gradio:*:*:*:*:*:python:*:*"
+      ],
+      "hail": [
+        "cpe:2.3:a:hail:hail:*:*:*:*:*:python:*:*"
+      ],
+      "horus": [
+        "cpe:2.3:a:pylonsproject:horus:*:*:*:*:*:pyramid:*:*"
+      ],
+      "html-to-csv": [
+        "cpe:2.3:a:html-to-csv_project:html-to-csv:*:*:*:*:*:python:*:*"
+      ],
+      "html2csv": [
+        "cpe:2.3:a:html2csv_project:html2csv:*:*:*:*:*:python:*:*"
+      ],
+      "httplib2": [
+        "cpe:2.3:a:httplib2_project:httplib2:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:httplib2_project:httplib2:*:*:*:*:*:python:*:*"
+      ],
+      "httpx": [
+        "cpe:2.3:a:encode:httpx:*:*:*:*:*:python:*:*"
+      ],
+      "hyper-bump-it": [
+        "cpe:2.3:a:plannigan:hyper_bump_it:*:*:*:*:*:python:*:*"
+      ],
+      "invenio-records": [
+        "cpe:2.3:a:inveniosoftware:invenio-records:*:*:*:*:*:*:*:*"
+      ],
+      "jupyterhub-systemdspawner": [
+        "cpe:2.3:a:jupyterhub:systemdspawner:*:*:*:*:*:*:*:*"
+      ],
+      "jw.util": [
+        "cpe:2.3:a:python:jw.util:*:*:*:*:*:python:*:*"
+      ],
+      "keep": [
+        "cpe:2.3:a:keep_project:keep:*:*:*:*:*:*:*:*"
+      ],
+      "keymaker": [
+        "cpe:2.3:a:keymaker_project:keymaker:*:*:*:*:*:*:*:*"
+      ],
+      "ladon": [
+        "cpe:2.3:a:ladon_project:ladon:*:*:*:*:*:*:*:*"
+      ],
+      "langchain-experimental": [
+        "cpe:2.3:a:langchain:langchain_experimental:*:*:*:*:*:python:*:*"
+      ],
+      "loguru": [
+        "cpe:2.3:a:loguru_project:loguru:*:*:*:*:*:python:*:*"
+      ],
+      "lxml": [
+        "cpe:2.3:a:lxml:lxml:*:*:*:*:*:*:*:*"
+      ],
+      "mage-ai": [
+        "cpe:2.3:a:mage:mage-ai:*:*:*:*:*:python:*:*"
+      ],
+      "marshmallow": [
+        "cpe:2.3:a:marshmallow_project:marshmallow:*:*:*:*:*:python:*:*"
+      ],
+      "mltable": [
+        "cpe:2.3:a:microsoft:azure_machine_learning_software_development_kit:*:*:*:*:*:*:*:*"
+      ],
+      "mpxj": [
+        "cpe:2.3:a:mpxj:mpxj:*:*:*:*:*:python:*:*"
+      ],
+      "nbconvert": [
+        "cpe:2.3:a:jupyter:nbconvert:*:*:*:*:*:python:*:*"
+      ],
+      "nbdime": [
+        "cpe:2.3:a:jupyter:nbdime:*:*:*:*:*:python:*:*"
+      ],
+      "networkx": [
+        "cpe:2.3:a:python:networkx:*:*:*:*:*:*:*:*"
+      ],
+      "novajoin": [
+        "cpe:2.3:a:python:novajoin:*:*:*:*:*:*:*:*"
+      ],
+      "oncall": [
+        "cpe:2.3:a:linkedin:oncall:*:*:*:*:*:*:*:*"
+      ],
+      "openapi-python-client": [
+        "cpe:2.3:a:openapi-python-client_project:openapi-python-client:*:*:*:*:*:*:*:*"
+      ],
+      "openpyxl": [
+        "cpe:2.3:a:python:openpyxl:*:*:*:*:*:*:*:*"
+      ],
+      "openssh-key-parser": [
+        "cpe:2.3:a:openssh_key_parser_project:openssh_key_parser:*:*:*:*:*:python:*:*"
+      ],
+      "ovirt-engine-sdk-python": [
+        "cpe:2.3:a:ovirt-engine-sdk-python_project:ovirt-engine-sdk-python:*:*:*:*:*:*:*:*"
+      ],
+      "pandasai": [
+        "cpe:2.3:a:gabrieleventuri:pandasai:*:*:*:*:*:python:*:*"
+      ],
+      "passeo": [
+        "cpe:2.3:a:passeo_project:passeo:*:*:*:*:*:python:*:*"
+      ],
+      "pdm": [
+        "cpe:2.3:a:frostming:pdm:*:*:*:*:*:python:*:*"
+      ],
+      "pipreqs": [
+        "cpe:2.3:a:pipreqs_project:pipreqs:*:*:*:*:*:python:*:*"
+      ],
+      "plone.namedfile": [
+        "cpe:2.3:a:plone:namedfile:*:*:*:*:*:*:*:*"
+      ],
+      "poetry": [
+        "cpe:2.3:a:python-poetry:poetry:*:*:*:*:*:python:*:*"
+      ],
+      "pretix": [
+        "cpe:2.3:a:rami:pretix:*:*:*:*:*:*:*:*"
+      ],
+      "protobuf": [
+        "cpe:2.3:a:google:protobuf-python:*:*:*:*:*:*:*:*"
+      ],
+      "proxy.py": [
+        "cpe:2.3:a:proxy.py_project:proxy.py:*:*:*:*:*:*:*:*"
+      ],
+      "py-bcrypt": [
+        "cpe:2.3:a:python:py-bcrypt:*:*:*:*:*:*:*:*"
+      ],
+      "py-xml": [
+        "cpe:2.3:a:py-xml_project:py-xml:*:*:*:*:*:python:*:*"
+      ],
+      "py7zr": [
+        "cpe:2.3:a:py7zr_project:py7zr:*:*:*:*:*:python:*:*"
+      ],
+      "pyRdfa3": [
+        "cpe:2.3:a:pyrdfa3_project:pyrdfa3:*:*:*:*:*:python:*:*"
+      ],
+      "pyanxdns": [
+        "cpe:2.3:a:pyanxdns_project:pyanxdns:*:*:*:*:*:*:*:*"
+      ],
+      "pyanyapi": [
+        "cpe:2.3:a:pyanyapi_project:pyanyapi:*:*:*:*:*:*:*:*"
+      ],
+      "pybluemonday": [
+        "cpe:2.3:a:python:pybluemonday:*:*:*:*:*:*:*:*"
+      ],
+      "pycryptodome": [
+        "cpe:2.3:a:pycryptodome:pycryptodome:*:*:*:*:*:python:*:*"
+      ],
+      "pycryptodomex": [
+        "cpe:2.3:a:pycryptodome:pycryptodomex:*:*:*:*:*:python:*:*"
+      ],
+      "pydash": [
+        "cpe:2.3:a:derrickgilland:pydash:*:*:*:*:*:python:*:*"
+      ],
+      "pyesasky": [
+        "cpe:2.3:a:esa:pyesasky:*:*:*:*:*:python:*:*"
+      ],
+      "pyload-ng": [
+        "cpe:2.3:a:pyload-ng_project:pyload-ng:*:*:*:*:*:python:*:*"
+      ],
+      "pymatgen": [
+        "cpe:2.3:a:pymatgen:pymatgen:*:*:*:*:*:*:*:*"
+      ],
+      "pyo": [
+        "cpe:2.3:a:pyo_project:pyo:*:*:*:*:*:*:*:*"
+      ],
+      "pypdf": [
+        "cpe:2.3:a:pypdf_project:pypdf:*:*:*:*:*:*:*:*"
+      ],
+      "pypiserver": [
+        "cpe:2.3:a:python:pypiserver:*:*:*:*:*:*:*:*"
+      ],
+      "pypolicyd-spf": [
+        "cpe:2.3:a:pypolicyd-spf_project:pypolicyd-spf:*:*:*:*:*:*:*:*"
+      ],
+      "python-gnupg": [
+        "cpe:2.3:a:python:python-gnupg:*:*:*:*:*:*:*:*"
+      ],
+      "python-jwt": [
+        "cpe:2.3:a:python-jwt_project:python-jwt:*:*:*:*:*:*:*:*"
+      ],
+      "python-libnmap": [
+        "cpe:2.3:a:python-libnmap_project:python-libnmap:*:*:*:*:*:python:*:*"
+      ],
+      "python-scciclient": [
+        "cpe:2.3:a:python-scciclient_project:python-scciclient:*:*:*:*:*:python:*:*"
+      ],
+      "pytorch-lightning": [
+        "cpe:2.3:a:pytorchlightning:pytorch_lightning:*:*:*:*:*:python:*:*"
+      ],
+      "rencode": [
+        "cpe:2.3:a:rencode_project:rencode:*:*:*:*:*:python:*:*"
+      ],
+      "reportlab": [
+        "cpe:2.3:a:reportlab:reportlab:*:*:*:*:*:*:*:*"
+      ],
+      "reqmgr2": [
+        "cpe:2.3:a:reqmgr2_project:reqmgr2:*:*:*:*:*:python:*:*"
+      ],
+      "reqmon": [
+        "cpe:2.3:a:reqmon_project:reqmon:*:*:*:*:*:python:*:*"
+      ],
+      "requests": [
+        "cpe:2.3:a:python:requests:*:*:*:*:*:*:*:*"
+      ],
+      "requests-xml": [
+        "cpe:2.3:a:requests-xml_project:requests-xml:*:*:*:*:*:python:*:*"
+      ],
+      "rondolu-yt-concate": [
+        "cpe:2.3:a:rondolu-yt-concate_project:rondolu-yt-concate:*:*:*:*:*:pypi:*:*"
+      ],
+      "rope": [
+        "cpe:2.3:a:rope_project:rope:*:*:*:*:*:python:*:*"
+      ],
+      "rply": [
+        "cpe:2.3:a:rply_project:rply:*:*:*:*:*:*:*:*"
+      ],
+      "rsa": [
+        "cpe:2.3:a:python:rsa:*:*:*:*:*:python:*:*"
+      ],
+      "ruamel.yaml": [
+        "cpe:2.3:a:ruamel.yaml_project:ruamel.yaml:*:*:*:*:*:*:*:*"
+      ],
+      "sap-xssec": [
+        "cpe:2.3:a:sap:sap-xssec:*:*:*:*:*:python:*:*"
+      ],
+      "scoptrial": [
+        "cpe:2.3:a:scoptrial_project:scoptrial:*:*:*:*:*:pypi:*:*"
+      ],
+      "sentry-sdk": [
+        "cpe:2.3:a:sentry:sentry_software_development_kit:*:*:*:*:*:python:*:*"
+      ],
+      "setuptools": [
+        "cpe:2.3:a:python:setuptools:*:*:*:*:*:*:*:*"
+      ],
+      "simiki": [
+        "cpe:2.3:a:simiki_project:simiki:*:*:*:*:*:*:*:*"
+      ],
+      "sixfab-power-python-api": [
+        "cpe:2.3:a:sixfab-tool_project:sixfab-tool:*:*:*:*:*:pypi:*:*"
+      ],
+      "slashify": [
+        "cpe:2.3:a:google:slashify:*:*:*:*:*:node.js:*:*"
+      ],
+      "snowflake-connector-python": [
+        "cpe:2.3:a:snowflake:snowflake-connector-python:*:*:*:*:*:*:*:*"
+      ],
+      "sockeye": [
+        "cpe:2.3:a:amazon:sockeye:*:*:*:*:*:python:*:*"
+      ],
+      "sopel-plugins.channelmgnt": [
+        "cpe:2.3:a:mirahezebots:channelmgnt:*:*:*:*:*:sopel:*:*"
+      ],
+      "spacy": [
+        "cpe:2.3:a:explosion:spacy:*:*:*:*:*:python:*:*"
+      ],
+      "sqlparse": [
+        "cpe:2.3:a:sqlparse_project:sqlparse:*:*:*:*:*:python:*:*"
+      ],
+      "starlette": [
+        "cpe:2.3:a:encode:starlette:*:*:*:*:*:python:*:*"
+      ],
+      "tablib": [
+        "cpe:2.3:a:python:tablib:*:*:*:*:*:*:*:*"
+      ],
+      "tkvideoplayer": [
+        "cpe:2.3:a:python:tkvideoplayer:*:*:*:*:*:*:*:*"
+      ],
+      "togglee": [
+        "cpe:2.3:a:togglee:togglee:*:*:*:*:*:pypi:*:*"
+      ],
+      "tuf": [
+        "cpe:2.3:a:linuxfoundation:the_update_framework:*:*:*:*:*:python:*:*"
+      ],
+      "unearth": [
+        "cpe:2.3:a:frostming:unearth:*:*:*:*:*:python:*:*"
+      ],
+      "untangle": [
+        "cpe:2.3:a:untangle_project:untangle:*:*:*:*:*:python:*:*"
+      ],
+      "urllib3": [
+        "cpe:2.3:a:python:urllib3:*:*:*:*:*:*:*:*"
+      ],
+      "validators": [
+        "cpe:2.3:a:validators_project:validators:*:*:*:*:*:python:*:*"
+      ],
+      "vault-cli": [
+        "cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*"
+      ],
+      "vyper": [
+        "cpe:2.3:a:vyperlang:vyper:*:*:*:*:*:python:*:*"
+      ],
+      "wikifaces": [
+        "cpe:2.3:a:wikifaces_project:wikifaces:*:*:*:*:*:pypi:*:*"
+      ],
+      "wmagent": [
+        "cpe:2.3:a:wmagent_project:wmagent:*:*:*:*:*:python:*:*"
+      ],
+      "xmpp-http-upload": [
+        "cpe:2.3:a:xmpp-http-upload_project:xmpp-http-upload:*:*:*:*:*:*:*:*"
+      ],
+      "zibalPlatform": [
+        "cpe:2.3:a:zibal_project:zibal:*:*:*:*:*:pypi:*:*"
+      ]
     },
     "rubygems": {
-      "Arabic-Prawn": "cpe:2.3:a:dynamixsolutions:arabic_prawn:*:*:*:*:*:ruby:*:*",
-      "VladTheEnterprising": "cpe:2.3:a:vladtheenterprising_project:vladtheenterprising:*:*:*:*:*:ruby:*:*",
-      "actionpack": "cpe:2.3:a:actionpack_project:actionpack:*:*:*:*:*:ruby:*:*",
-      "actionview": "cpe:2.3:a:action_view_project:action_view:*:*:*:*:*:ruby:*:*",
-      "activerecord": "cpe:2.3:a:activerecord_project:activerecord:*:*:*:*:*:ruby:*:*",
-      "activesupport": "cpe:2.3:a:activesupport_project:activesupport:*:*:*:*:*:ruby:*:*",
-      "arvados": "cpe:2.3:a:arvados:arvados:*:*:*:*:*:ruby:*:*",
-      "avo": "cpe:2.3:a:avohq:avo:*:*:*:*:*:ruby:*:*",
-      "backup-agoddard": "cpe:2.3:a:backup-agoddard_project:backup-agoddard:*:*:*:*:*:ruby:*:*",
-      "backup_checksum": "cpe:2.3:a:backup_checksum_project:backup_checksum:*:*:*:*:*:ruby:*:*",
-      "better_errors": "cpe:2.3:a:better_errors_project:better_errors:*:*:*:*:*:ruby:*:*",
-      "bindata": "cpe:2.3:a:bindata_project:bindata:*:*:*:*:*:ruby:*:*",
-      "bio-basespace-sdk": "cpe:2.3:a:basespace_ruby_sdk_project:basespace_ruby_sdk:*:*:*:*:*:ruby:*:*",
-      "brbackup": "cpe:2.3:a:brbackup_project:brbackup:*:*:*:*:*:ruby:*:*",
-      "bson": "cpe:2.3:a:bson_project:bson:*:*:*:*:*:ruby:*:*",
-      "cap-strap": "cpe:2.3:a:cap-strap_project:cap-strap:*:*:*:*:*:ruby:*:*",
-      "carrierwave": "cpe:2.3:a:carrierwave_project:carrierwave:*:*:*:*:*:ruby:*:*",
-      "cgi": "cpe:2.3:a:ruby-lang:cgi:*:*:*:*:*:ruby:*:*",
-      "ciborg": "cpe:2.3:a:ciborg_project:ciborg:*:*:*:*:*:ruby:*:*",
-      "cocoapods-downloader": "cpe:2.3:a:cocoapods:cocoapods-downloader:*:*:*:*:*:ruby:*:*",
-      "codders-dataset": "cpe:2.3:a:codders-dataset_project:codders-dataset:*:*:*:*:*:ruby:*:*",
-      "codecov": "cpe:2.3:a:codecov:codecov:*:*:*:*:*:ruby:*:*",
-      "colorscore": "cpe:2.3:a:colorscore_project:colorscore:*:*:*:*:*:ruby:*:*",
-      "commonmarker": "cpe:2.3:a:gjtorikian:commonmarker:*:*:*:*:*:ruby:*:*",
-      "consul": "cpe:2.3:a:makandra:consul:*:*:*:*:*:ruby:*:*",
-      "cremefraiche": "cpe:2.3:a:uplawski:creme_fraiche:*:*:*:*:*:ruby:*:*",
-      "csv-safe": "cpe:2.3:a:csv-safe_project:csv-safe:*:*:*:*:*:ruby:*:*",
-      "csv_sniffer": "cpe:2.3:a:csv-sniffer_project:csv-sniffer:*:*:*:*:*:rust:*:*",
-      "curl": "cpe:2.3:a:curl_project:curl:*:*:*:*:*:ruby:*:*",
-      "datagrid": "cpe:2.3:a:datagrid_project:datagrid:*:*:*:*:*:ruby:*:*",
-      "date": "cpe:2.3:a:ruby-lang:date:*:*:*:*:*:ruby:*:*",
-      "decidim": "cpe:2.3:a:decidim:decidim:*:*:*:*:*:ruby:*:*",
-      "devise": "cpe:2.3:a:heartcombo:devise:*:*:*:*:*:ruby:*:*",
-      "diffy": "cpe:2.3:a:diffy_project:diffy:*:*:*:*:*:ruby:*:*",
-      "discordrb": "cpe:2.3:a:discordrb_project:discordrb:*:*:*:*:*:ruby:*:*",
-      "dragonfly": "cpe:2.3:a:dragonfly_project:dragonfly:*:*:*:*:*:ruby:*:*",
-      "easymon": "cpe:2.3:a:basecamp:easymon:*:*:*:*:*:ruby:*:*",
-      "echor": "cpe:2.3:a:echor_project:echor:*:*:*:*:*:ruby:*:*",
-      "encoded_id-rails": "cpe:2.3:a:diaconou:encodedid\\:\\:rails:*:*:*:*:*:ruby:*:*",
-      "faye": "cpe:2.3:a:faye_project:faye:*:*:*:*:*:ruby:*:*",
-      "field_test": "cpe:2.3:a:field_test_project:field_test:*:*:*:*:*:ruby:*:*",
-      "fileutils": "cpe:2.3:a:ruby:fileutils:*:*:*:*:*:*:*:*",
-      "flash_tool": "cpe:2.3:a:milboj:flash_tool:*:*:*:*:*:ruby:*:*",
-      "fog-dragonfly": "cpe:2.3:a:mark_evans:fog-dragonfly:*:*:*:*:*:ruby:*:*",
-      "ftpd": "cpe:2.3:a:ftpd_project:ftpd:*:*:*:*:*:ruby:*:*",
-      "geminabox": "cpe:2.3:a:geminabox_project:geminabox:*:*:*:*:*:ruby:*:*",
-      "gemirro": "cpe:2.3:a:gemirro_project:gemirro:*:*:*:*:*:ruby:*:*",
-      "geokit-rails": "cpe:2.3:a:geokit:geokit-rails:*:*:*:*:*:rails:*:*",
-      "gibbon": "cpe:2.3:a:gibbon_project:gibbon:*:*:*:*:*:ruby:*:*",
-      "globalid": "cpe:2.3:a:rubyonrails:globalid:*:*:*:*:*:ruby:*:*",
-      "goliath": "cpe:2.3:a:goliath_project:goliath:*:*:*:*:*:ruby:*:*",
-      "gollum-grit_adapter": "cpe:2.3:a:gollum_project:grit_adapter:*:*:*:*:*:*:*:*",
-      "gon": "cpe:2.3:a:gon_project:gon:*:*:*:*:*:ruby:*:*",
-      "gyazo": "cpe:2.3:a:gyazo_project:gyazo:*:*:*:*:*:ruby:*:*",
-      "haml": "cpe:2.3:a:haml:haml:*:*:*:*:*:ruby:*:*",
-      "iodine": "cpe:2.3:a:boazsegev:iodine:*:*:*:*:*:ruby:*:*",
-      "json": "cpe:2.3:a:json_project:json:*:*:*:*:*:ruby:*:*",
-      "json-jwt": "cpe:2.3:a:json-jwt_project:json-jwt:*:*:*:*:*:ruby:*:*",
-      "kafo": "cpe:2.3:a:theforeman:kafo:*:*:*:*:*:*:*:*",
-      "kajam": "cpe:2.3:a:kajam_project:kajam:*:*:*:*:*:ruby:*:*",
-      "karo": "cpe:2.3:a:karo_project:karo:*:*:*:*:*:ruby:*:*",
-      "kcapifony": "cpe:2.3:a:kcapifony_project:kcapifony:*:*:*:*:*:ruby:*:*",
-      "keynote": "cpe:2.3:a:keynote_project:keynote:*:*:*:*:*:ruby:*:*",
-      "kitchen-terraform": "cpe:2.3:a:kitchen-terraform_project:kitchen-terraform:*:*:*:*:*:ruby:*:*",
-      "kramdown": "cpe:2.3:a:kramdown_project:kramdown:*:*:*:*:*:ruby:*:*",
-      "lawn-login": "cpe:2.3:a:lawn-login_project:lawn-login:*:*:*:*:*:ruby:*:*",
-      "lean-ruport": "cpe:2.3:a:lean-ruport_project:lean-ruport:*:*:*:*:*:ruby:*:*",
-      "loofah": "cpe:2.3:a:loofah_project:loofah:*:*:*:*:*:ruby:*:*",
-      "lynx": "cpe:2.3:a:lynx_project:lynx:*:*:*:*:*:ruby:*:*",
-      "mechanize": "cpe:2.3:a:mechanize_project:mechanize:*:*:*:*:*:ruby:*:*",
-      "message_bus": "cpe:2.3:a:discourse:message_bus:*:*:*:*:*:ruby:*:*",
-      "minitar": "cpe:2.3:a:minitar:minitar:*:*:*:*:*:ruby:*:*",
-      "moped": "cpe:2.3:a:moped_project:moped:*:*:*:*:*:ruby:*:*",
-      "mpxj": "cpe:2.3:a:mpxj:mpxj:*:*:*:*:*:ruby:*:*",
-      "net-ldap": "cpe:2.3:a:net-ldap_project:net-ldap:*:*:*:*:*:ruby:*:*",
-      "net-ssh": "cpe:2.3:a:net-ssh:net-ssh:*:*:*:*:*:ruby:*:*",
-      "netaddr": "cpe:2.3:a:netaddr_project:netaddr:*:*:*:*:*:ruby:*:*",
-      "nokogiri": "cpe:2.3:a:nokogiri:nokogiri:*:*:*:*:*:ruby:*:*",
-      "octokit": "cpe:2.3:a:octokit_project:octokit:*:*:*:*:*:ruby:*:*",
-      "octopoller": "cpe:2.3:a:octopoller_project:octopoller:*:*:*:*:*:ruby:*:*",
-      "omniauth": "cpe:2.3:a:omniauth:omniauth:*:*:*:*:*:ruby:*:*",
-      "omniauth-apple": "cpe:2.3:a:omniauth-apple_project:omniauth-apple:*:*:*:*:*:ruby:*:*",
-      "omniauth-auth0": "cpe:2.3:a:auth0:omniauth-auth0:*:*:*:*:*:ruby:*:*",
-      "omniauth-facebook": "cpe:2.3:a:omniauth-facebook_project:omniauth-facebook:*:*:*:*:*:ruby:*:*",
-      "omniauth-oauth2": "cpe:2.3:a:omniauth-oauth2_project:omniauth-oauth2:*:*:*:*:*:ruby:*:*",
-      "open-uri-cached": "cpe:2.3:a:open-uri-cached_project:open-uri-cached:*:*:*:*:*:ruby:*:*",
-      "openshift-origin-controller": "cpe:2.3:a:openshift-origin-controller_project:openshift-origin-controller:*:*:*:*:*:ruby:*:*",
-      "openshift-origin-node": "cpe:2.3:a:redhat:openshift_origin:*:*:*:*:*:*:*:*",
-      "openssl": "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:*:*:*",
-      "ox": "cpe:2.3:a:ox_project:ox:*:*:*:*:*:ruby:*:*",
-      "papercrop": "cpe:2.3:a:papercrop_project:papercrop:*:*:*:*:*:ruby:*:*",
-      "paranoid2": "cpe:2.3:a:anjlab:paranoid2:*:*:*:*:*:ruby:*:*",
-      "paratrooper-pingdom": "cpe:2.3:a:tobias_maier:paratrooper-pingdom:*:*:-:*:-:ruby:*:*",
-      "pay": "cpe:2.3:a:pay_project:pay:*:*:*:*:*:ruby:*:*",
-      "pdf_info": "cpe:2.3:a:newspaperclub:pdf_info:*:*:*:*:*:ruby:*:*",
-      "pdfkit": "cpe:2.3:a:pdfkit_project:pdfkit:*:*:*:*:*:ruby:*:*",
-      "pghero": "cpe:2.3:a:pghero_project:pghero:*:*:*:*:*:ruby:*:*",
-      "point-cli": "cpe:2.3:a:point-cli_project:point-cli:*:*:*:*:*:ruby:*:*",
-      "private_address_check": "cpe:2.3:a:private_address_check_project:private_address_check:*:*:*:*:*:ruby:*:*",
-      "puma": "cpe:2.3:a:puma:puma:*:*:*:*:*:ruby:*:*",
-      "rack-cors": "cpe:2.3:a:rack-cors_project:rack-cors:*:*:*:*:*:ruby:*:*",
-      "rack-ssl": "cpe:2.3:a:joshua_peek:rack-ssl:*:*:*:*:*:ruby:*:*",
-      "rails": "cpe:2.3:a:rubyonrails:rails:*:*:*:*:*:*:*:*",
-      "rails-html-sanitizer": "cpe:2.3:a:rubyonrails:rails_html_sanitizers:*:*:*:*:*:rails:*:*",
-      "rails_multisite": "cpe:2.3:a:discourse:rails_multisite:*:*:*:*:*:ruby:*:*",
-      "rake": "cpe:2.3:a:ruby-lang:rake:*:*:*:*:*:*:*:*",
-      "random_password_generator": "cpe:2.3:a:random_password_generator_project:random_password_generator:*:*:*:*:*:ruby:*:*",
-      "rbovirt": "cpe:2.3:a:amos_benari:rbovirt:*:*:*:*:*:ruby:*:*",
-      "rdoc": "cpe:2.3:a:ruby-lang:rdoc:*:*:*:*:*:ruby:*:*",
-      "redcarpet": "cpe:2.3:a:redcarpet_project:redcarpet:*:*:*:*:*:ruby:*:*",
-      "resque": "cpe:2.3:a:resque:resque:*:*:*:*:*:ruby:*:*",
-      "resque-scheduler": "cpe:2.3:a:resque-scheduler_project:resque-scheduler:*:*:*:*:*:ruby:*:*",
-      "rest-client": "cpe:2.3:a:rest-client_project:rest-client:*:*:*:*:*:ruby:*:*",
-      "rexml": "cpe:2.3:a:ruby-lang:rexml:*:*:*:*:*:ruby:*:*",
-      "rgpg": "cpe:2.3:a:richard_cook:rgpg:*:*:*:*:*:ruby:*:*",
-      "rmagick": "cpe:2.3:a:rmagick:rmagick:*:*:*:*:*:ruby:*:*",
-      "ruby": "cpe:2.3:a:ruby-lang:ruby:*:*:*:*:*:*:*:*",
-      "ruby-jss": "cpe:2.3:a:pixar:ruby-jss:*:*:*:*:*:ruby:*:*",
-      "ruby-mysql": "cpe:2.3:a:ruby-mysql_project:ruby-mysql:*:*:*:*:*:ruby:*:*",
-      "rubygems-update": "cpe:2.3:a:rubygems:rubygems:*:*:*:*:*:*:*:*",
-      "safemode": "cpe:2.3:a:safemode_project:safemode:*:*:*:*:*:ruby:*:*",
-      "sanitize": "cpe:2.3:a:sanitize_project:sanitize:*:*:*:*:*:ruby:*:*",
-      "secure_headers": "cpe:2.3:a:twitter:secure_headers:*:*:*:*:*:ruby:*:*",
-      "sfpagent": "cpe:2.3:a:herry:sfpagent:*:*:*:*:*:ruby:*:*",
-      "show_in_browser": "cpe:2.3:a:jonathan_leung:show_in_browser:*:*:*:*:*:ruby:*:*",
-      "simple_captcha2": "cpe:2.3:a:simple_captcha2_project:simple_captcha2:*:*:*:*:*:ruby:*:*",
-      "solidus_auth_devise": "cpe:2.3:a:nebulab:solidus_auth_devise:*:*:*:*:*:ruby:*:*",
-      "sounder": "cpe:2.3:a:adam_zaninovich:sounder:*:*:*:*:*:*:*:*",
-      "spree_auth_devise": "cpe:2.3:a:spreecommerce:spree_auth_devise:*:*:*:*:*:ruby:*:*",
-      "sprockets": "cpe:2.3:a:sprockets_project:sprockets:*:*:*:*:*:*:*:*",
-      "sprockets-rails": "cpe:2.3:a:sprockets_project:sprockets:*:*:*:*:*:*:*:*",
-      "sprout": "cpe:2.3:a:projectsprouts:sprout:*:*:-:*:-:ruby:*:*",
-      "strong_password": "cpe:2.3:a:strong_password_project:strong_password:*:*:*:*:*:ruby:*:*",
-      "time": "cpe:2.3:a:ruby-lang:time:*:*:*:*:*:ruby:*:*",
-      "trestle-auth": "cpe:2.3:a:trestle-auth_project:trestle-auth:*:*:*:*:*:ruby:*:*",
-      "trilogy": "cpe:2.3:a:trilogy_project:trilogy:*:*:*:*:*:ruby:*:*",
-      "tweetstream": "cpe:2.3:a:tweetstream_project:tweetstream:*:*:*:*:*:ruby:*:*",
-      "update_by_case": "cpe:2.3:a:update_by_case_project:update_by_case:*:*:*:*:*:ruby:*:*",
-      "uri": "cpe:2.3:a:ruby-lang:uri:*:*:*:*:*:ruby:*:*",
-      "view_component": "cpe:2.3:a:viewcomponent:view_component:*:*:*:*:*:ruby:*:*",
-      "webbynode": "cpe:2.3:a:webbynode:webbynode:*:*:-:*:-:ruby:*:*",
-      "webrick": "cpe:2.3:a:ruby-lang:webrick:*:*:*:*:*:ruby:*:*",
-      "websocket-extensions": "cpe:2.3:a:websocket-extensions_project:websocket-extensions:*:*:*:*:*:ruby:*:*"
+      "Arabic-Prawn": [
+        "cpe:2.3:a:dynamixsolutions:arabic_prawn:*:*:*:*:*:ruby:*:*"
+      ],
+      "VladTheEnterprising": [
+        "cpe:2.3:a:vladtheenterprising_project:vladtheenterprising:*:*:*:*:*:ruby:*:*"
+      ],
+      "actionpack": [
+        "cpe:2.3:a:actionpack_project:actionpack:*:*:*:*:*:ruby:*:*"
+      ],
+      "actionview": [
+        "cpe:2.3:a:action_view_project:action_view:*:*:*:*:*:ruby:*:*"
+      ],
+      "activerecord": [
+        "cpe:2.3:a:activerecord_project:activerecord:*:*:*:*:*:ruby:*:*"
+      ],
+      "activesupport": [
+        "cpe:2.3:a:activesupport_project:activesupport:*:*:*:*:*:ruby:*:*"
+      ],
+      "arvados": [
+        "cpe:2.3:a:arvados:arvados:*:*:*:*:*:ruby:*:*"
+      ],
+      "avo": [
+        "cpe:2.3:a:avohq:avo:*:*:*:*:*:ruby:*:*"
+      ],
+      "backup-agoddard": [
+        "cpe:2.3:a:backup-agoddard_project:backup-agoddard:*:*:*:*:*:ruby:*:*"
+      ],
+      "backup_checksum": [
+        "cpe:2.3:a:backup_checksum_project:backup_checksum:*:*:*:*:*:ruby:*:*"
+      ],
+      "better_errors": [
+        "cpe:2.3:a:better_errors_project:better_errors:*:*:*:*:*:ruby:*:*"
+      ],
+      "bindata": [
+        "cpe:2.3:a:bindata_project:bindata:*:*:*:*:*:ruby:*:*"
+      ],
+      "bio-basespace-sdk": [
+        "cpe:2.3:a:basespace_ruby_sdk_project:basespace_ruby_sdk:*:*:*:*:*:ruby:*:*"
+      ],
+      "brbackup": [
+        "cpe:2.3:a:brbackup_project:brbackup:*:*:*:*:*:ruby:*:*"
+      ],
+      "bson": [
+        "cpe:2.3:a:bson_project:bson:*:*:*:*:*:ruby:*:*"
+      ],
+      "cap-strap": [
+        "cpe:2.3:a:cap-strap_project:cap-strap:*:*:*:*:*:ruby:*:*"
+      ],
+      "carrierwave": [
+        "cpe:2.3:a:carrierwave_project:carrierwave:*:*:*:*:*:ruby:*:*"
+      ],
+      "cgi": [
+        "cpe:2.3:a:ruby-lang:cgi:*:*:*:*:*:ruby:*:*"
+      ],
+      "ciborg": [
+        "cpe:2.3:a:ciborg_project:ciborg:*:*:*:*:*:ruby:*:*"
+      ],
+      "cocoapods-downloader": [
+        "cpe:2.3:a:cocoapods:cocoapods-downloader:*:*:*:*:*:ruby:*:*"
+      ],
+      "codders-dataset": [
+        "cpe:2.3:a:codders-dataset_project:codders-dataset:*:*:*:*:*:ruby:*:*"
+      ],
+      "codecov": [
+        "cpe:2.3:a:codecov:codecov:*:*:*:*:*:ruby:*:*"
+      ],
+      "colorscore": [
+        "cpe:2.3:a:colorscore_project:colorscore:*:*:*:*:*:ruby:*:*"
+      ],
+      "commonmarker": [
+        "cpe:2.3:a:gjtorikian:commonmarker:*:*:*:*:*:ruby:*:*"
+      ],
+      "consul": [
+        "cpe:2.3:a:makandra:consul:*:*:*:*:*:ruby:*:*"
+      ],
+      "cremefraiche": [
+        "cpe:2.3:a:uplawski:creme_fraiche:*:*:*:*:*:ruby:*:*"
+      ],
+      "csv-safe": [
+        "cpe:2.3:a:csv-safe_project:csv-safe:*:*:*:*:*:ruby:*:*"
+      ],
+      "csv_sniffer": [
+        "cpe:2.3:a:csv-sniffer_project:csv-sniffer:*:*:*:*:*:rust:*:*"
+      ],
+      "curl": [
+        "cpe:2.3:a:curl_project:curl:*:*:*:*:*:ruby:*:*"
+      ],
+      "datagrid": [
+        "cpe:2.3:a:datagrid_project:datagrid:*:*:*:*:*:ruby:*:*"
+      ],
+      "date": [
+        "cpe:2.3:a:ruby-lang:date:*:*:*:*:*:ruby:*:*"
+      ],
+      "decidim": [
+        "cpe:2.3:a:decidim:decidim:*:*:*:*:*:ruby:*:*"
+      ],
+      "devise": [
+        "cpe:2.3:a:heartcombo:devise:*:*:*:*:*:ruby:*:*"
+      ],
+      "diffy": [
+        "cpe:2.3:a:diffy_project:diffy:*:*:*:*:*:ruby:*:*"
+      ],
+      "discordrb": [
+        "cpe:2.3:a:discordrb_project:discordrb:*:*:*:*:*:ruby:*:*"
+      ],
+      "dragonfly": [
+        "cpe:2.3:a:dragonfly_project:dragonfly:*:*:*:*:*:ruby:*:*"
+      ],
+      "easymon": [
+        "cpe:2.3:a:basecamp:easymon:*:*:*:*:*:ruby:*:*"
+      ],
+      "echor": [
+        "cpe:2.3:a:echor_project:echor:*:*:*:*:*:ruby:*:*"
+      ],
+      "encoded_id-rails": [
+        "cpe:2.3:a:diaconou:encodedid\\:\\:rails:*:*:*:*:*:ruby:*:*"
+      ],
+      "faye": [
+        "cpe:2.3:a:faye_project:faye:*:*:*:*:*:ruby:*:*"
+      ],
+      "field_test": [
+        "cpe:2.3:a:field_test_project:field_test:*:*:*:*:*:ruby:*:*"
+      ],
+      "fileutils": [
+        "cpe:2.3:a:fileutils_project:fileutils:*:*:*:*:*:ruby:*:*",
+        "cpe:2.3:a:ruby:fileutils:*:*:*:*:*:*:*:*"
+      ],
+      "flash_tool": [
+        "cpe:2.3:a:milboj:flash_tool:*:*:*:*:*:ruby:*:*"
+      ],
+      "fog-dragonfly": [
+        "cpe:2.3:a:mark_evans:fog-dragonfly:*:*:*:*:*:ruby:*:*"
+      ],
+      "ftpd": [
+        "cpe:2.3:a:ftpd_project:ftpd:*:*:*:*:*:ruby:*:*"
+      ],
+      "geminabox": [
+        "cpe:2.3:a:geminabox_project:geminabox:*:*:*:*:*:ruby:*:*"
+      ],
+      "gemirro": [
+        "cpe:2.3:a:gemirro_project:gemirro:*:*:*:*:*:ruby:*:*"
+      ],
+      "geokit-rails": [
+        "cpe:2.3:a:geokit:geokit-rails:*:*:*:*:*:rails:*:*"
+      ],
+      "gibbon": [
+        "cpe:2.3:a:gibbon_project:gibbon:*:*:*:*:*:ruby:*:*"
+      ],
+      "globalid": [
+        "cpe:2.3:a:rubyonrails:globalid:*:*:*:*:*:ruby:*:*"
+      ],
+      "goliath": [
+        "cpe:2.3:a:goliath_project:goliath:*:*:*:*:*:ruby:*:*"
+      ],
+      "gollum-grit_adapter": [
+        "cpe:2.3:a:gollum_project:grit_adapter:*:*:*:*:*:*:*:*"
+      ],
+      "gon": [
+        "cpe:2.3:a:gon_project:gon:*:*:*:*:*:ruby:*:*"
+      ],
+      "gyazo": [
+        "cpe:2.3:a:gyazo_project:gyazo:*:*:*:*:*:ruby:*:*"
+      ],
+      "haml": [
+        "cpe:2.3:a:haml:haml:*:*:*:*:*:ruby:*:*"
+      ],
+      "iodine": [
+        "cpe:2.3:a:boazsegev:iodine:*:*:*:*:*:ruby:*:*"
+      ],
+      "json": [
+        "cpe:2.3:a:json_project:json:*:*:*:*:*:ruby:*:*"
+      ],
+      "json-jwt": [
+        "cpe:2.3:a:json-jwt_project:json-jwt:*:*:*:*:*:ruby:*:*"
+      ],
+      "kafo": [
+        "cpe:2.3:a:theforeman:kafo:*:*:*:*:*:*:*:*"
+      ],
+      "kajam": [
+        "cpe:2.3:a:kajam_project:kajam:*:*:*:*:*:ruby:*:*"
+      ],
+      "karo": [
+        "cpe:2.3:a:karo_project:karo:*:*:*:*:*:ruby:*:*"
+      ],
+      "kcapifony": [
+        "cpe:2.3:a:kcapifony_project:kcapifony:*:*:*:*:*:ruby:*:*"
+      ],
+      "keynote": [
+        "cpe:2.3:a:keynote_project:keynote:*:*:*:*:*:ruby:*:*"
+      ],
+      "kitchen-terraform": [
+        "cpe:2.3:a:kitchen-terraform_project:kitchen-terraform:*:*:*:*:*:ruby:*:*"
+      ],
+      "kramdown": [
+        "cpe:2.3:a:kramdown_project:kramdown:*:*:*:*:*:ruby:*:*"
+      ],
+      "lawn-login": [
+        "cpe:2.3:a:lawn-login_project:lawn-login:*:*:*:*:*:ruby:*:*"
+      ],
+      "lean-ruport": [
+        "cpe:2.3:a:lean-ruport_project:lean-ruport:*:*:*:*:*:ruby:*:*"
+      ],
+      "loofah": [
+        "cpe:2.3:a:loofah_project:loofah:*:*:*:*:*:ruby:*:*"
+      ],
+      "lynx": [
+        "cpe:2.3:a:lynx_project:lynx:*:*:*:*:*:ruby:*:*"
+      ],
+      "mechanize": [
+        "cpe:2.3:a:mechanize_project:mechanize:*:*:*:*:*:ruby:*:*"
+      ],
+      "message_bus": [
+        "cpe:2.3:a:discourse:message_bus:*:*:*:*:*:ruby:*:*"
+      ],
+      "minitar": [
+        "cpe:2.3:a:minitar:archive-tar-minitar:*:*:*:*:*:ruby:*:*",
+        "cpe:2.3:a:minitar:minitar:*:*:*:*:*:ruby:*:*"
+      ],
+      "moped": [
+        "cpe:2.3:a:moped_project:moped:*:*:*:*:*:ruby:*:*"
+      ],
+      "mpxj": [
+        "cpe:2.3:a:mpxj:mpxj:*:*:*:*:*:ruby:*:*"
+      ],
+      "net-ldap": [
+        "cpe:2.3:a:net-ldap_project:net-ldap:*:*:*:*:*:ruby:*:*"
+      ],
+      "net-ssh": [
+        "cpe:2.3:a:net-ssh:net-ssh:*:*:*:*:*:ruby:*:*"
+      ],
+      "netaddr": [
+        "cpe:2.3:a:netaddr_project:netaddr:*:*:*:*:*:ruby:*:*"
+      ],
+      "nokogiri": [
+        "cpe:2.3:a:nokogiri:nokogiri:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:nokogiri:nokogiri:*:*:*:*:*:ruby:*:*"
+      ],
+      "octokit": [
+        "cpe:2.3:a:octokit_project:octokit:*:*:*:*:*:ruby:*:*"
+      ],
+      "octopoller": [
+        "cpe:2.3:a:octopoller_project:octopoller:*:*:*:*:*:ruby:*:*"
+      ],
+      "omniauth": [
+        "cpe:2.3:a:omniauth:omniauth:*:*:*:*:*:ruby:*:*"
+      ],
+      "omniauth-apple": [
+        "cpe:2.3:a:omniauth-apple_project:omniauth-apple:*:*:*:*:*:ruby:*:*"
+      ],
+      "omniauth-auth0": [
+        "cpe:2.3:a:auth0:omniauth-auth0:*:*:*:*:*:ruby:*:*"
+      ],
+      "omniauth-facebook": [
+        "cpe:2.3:a:omniauth-facebook_project:omniauth-facebook:*:*:*:*:*:ruby:*:*"
+      ],
+      "omniauth-oauth2": [
+        "cpe:2.3:a:omniauth-oauth2_project:omniauth-oauth2:*:*:*:*:*:ruby:*:*"
+      ],
+      "open-uri-cached": [
+        "cpe:2.3:a:open-uri-cached_project:open-uri-cached:*:*:*:*:*:ruby:*:*"
+      ],
+      "openshift-origin-controller": [
+        "cpe:2.3:a:openshift-origin-controller_project:openshift-origin-controller:*:*:*:*:*:ruby:*:*"
+      ],
+      "openshift-origin-node": [
+        "cpe:2.3:a:redhat:openshift_origin:*:*:*:*:*:*:*:*"
+      ],
+      "openssl": [
+        "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:ruby:*:*"
+      ],
+      "ox": [
+        "cpe:2.3:a:ox_project:ox:*:*:*:*:*:ruby:*:*"
+      ],
+      "papercrop": [
+        "cpe:2.3:a:papercrop_project:papercrop:*:*:*:*:*:ruby:*:*"
+      ],
+      "paranoid2": [
+        "cpe:2.3:a:anjlab:paranoid2:*:*:*:*:*:ruby:*:*"
+      ],
+      "paratrooper-pingdom": [
+        "cpe:2.3:a:tobias_maier:paratrooper-pingdom:*:*:-:*:-:ruby:*:*"
+      ],
+      "pay": [
+        "cpe:2.3:a:pay_project:pay:*:*:*:*:*:ruby:*:*"
+      ],
+      "pdf_info": [
+        "cpe:2.3:a:newspaperclub:pdf_info:*:*:*:*:*:ruby:*:*"
+      ],
+      "pdfkit": [
+        "cpe:2.3:a:pdfkit_project:pdfkit:*:*:*:*:*:ruby:*:*"
+      ],
+      "pghero": [
+        "cpe:2.3:a:pghero_project:pghero:*:*:*:*:*:ruby:*:*"
+      ],
+      "point-cli": [
+        "cpe:2.3:a:point-cli_project:point-cli:*:*:*:*:*:ruby:*:*"
+      ],
+      "private_address_check": [
+        "cpe:2.3:a:private_address_check_project:private_address_check:*:*:*:*:*:ruby:*:*"
+      ],
+      "puma": [
+        "cpe:2.3:a:puma:puma:*:*:*:*:*:ruby:*:*"
+      ],
+      "rack-cors": [
+        "cpe:2.3:a:rack-cors_project:rack-cors:*:*:*:*:*:ruby:*:*"
+      ],
+      "rack-ssl": [
+        "cpe:2.3:a:joshua_peek:rack-ssl:*:*:*:*:*:ruby:*:*"
+      ],
+      "rails": [
+        "cpe:2.3:a:rubyonrails:rails:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:rubyonrails:ruby_on_rails:*:*:*:*:*:*:*:*"
+      ],
+      "rails-html-sanitizer": [
+        "cpe:2.3:a:rubyonrails:rails_html_sanitizers:*:*:*:*:*:rails:*:*"
+      ],
+      "rails_multisite": [
+        "cpe:2.3:a:discourse:rails_multisite:*:*:*:*:*:ruby:*:*"
+      ],
+      "rake": [
+        "cpe:2.3:a:ruby-lang:rake:*:*:*:*:*:*:*:*"
+      ],
+      "random_password_generator": [
+        "cpe:2.3:a:random_password_generator_project:random_password_generator:*:*:*:*:*:ruby:*:*"
+      ],
+      "rbovirt": [
+        "cpe:2.3:a:amos_benari:rbovirt:*:*:*:*:*:ruby:*:*"
+      ],
+      "rdoc": [
+        "cpe:2.3:a:ruby-lang:rdoc:*:*:*:*:*:ruby:*:*"
+      ],
+      "redcarpet": [
+        "cpe:2.3:a:redcarpet_project:redcarpet:*:*:*:*:*:ruby:*:*"
+      ],
+      "resque": [
+        "cpe:2.3:a:resque:resque:*:*:*:*:*:ruby:*:*"
+      ],
+      "resque-scheduler": [
+        "cpe:2.3:a:resque-scheduler_project:resque-scheduler:*:*:*:*:*:ruby:*:*"
+      ],
+      "rest-client": [
+        "cpe:2.3:a:rest-client_project:rest-client:*:*:*:*:*:ruby:*:*"
+      ],
+      "rexml": [
+        "cpe:2.3:a:ruby-lang:rexml:*:*:*:*:*:ruby:*:*"
+      ],
+      "rgpg": [
+        "cpe:2.3:a:richard_cook:rgpg:*:*:*:*:*:ruby:*:*"
+      ],
+      "rmagick": [
+        "cpe:2.3:a:rmagick:rmagick:*:*:*:*:*:ruby:*:*"
+      ],
+      "ruby": [
+        "cpe:2.3:a:ruby-lang:ruby:*:*:*:*:*:*:*:*"
+      ],
+      "ruby-jss": [
+        "cpe:2.3:a:pixar:ruby-jss:*:*:*:*:*:ruby:*:*"
+      ],
+      "ruby-mysql": [
+        "cpe:2.3:a:ruby-mysql_project:ruby-mysql:*:*:*:*:*:ruby:*:*"
+      ],
+      "rubygems-update": [
+        "cpe:2.3:a:rubygems:rubygems:*:*:*:*:*:*:*:*"
+      ],
+      "safemode": [
+        "cpe:2.3:a:safemode_project:safemode:*:*:*:*:*:ruby:*:*"
+      ],
+      "sanitize": [
+        "cpe:2.3:a:sanitize_project:sanitize:*:*:*:*:*:ruby:*:*"
+      ],
+      "secure_headers": [
+        "cpe:2.3:a:twitter:secure_headers:*:*:*:*:*:ruby:*:*"
+      ],
+      "sfpagent": [
+        "cpe:2.3:a:herry:sfpagent:*:*:*:*:*:ruby:*:*"
+      ],
+      "show_in_browser": [
+        "cpe:2.3:a:jonathan_leung:show_in_browser:*:*:*:*:*:ruby:*:*"
+      ],
+      "simple_captcha2": [
+        "cpe:2.3:a:simple_captcha2_project:simple_captcha2:*:*:*:*:*:ruby:*:*"
+      ],
+      "solidus_auth_devise": [
+        "cpe:2.3:a:nebulab:solidus_auth_devise:*:*:*:*:*:ruby:*:*"
+      ],
+      "sounder": [
+        "cpe:2.3:a:adam_zaninovich:sounder:*:*:*:*:*:*:*:*"
+      ],
+      "spree_auth_devise": [
+        "cpe:2.3:a:spreecommerce:spree_auth_devise:*:*:*:*:*:ruby:*:*"
+      ],
+      "sprockets": [
+        "cpe:2.3:a:sprockets_project:sprockets:*:*:*:*:*:*:*:*"
+      ],
+      "sprockets-rails": [
+        "cpe:2.3:a:sprockets_project:sprockets:*:*:*:*:*:*:*:*"
+      ],
+      "sprout": [
+        "cpe:2.3:a:projectsprouts:sprout:*:*:-:*:-:ruby:*:*"
+      ],
+      "strong_password": [
+        "cpe:2.3:a:strong_password_project:strong_password:*:*:*:*:*:ruby:*:*"
+      ],
+      "time": [
+        "cpe:2.3:a:ruby-lang:time:*:*:*:*:*:ruby:*:*"
+      ],
+      "trestle-auth": [
+        "cpe:2.3:a:trestle-auth_project:trestle-auth:*:*:*:*:*:ruby:*:*"
+      ],
+      "trilogy": [
+        "cpe:2.3:a:trilogy_project:trilogy:*:*:*:*:*:ruby:*:*"
+      ],
+      "tweetstream": [
+        "cpe:2.3:a:tweetstream_project:tweetstream:*:*:*:*:*:ruby:*:*"
+      ],
+      "update_by_case": [
+        "cpe:2.3:a:update_by_case_project:update_by_case:*:*:*:*:*:ruby:*:*"
+      ],
+      "uri": [
+        "cpe:2.3:a:ruby-lang:uri:*:*:*:*:*:ruby:*:*"
+      ],
+      "view_component": [
+        "cpe:2.3:a:viewcomponent:view_component:*:*:*:*:*:ruby:*:*"
+      ],
+      "webbynode": [
+        "cpe:2.3:a:webbynode:webbynode:*:*:-:*:-:ruby:*:*"
+      ],
+      "webrick": [
+        "cpe:2.3:a:ruby-lang:webrick:*:*:*:*:*:ruby:*:*"
+      ],
+      "websocket-extensions": [
+        "cpe:2.3:a:websocket-extensions_project:websocket-extensions:*:*:*:*:*:ruby:*:*"
+      ]
     },
     "rust_crates": {
-      "abomonation": "cpe:2.3:a:abomonation_project:abomonation:*:*:*:*:*:rust:*:*",
-      "abox": "cpe:2.3:a:abox_project:abox:*:*:*:*:*:rust:*:*",
-      "acc_reader": "cpe:2.3:a:acc_reader_project:acc_reader:*:*:*:*:*:rust:*:*",
-      "actix-codec": "cpe:2.3:a:actix:actix-codec:*:*:*:*:*:rust:*:*",
-      "actix-http": "cpe:2.3:a:actix:actix-http:*:*:*:*:*:rust:*:*",
-      "actix-service": "cpe:2.3:a:actix:actix-service:*:*:*:*:*:rust:*:*",
-      "actix-utils": "cpe:2.3:a:actix:actix-utils:*:*:*:*:*:rust:*:*",
-      "actix-web": "cpe:2.3:a:actix:actix-web:*:*:*:*:*:rust:*:*",
-      "adtensor": "cpe:2.3:a:adtensor_project:adtensor:*:*:*:*:*:rust:*:*",
-      "algorithmica": "cpe:2.3:a:algorithmica_project:algorithmica:*:*:*:*:*:rust:*:*",
-      "alpm-rs": "cpe:2.3:a:alpm-rs_project:alpm-rs:*:*:*:*:*:rust:*:*",
-      "ammonia": "cpe:2.3:a:ammonia_project:ammonia:*:*:*:*:*:rust:*:*",
-      "anymap": "cpe:2.3:a:anymap_project:anymap:*:*:*:*:*:rust:*:*",
-      "aovec": "cpe:2.3:a:aovec_project:aovec:*:*:*:*:*:rust:*:*",
-      "arenavec": "cpe:2.3:a:arenavec_project:arenavec:*:*:*:*:*:rust:*:*",
-      "arr": "cpe:2.3:a:arr_project:arr:*:*:*:*:*:rust:*:*",
-      "array-queue": "cpe:2.3:a:array-queue_project:array-queue:*:*:*:*:*:rust:*:*",
-      "array-tools": "cpe:2.3:a:array-tools_project:array-tools:*:*:*:*:*:rust:*:*",
-      "ash": "cpe:2.3:a:ash_project:ash:*:*:*:*:*:rust:*:*",
-      "asn1_der": "cpe:2.3:a:asn1_der_project:asn1_der:*:*:*:*:*:*:*:*",
-      "async-h1": "cpe:2.3:a:rust-lang:async-h1:*:*:*:*:*:rust:*:*",
-      "atom": "cpe:2.3:a:atom_project:atom:*:*:*:*:*:rust:*:*",
-      "atomic-option": "cpe:2.3:a:atomic-option_project:atomic-option:*:*:*:*:*:rust:*:*",
-      "autorand": "cpe:2.3:a:autorand_project:autorand:*:*:*:*:*:rust:*:*",
-      "axum-core": "cpe:2.3:a:axum-core_project:axum-core:*:*:*:*:*:rust:*:*",
-      "bam": "cpe:2.3:a:bam_project:bam:*:*:*:*:*:rust:*:*",
-      "basic_dsp_matrix": "cpe:2.3:a:basic_dsp_matrix_project:basic_dsp_matrix:*:*:*:*:*:rust:*:*",
-      "bat": "cpe:2.3:a:bat_project:bat:*:*:*:*:*:rust:*:*",
-      "beef": "cpe:2.3:a:beef_project:beef:*:*:*:*:*:rust:*:*",
-      "bigint": "cpe:2.3:a:bigint_project:bigint:*:*:*:*:*:rust:*:*",
-      "binjs_io": "cpe:2.3:a:binjs_io_project:binjs_io:*:*:*:*:*:rust:*:*",
-      "biscuit-auth": "cpe:2.3:a:biscuitsec:biscuit-auth:*:*:*:*:*:rust:*:*",
-      "bite": "cpe:2.3:a:bite_project:bite:*:*:*:*:*:rust:*:*",
-      "bitvec": "cpe:2.3:a:bitvec_project:bitvec:*:*:*:*:*:rust:*:*",
-      "bra": "cpe:2.3:a:bra_project:bra:*:*:*:*:*:rust:*:*",
-      "branca": "cpe:2.3:a:hakobaito:branca:*:*:*:*:*:rust:*:*",
-      "bronzedb-protocol": "cpe:2.3:a:bronzedb-protocol_project:bronzedb-protocol:*:*:*:*:*:rust:*:*",
-      "buffoon": "cpe:2.3:a:buffoon_project:buffoon:*:*:*:*:*:rust:*:*",
-      "buttplug": "cpe:2.3:a:nonpolynomial:buttplug:*:*:*:*:*:rust:*:*",
-      "bzip2": "cpe:2.3:a:bzip2_project:bzip2:*:*:*:*:*:rust:*:*",
-      "cache": "cpe:2.3:a:cache_project:cache:*:*:*:*:*:rust:*:*",
-      "cached": "cpe:2.3:a:cached_project:cached:*:*:*:*:*:rust:*:*",
-      "candid": "cpe:2.3:a:dfinity:candid:*:*:*:*:*:rust:*:*",
-      "capnp": "cpe:2.3:a:capnproto:capnp:*:*:*:*:*:rust:*:*",
-      "cbox": "cpe:2.3:a:cbox_project:cbox:*:*:*:*:*:rust:*:*",
-      "cdr": "cpe:2.3:a:cdr_project:cdr:*:*:*:*:*:rust:*:*",
-      "ckb": "cpe:2.3:a:nervos:ckb:*:*:*:*:*:rust:*:*",
-      "columnar": "cpe:2.3:a:columnar_project:columnar:*:*:*:*:*:rust:*:*",
-      "comrak": "cpe:2.3:a:comrak_project:comrak:*:*:*:*:*:rust:*:*",
-      "concread": "cpe:2.3:a:concread_project:concread:*:*:*:*:*:rust:*:*",
-      "conduit-hyper": "cpe:2.3:a:conduit-hyper_project:conduit-hyper:*:*:*:*:*:rust:*:*",
-      "conqueue": "cpe:2.3:a:conqueue_project:conqueue:*:*:*:*:*:rust:*:*",
-      "containers": "cpe:2.3:a:containers_project:containers:*:*:*:*:*:rust:*:*",
-      "cranelift-codegen": "cpe:2.3:a:bytecodealliance:cranelift-codegen:*:*:*:*:*:rust:*:*",
-      "crossbeam": "cpe:2.3:a:crossbeam_project:crossbeam:*:*:*:*:*:rust:*:*",
-      "crossbeam-channel": "cpe:2.3:a:crossbeam-channel_project:crossbeam-channel:*:*:*:*:*:rust:*:*",
-      "crypto2": "cpe:2.3:a:crypto2_project:crypto2:*:*:*:*:*:rust:*:*",
-      "derive-com-impl": "cpe:2.3:a:derive-com-impl_project:derive-com-impl:*:*:*:*:*:rust:*:*",
-      "diesel": "cpe:2.3:a:diesel:diesel:*:*:*:*:*:rust:*:*",
-      "dync": "cpe:2.3:a:dync_project:dync:*:*:*:*:*:rust:*:*",
-      "endian_trait": "cpe:2.3:a:endian_trait_project:endian_trait:*:*:*:*:*:rust:*:*",
-      "eventio": "cpe:2.3:a:petabi:eventio:*:*:*:*:*:rust:*:*",
-      "evm": "cpe:2.3:a:evm_project:evm:*:*:*:*:*:rust:*:*",
-      "failure": "cpe:2.3:a:failure_project:failure:*:*:*:*:*:rust:*:*",
-      "fil-ocl": "cpe:2.3:a:fil-ocl_project:fil-ocl:*:*:*:*:*:rust:*:*",
-      "flatbuffers": "cpe:2.3:a:google:flatbuffers:*:*:*:*:*:rust:*:*",
-      "flumedb": "cpe:2.3:a:flumedb_project:flumedb:*:*:*:*:*:rust:*:*",
-      "fruity": "cpe:2.3:a:fruity_project:fruity:*:*:*:*:*:rust:*:*",
-      "futures-intrusive": "cpe:2.3:a:futures-intrusive_project:futures-intrusive:*:*:*:*:*:rust:*:*",
-      "futures-task": "cpe:2.3:a:rust-lang:futures-task:*:*:*:*:*:rust:*:*",
-      "generator": "cpe:2.3:a:generator_project:generator:*:*:*:*:*:rust:*:*",
-      "generic-array": "cpe:2.3:a:generic-array_project:generic-array:*:*:*:*:*:rust:*:*",
-      "getrandom": "cpe:2.3:a:getrandom_project:getrandom:*:*:*:*:*:rust:*:*",
-      "gfx-auxil": "cpe:2.3:a:gfx-auxil_project:gfx-auxil:*:*:*:*:*:rust:*:*",
-      "glsl-layout": "cpe:2.3:a:glsl-layout_project:glsl-layout:*:*:*:*:*:rust:*:*",
-      "hashconsing": "cpe:2.3:a:hashconsing_project:hashconsing:*:*:*:*:*:rust:*:*",
-      "heapless": "cpe:2.3:a:heapless_project:heapless:*:*:*:*:*:rust:*:*",
-      "iced-x86": "cpe:2.3:a:iced-x86_project:iced-x86:*:*:*:*:*:rust:*:*",
-      "id-map": "cpe:2.3:a:id-map_project:id-map:*:*:*:*:*:rust:*:*",
-      "insert_many": "cpe:2.3:a:insert_many_project:insert_many:*:*:*:*:*:rust:*:*",
-      "internment": "cpe:2.3:a:internment_project:internment:*:*:*:*:*:rust:*:*",
-      "juniper": "cpe:2.3:a:juniper_project:juniper:*:*:*:*:*:rust:*:*",
-      "kamadak-exif": "cpe:2.3:a:kamadak-exif_project:kamadak-exif:*:*:*:*:*:rust:*:*",
-      "kekbit": "cpe:2.3:a:kekbit_project:kekbit:*:*:*:*:*:rust:*:*",
-      "lazy-init": "cpe:2.3:a:lazy-init_project:lazy-init:*:*:*:*:*:rust:*:*",
-      "lettre": "cpe:2.3:a:lettre:lettre:*:*:*:*:*:rust:*:*",
-      "lever": "cpe:2.3:a:lever_project:lever:*:*:*:*:*:rust:*:*",
-      "libp2p": "cpe:2.3:a:protocol:libp2p:*:*:*:*:*:rust:*:*",
-      "libp2p-deflate": "cpe:2.3:a:libp2p:libp2p-deflate:*:*:*:*:*:rust:*:*",
-      "libpulse-binding": "cpe:2.3:a:libpulse-binding_project:libpulse-binding:*:*:*:*:*:rust:*:*",
-      "libsbc": "cpe:2.3:a:libsbc_project:libsbc:*:*:*:*:*:rust:*:*",
-      "libsecp256k1": "cpe:2.3:a:parity:libsecp256k1:*:*:*:*:*:rust:*:*",
-      "linked-list-allocator": "cpe:2.3:a:rust-osdev:linked-list-allocator:*:*:*:*:*:rust:*:*",
-      "linux-loader": "cpe:2.3:a:linux-loader_project:linux-loader:*:*:*:*:*:rust:*:*",
-      "lock_api": "cpe:2.3:a:lock_api_project:lock_api:*:*:*:*:*:rust:*:*",
-      "lru": "cpe:2.3:a:lru_project:lru:*:*:*:*:*:rust:*:*",
-      "lru-cache": "cpe:2.3:a:lru-cache_project:lru-cache:*:*:*:*:*:rust:*:*",
-      "lucet-runtime": "cpe:2.3:a:bytecodealliance:lucet:*:*:*:*:*:rust:*:*",
-      "lucet-runtime-internals": "cpe:2.3:a:lucet-runtime-internals_project:lucet-runtime-internals:*:*:*:*:*:rust:*:*",
-      "magnetic": "cpe:2.3:a:magnetic_project:magnetic:*:*:*:*:*:rust:*:*",
-      "may": "cpe:2.3:a:may_project:may:*:*:*:*:*:rust:*:*",
-      "mdbook": "cpe:2.3:a:rust-lang:mdbook:*:*:*:*:*:rust:*:*",
-      "messagepack-rs": "cpe:2.3:a:messagepack-rs_project:messagepack-rs:*:*:*:*:*:rust:*:*",
-      "metrics-util": "cpe:2.3:a:metrics-util_project:metrics-util:*:*:*:*:*:rust:*:*",
-      "molecule": "cpe:2.3:a:nervos:molecule:*:*:*:*:*:rust:*:*",
-      "mopa": "cpe:2.3:a:mopa_project:mopa:*:*:*:*:*:rust:*:*",
-      "mozwire": "cpe:2.3:a:mozwire_project:mozwire:*:*:*:*:*:rust:*:*",
-      "multiqueue2": "cpe:2.3:a:multiqueue2_project:multiqueue2:*:*:*:*:*:rust:*:*",
-      "nalgebra": "cpe:2.3:a:dimforge:nalgebra:*:*:*:*:*:rust:*:*",
-      "nano_arena": "cpe:2.3:a:nano_arena_project:nano_arena:*:*:*:*:*:rust:*:*",
-      "nanorand": "cpe:2.3:a:nanorand_project:nanorand:*:*:*:*:*:rust:*:*",
-      "nb-connect": "cpe:2.3:a:nb-connect_project:nb-connect:*:*:*:*:*:rust:*:*",
-      "ncurses": "cpe:2.3:a:ncurses_project:ncurses:*:*:*:*:*:rust:*:*",
-      "nix": "cpe:2.3:a:nix_project:nix:*:*:*:*:*:rust:*:*",
-      "ntpd": "cpe:2.3:a:tweedegolf:ntpd-rs:*:*:*:*:*:rust:*:*",
-      "obstack": "cpe:2.3:a:obstack_project:obstack:*:*:*:*:*:rust:*:*",
-      "outer_cgi": "cpe:2.3:a:outer_cgi_project:outer_cgi:*:*:*:*:*:rust:*:*",
-      "ozone": "cpe:2.3:a:ozone_project:ozone:*:*:*:*:*:rust:*:*",
-      "pancurses": "cpe:2.3:a:pancurses_project:pancurses:*:*:*:*:*:rust:*:*",
-      "parc": "cpe:2.3:a:parc_project:parc:*:*:*:*:*:rust:*:*",
-      "parse_duration": "cpe:2.3:a:parse_duration_project:parse_duration:*:*:*:*:*:rust:*:*",
-      "phonenumber": "cpe:2.3:a:whisperfish:phonenumber:*:*:*:*:*:rust:*:*",
-      "pnet": "cpe:2.3:a:pnet_project:pnet:*:*:*:*:*:rust:*:*",
-      "pomsky": "cpe:2.3:a:pomsky-lang:pomsky:*:*:*:*:*:rust:*:*",
-      "portaudio-rs": "cpe:2.3:a:portaudio-rs_project:portaudio-rs:*:*:*:*:*:*:*:*",
-      "postscript": "cpe:2.3:a:postscript_project:postscript:*:*:*:*:*:rust:*:*",
-      "quinn": "cpe:2.3:a:quinn_project:quinn:*:*:*:*:*:rust:*:*",
-      "qwutils": "cpe:2.3:a:qwutils_project:qwutils:*:*:*:*:*:rust:*:*",
-      "rand": "cpe:2.3:a:rand_project:rand:*:*:*:*:*:*:*:*",
-      "rand_core": "cpe:2.3:a:rand_core_project:rand_core:*:*:*:*:*:rust:*:*",
-      "raw-cpuid": "cpe:2.3:a:raw-cpuid_project:raw-cpuid:*:*:*:*:*:rust:*:*",
-      "rdiff": "cpe:2.3:a:rdiff_project:rdiff:*:*:*:*:*:rust:*:*",
-      "reorder": "cpe:2.3:a:reorder_project:reorder:*:*:*:*:*:rust:*:*",
-      "rio": "cpe:2.3:a:rio_project:rio:*:*:*:*:*:rust:*:*",
-      "rkyv": "cpe:2.3:a:rkyv_project:rkyv:*:*:*:*:*:rust:*:*",
-      "rsa": "cpe:2.3:a:rustcrypto:rsa:*:*:*:*:*:rust:*:*",
-      "rulinalg": "cpe:2.3:a:rulinalg_project:rulinalg:*:*:*:*:*:rust:*:*",
-      "rusqlite": "cpe:2.3:a:rusqlite_project:rusqlite:*:*:*:*:*:rust:*:*",
-      "rust-embed": "cpe:2.3:a:rust-embed_project:rust-embed:*:*:*:*:*:rust:*:*",
-      "scratchpad": "cpe:2.3:a:scratchpad_project:scratchpad:*:*:*:*:*:rust:*:*",
-      "serde_v8": "cpe:2.3:a:deno:serde_v8:*:*:*:*:*:rust:*:*",
-      "sgx_tstd": "cpe:2.3:a:sgx_tstd_project:sgx_tstd:*:*:*:*:*:rust:*:*",
-      "sha2": "cpe:2.3:a:sha2_project:sha2:*:*:*:*:*:rust:*:*",
-      "simple_asn1": "cpe:2.3:a:simple_asn1_project:simple_asn1:*:*:*:*:*:rust:*:*",
-      "slack_morphism": "cpe:2.3:a:slack_morphism_project:slack_morphism:*:*:*:*:*:rust:*:*",
-      "slice-deque": "cpe:2.3:a:slice-deque_project:slice-deque:*:*:*:*:*:rust:*:*",
-      "smallvec": "cpe:2.3:a:servo:smallvec:*:*:*:*:*:rust:*:*",
-      "stack": "cpe:2.3:a:stack_project:stack:*:*:*:*:*:rust:*:*",
-      "stack_dst": "cpe:2.3:a:stack_dst_project:stack_dst:*:*:*:*:*:rust:*:*",
-      "stackvector": "cpe:2.3:a:stackvector_project:stackvector:*:*:*:*:*:rust:*:*",
-      "syncpool": "cpe:2.3:a:syncpool_project:syncpool:*:*:*:*:*:rust:*:*",
-      "sys-info": "cpe:2.3:a:sys-info_project:sys-info:*:*:*:*:*:rust:*:*",
-      "tar": "cpe:2.3:a:tar_project:tar:*:*:*:*:*:rust:*:*",
-      "tectonic_xdv": "cpe:2.3:a:tectonic_xdv_project:tectonic_xdv:*:*:*:*:*:rust:*:*",
-      "telemetry": "cpe:2.3:a:telemetry_project:telemetry:*:*:*:*:*:rust:*:*",
-      "thex": "cpe:2.3:a:thex_project:thex:*:*:*:*:*:rust:*:*",
-      "through": "cpe:2.3:a:through_project:through:*:*:*:*:*:rust:*:*",
-      "ticketed_lock": "cpe:2.3:a:ticketed_lock_project:ticketed_lock:*:*:*:*:*:rust:*:*",
-      "tiny_future": "cpe:2.3:a:tiny_future_project:tiny_future:*:*:*:*:*:rust:*:*",
-      "tiny_http": "cpe:2.3:a:tiny-http_project:tiny-http:*:*:*:*:*:rust:*:*",
-      "tokio": "cpe:2.3:a:tokio:tokio:*:*:*:*:*:rust:*:*",
-      "tokio-rustls": "cpe:2.3:a:tokio:tokio-rustls:*:*:*:*:*:rust:*:*",
-      "toodee": "cpe:2.3:a:toodee_project:toodee:*:*:*:*:*:rust:*:*",
-      "totp-rs": "cpe:2.3:a:totp-rs_project:totp-rs:*:*:*:*:*:rust:*:*",
-      "tough": "cpe:2.3:a:amazon:tough:*:*:*:*:*:rust:*:*",
-      "traitobject": "cpe:2.3:a:traitobject_project:traitobject:*:*:*:*:*:rust:*:*",
-      "tremor-script": "cpe:2.3:a:linuxfoundation:tremor-script:*:*:*:*:*:rust:*:*",
-      "truetype": "cpe:2.3:a:truetype_project:truetype:*:*:*:*:*:rust:*:*",
-      "trust-dns-proto": "cpe:2.3:a:trust-dns-proto_project:trust-dns-proto:*:*:*:*:*:*:*:*",
-      "trust-dns-server": "cpe:2.3:a:trust-dns-server_project:trust-dns-server:*:*:*:*:*:rust:*:*",
-      "try-mutex": "cpe:2.3:a:try-mutex_project:try-mutex:*:*:*:*:*:rust:*:*",
-      "tungstenite": "cpe:2.3:a:snapview:tungstenite:*:*:*:*:*:rust:*:*",
-      "unicycle": "cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*",
-      "uu_od": "cpe:2.3:a:uu_od_project:uu_od:*:*:*:*:*:rust:*:*",
-      "v9": "cpe:2.3:a:v9_project:v9:*:*:*:*:*:rust:*:*",
-      "va-ts": "cpe:2.3:a:va-ts_project:va-ts:*:*:*:*:*:rust:*:*",
-      "vec-const": "cpe:2.3:a:vec-const_project:vec-const:*:*:*:*:*:rust:*:*",
-      "versionize": "cpe:2.3:a:versionize_project:versionize:*:*:*:*:*:rust:*:*",
-      "wasmtime": "cpe:2.3:a:bytecodealliance:wasmtime:*:*:*:*:*:rust:*:*",
-      "ws": "cpe:2.3:a:ws-rs_project:ws-rs:*:*:*:*:*:rust:*:*",
-      "yottadb": "cpe:2.3:a:yottadb:yottadb:*:*:*:*:*:rust:*:*",
-      "zeroize_derive": "cpe:2.3:a:zeroize_derive_project:zeroize_derive:*:*:*:*:*:rust:*:*"
+      "abomonation": [
+        "cpe:2.3:a:abomonation_project:abomonation:*:*:*:*:*:rust:*:*"
+      ],
+      "abox": [
+        "cpe:2.3:a:abox_project:abox:*:*:*:*:*:rust:*:*"
+      ],
+      "acc_reader": [
+        "cpe:2.3:a:acc_reader_project:acc_reader:*:*:*:*:*:rust:*:*"
+      ],
+      "actix-codec": [
+        "cpe:2.3:a:actix:actix-codec:*:*:*:*:*:rust:*:*"
+      ],
+      "actix-http": [
+        "cpe:2.3:a:actix:actix-http:*:*:*:*:*:rust:*:*"
+      ],
+      "actix-service": [
+        "cpe:2.3:a:actix:actix-service:*:*:*:*:*:rust:*:*"
+      ],
+      "actix-utils": [
+        "cpe:2.3:a:actix:actix-utils:*:*:*:*:*:rust:*:*"
+      ],
+      "actix-web": [
+        "cpe:2.3:a:actix:actix-web:*:*:*:*:*:rust:*:*"
+      ],
+      "adtensor": [
+        "cpe:2.3:a:adtensor_project:adtensor:*:*:*:*:*:rust:*:*"
+      ],
+      "algorithmica": [
+        "cpe:2.3:a:algorithmica_project:algorithmica:*:*:*:*:*:rust:*:*"
+      ],
+      "alpm-rs": [
+        "cpe:2.3:a:alpm-rs_project:alpm-rs:*:*:*:*:*:rust:*:*"
+      ],
+      "ammonia": [
+        "cpe:2.3:a:ammonia_project:ammonia:*:*:*:*:*:rust:*:*"
+      ],
+      "anymap": [
+        "cpe:2.3:a:anymap_project:anymap:*:*:*:*:*:rust:*:*"
+      ],
+      "aovec": [
+        "cpe:2.3:a:aovec_project:aovec:*:*:*:*:*:rust:*:*"
+      ],
+      "arenavec": [
+        "cpe:2.3:a:arenavec_project:arenavec:*:*:*:*:*:rust:*:*"
+      ],
+      "arr": [
+        "cpe:2.3:a:arr_project:arr:*:*:*:*:*:rust:*:*"
+      ],
+      "array-queue": [
+        "cpe:2.3:a:array-queue_project:array-queue:*:*:*:*:*:rust:*:*"
+      ],
+      "array-tools": [
+        "cpe:2.3:a:array-tools_project:array-tools:*:*:*:*:*:rust:*:*"
+      ],
+      "ash": [
+        "cpe:2.3:a:ash_project:ash:*:*:*:*:*:rust:*:*"
+      ],
+      "asn1_der": [
+        "cpe:2.3:a:asn1_der_project:asn1_der:*:*:*:*:*:*:*:*"
+      ],
+      "async-h1": [
+        "cpe:2.3:a:rust-lang:async-h1:*:*:*:*:*:rust:*:*"
+      ],
+      "atom": [
+        "cpe:2.3:a:atom_project:atom:*:*:*:*:*:rust:*:*"
+      ],
+      "atomic-option": [
+        "cpe:2.3:a:atomic-option_project:atomic-option:*:*:*:*:*:rust:*:*"
+      ],
+      "autorand": [
+        "cpe:2.3:a:autorand_project:autorand:*:*:*:*:*:rust:*:*"
+      ],
+      "axum-core": [
+        "cpe:2.3:a:axum-core_project:axum-core:*:*:*:*:*:rust:*:*"
+      ],
+      "bam": [
+        "cpe:2.3:a:bam_project:bam:*:*:*:*:*:rust:*:*"
+      ],
+      "basic_dsp_matrix": [
+        "cpe:2.3:a:basic_dsp_matrix_project:basic_dsp_matrix:*:*:*:*:*:rust:*:*"
+      ],
+      "bat": [
+        "cpe:2.3:a:bat_project:bat:*:*:*:*:*:rust:*:*"
+      ],
+      "beef": [
+        "cpe:2.3:a:beef_project:beef:*:*:*:*:*:rust:*:*"
+      ],
+      "bigint": [
+        "cpe:2.3:a:bigint_project:bigint:*:*:*:*:*:rust:*:*"
+      ],
+      "binjs_io": [
+        "cpe:2.3:a:binjs_io_project:binjs_io:*:*:*:*:*:rust:*:*"
+      ],
+      "biscuit-auth": [
+        "cpe:2.3:a:biscuitsec:biscuit-auth:*:*:*:*:*:rust:*:*"
+      ],
+      "bite": [
+        "cpe:2.3:a:bite_project:bite:*:*:*:*:*:rust:*:*"
+      ],
+      "bitvec": [
+        "cpe:2.3:a:bitvec_project:bitvec:*:*:*:*:*:rust:*:*"
+      ],
+      "bra": [
+        "cpe:2.3:a:bra_project:bra:*:*:*:*:*:rust:*:*"
+      ],
+      "branca": [
+        "cpe:2.3:a:hakobaito:branca:*:*:*:*:*:rust:*:*"
+      ],
+      "bronzedb-protocol": [
+        "cpe:2.3:a:bronzedb-protocol_project:bronzedb-protocol:*:*:*:*:*:rust:*:*"
+      ],
+      "buffoon": [
+        "cpe:2.3:a:buffoon_project:buffoon:*:*:*:*:*:rust:*:*"
+      ],
+      "buttplug": [
+        "cpe:2.3:a:nonpolynomial:buttplug:*:*:*:*:*:rust:*:*"
+      ],
+      "bzip2": [
+        "cpe:2.3:a:bzip2_project:bzip2:*:*:*:*:*:rust:*:*"
+      ],
+      "cache": [
+        "cpe:2.3:a:cache_project:cache:*:*:*:*:*:rust:*:*"
+      ],
+      "cached": [
+        "cpe:2.3:a:cached_project:cached:*:*:*:*:*:rust:*:*"
+      ],
+      "candid": [
+        "cpe:2.3:a:dfinity:candid:*:*:*:*:*:rust:*:*"
+      ],
+      "capnp": [
+        "cpe:2.3:a:capnproto:capnp:*:*:*:*:*:rust:*:*"
+      ],
+      "cbox": [
+        "cpe:2.3:a:cbox_project:cbox:*:*:*:*:*:rust:*:*"
+      ],
+      "cdr": [
+        "cpe:2.3:a:cdr_project:cdr:*:*:*:*:*:rust:*:*"
+      ],
+      "ckb": [
+        "cpe:2.3:a:nervos:ckb:*:*:*:*:*:rust:*:*"
+      ],
+      "columnar": [
+        "cpe:2.3:a:columnar_project:columnar:*:*:*:*:*:rust:*:*"
+      ],
+      "comrak": [
+        "cpe:2.3:a:comrak_project:comrak:*:*:*:*:*:rust:*:*"
+      ],
+      "concread": [
+        "cpe:2.3:a:concread_project:concread:*:*:*:*:*:rust:*:*"
+      ],
+      "conduit-hyper": [
+        "cpe:2.3:a:conduit-hyper_project:conduit-hyper:*:*:*:*:*:rust:*:*"
+      ],
+      "conqueue": [
+        "cpe:2.3:a:conqueue_project:conqueue:*:*:*:*:*:rust:*:*"
+      ],
+      "containers": [
+        "cpe:2.3:a:containers_project:containers:*:*:*:*:*:rust:*:*"
+      ],
+      "cranelift-codegen": [
+        "cpe:2.3:a:bytecodealliance:cranelift-codegen:*:*:*:*:*:rust:*:*"
+      ],
+      "crossbeam": [
+        "cpe:2.3:a:crossbeam_project:crossbeam:*:*:*:*:*:rust:*:*"
+      ],
+      "crossbeam-channel": [
+        "cpe:2.3:a:crossbeam-channel_project:crossbeam-channel:*:*:*:*:*:rust:*:*"
+      ],
+      "crypto2": [
+        "cpe:2.3:a:crypto2_project:crypto2:*:*:*:*:*:rust:*:*"
+      ],
+      "derive-com-impl": [
+        "cpe:2.3:a:derive-com-impl_project:derive-com-impl:*:*:*:*:*:rust:*:*"
+      ],
+      "diesel": [
+        "cpe:2.3:a:diesel:diesel:*:*:*:*:*:rust:*:*"
+      ],
+      "dync": [
+        "cpe:2.3:a:dync_project:dync:*:*:*:*:*:rust:*:*"
+      ],
+      "endian_trait": [
+        "cpe:2.3:a:endian_trait_project:endian_trait:*:*:*:*:*:rust:*:*"
+      ],
+      "eventio": [
+        "cpe:2.3:a:petabi:eventio:*:*:*:*:*:rust:*:*"
+      ],
+      "evm": [
+        "cpe:2.3:a:evm_project:evm:*:*:*:*:*:rust:*:*"
+      ],
+      "failure": [
+        "cpe:2.3:a:failure_project:failure:*:*:*:*:*:rust:*:*"
+      ],
+      "fil-ocl": [
+        "cpe:2.3:a:fil-ocl_project:fil-ocl:*:*:*:*:*:rust:*:*"
+      ],
+      "flatbuffers": [
+        "cpe:2.3:a:google:flatbuffers:*:*:*:*:*:rust:*:*"
+      ],
+      "flumedb": [
+        "cpe:2.3:a:flumedb_project:flumedb:*:*:*:*:*:rust:*:*"
+      ],
+      "fruity": [
+        "cpe:2.3:a:fruity_project:fruity:*:*:*:*:*:rust:*:*"
+      ],
+      "futures-intrusive": [
+        "cpe:2.3:a:futures-intrusive_project:futures-intrusive:*:*:*:*:*:rust:*:*"
+      ],
+      "futures-task": [
+        "cpe:2.3:a:rust-lang:futures-task:*:*:*:*:*:rust:*:*"
+      ],
+      "generator": [
+        "cpe:2.3:a:generator_project:generator:*:*:*:*:*:rust:*:*"
+      ],
+      "generic-array": [
+        "cpe:2.3:a:generic-array_project:generic-array:*:*:*:*:*:rust:*:*"
+      ],
+      "getrandom": [
+        "cpe:2.3:a:getrandom_project:getrandom:*:*:*:*:*:rust:*:*"
+      ],
+      "gfx-auxil": [
+        "cpe:2.3:a:gfx-auxil_project:gfx-auxil:*:*:*:*:*:rust:*:*"
+      ],
+      "glsl-layout": [
+        "cpe:2.3:a:glsl-layout_project:glsl-layout:*:*:*:*:*:rust:*:*"
+      ],
+      "hashconsing": [
+        "cpe:2.3:a:hashconsing_project:hashconsing:*:*:*:*:*:rust:*:*"
+      ],
+      "heapless": [
+        "cpe:2.3:a:heapless_project:heapless:*:*:*:*:*:rust:*:*"
+      ],
+      "iced-x86": [
+        "cpe:2.3:a:iced-x86_project:iced-x86:*:*:*:*:*:rust:*:*"
+      ],
+      "id-map": [
+        "cpe:2.3:a:id-map_project:id-map:*:*:*:*:*:rust:*:*"
+      ],
+      "insert_many": [
+        "cpe:2.3:a:insert_many_project:insert_many:*:*:*:*:*:rust:*:*"
+      ],
+      "internment": [
+        "cpe:2.3:a:internment_project:internment:*:*:*:*:*:rust:*:*"
+      ],
+      "juniper": [
+        "cpe:2.3:a:juniper_project:juniper:*:*:*:*:*:rust:*:*"
+      ],
+      "kamadak-exif": [
+        "cpe:2.3:a:kamadak-exif_project:kamadak-exif:*:*:*:*:*:rust:*:*"
+      ],
+      "kekbit": [
+        "cpe:2.3:a:kekbit_project:kekbit:*:*:*:*:*:rust:*:*"
+      ],
+      "lazy-init": [
+        "cpe:2.3:a:lazy-init_project:lazy-init:*:*:*:*:*:rust:*:*"
+      ],
+      "lettre": [
+        "cpe:2.3:a:lettre:lettre:*:*:*:*:*:rust:*:*"
+      ],
+      "lever": [
+        "cpe:2.3:a:lever_project:lever:*:*:*:*:*:rust:*:*"
+      ],
+      "libp2p": [
+        "cpe:2.3:a:protocol:libp2p:*:*:*:*:*:rust:*:*"
+      ],
+      "libp2p-deflate": [
+        "cpe:2.3:a:libp2p:libp2p-deflate:*:*:*:*:*:rust:*:*"
+      ],
+      "libpulse-binding": [
+        "cpe:2.3:a:libpulse-binding_project:libpulse-binding:*:*:*:*:*:rust:*:*"
+      ],
+      "libsbc": [
+        "cpe:2.3:a:libsbc_project:libsbc:*:*:*:*:*:rust:*:*"
+      ],
+      "libsecp256k1": [
+        "cpe:2.3:a:parity:libsecp256k1:*:*:*:*:*:rust:*:*"
+      ],
+      "linked-list-allocator": [
+        "cpe:2.3:a:rust-osdev:linked-list-allocator:*:*:*:*:*:rust:*:*"
+      ],
+      "linux-loader": [
+        "cpe:2.3:a:linux-loader_project:linux-loader:*:*:*:*:*:rust:*:*"
+      ],
+      "lock_api": [
+        "cpe:2.3:a:lock_api_project:lock_api:*:*:*:*:*:rust:*:*"
+      ],
+      "lru": [
+        "cpe:2.3:a:lru_project:lru:*:*:*:*:*:rust:*:*"
+      ],
+      "lru-cache": [
+        "cpe:2.3:a:lru-cache_project:lru-cache:*:*:*:*:*:rust:*:*"
+      ],
+      "lucet-runtime": [
+        "cpe:2.3:a:bytecodealliance:lucet:*:*:*:*:*:rust:*:*"
+      ],
+      "lucet-runtime-internals": [
+        "cpe:2.3:a:lucet-runtime-internals_project:lucet-runtime-internals:*:*:*:*:*:rust:*:*"
+      ],
+      "magnetic": [
+        "cpe:2.3:a:magnetic_project:magnetic:*:*:*:*:*:rust:*:*"
+      ],
+      "may": [
+        "cpe:2.3:a:may_project:may:*:*:*:*:*:rust:*:*"
+      ],
+      "mdbook": [
+        "cpe:2.3:a:rust-lang:mdbook:*:*:*:*:*:rust:*:*"
+      ],
+      "messagepack-rs": [
+        "cpe:2.3:a:messagepack-rs_project:messagepack-rs:*:*:*:*:*:rust:*:*"
+      ],
+      "metrics-util": [
+        "cpe:2.3:a:metrics-util_project:metrics-util:*:*:*:*:*:rust:*:*"
+      ],
+      "molecule": [
+        "cpe:2.3:a:nervos:molecule:*:*:*:*:*:rust:*:*"
+      ],
+      "mopa": [
+        "cpe:2.3:a:mopa_project:mopa:*:*:*:*:*:rust:*:*"
+      ],
+      "mozwire": [
+        "cpe:2.3:a:mozwire_project:mozwire:*:*:*:*:*:rust:*:*"
+      ],
+      "multiqueue2": [
+        "cpe:2.3:a:multiqueue2_project:multiqueue2:*:*:*:*:*:rust:*:*"
+      ],
+      "nalgebra": [
+        "cpe:2.3:a:dimforge:nalgebra:*:*:*:*:*:rust:*:*"
+      ],
+      "nano_arena": [
+        "cpe:2.3:a:nano_arena_project:nano_arena:*:*:*:*:*:rust:*:*"
+      ],
+      "nanorand": [
+        "cpe:2.3:a:nanorand_project:nanorand:*:*:*:*:*:rust:*:*"
+      ],
+      "nb-connect": [
+        "cpe:2.3:a:nb-connect_project:nb-connect:*:*:*:*:*:rust:*:*"
+      ],
+      "ncurses": [
+        "cpe:2.3:a:ncurses_project:ncurses:*:*:*:*:*:rust:*:*"
+      ],
+      "nix": [
+        "cpe:2.3:a:nix_project:nix:*:*:*:*:*:rust:*:*"
+      ],
+      "ntpd": [
+        "cpe:2.3:a:tweedegolf:ntpd-rs:*:*:*:*:*:rust:*:*"
+      ],
+      "obstack": [
+        "cpe:2.3:a:obstack_project:obstack:*:*:*:*:*:rust:*:*"
+      ],
+      "outer_cgi": [
+        "cpe:2.3:a:outer_cgi_project:outer_cgi:*:*:*:*:*:rust:*:*"
+      ],
+      "ozone": [
+        "cpe:2.3:a:ozone_project:ozone:*:*:*:*:*:rust:*:*"
+      ],
+      "pancurses": [
+        "cpe:2.3:a:pancurses_project:pancurses:*:*:*:*:*:rust:*:*"
+      ],
+      "parc": [
+        "cpe:2.3:a:parc_project:parc:*:*:*:*:*:rust:*:*"
+      ],
+      "parse_duration": [
+        "cpe:2.3:a:parse_duration_project:parse_duration:*:*:*:*:*:rust:*:*"
+      ],
+      "phonenumber": [
+        "cpe:2.3:a:whisperfish:phonenumber:*:*:*:*:*:rust:*:*"
+      ],
+      "pnet": [
+        "cpe:2.3:a:pnet_project:pnet:*:*:*:*:*:rust:*:*"
+      ],
+      "pomsky": [
+        "cpe:2.3:a:pomsky-lang:pomsky:*:*:*:*:*:rust:*:*"
+      ],
+      "portaudio-rs": [
+        "cpe:2.3:a:portaudio-rs_project:portaudio-rs:*:*:*:*:*:*:*:*"
+      ],
+      "postscript": [
+        "cpe:2.3:a:postscript_project:postscript:*:*:*:*:*:rust:*:*"
+      ],
+      "quinn": [
+        "cpe:2.3:a:quinn_project:quinn:*:*:*:*:*:rust:*:*"
+      ],
+      "qwutils": [
+        "cpe:2.3:a:qwutils_project:qwutils:*:*:*:*:*:rust:*:*"
+      ],
+      "rand": [
+        "cpe:2.3:a:rand_project:rand:*:*:*:*:*:*:*:*"
+      ],
+      "rand_core": [
+        "cpe:2.3:a:rand_core_project:rand_core:*:*:*:*:*:rust:*:*"
+      ],
+      "raw-cpuid": [
+        "cpe:2.3:a:raw-cpuid_project:raw-cpuid:*:*:*:*:*:rust:*:*"
+      ],
+      "rdiff": [
+        "cpe:2.3:a:rdiff_project:rdiff:*:*:*:*:*:rust:*:*"
+      ],
+      "reorder": [
+        "cpe:2.3:a:reorder_project:reorder:*:*:*:*:*:rust:*:*"
+      ],
+      "rio": [
+        "cpe:2.3:a:rio_project:rio:*:*:*:*:*:rust:*:*"
+      ],
+      "rkyv": [
+        "cpe:2.3:a:rkyv_project:rkyv:*:*:*:*:*:rust:*:*"
+      ],
+      "rsa": [
+        "cpe:2.3:a:rustcrypto:rsa:*:*:*:*:*:rust:*:*"
+      ],
+      "rulinalg": [
+        "cpe:2.3:a:rulinalg_project:rulinalg:*:*:*:*:*:rust:*:*"
+      ],
+      "rusqlite": [
+        "cpe:2.3:a:rusqlite_project:rusqlite:*:*:*:*:*:rust:*:*"
+      ],
+      "rust-embed": [
+        "cpe:2.3:a:rust-embed_project:rust-embed:*:*:*:*:*:rust:*:*"
+      ],
+      "scratchpad": [
+        "cpe:2.3:a:scratchpad_project:scratchpad:*:*:*:*:*:rust:*:*"
+      ],
+      "serde_v8": [
+        "cpe:2.3:a:deno:serde_v8:*:*:*:*:*:rust:*:*"
+      ],
+      "sgx_tstd": [
+        "cpe:2.3:a:sgx_tstd_project:sgx_tstd:*:*:*:*:*:rust:*:*"
+      ],
+      "sha2": [
+        "cpe:2.3:a:sha2_project:sha2:*:*:*:*:*:rust:*:*"
+      ],
+      "simple_asn1": [
+        "cpe:2.3:a:simple_asn1_project:simple_asn1:*:*:*:*:*:rust:*:*"
+      ],
+      "slack_morphism": [
+        "cpe:2.3:a:slack_morphism_project:slack_morphism:*:*:*:*:*:rust:*:*"
+      ],
+      "slice-deque": [
+        "cpe:2.3:a:slice-deque_project:slice-deque:*:*:*:*:*:rust:*:*"
+      ],
+      "smallvec": [
+        "cpe:2.3:a:servo:smallvec:*:*:*:*:*:rust:*:*"
+      ],
+      "stack": [
+        "cpe:2.3:a:stack_project:stack:*:*:*:*:*:rust:*:*"
+      ],
+      "stack_dst": [
+        "cpe:2.3:a:stack_dst_project:stack_dst:*:*:*:*:*:rust:*:*"
+      ],
+      "stackvector": [
+        "cpe:2.3:a:stackvector_project:stackvector:*:*:*:*:*:rust:*:*"
+      ],
+      "syncpool": [
+        "cpe:2.3:a:syncpool_project:syncpool:*:*:*:*:*:rust:*:*"
+      ],
+      "sys-info": [
+        "cpe:2.3:a:sys-info_project:sys-info:*:*:*:*:*:rust:*:*"
+      ],
+      "tar": [
+        "cpe:2.3:a:tar_project:tar:*:*:*:*:*:rust:*:*"
+      ],
+      "tectonic_xdv": [
+        "cpe:2.3:a:tectonic_xdv_project:tectonic_xdv:*:*:*:*:*:rust:*:*"
+      ],
+      "telemetry": [
+        "cpe:2.3:a:telemetry_project:telemetry:*:*:*:*:*:rust:*:*"
+      ],
+      "thex": [
+        "cpe:2.3:a:thex_project:thex:*:*:*:*:*:rust:*:*"
+      ],
+      "through": [
+        "cpe:2.3:a:through_project:through:*:*:*:*:*:rust:*:*"
+      ],
+      "ticketed_lock": [
+        "cpe:2.3:a:ticketed_lock_project:ticketed_lock:*:*:*:*:*:rust:*:*"
+      ],
+      "tiny_future": [
+        "cpe:2.3:a:tiny_future_project:tiny_future:*:*:*:*:*:rust:*:*"
+      ],
+      "tiny_http": [
+        "cpe:2.3:a:tiny-http_project:tiny-http:*:*:*:*:*:rust:*:*"
+      ],
+      "tokio": [
+        "cpe:2.3:a:tokio:tokio:*:*:*:*:*:rust:*:*"
+      ],
+      "tokio-rustls": [
+        "cpe:2.3:a:tokio:tokio-rustls:*:*:*:*:*:rust:*:*"
+      ],
+      "toodee": [
+        "cpe:2.3:a:toodee_project:toodee:*:*:*:*:*:rust:*:*"
+      ],
+      "totp-rs": [
+        "cpe:2.3:a:totp-rs_project:totp-rs:*:*:*:*:*:rust:*:*"
+      ],
+      "tough": [
+        "cpe:2.3:a:amazon:tough:*:*:*:*:*:rust:*:*"
+      ],
+      "traitobject": [
+        "cpe:2.3:a:traitobject_project:traitobject:*:*:*:*:*:rust:*:*"
+      ],
+      "tremor-script": [
+        "cpe:2.3:a:linuxfoundation:tremor-script:*:*:*:*:*:rust:*:*"
+      ],
+      "truetype": [
+        "cpe:2.3:a:truetype_project:truetype:*:*:*:*:*:rust:*:*"
+      ],
+      "trust-dns-proto": [
+        "cpe:2.3:a:trust-dns-proto_project:trust-dns-proto:*:*:*:*:*:*:*:*"
+      ],
+      "trust-dns-server": [
+        "cpe:2.3:a:trust-dns-server_project:trust-dns-server:*:*:*:*:*:rust:*:*"
+      ],
+      "try-mutex": [
+        "cpe:2.3:a:try-mutex_project:try-mutex:*:*:*:*:*:rust:*:*"
+      ],
+      "tungstenite": [
+        "cpe:2.3:a:snapview:tungstenite:*:*:*:*:*:rust:*:*"
+      ],
+      "unicycle": [
+        "cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*"
+      ],
+      "uu_od": [
+        "cpe:2.3:a:uu_od_project:uu_od:*:*:*:*:*:rust:*:*"
+      ],
+      "v9": [
+        "cpe:2.3:a:v9_project:v9:*:*:*:*:*:rust:*:*"
+      ],
+      "va-ts": [
+        "cpe:2.3:a:va-ts_project:va-ts:*:*:*:*:*:rust:*:*"
+      ],
+      "vec-const": [
+        "cpe:2.3:a:vec-const_project:vec-const:*:*:*:*:*:rust:*:*"
+      ],
+      "versionize": [
+        "cpe:2.3:a:versionize_project:versionize:*:*:*:*:*:rust:*:*"
+      ],
+      "wasmtime": [
+        "cpe:2.3:a:bytecodealliance:wasmtime:*:*:*:*:*:rust:*:*"
+      ],
+      "ws": [
+        "cpe:2.3:a:ws-rs_project:ws-rs:*:*:*:*:*:rust:*:*"
+      ],
+      "yottadb": [
+        "cpe:2.3:a:yottadb:yottadb:*:*:*:*:*:rust:*:*"
+      ],
+      "zeroize_derive": [
+        "cpe:2.3:a:zeroize_derive_project:zeroize_derive:*:*:*:*:*:rust:*:*"
+      ]
     }
   }
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate.go
@@ -167,16 +167,24 @@ func indexCPEList(list CpeList) *dictionary.Indexed {
 	return indexed
 }
 
+func updateIndex(indexed *dictionary.Indexed, ecosystem string, pkgName string, cpe string) {
+	if _, exists := indexed.EcosystemPackages[ecosystem]; !exists {
+		indexed.EcosystemPackages[ecosystem] = make(dictionary.Packages)
+	}
+
+	if indexed.EcosystemPackages[ecosystem][pkgName] == nil {
+		indexed.EcosystemPackages[ecosystem][pkgName] = dictionary.NewSet()
+	}
+
+	indexed.EcosystemPackages[ecosystem][pkgName].Add(cpe)
+}
+
 func addEntryForRustCrate(indexed *dictionary.Indexed, ref string, cpeItemName string) {
 	// Prune off the non-package-name parts of the URL
 	ref = strings.TrimPrefix(ref, prefixForRustCrates)
 	ref = strings.Split(ref, "/")[0]
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemRustCrates]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemRustCrates] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemRustCrates][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemRustCrates, ref, cpeItemName)
 }
 
 func addEntryForJenkinsPluginGitHub(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -190,12 +198,7 @@ func addEntryForJenkinsPluginGitHub(indexed *dictionary.Indexed, ref string, cpe
 	}
 
 	ref = strings.TrimSuffix(ref, "-plugin")
-
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemJenkinsPlugins, ref, cpeItemName)
 }
 
 func addEntryForJenkinsPlugin(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -207,11 +210,7 @@ func addEntryForJenkinsPlugin(indexed *dictionary.Indexed, ref string, cpeItemNa
 		return
 	}
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemJenkinsPlugins][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemJenkinsPlugins, ref, cpeItemName)
 }
 
 func addEntryForPyPIPackage(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -219,11 +218,7 @@ func addEntryForPyPIPackage(indexed *dictionary.Indexed, ref string, cpeItemName
 	ref = strings.TrimPrefix(ref, prefixForPyPIPackages)
 	ref = strings.Split(ref, "/")[0]
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemPyPI]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemPyPI] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemPyPI][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemPyPI, ref, cpeItemName)
 }
 
 func addEntryForNativeRubyGem(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -231,11 +226,7 @@ func addEntryForNativeRubyGem(indexed *dictionary.Indexed, ref string, cpeItemNa
 	ref = strings.TrimPrefix(ref, prefixForNativeRubyGems)
 	ref = strings.Split(ref, "/")[0]
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemRubyGems]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemRubyGems] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemRubyGems][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemRubyGems, ref, cpeItemName)
 }
 
 func addEntryForRubyGem(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -244,11 +235,7 @@ func addEntryForRubyGem(indexed *dictionary.Indexed, ref string, cpeItemName str
 	ref = strings.TrimPrefix(ref, prefixForRubyGemsHTTP)
 	ref = strings.Split(ref, "/")[0]
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemRubyGems]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemRubyGems] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemRubyGems][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemRubyGems, ref, cpeItemName)
 }
 
 func addEntryForNPMPackage(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -257,11 +244,7 @@ func addEntryForNPMPackage(indexed *dictionary.Indexed, ref string, cpeItemName 
 	ref = strings.Split(ref, "?")[0]
 	ref = strings.TrimPrefix(ref, prefixForNPMPackages)
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemNPM]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemNPM] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemNPM][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemNPM, ref, cpeItemName)
 }
 
 func phpExtensionPackageFromURLFragment(ref string) string {
@@ -301,11 +284,7 @@ func addEntryForPHPPearPackage(indexed *dictionary.Indexed, ref string, cpeItemN
 		return
 	}
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemPHPPear]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemPHPPear] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemPHPPear][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemPHPPear, ref, cpeItemName)
 }
 
 func addEntryForPHPPeclPackage(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -317,11 +296,7 @@ func addEntryForPHPPeclPackage(indexed *dictionary.Indexed, ref string, cpeItemN
 		return
 	}
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemPHPPecl]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemPHPPecl] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemPHPPecl][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemPHPPecl, ref, cpeItemName)
 }
 
 func addEntryForPHPComposerPackage(indexed *dictionary.Indexed, ref string, cpeItemName string) {
@@ -335,9 +310,5 @@ func addEntryForPHPComposerPackage(indexed *dictionary.Indexed, ref string, cpeI
 
 	ref = components[0] + "/" + components[1]
 
-	if _, ok := indexed.EcosystemPackages[dictionary.EcosystemPHPComposer]; !ok {
-		indexed.EcosystemPackages[dictionary.EcosystemPHPComposer] = make(dictionary.Packages)
-	}
-
-	indexed.EcosystemPackages[dictionary.EcosystemPHPComposer][ref] = cpeItemName
+	updateIndex(indexed, dictionary.EcosystemPHPComposer, ref, cpeItemName)
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/generate_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -59,7 +60,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemRustCrates: {
-						"unicycle": "cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*",
+						"unicycle": dictionary.NewSet("cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*"),
 					},
 				},
 			},
@@ -72,7 +73,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemJenkinsPlugins: {
-						"sonarqube": "cpe:2.3:a:sonarsource:sonarqube_scanner:2.7:*:*:*:*:jenkins:*:*",
+						"sonarqube": dictionary.NewSet("cpe:2.3:a:sonarsource:sonarqube_scanner:2.7:*:*:*:*:jenkins:*:*"),
 					},
 				},
 			},
@@ -94,7 +95,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemJenkinsPlugins: {
-						"svn-partial-release-mgr": "cpe:2.3:a:jenkins:subversion_partial_release_manager:1.0.1:*:*:*:*:jenkins:*:*",
+						"svn-partial-release-mgr": dictionary.NewSet("cpe:2.3:a:jenkins:subversion_partial_release_manager:1.0.1:*:*:*:*:jenkins:*:*"),
 					},
 				},
 			},
@@ -107,7 +108,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPyPI: {
-						"vault-cli": "cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*",
+						"vault-cli": dictionary.NewSet("cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*"),
 					},
 				},
 			},
@@ -120,7 +121,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemRubyGems: {
-						"openssl": "cpe:2.3:a:ruby-lang:openssl:-:*:*:*:*:ruby:*:*",
+						"openssl": dictionary.NewSet("cpe:2.3:a:ruby-lang:openssl:-:*:*:*:*:ruby:*:*"),
 					},
 				},
 			},
@@ -133,7 +134,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemRubyGems: {
-						"actionview": "cpe:2.3:a:action_view_project:action_view:*:*:*:*:*:ruby:*:*",
+						"actionview": dictionary.NewSet("cpe:2.3:a:action_view_project:action_view:*:*:*:*:*:ruby:*:*"),
 					},
 				},
 			},
@@ -146,7 +147,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemRubyGems: {
-						"rbovirt": "cpe:2.3:a:amos_benari:rbovirt:*:*:*:*:*:ruby:*:*",
+						"rbovirt": dictionary.NewSet("cpe:2.3:a:amos_benari:rbovirt:*:*:*:*:*:ruby:*:*"),
 					},
 				},
 			},
@@ -159,7 +160,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemNPM: {
-						"@nubosoftware/node-static": "cpe:2.3:a:\\@nubosoftware\\/node-static_project:\\@nubosoftware\\/node-static:-:*:*:*:*:node.js:*:*",
+						"@nubosoftware/node-static": dictionary.NewSet("cpe:2.3:a:\\@nubosoftware\\/node-static_project:\\@nubosoftware\\/node-static:-:*:*:*:*:node.js:*:*"),
 					},
 				},
 			},
@@ -172,7 +173,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPHPPecl: {
-						"imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
+						"imagick": dictionary.NewSet("cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*"),
 					},
 				},
 			},
@@ -185,7 +186,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPHPPecl: {
-						"memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
+						"memcached": dictionary.NewSet("cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*"),
 					},
 				},
 			},
@@ -198,7 +199,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPHPPear: {
-						"PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
+						"PEAR": dictionary.NewSet("cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*"),
 					},
 				},
 			},
@@ -211,7 +212,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPHPPear: {
-						"abcdefg": "cpe:2.3:a:php:abcdefg:*:*:*:*:*:*:*:*",
+						"abcdefg": dictionary.NewSet("cpe:2.3:a:php:abcdefg:*:*:*:*:*:*:*:*"),
 					},
 				},
 			},
@@ -224,7 +225,7 @@ func Test_addEntryFuncs(t *testing.T) {
 			expectedIndexed: dictionary.Indexed{
 				EcosystemPackages: map[string]dictionary.Packages{
 					dictionary.EcosystemPHPComposer: {
-						"frappant/frp-form-answers": "cpe:2.3:a:frappant:forms_export:*:*:*:*:*:*:*:*",
+						"frappant/frp-form-answers": dictionary.NewSet("cpe:2.3:a:frappant:forms_export:*:*:*:*:*:*:*:*"),
 					},
 				},
 			},
@@ -239,7 +240,7 @@ func Test_addEntryFuncs(t *testing.T) {
 
 			tt.addEntryFunc(indexed, tt.inputRef, tt.inputCpeItemName)
 
-			if diff := cmp.Diff(tt.expectedIndexed, *indexed); diff != "" {
+			if diff := cmp.Diff(tt.expectedIndexed, *indexed, cmp.AllowUnexported(strset.Set{})); diff != "" {
 				t.Errorf("addEntry* mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/expected-cpe-index.json
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/expected-cpe-index.json
@@ -1,44 +1,97 @@
 {
   "ecosystems": {
     "jenkins_plugins": {
-      "fireline": "cpe:2.3:a:jenkins:360_fireline:*:*:*:*:*:jenkins:*:*",
-      "sonarqube": "cpe:2.3:a:sonarsource:sonarqube_scanner:*:*:*:*:*:jenkins:*:*",
-      "svn-partial-release-mgr": "cpe:2.3:a:jenkins:subversion_partial_release_manager:*:*:*:*:*:jenkins:*:*"
+      "anchore-container-scanner": [
+        "cpe:2.3:a:anchore:container_image_scanner:*:*:*:*:*:jenkins:*:*",
+        "cpe:2.3:a:jenkins:anchore_container_image_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "fireline": [
+        "cpe:2.3:a:jenkins:360_fireline:*:*:*:*:*:jenkins:*:*"
+      ],
+      "sonarqube": [
+        "cpe:2.3:a:sonarsource:sonarqube_scanner:*:*:*:*:*:jenkins:*:*"
+      ],
+      "svn-partial-release-mgr": [
+        "cpe:2.3:a:jenkins:subversion_partial_release_manager:*:*:*:*:*:jenkins:*:*"
+      ]
     },
     "npm": {
-      "merge-recursive": "cpe:2.3:a:umbraengineering:merge-recursive:*:*:*:*:*:node.js:*:*",
-      "ps": "cpe:2.3:a:umbraengineering:ps:*:*:*:*:*:node.js:*:*",
-      "static-dev-server": "cpe:2.3:a:static-dev-server_project:static-dev-server:*:*:*:*:*:node.js:*:*",
-      "umount": "cpe:2.3:a:umount_project:umount:*:*:*:*:*:node.js:*:*",
-      "undefsafe": "cpe:2.3:a:undefsafe_project:undefsafe:*:*:*:*:*:node.js:*:*",
-      "underscore": "cpe:2.3:a:underscorejs:underscore:*:*:*:*:*:node.js:*:*",
-      "underscore-99xp": "cpe:2.3:a:underscore-99xp_project:underscore-99xp:*:*:*:*:*:node.js:*:*",
-      "ungit": "cpe:2.3:a:ungit_project:ungit:*:*:*:*:*:node.js:*:*",
-      "unicode": "cpe:2.3:a:unicode_project:unicode:*:*:*:*:*:node.js:*:*",
-      "unicode-json": "cpe:2.3:a:unicode:unicode-json:*:*:*:*:*:node.js:*:*",
-      "unicorn-list": "cpe:2.3:a:unicorn-list_project:unicorn-list:*:*:*:*:*:node.js:*:*"
+      "merge-recursive": [
+        "cpe:2.3:a:umbraengineering:merge-recursive:*:*:*:*:*:node.js:*:*"
+      ],
+      "ps": [
+        "cpe:2.3:a:umbraengineering:ps:*:*:*:*:*:node.js:*:*"
+      ],
+      "static-dev-server": [
+        "cpe:2.3:a:static-dev-server_project:static-dev-server:*:*:*:*:*:node.js:*:*"
+      ],
+      "umount": [
+        "cpe:2.3:a:umount_project:umount:*:*:*:*:*:node.js:*:*"
+      ],
+      "undefsafe": [
+        "cpe:2.3:a:undefsafe_project:undefsafe:*:*:*:*:*:node.js:*:*"
+      ],
+      "underscore": [
+        "cpe:2.3:a:underscorejs:underscore:*:*:*:*:*:node.js:*:*"
+      ],
+      "underscore-99xp": [
+        "cpe:2.3:a:underscore-99xp_project:underscore-99xp:*:*:*:*:*:node.js:*:*"
+      ],
+      "ungit": [
+        "cpe:2.3:a:ungit_project:ungit:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicode": [
+        "cpe:2.3:a:unicode_project:unicode:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicode-json": [
+        "cpe:2.3:a:unicode:unicode-json:*:*:*:*:*:node.js:*:*"
+      ],
+      "unicorn-list": [
+        "cpe:2.3:a:unicorn-list_project:unicorn-list:*:*:*:*:*:node.js:*:*"
+      ]
     },
     "php_composer": {
-      "frappant/frp-form-answers": "cpe:2.3:a:frappant:forms_export:*:*:*:*:*:typo3:*:*"
+      "frappant/frp-form-answers": [
+        "cpe:2.3:a:frappant:forms_export:*:*:*:*:*:typo3:*:*"
+      ]
     },
     "php_pear": {
-      "HTML_QuickForm": "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*",
-      "PEAR": "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*",
-      "XML_RPC": "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*"
+      "HTML_QuickForm": [
+        "cpe:2.3:a:html_quickform_project:html_quickform:*:*:*:*:*:*:*:*"
+      ],
+      "PEAR": [
+        "cpe:2.3:a:php:pear:*:*:*:*:*:*:*:*"
+      ],
+      "XML_RPC": [
+        "cpe:2.3:a:php:xml_rpc:*:*:*:*:*:pear:*:*"
+      ]
     },
     "php_pecl": {
-      "imagick": "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*",
-      "memcached": "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*",
-      "xhprof": "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+      "imagick": [
+        "cpe:2.3:a:php:imagick:*:*:*:*:*:*:*:*"
+      ],
+      "memcached": [
+        "cpe:2.3:a:php:memcached:*:*:*:*:*:*:*:*"
+      ],
+      "xhprof": [
+        "cpe:2.3:a:php:xhprof:*:*:*:*:*:*:*:*"
+      ]
     },
     "pypi": {
-      "vault-cli": "cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*"
+      "vault-cli": [
+        "cpe:2.3:a:vault-cli_project:vault-cli:*:*:*:*:*:python:*:*"
+      ]
     },
     "rubygems": {
-      "openssl": "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:*:*:*"
+      "openssl": [
+        "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:*:*:*",
+        "cpe:2.3:a:ruby-lang:openssl:*:*:*:*:*:ruby:*:*"
+      ]
     },
     "rust_crates": {
-      "unicycle": "cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*"
+      "unicycle": [
+        "cpe:2.3:a:unicycle_project:unicycle:*:*:*:*:*:rust:*:*"
+      ]
     }
   }
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/official-cpe-dictionary_v2.3.xml
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/index-generator/testdata/official-cpe-dictionary_v2.3.xml
@@ -25014,6 +25014,40 @@
     </references>
     <cpe-23:cpe23-item name="cpe:2.3:a:jenkins:360_fireline:1.0:*:*:*:*:jenkins:*:*"/>
   </cpe-item>
+  <cpe-item name="cpe:/a:anchore:container_image_scanner:-::~~~jenkins~~">
+    <title xml:lang="en-US">Anchore Container Image Scanner for Jenkins</title>
+    <references>
+      <reference href="https://jenkins.io/security/advisory/2018-07-30/#SECURITY-1039">Advisory</reference>
+      <reference href="https://github.com/jenkinsci/anchore-container-scanner-plugin/releases">Version</reference>
+      <reference href="https://plugins.jenkins.io/anchore-container-scanner">Product</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:anchore:container_image_scanner:-:*:*:*:*:jenkins:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:anchore:container_image_scanner:1.0.0::~~~jenkins~~">
+    <title xml:lang="en-US">Anchore Container Image Scanner 1.0.0 for Jenkins</title>
+    <references>
+      <reference href="https://jenkins.io/security/advisory/2018-07-30/#SECURITY-1039">Advisory</reference>
+      <reference href="https://github.com/jenkinsci/anchore-container-scanner-plugin/releases">Version</reference>
+      <reference href="https://plugins.jenkins.io/anchore-container-scanner">Product</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:anchore:container_image_scanner:1.0.0:*:*:*:*:jenkins:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:jenkins:anchore_container_image_scanner:1.0.0::~~~jenkins~~">
+    <title xml:lang="en-US">Jenkins Anchore Container Image Scanner 1.0.0 for Jenkins</title>
+    <references>
+      <reference href="https://plugins.jenkins.io/anchore-container-scanner">Product</reference>
+      <reference href="https://github.com/jenkinsci/anchore-container-scanner-plugin">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:jenkins:anchore_container_image_scanner:1.0.0:*:*:*:*:jenkins:*:*"/>
+  </cpe-item>
+  <cpe-item name="cpe:/a:jenkins:anchore_container_image_scanner:1.0.1::~~~jenkins~~">
+    <title xml:lang="en-US">Jenkins Anchore Container Image Scanner 1.0.1 for Jenkins</title>
+    <references>
+      <reference href="https://plugins.jenkins.io/anchore-container-scanner">Product</reference>
+      <reference href="https://github.com/jenkinsci/anchore-container-scanner-plugin">Version</reference>
+    </references>
+    <cpe-23:cpe23-item name="cpe:2.3:a:jenkins:anchore_container_image_scanner:1.0.1:*:*:*:*:jenkins:*:*"/>
+  </cpe-item>
 </cpe-list>
 </cpe-list>
 </cpe-list>

--- a/syft/pkg/cataloger/internal/cpegenerate/dictionary/types.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/dictionary/types.go
@@ -1,5 +1,12 @@
 package dictionary
 
+import (
+	"encoding/json"
+	"slices"
+
+	"github.com/scylladb/go-set/strset"
+)
+
 const (
 	EcosystemNPM            = "npm"
 	EcosystemRubyGems       = "rubygems"
@@ -15,4 +22,29 @@ type Indexed struct {
 	EcosystemPackages map[string]Packages `json:"ecosystems"`
 }
 
-type Packages map[string]string
+type Set struct {
+	*strset.Set
+}
+
+type Packages map[string]*Set
+
+func NewSet(ts ...string) *Set {
+	return &Set{strset.New(ts...)}
+}
+
+func (s *Set) MarshalJSON() ([]byte, error) {
+	l := s.List()
+	slices.Sort(l)
+	return json.Marshal(l)
+}
+
+func (s *Set) UnmarshalJSON(data []byte) error {
+	var strSlice []string
+
+	if err := json.Unmarshal(data, &strSlice); err == nil {
+		*s = *NewSet(strSlice...)
+	} else {
+		return err
+	}
+	return nil
+}

--- a/syft/pkg/cataloger/internal/cpegenerate/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate.go
@@ -58,58 +58,66 @@ func GetIndexedDictionary() (_ *dictionary.Indexed, err error) {
 	return indexedCPEDictionary, err
 }
 
-func FromDictionaryFind(p pkg.Package) (cpe.CPE, bool) {
+func FromDictionaryFind(p pkg.Package) ([]cpe.CPE, bool) {
 	dict, err := GetIndexedDictionary()
+	parsedCPEs := []cpe.CPE{}
 	if err != nil {
 		log.Debugf("CPE dictionary lookup not available: %+v", err)
-		return cpe.CPE{}, false
+		return parsedCPEs, false
 	}
 
 	var (
-		cpeString string
-		ok        bool
+		cpes *dictionary.Set
+		ok   bool
 	)
 
 	switch p.Type {
 	case pkg.NpmPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemNPM][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemNPM][p.Name]
 
 	case pkg.GemPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemRubyGems][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemRubyGems][p.Name]
 
 	case pkg.PythonPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemPyPI][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemPyPI][p.Name]
 
 	case pkg.JenkinsPluginPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemJenkinsPlugins][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemJenkinsPlugins][p.Name]
 
 	case pkg.RustPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemRustCrates][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemRustCrates][p.Name]
 
 	case pkg.PhpComposerPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemPHPComposer][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemPHPComposer][p.Name]
 
 	case pkg.PhpPeclPkg:
-		cpeString, ok = dict.EcosystemPackages[dictionary.EcosystemPHPPecl][p.Name]
+		cpes, ok = dict.EcosystemPackages[dictionary.EcosystemPHPPecl][p.Name]
 
 	default:
 		// The dictionary doesn't support this package type yet.
-		return cpe.CPE{}, false
+		return parsedCPEs, false
 	}
 
 	if !ok {
 		// The dictionary doesn't have a CPE for this package.
-		return cpe.CPE{}, false
+		return parsedCPEs, false
 	}
 
-	parsedCPE, err := cpe.New(cpeString, cpe.NVDDictionaryLookupSource)
-	if err != nil {
-		return cpe.CPE{}, false
+	for _, c := range cpes.List() {
+		parsedCPE, err := cpe.New(c, cpe.NVDDictionaryLookupSource)
+		if err != nil {
+			continue
+		}
+
+		parsedCPE.Attributes.Version = p.Version
+		parsedCPEs = append(parsedCPEs, parsedCPE)
 	}
 
-	parsedCPE.Attributes.Version = p.Version
+	if len(parsedCPEs) == 0 {
+		return []cpe.CPE{}, false
+	}
 
-	return parsedCPE, true
+	return parsedCPEs, true
 }
 
 // FromPackageAttributes Create a list of CPEs for a given package, trying to guess the vendor, product tuple. We should be trying to


### PR DESCRIPTION
It is possible that a given package has multiple known "official" CPEs active in the dictionary at once, so the index should support a slice of CPE strings per package