### PR TITLE
Fix redundant package deletions when considering ELF packages

### DIFF
--- a/cmd/syft/internal/test/integration/package_binary_elf_relationships_test.go
+++ b/cmd/syft/internal/test/integration/package_binary_elf_relationships_test.go
@@ -1,10 +1,12 @@
 package integration
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/source"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestBinaryElfRelationships(t *testing.T) {

--- a/internal/relationship/binary/shared_library_index_test.go
+++ b/internal/relationship/binary/shared_library_index_test.go
@@ -27,7 +27,7 @@ func Test_newShareLibIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor := newAccesor(tt.packages, tt.coordinateIndex, tt.prexistingRelationships)
+			accessor := newAccessor(tt.packages, tt.coordinateIndex, tt.prexistingRelationships)
 			sharedLibraryIndex := newShareLibIndex(tt.resolver, accessor)
 			if sharedLibraryIndex == nil {
 				t.Errorf("newShareLibIndex() = %v, want non-nil", sharedLibraryIndex)
@@ -93,7 +93,7 @@ func Test_sharedLibraryIndex_build(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor := newAccesor(tt.packages, tt.coordinateIndex, tt.prexistingRelationships)
+			accessor := newAccessor(tt.packages, tt.coordinateIndex, tt.prexistingRelationships)
 			sharedLibraryIndex := newShareLibIndex(tt.resolver, accessor)
 			sharedLibraryIndex.build(tt.resolver, accessor)
 			pkgs := sharedLibraryIndex.owningLibraryPackage(path.Base(glibcCoordinate.RealPath))


### PR DESCRIPTION
This PR fixes a subtle behavior when there is an SBOM with binary packages and no ELF packages. Currently the binary packages are being removed since the package comparison is meant to only be considering ELF packages primarily and not all binary packages (which are ELF packages + binary classifier packages).