### PR TITLE
chore: fix small tooling error for go.mod

### DIFF
--- a/syft/pkg/cataloger/golang/test-fixtures/glob-paths/src/go.mod
+++ b/syft/pkg/cataloger/golang/test-fixtures/glob-paths/src/go.mod
@@ -1,1 +1,3 @@
-// bogus go.mod
+module bogus
+
+go 1.22.1


### PR DESCRIPTION
## Summary
On certain IDE and versions of neovim that develop syft an error can be encountered when running `go list -m -json all`

This is because the IDE or editor tooling tries to run this command for all `go.mod` for a given source tree.

This PR fixes a `bogus` `go.mod` so that it still fulfills the test case, but doesn't break editor tooling:

### Example of error before fix
![Screenshot 2024-05-13 at 11 25 59 AM](https://github.com/anchore/syft/assets/32073428/768ded67-a75e-4b77-accb-d7104c2aa5bd)

