### PR TITLE
Fix DecoderCollection discarding input from non-seekable Readers

### DIFF
--- a/syft/format/decoders_collection.go
+++ b/syft/format/decoders_collection.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/format/internal/stream"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -20,10 +22,16 @@ func NewDecoderCollection(decoders ...sbom.FormatDecoder) sbom.FormatDecoder {
 }
 
 // Decode takes a set of bytes and attempts to decode it into an SBOM relative to the decoders in the collection.
-func (c *DecoderCollection) Decode(reader io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) {
-	if reader == nil {
+func (c *DecoderCollection) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) {
+	if r == nil {
 		return nil, "", "", fmt.Errorf("no SBOM bytes provided")
 	}
+
+	reader, err := stream.SeekableReader(r)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("unable to create a seekable reader: %w", err)
+	}
+
 	var bestID sbom.FormatID
 	for _, d := range c.decoders {
 		id, version := d.Identify(reader)
@@ -45,10 +53,17 @@ func (c *DecoderCollection) Decode(reader io.Reader) (*sbom.SBOM, sbom.FormatID,
 }
 
 // Identify takes a set of bytes and attempts to identify the format of the SBOM relative to the decoders in the collection.
-func (c *DecoderCollection) Identify(reader io.Reader) (sbom.FormatID, string) {
-	if reader == nil {
+func (c *DecoderCollection) Identify(r io.Reader) (sbom.FormatID, string) {
+	if r == nil {
 		return "", ""
 	}
+
+	reader, err := stream.SeekableReader(r)
+	if err != nil {
+		log.Debugf("unable to create a seekable reader: %v", err)
+		return "", ""
+	}
+
 	for _, d := range c.decoders {
 		id, version := d.Identify(reader)
 		if id != "" && version != "" {

--- a/syft/format/decoders_collection_test.go
+++ b/syft/format/decoders_collection_test.go
@@ -2,12 +2,14 @@ package format
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/format/syftjson"
 	"github.com/anchore/syft/syft/sbom"
 )
@@ -35,6 +37,17 @@ func TestIdentify(t *testing.T) {
 
 		})
 	}
+}
+
+func TestDecodeUnseekable(t *testing.T) {
+	reader, err := os.Open("spdxjson/test-fixtures/spdx/example7-go-module.spdx.json")
+	assert.NoError(t, err)
+
+	// io.NopCloser wraps the reader in a non-seekable type
+	unseekableReader := io.NopCloser(reader)
+	_, formatID, _, err := Decode(unseekableReader)
+	assert.NoError(t, err)
+	assert.Equal(t, spdxjson.ID, formatID)
 }
 
 func TestFormats_EmptyInput(t *testing.T) {


### PR DESCRIPTION
This fixes a bug where a `DecoderCollection` would inadvertently consume from the input stream it was given while iterating through candidate formats, unless it was passed an `io.ReadSeeker`.

This doesn't seem to currently affect the CLI.