### PR TITLE
chore: enable go-critic deferInLoop lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,9 @@ linters-settings:
     # If lower than 0, disable the check.
     # Default: 40
     statements: 50
+  gocritic:
+    enabled-checks:
+      - deferInLoop
 output:
   uniq-by-line: false
 run:


### PR DESCRIPTION
The goal here is to be more careful about leaking file handles and other resources.

Issue #2819 alerted us that we are not closing file handles aggressively enough.

This lint is not on by default, because it is still tagged as experimental, see https://go-critic.com/overview.html#deferinloop

## Manual testing:

Introduce the following diff locally (note `defer reader.Close()` in the loop):

``` diff
git diff -W | head -n 20
diff --git a/syft/pkg/cataloger/binary/elf_package_cataloger.go b/syft/pkg/cataloger/binary/elf_package_cataloger.go
index 94f65640..7a384fb5 100644
--- a/syft/pkg/cataloger/binary/elf_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/elf_package_cataloger.go
@@ -51,56 +51,57 @@ func (c *elfPackageCataloger) Name() string {
 func (c *elfPackageCataloger) Catalog(_ context.Context, resolver file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
        locations, err := resolver.FilesByMIMEType(mimetype.ExecutableMIMETypeSet.List()...)
        if err != nil {
                return nil, nil, fmt.Errorf("unable to get binary files by mime type: %w", err)
        }
 
        // first find all ELF binaries that have notes
        var notesByLocation = make(map[elfPackageKey][]elfBinaryPackageNotes)
        for _, location := range locations {
                reader, err := resolver.FileContentsByLocation(location)
                if err != nil {
                        return nil, nil, fmt.Errorf("unable to get binary contents %q: %w", location.Path(), err)
                }
+               defer reader.Close()

```

On `main`, `make lint` with this diff exits 0.

On this branch, `make lint` fails like this:

``` sh
make lint                                             
task: [lint] .tool/golangci-lint run --tests=false
syft/pkg/cataloger/binary/elf_package_cataloger.go:64:3: deferInLoop: Possible resource leak, 'defer' is called in the 'for' loop (gocritic)
                defer reader.Close()
                ^
task: Failed to run task "lint": exit status 1
make: *** [lint] Error 201
```

Also, the following command was used to confirm that enabling additional lints for `gocritic` appends to the set of enabled lints, rather than overwriting it (note that this is the set of `gocritic` lints, not the whole set of `golangci-lint` lints):

``` sh
$ GL_DEBUG=gocritic ./.tool/golangci-lint run --enable=gocritic 1>/dev/null 2>&1 1>&2 | grep "Final used checks"
level=debug msg="[gocritic] Final used checks (35): [appendAssign argOrder assignOp badCall 
badCond captLocal caseOrder codegenComment commentFormatting defaultCaseOrder 
deferInLoop <<< this one is new 
deprecatedComment dupArg dupBranchBody dupCase dupSubExpr elseif exitAfterDefer flagDeref 
flagName ifElseChain mapKey newDeref offBy1 regexpMust singleCaseSwitch sloppyLen 
sloppyTypeAssert switchTrue typeSwitchVar underef unlambda unslice valSwap wrapperFunc]"
```