### PR TITLE
fix: re-use embedded union reader if possible

### DIFF
--- a/syft/internal/unionreader/union_reader.go
+++ b/syft/internal/unionreader/union_reader.go
@@ -3,6 +3,7 @@ package unionreader
 import (
 	"bytes"
 	"fmt"
+	"github.com/anchore/syft/syft/file"
 	"io"
 
 	macho "github.com/anchore/go-macholibre"
@@ -42,6 +43,17 @@ func GetUnionReader(readerCloser io.ReadCloser) (UnionReader, error) {
 	reader, ok := readerCloser.(UnionReader)
 	if ok {
 		return reader, nil
+	}
+
+	// file.LocationReadCloser embeds a ReadCloser, which is likely
+	// to implement UnionReader. Check whether the embedded read closer
+	// implements UnionReader, and just return that if so.
+	r, ok := readerCloser.(file.LocationReadCloser)
+	if ok {
+		ur, ok := r.ReadCloser.(UnionReader)
+		if ok {
+			return ur, nil
+		}
 	}
 
 	b, err := io.ReadAll(readerCloser)

--- a/syft/internal/unionreader/union_reader.go
+++ b/syft/internal/unionreader/union_reader.go
@@ -3,11 +3,11 @@ package unionreader
 import (
 	"bytes"
 	"fmt"
-	"github.com/anchore/syft/syft/file"
 	"io"
 
 	macho "github.com/anchore/go-macholibre"
 	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/file"
 )
 
 // UnionReader is a single interface with all reading functions needed by multi-arch binary catalogers

--- a/syft/internal/unionreader/union_reader_test.go
+++ b/syft/internal/unionreader/union_reader_test.go
@@ -49,13 +49,15 @@ func (p2 *panickingUnionReader) Close() error {
 	panic("don't call this in your unit test!")
 }
 
+var _ UnionReader = (*panickingUnionReader)(nil)
+
 func Test_getUnionReader_fileLocationReadCloser(t *testing.T) {
 	// panickingUnionReader is a UnionReader
-	var _ UnionReader = (*panickingUnionReader)(nil)
-	embedsUnionReader := file.NewLocationReadCloser(file.Location{}, &panickingUnionReader{})
+	p := &panickingUnionReader{}
+	embedsUnionReader := file.NewLocationReadCloser(file.Location{}, p)
 
 	// embedded union reader is returned without "ReadAll" invocation
 	ur, err := GetUnionReader(embedsUnionReader)
 	require.NoError(t, err)
-	require.NotNil(t, ur)
+	require.Equal(t, p, ur)
 }

--- a/syft/internal/unionreader/union_reader_test.go
+++ b/syft/internal/unionreader/union_reader_test.go
@@ -1,13 +1,14 @@
 package unionreader
 
 import (
-	"github.com/anchore/syft/syft/file"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/file"
 )
 
 func Test_getUnionReader_notUnionReader(t *testing.T) {


### PR DESCRIPTION
Supersedes #2811, at least for now.

Previously, because file.LocationReadCloser embeds a ReadCloser that might be a UnionReader, but doesn't implement the interface itself, the type assertion would fall and Syft would fall back to io.ReadAll to enable seeking on the underlying reader, resulting in a potentially large extra allocation.

Instead, check whether the passed ReadCloser is a
file.LocationReadCloser, and if so, try to use the embedded ReadCloser as a UnionReader.