### PR TITLE
fix: better clean up of file handles

### DIFF
--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -118,21 +118,20 @@ func (c *Cataloger) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.
 	}
 
 	for _, req := range c.selectFiles(resolver) {
-		log.WithFields("path", req.Location.RealPath).Trace("parsing file contents")
+		location, parser := req.Location, req.Parser
 
-		invokeParser := func(location file.Location, parser Parser) ([]pkg.Package, []artifact.Relationship, error) {
-			contentReader, err := resolver.FileContentsByLocation(location)
-			if err != nil {
-				logger.WithFields("location", location.RealPath, "error", err).Warn("unable to fetch contents")
-				return nil, nil, nil
-			}
-			defer internal.CloseAndLogError(contentReader, location.AccessPath)
+		log.WithFields("path", location.RealPath).Trace("parsing file contents")
 
-			return parser(ctx, resolver, &env, file.NewLocationReadCloser(location, contentReader))
-		}
-		discoveredPackages, discoveredRelationships, err := invokeParser(req.Location, req.Parser)
+		contentReader, err := resolver.FileContentsByLocation(location)
 		if err != nil {
-			logger.WithFields("location", req.Location.RealPath, "error", err).Warnf("cataloger failed")
+			logger.WithFields("location", location.RealPath, "error", err).Warn("unable to fetch contents")
+			continue
+		}
+
+		discoveredPackages, discoveredRelationships, err := parser(ctx, resolver, &env, file.NewLocationReadCloser(location, contentReader))
+		internal.CloseAndLogError(contentReader, location.AccessPath)
+		if err != nil {
+			logger.WithFields("location", location.RealPath, "error", err).Warnf("cataloger failed")
 			continue
 		}
 

--- a/syft/pkg/cataloger/generic/cataloger_test.go
+++ b/syft/pkg/cataloger/generic/cataloger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,104 @@ func Test_Cataloger(t *testing.T) {
 			t.Errorf("bad contents mapping: %+v", p.Locations)
 		}
 	}
+}
+
+type spyReturningFileResolver struct {
+	m *file.MockResolver
+	s *spyingIoReadCloser
+}
+
+type spyingIoReadCloser struct {
+	rc     io.ReadCloser
+	closed bool
+}
+
+func newSpyReturningFileResolver(s *spyingIoReadCloser, paths ...string) file.Resolver {
+	m := file.NewMockResolverForPaths(paths...)
+	return spyReturningFileResolver{
+		m: m,
+		s: s,
+	}
+}
+
+func (s *spyingIoReadCloser) Read(p []byte) (n int, err error) {
+	return s.Read(p)
+}
+
+func (s *spyingIoReadCloser) Close() error {
+	s.closed = true
+	return s.rc.Close()
+}
+
+var _ io.ReadCloser = (*spyingIoReadCloser)(nil)
+
+func (m spyReturningFileResolver) FileContentsByLocation(location file.Location) (io.ReadCloser, error) {
+	return m.s, nil
+}
+
+func (m spyReturningFileResolver) HasPath(path string) bool {
+	return m.m.HasPath(path)
+}
+
+func (m spyReturningFileResolver) FilesByPath(paths ...string) ([]file.Location, error) {
+	return m.m.FilesByPath(paths...)
+}
+
+func (m spyReturningFileResolver) FilesByGlob(patterns ...string) ([]file.Location, error) {
+	return m.m.FilesByGlob(patterns...)
+}
+
+func (m spyReturningFileResolver) FilesByMIMEType(types ...string) ([]file.Location, error) {
+	return m.m.FilesByMIMEType(types...)
+}
+
+func (m spyReturningFileResolver) RelativeFileByPath(f file.Location, path string) *file.Location {
+	return m.m.RelativeFileByPath(f, path)
+}
+
+func (m spyReturningFileResolver) AllLocations(ctx context.Context) <-chan file.Location {
+	return m.m.AllLocations(ctx)
+}
+
+func (m spyReturningFileResolver) FileMetadataByLocation(location file.Location) (file.Metadata, error) {
+	return m.m.FileMetadataByLocation(location)
+}
+
+var _ file.Resolver = (*spyReturningFileResolver)(nil)
+
+func TestClosesFileOnParserPanic(t *testing.T) {
+	rc := io.NopCloser(strings.NewReader("some string"))
+	spy := spyingIoReadCloser{
+		rc: rc,
+	}
+	resolver := newSpyReturningFileResolver(&spy, "test-fixtures/another-path.txt")
+	ctx := context.TODO()
+
+	processors := []processor{
+		func(resolver file.Resolver, env Environment) []request {
+			return []request{
+				{
+					Location: file.Location{
+						LocationData: file.LocationData{
+							Coordinates: file.Coordinates{},
+							AccessPath:  "/some/access/path",
+						},
+					},
+					Parser: func(context.Context, file.Resolver, *Environment, file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+						panic("panic!")
+					},
+				},
+			}
+		},
+	}
+
+	c := Cataloger{
+		processor:         processors,
+		upstreamCataloger: "unit-test-cataloger",
+	}
+
+	assert.PanicsWithValue(t, "panic!", func() {
+		_, _, _ = c.Catalog(ctx, resolver)
+	})
+	require.True(t, spy.closed)
 }


### PR DESCRIPTION
Previously, the ELF binary package cataloger would leak file handles, and the generic cataloger loop would leak file handles if parsing the file panicked. Instead, ensure both situations `defer close` new file readers as soon as they are made.

The incorrect behavior had been happening for some time, but was probably exposed by #2814 which caused the ELF binary package cataloger to rely more on file handles and less on in-memory buffers.

Fixes #2819 - in my testing, syft 1.3.0 needs about 1500 concurrent file handles to parse `pytorch/pytorch:latest`; after this change, the number is closer to 800.