### PR TITLE
feat: add license field to ELF binary package metadata

### DIFF
--- a/syft/pkg/cataloger/binary/elf_package.go
+++ b/syft/pkg/cataloger/binary/elf_package.go
@@ -6,11 +6,11 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-func newELFPackage(metadata elfBinaryPackageNotes, locations file.LocationSet, licenses []pkg.License) pkg.Package {
+func newELFPackage(metadata elfBinaryPackageNotes, locations file.LocationSet) pkg.Package {
 	p := pkg.Package{
 		Name:      metadata.Name,
 		Version:   metadata.Version,
-		Licenses:  pkg.NewLicenseSet(licenses...),
+		Licenses:  pkg.NewLicenseSet(pkg.NewLicense(metadata.License)),
 		PURL:      packageURL(metadata),
 		Type:      pkg.BinaryPkg,
 		Locations: locations,

--- a/syft/pkg/cataloger/binary/elf_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/elf_package_cataloger.go
@@ -79,7 +79,7 @@ func (c *elfPackageCataloger) Catalog(_ context.Context, resolver file.Resolver)
 		}
 
 		// create a package for each unique name/version pair (based on the first note found)
-		pkgs = append(pkgs, newELFPackage(notes[0], noteLocations, nil))
+		pkgs = append(pkgs, newELFPackage(notes[0], noteLocations))
 	}
 
 	// why not return relationships? We have an executable cataloger that will note the dynamic libraries imported by

--- a/syft/pkg/cataloger/binary/elf_package_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/elf_package_cataloger_test.go
@@ -20,6 +20,10 @@ func Test_ELF_Package_Cataloger(t *testing.T) {
 				file.NewVirtualLocation("/usr/local/bin/elftests/elfbinwithsisterlib/lib/libhello_world.so", "/usr/local/bin/elftests/elfbinwithsisterlib/lib/libhello_world.so"),
 				file.NewVirtualLocation("/usr/local/bin/elftests/elfbinwithsisterlib/lib/libhello_world2.so", "/usr/local/bin/elftests/elfbinwithsisterlib/lib/libhello_world2.so"),
 			),
+			Licenses: pkg.NewLicenseSet(
+				pkg.License{Value: "MIT", SPDXExpression: "MIT", Type: "declared"},
+			),
+
 			Language: "",
 			Type:     pkg.BinaryPkg,
 			Metadata: pkg.ELFBinaryPackageNoteJSONPayload{
@@ -39,6 +43,9 @@ func Test_ELF_Package_Cataloger(t *testing.T) {
 				file.NewLocation("/usr/local/bin/elftests/elfbinwithnestedlib/bin/elfbinwithnestedlib").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 				file.NewLocation("/usr/local/bin/elftests/elfbinwithsisterlib/bin/elfwithparallellibbin1").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 				file.NewLocation("/usr/local/bin/elftests/elfbinwithsisterlib/bin/elfwithparallellibbin2").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+			),
+			Licenses: pkg.NewLicenseSet(
+				pkg.License{Value: "MIT", SPDXExpression: "MIT", Type: "declared"},
 			),
 			Language: "",
 			Type:     pkg.BinaryPkg,

--- a/syft/pkg/cataloger/binary/elf_package_test.go
+++ b/syft/pkg/cataloger/binary/elf_package_test.go
@@ -82,7 +82,7 @@ func Test_newELFPackage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := newELFPackage(test.metadata, file.NewLocationSet(), nil)
+			actual := newELFPackage(test.metadata, file.NewLocationSet())
 			if diff := cmp.Diff(test.expected, actual, cmpopts.IgnoreFields(pkg.Package{}, "id"), cmpopts.IgnoreUnexported(pkg.Package{}, file.LocationSet{}, pkg.LicenseSet{})); diff != "" {
 				t.Errorf("newELFPackage() mismatch (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Adds a field for License information into the elf binary package metadata structure, which is set to omit if empty from sbom. 