### PR TITLE
Capture dependencies when parsing SPDX SBOMs

### DIFF
--- a/syft/format/common/spdxhelpers/to_syft_model.go
+++ b/syft/format/common/spdxhelpers/to_syft_model.go
@@ -381,6 +381,13 @@ func collectDocRelationships(spdxIDMap map[string]any, doc *spdx.Document) (out 
 			}
 		} else {
 			switch helpers.RelationshipType(r.Relationship) {
+			case helpers.DependencyOfRelationship:
+				typ = artifact.DependencyOfRelationship
+				to = toPackage
+			case helpers.DependsOnRelationship:
+				typ = artifact.DependencyOfRelationship
+				to = from
+				from = toPackage
 			case helpers.ContainsRelationship:
 				typ = artifact.ContainsRelationship
 				to = toPackage

--- a/syft/format/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/format/common/spdxhelpers/to_syft_model_test.go
@@ -414,6 +414,66 @@ func Test_toSyftRelationships(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "dependency-of relationship",
+			args: args{
+				spdxIDMap: map[string]any{
+					string(toSPDXID(pkg2)): pkg2,
+					string(toSPDXID(pkg3)): pkg3,
+				},
+				doc: &spdx.Document{
+					Relationships: []*spdx.Relationship{
+						{
+							RefA: common.DocElementID{
+								ElementRefID: toSPDXID(pkg2),
+							},
+							RefB: common.DocElementID{
+								ElementRefID: toSPDXID(pkg3),
+							},
+							Relationship:        spdx.RelationshipDependencyOf,
+							RelationshipComment: "dependency-of: indicates that the package in RefA is a dependency of the package in RefB",
+						},
+					},
+				},
+			},
+			want: []artifact.Relationship{
+				{
+					From: pkg2,
+					To:   pkg3,
+					Type: artifact.DependencyOfRelationship,
+				},
+			},
+		},
+		{
+			name: "dependends-on relationship",
+			args: args{
+				spdxIDMap: map[string]any{
+					string(toSPDXID(pkg2)): pkg2,
+					string(toSPDXID(pkg3)): pkg3,
+				},
+				doc: &spdx.Document{
+					Relationships: []*spdx.Relationship{
+						{
+							RefA: common.DocElementID{
+								ElementRefID: toSPDXID(pkg3),
+							},
+							RefB: common.DocElementID{
+								ElementRefID: toSPDXID(pkg2),
+							},
+							Relationship:        spdx.RelationshipDependsOn,
+							RelationshipComment: "dependends-on: indicates that the package in RefA depends on the package in RefB",
+						},
+					},
+				},
+			},
+			want: []artifact.Relationship{
+				{
+					From: pkg2,
+					To:   pkg3,
+					Type: artifact.DependencyOfRelationship,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When parsing SPDX SBOMs, translate DEPENDS_ON and DEPENDENCY_OF relationships into a dependency-of relationship in the Syft model.