### PR TITLE
chore: use ruleguard to test for missing defer statements

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,6 +52,10 @@ linters-settings:
   gocritic:
     enabled-checks:
       - deferInLoop
+      - ruleguard
+    settings:
+      ruleguard:
+        rules: "test/rules/rules.go"
 output:
   uniq-by-line: false
 run:

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,8 @@ require (
 	modernc.org/sqlite v1.29.8
 )
 
+require github.com/quasilyte/go-ruleguard/dsl v0.3.22
+
 require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pelletier/go-toml v1.9.5
+	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	github.com/saferwall/pe v1.5.2
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d
 	github.com/sanity-io/litter v1.5.5
@@ -82,8 +83,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.29.8
 )
-
-require github.com/quasilyte/go-ruleguard/dsl v0.3.22
 
 require (
 	dario.cat/mergo v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -660,6 +660,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
+github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -156,6 +156,7 @@ func findReleases(resolver file.Resolver, dbPath string) []linux.Release {
 		log.Tracef("unable to fetch contents for APK repositories file %q: %+v", reposLocation, err)
 		return nil
 	}
+	defer internal.CloseAndLogError(reposReader, location.RealPath)
 
 	return parseReleasesFromAPKRepository(file.LocationReadCloser{
 		Location:   location,

--- a/syft/pkg/cataloger/arch/parse_alpm_db.go
+++ b/syft/pkg/cataloger/arch/parse_alpm_db.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/vbatts/go-mtree"
 
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -132,6 +133,7 @@ func getFileReader(path string, resolver file.Resolver) (io.Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer internal.CloseAndLogError(dbContentReader, locs[0].RealPath)
 	return dbContentReader, nil
 }
 

--- a/syft/pkg/cataloger/binary/classifier.go
+++ b/syft/pkg/cataloger/binary/classifier.go
@@ -17,7 +17,6 @@ import (
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
-	"github.com/anchore/syft/syft/internal/unionreader"
 	"github.com/anchore/syft/syft/pkg"
 )
 
@@ -231,14 +230,10 @@ func getContents(resolver file.Resolver, location file.Location) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-
-	unionReader, err := unionreader.GetUnionReader(reader)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get union reader for file: %w", err)
-	}
+	defer internal.CloseAndLogError(reader, location.AccessPath)
 
 	// TODO: there may be room for improvement here, as this may use an excessive amount of memory. Alternate approach is to leverage a RuneReader.
-	contents, err := io.ReadAll(unionReader)
+	contents, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get contents for file: %w", err)
 	}

--- a/syft/pkg/cataloger/debian/package.go
+++ b/syft/pkg/cataloger/debian/package.go
@@ -265,8 +265,9 @@ func fetchCopyrightContents(resolver file.Resolver, dbLocation file.Location, m 
 
 	reader, err := resolver.FileContentsByLocation(*location)
 	if err != nil {
-		log.Warnf("failed to fetch deb copyright contents (package=%s): %w", m.Package, err)
+		log.Warnf("failed to fetch deb copyright contents (package=%s): %s", m.Package, err)
 	}
+	defer internal.CloseAndLogError(reader, location.RealPath)
 
 	l := location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation)
 

--- a/syft/pkg/cataloger/gentoo/parse_portage_contents.go
+++ b/syft/pkg/cataloger/gentoo/parse_portage_contents.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/scylladb/go-set/strset"
 
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
@@ -65,6 +66,7 @@ func addFiles(resolver file.Resolver, dbLocation file.Location, p *pkg.Package) 
 		log.WithFields("path", dbLocation.RealPath).Warnf("failed to fetch portage contents (package=%s): %+v", p.Name, err)
 		return
 	}
