### PR TITLE
Restore version file update on release

### DIFF
--- a/.github/scripts/update-version-file.sh
+++ b/.github/scripts/update-version-file.sh
@@ -2,8 +2,8 @@
 set -ue
 
 BIN="syft"
-DISTDIR=$1
-VERSION=$2
+VERSION_FILE="VERSION"
+VERSION=$1
 
 # the source of truth as to whether we want to notify users of an update is if the release just created is NOT
 # flagged as a pre-release on github
@@ -12,10 +12,9 @@ if [[ "$(curl -SsL https://api.github.com/repos/anchore/${BIN}/releases/tags/${V
    exit 0
 fi
 
-echo "creating and publishing version file"
+echo "creating and publishing version file (${VERSION})"
 
 # create a version file for version-update checks
-VERSION_FILE="${DISTDIR}/VERSION"
 echo "${VERSION}" | tee "${VERSION_FILE}"
 
 # upload the version file that supports the application version update check

--- a/.github/workflows/release-version-file.yaml
+++ b/.github/workflows/release-version-file.yaml
@@ -1,0 +1,33 @@
+name: "Release"
+
+on:
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: release version to update the version file with (prefixed with v)
+        required: true
+
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        description: release version to update the version file with (prefixed with v)
+        required: true
+
+jobs:
+
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
+        with:
+          fetch-depth: 0
+
+      - name: Update version file
+        run: make ci-release-version-file
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
+          # for updating the VERSION file in S3...
+          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-version-file.yaml
+++ b/.github/workflows/release-version-file.yaml
@@ -21,8 +21,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
-        with:
-          fetch-depth: 0
 
       - name: Update version file
         run: make ci-release-version-file

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,9 +139,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # for updating brew formula in anchore/homebrew-syft
           GITHUB_BREW_TOKEN: ${{ secrets.ANCHOREOPS_GITHUB_OSS_WRITE_TOKEN }}
-          # for updating the VERSION file in S3...
-          AWS_ACCESS_KEY_ID: ${{ secrets.TOOLBOX_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.TOOLBOX_AWS_SECRET_ACCESS_KEY }}
 
       - uses: anchore/sbom-action@7ccf588e3cf3cc2611714c2eeae48550fbc17552 #v0.15.11
         continue-on-error: true
@@ -157,3 +154,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_TOOLBOX_WEBHOOK_URL }}
         if: ${{ success() }}
+
+  release-version-file:
+    needs: [release]
+    uses: ./.github/workflows/release-version-file.yaml
+    with:
+      version: ${{ github.event.inputs.version }}
+    secrets: inherit

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -470,6 +470,16 @@ tasks:
         silent: true
       - "{{ .RELEASE_CMD }}"
 
+  ci-release-version-file:
+    # desc: "[CI only] Update the version file"
+    deps: [tools]
+    cmds:
+      - task: ci-check
+      - ".github/scripts/update-version-file.sh {{ .RELEASE_VERSION }}"
+    requires:
+      vars:
+        - RELEASE_VERSION
+
 
   ## Cleanup targets #################################
 


### PR DESCRIPTION
It seems that the version file update during release was dropped post v0.94.0, this PR restores this functionality. This is not added in the release job as done in the past, instead a reusable workflow is leveraged in order to allow for running independent of a release or to be able to safely re-run outside of a release incase of failure (bad credentials, bad value, network error, etc).