### PR TITLE
Use values in relationship To/From fields

### DIFF
--- a/internal/cmptest/common_options.go
+++ b/internal/cmptest/common_options.go
@@ -1,0 +1,71 @@
+package cmptest
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func DefaultCommonOptions() []cmp.Option {
+	return CommonOptions(nil, nil)
+}
+
+func CommonOptions(licenseCmp LicenseComparer, locationCmp LocationComparer) []cmp.Option {
+	if licenseCmp == nil {
+		licenseCmp = DefaultLicenseComparer
+	}
+
+	if locationCmp == nil {
+		locationCmp = DefaultLocationComparer
+	}
+
+	return []cmp.Option{
+		cmpopts.IgnoreFields(pkg.Package{}, "id"), // note: ID is not deterministic for test purposes
+		cmpopts.SortSlices(pkg.Less),
+		cmpopts.SortSlices(DefaultRelationshipComparer),
+		cmp.Comparer(
+			func(x, y file.LocationSet) bool {
+				xs := x.ToSlice()
+				ys := y.ToSlice()
+
+				if len(xs) != len(ys) {
+					return false
+				}
+				for i, xe := range xs {
+					ye := ys[i]
+					if !locationCmp(xe, ye) {
+						return false
+					}
+				}
+
+				return true
+			},
+		),
+		cmp.Comparer(
+			func(x, y pkg.LicenseSet) bool {
+				xs := x.ToSlice()
+				ys := y.ToSlice()
+
+				if len(xs) != len(ys) {
+					return false
+				}
+				for i, xe := range xs {
+					ye := ys[i]
+					if !licenseCmp(xe, ye) {
+						return false
+					}
+				}
+
+				return true
+			},
+		),
+		cmp.Comparer(
+			locationCmp,
+		),
+		cmp.Comparer(
+			licenseCmp,
+		),
+	}
+}

--- a/internal/cmptest/diff_reporter.go
+++ b/internal/cmptest/diff_reporter.go
@@ -1,0 +1,37 @@
+package cmptest
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// DiffReporter is a simple custom reporter that only records differences detected during comparison.
+type DiffReporter struct {
+	path  cmp.Path
+	diffs []string
+}
+
+func NewDiffReporter() DiffReporter {
+	return DiffReporter{}
+}
+
+func (r *DiffReporter) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+func (r *DiffReporter) Report(rs cmp.Result) {
+	if !rs.Equal() {
+		vx, vy := r.path.Last().Values()
+		r.diffs = append(r.diffs, fmt.Sprintf("%#v:\n\t-: %+v\n\t+: %+v\n", r.path, vx, vy))
+	}
+}
+
+func (r *DiffReporter) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}
+
+func (r *DiffReporter) String() string {
+	return strings.Join(r.diffs, "\n")
+}