+	defer internal.CloseAndLogError(contentsReader, dbLocation.RealPath)
 
 	entry, ok := p.Metadata.(pkg.PortageEntry)
 	if !ok {
@@ -106,6 +108,7 @@ func addLicenses(resolver file.Resolver, dbLocation file.Location, p *pkg.Packag
 		log.WithFields("path", dbLocation.RealPath).Warnf("failed to fetch portage LICENSE: %+v", err)
 		return
 	}
+	defer internal.CloseAndLogError(licenseReader, location.RealPath)
 
 	findings := strset.New()
 	scanner := bufio.NewScanner(licenseReader)
@@ -141,6 +144,7 @@ func addSize(resolver file.Resolver, dbLocation file.Location, p *pkg.Package) {
 		log.WithFields("name", p.Name).Warnf("failed to fetch portage SIZE: %+v", err)
 		return
 	}
+	defer internal.CloseAndLogError(sizeReader, location.RealPath)
 
 	scanner := bufio.NewScanner(sizeReader)
 	for scanner.Scan() {

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/mod/modfile"
 
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
@@ -119,6 +120,7 @@ func parseGoSumFile(resolver file.Resolver, reader file.LocationReadCloser) (map
 	if err != nil {
 		return nil, err
 	}
+	defer internal.CloseAndLogError(contents, goSumLocation.AccessPath)
 
 	// go.sum has the format like:
 	// github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -253,35 +254,43 @@ func addLicenses(name string, resolver file.Resolver, location file.Location) (a
 	}
 
 	for _, l := range locations {
-		contentReader, err := resolver.FileContentsByLocation(l)
+		licenses, err := parseLicensesFromLocation(l, resolver, pkgFile)
 		if err != nil {
-			log.Debugf("error getting file content reader for %s: %v", pkgFile, err)
 			return allLicenses
 		}
-
-		contents, err := io.ReadAll(contentReader)
-		if err != nil {
-			log.Debugf("error reading file contents for %s: %v", pkgFile, err)
-			return allLicenses
-		}
-
-		var pkgJSON packageJSON
-		err = json.Unmarshal(contents, &pkgJSON)
-		if err != nil {
-			log.Debugf("error parsing %s: %v", pkgFile, err)
-			return allLicenses
-		}
-
-		licenses, err := pkgJSON.licensesFromJSON()
-		if err != nil {
-			log.Debugf("error getting licenses from %s: %v", pkgFile, err)
-			return allLicenses
-		}
-
 		allLicenses = append(allLicenses, licenses...)
 	}
 
 	return allLicenses
+}
+
+func parseLicensesFromLocation(l file.Location, resolver file.Resolver, pkgFile string) ([]string, error) {
+	contentReader, err := resolver.FileContentsByLocation(l)
+	if err != nil {
+		log.Debugf("error getting file content reader for %s: %v", pkgFile, err)
+		return nil, err
+	}
+	defer internal.CloseAndLogError(contentReader, l.RealPath)
+
+	contents, err := io.ReadAll(contentReader)
+	if err != nil {
+		log.Debugf("error reading file contents for %s: %v", pkgFile, err)
+		return nil, err
+	}
+
+	var pkgJSON packageJSON
+	err = json.Unmarshal(contents, &pkgJSON)
+	if err != nil {
+		log.Debugf("error parsing %s: %v", pkgFile, err)
+		return nil, err
+	}
+
+	licenses, err := pkgJSON.licensesFromJSON()
+	if err != nil {
+		log.Debugf("error getting licenses from %s: %v", pkgFile, err)
+		return nil, err
+	}
+	return licenses, nil
 }
 
 // packageURL returns the PURL for the specific NPM package (see https://github.com/package-url/purl-spec)

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -6,10 +6,10 @@ import "github.com/quasilyte/go-ruleguard/dsl"
 
 // nolint:unused
 func resourceCleanup(m dsl.Matcher) {
-	m.Match(`$res, $err := $resolver.FileContentsByLocation($*_); if $*_ { $*_ }; $next`).
+	m.Match(`$res, $err := $resolver.FileContentsByLocation($loc); if $*_ { $*_ }; $next`).
 		Where(m["res"].Type.Implements(`io.Closer`) &&
 			m["err"].Type.Implements(`error`) &&
 			m["res"].Type.Implements(`io.Closer`) &&
 			!m["next"].Text.Matches(`defer internal.CloseAndLogError`)).
-		Report(`internal.CloseAndLogError should be deferred right after the error returned from $resolver.FileContentsByLocation is checked.`)
+		Report(`please call "defer internal.CloseAndLogError($res, $loc.RealPath)" right after checking the error returned from $resolver.FileContentsByLocation.`)
 }

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -1,0 +1,15 @@
+//go:build gorules
+
+package rules
+
+import "github.com/quasilyte/go-ruleguard/dsl"
+
+// nolint:unused
+func resourceCleanup(m dsl.Matcher) {
+	m.Match(`$res, $err := $resolver.FileContentsByLocation($*_); if $*_ { $*_ }; $next`).
+		Where(m["res"].Type.Implements(`io.Closer`) &&
+			m["err"].Type.Implements(`error`) &&
+			m["res"].Type.Implements(`io.Closer`) &&
+			!m["next"].Text.Matches(`defer internal.CloseAndLogError`)).
+		Report(`internal.CloseAndLogError should be deferred right after the error returned from $resolver.FileContentsByLocation is checked.`)
+}


### PR DESCRIPTION
See #2826 

Supersedes https://github.com/anchore/syft/pull/2836.

The only hang-up I've seen is that calls to `make lint` can run an old version of the rules unless `./.tool/golangci-lint cache clean` is called first, which could be annoying when PRing future rule changes.