--- a/internal/cmptest/license.go
+++ b/internal/cmptest/license.go
@@ -1,0 +1,29 @@
+package cmptest
+
+import (
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+type LicenseComparer func(x, y pkg.License) bool
+
+func DefaultLicenseComparer(x, y pkg.License) bool {
+	return cmp.Equal(x, y, cmp.Comparer(DefaultLocationComparer), cmp.Comparer(
+		func(x, y file.LocationSet) bool {
+			xs := x.ToSlice()
+			ys := y.ToSlice()
+			if len(xs) != len(ys) {
+				return false
+			}
+			for i, xe := range xs {
+				ye := ys[i]
+				if !DefaultLocationComparer(xe, ye) {
+					return false
+				}
+			}
+			return true
+		},
+	))
+}

--- a/internal/cmptest/location.go
+++ b/internal/cmptest/location.go
@@ -1,0 +1,13 @@
+package cmptest
+
+import (
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/anchore/syft/syft/file"
+)
+
+type LocationComparer func(x, y file.Location) bool
+
+func DefaultLocationComparer(x, y file.Location) bool {
+	return cmp.Equal(x.Coordinates, y.Coordinates) && cmp.Equal(x.AccessPath, y.AccessPath)
+}

--- a/internal/cmptest/relationship.go
+++ b/internal/cmptest/relationship.go
@@ -1,0 +1,26 @@
+package cmptest
+
+import (
+	"github.com/sanity-io/litter"
+
+	"github.com/anchore/syft/syft/artifact"
+)
+
+type RelationshipComparer func(x, y artifact.Relationship) bool
+
+var relationshipStringer = litter.Options{
+	Compact:           true,
+	StripPackageNames: false,
+	HidePrivateFields: true, // we want to ignore package IDs
+	HideZeroValues:    true,
+	StrictGo:          true,
+	//FieldExclusions: ...  // these can be added for future values that need to be ignored
+	//FieldFilter: ...
+}
+
+func DefaultRelationshipComparer(x, y artifact.Relationship) bool {
+	// we just need a stable sort, the ordering does not need to be sensible
+	xStr := relationshipStringer.Sdump(x)
+	yStr := relationshipStringer.Sdump(y)
+	return xStr < yStr
+}

--- a/internal/relationship/by_file_ownership.go
+++ b/internal/relationship/by_file_ownership.go
@@ -59,8 +59,8 @@ func byFileOwnershipOverlap(catalog *pkg.Collection) []artifact.Relationship {
 			child := catalog.Package(childID)   // TODO: this is potentially expensive
 
 			edges = append(edges, artifact.Relationship{
-				From: parent,
-				To:   child,
+				From: *parent,
+				To:   *child,
 				Type: artifact.OwnershipByFileOverlapRelationship,
 				Data: ownershipByFilesMetadata{
 					Files: fs,

--- a/internal/relationship/by_file_ownership.go
+++ b/internal/relationship/by_file_ownership.go
@@ -58,6 +58,16 @@ func byFileOwnershipOverlap(catalog *pkg.Collection) []artifact.Relationship {
 			parent := catalog.Package(parentID) // TODO: this is potentially expensive
 			child := catalog.Package(childID)   // TODO: this is potentially expensive
 
+			if parent == nil {
+				log.Tracef("parent package not found: %v", parentID)
+				continue
+			}
+
+			if child == nil {
+				log.Tracef("child package not found: %v", childID)
+				continue
+			}
+
 			edges = append(edges, artifact.Relationship{
 				From: *parent,
 				To:   *child,

--- a/internal/relationship/by_file_ownership_test.go
+++ b/internal/relationship/by_file_ownership_test.go
@@ -3,8 +3,10 @@ package relationship
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/anchore/syft/internal/cmptest"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
@@ -143,10 +145,9 @@ func TestOwnershipByFilesRelationship(t *testing.T) {
 			assert.Len(t, relationships, len(expectedRelations))
 			for idx, expectedRelationship := range expectedRelations {
 				actualRelationship := relationships[idx]
-				assert.Equal(t, expectedRelationship.From.ID(), actualRelationship.From.ID())
-				assert.Equal(t, expectedRelationship.To.ID(), actualRelationship.To.ID())
-				assert.Equal(t, expectedRelationship.Type, actualRelationship.Type)
-				assert.Equal(t, expectedRelationship.Data, actualRelationship.Data)
+				if d := cmp.Diff(expectedRelationship, actualRelationship, cmptest.DefaultCommonOptions()...); d != "" {
+					t.Errorf("unexpected relationship (-want, +got): %s", d)
+				}
 			}
 		})
 	}

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -44,5 +44,5 @@ func packagesInRelationshipsAsValues(m dsl.Matcher) {
 		`$x.To = $y`,
 	).
 		Where(isRelationship(m) && hasPointerType(m)).
-		Report("pointer used as a value for From/To field in artifact.Relationship")
+		Report("pointer used as a value for From/To field in artifact.Relationship (use values instead)")
 }

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -1,4 +1,4 @@
-////go:build gorules
+//go:build gorules
 
 package rules
 

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -2,14 +2,44 @@
 
 package rules
 
-import "github.com/quasilyte/go-ruleguard/dsl"
+import (
+	"strings"
+
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+type Relationship struct {
+	From any
+	To   any
+	Type string
+	Data any
+}
 
 // nolint:unused
 func resourceCleanup(m dsl.Matcher) {
+	// this rule defends against use of internal.CloseAndLogError() without a defer statement
 	m.Match(`$res, $err := $resolver.FileContentsByLocation($loc); if $*_ { $*_ }; $next`).
 		Where(m["res"].Type.Implements(`io.Closer`) &&
 			m["res"].Type.Implements(`io.Reader`) &&
 			m["err"].Type.Implements(`error`) &&
 			!m["next"].Text.Matches(`defer internal.CloseAndLogError`)).
 		Report(`please call "defer internal.CloseAndLogError($res, $loc.RealPath)" right after checking the error returned from $resolver.FileContentsByLocation.`)
+}
+
+// nolint:unused
+func isPtr(ctx *dsl.VarFilterContext) bool {
+	return strings.HasPrefix(ctx.Type.String(), "*") || strings.HasPrefix(ctx.Type.Underlying().String(), "*")
+}
+
+// nolint:unused
+func packagesInRelationshipsAsValues(m dsl.Matcher) {
+	// this rule defends against using pointers as values in artifact.Relationship
+	m.Match(
+		`$x.From = $y`, `$x.To = $y`,
+		`$x.From = &$y`, `$x.To = &$y`,
+		`artifact.Relationship{From: $y, $*_}`,
+		`artifact.Relationship{To: $y, $*_}`,
+	).
+		Where(m["y"].Filter(isPtr)).
+		Report("pointer used as a value for From/To field in artifact.Relationship")
 }

--- a/test/rules/rules.go
+++ b/test/rules/rules.go
@@ -8,13 +8,6 @@ import (
 	"github.com/quasilyte/go-ruleguard/dsl"
 )
 
-type Relationship struct {
-	From any
-	To   any
-	Type string
-	Data any
-}
-
 // nolint:unused
 func resourceCleanup(m dsl.Matcher) {
 	// this rule defends against use of internal.CloseAndLogError() without a defer statement


### PR DESCRIPTION
Related to https://github.com/anchore/grype/pull/1857

This PR adjusts all locations where we are writing references into the `To` and `From` fields of the `artifact.Relationship` type such that no variable references are used in those fields. This allows for consumers to more easily type assert out specific elements without having to also check references for those types.

A new ruleguard linter rule has been introduced to help prevent from this occurring in the future.

While fixing the test for this it became apparent that lifting up `cmp.Diff` options to a common package would be useful, thus the `internal/cmptest` package was created (should only be used in testing).