### PR TITLE
Go Mod Cataloger: Remove Replaced Packages

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -70,6 +70,10 @@ func (c *goModCataloger) parseGoModFile(_ context.Context, resolver file.Resolve
 			log.Tracef("error getting licenses for package: %s %v", m.New.Path, err)
 		}
 
+		// the old path and new path may be the same, in which case this is a noop,
+		// but if they're different we need to remove the old package.
+		delete(packages, m.Old.Path)
+
 		packages[m.New.Path] = pkg.Package{
 			Name:      m.New.Path,
 			Version:   m.New.Version,

--- a/syft/pkg/cataloger/golang/parse_go_mod_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod_test.go
@@ -32,6 +32,15 @@ func TestParseGoMod(t *testing.T) {
 			fixture: "test-fixtures/many-packages",
 			expected: []pkg.Package{
 				{
+					Name:      "github.com/anchore/archiver/v3",
+					Version:   "v3.5.2",
+					PURL:      "pkg:golang/github.com/anchore/archiver@v3.5.2#v3",
+					Locations: file.NewLocationSet(file.NewLocation("test-fixtures/many-packages")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
 					Name:      "github.com/anchore/go-testutils",
 					Version:   "v0.0.0-20200624184116-66aa578126db",
 					PURL:      "pkg:golang/github.com/anchore/go-testutils@v0.0.0-20200624184116-66aa578126db",

--- a/syft/pkg/cataloger/golang/test-fixtures/many-packages
+++ b/syft/pkg/cataloger/golang/test-fixtures/many-packages
@@ -11,11 +11,14 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db // github.com/bogus/package v10.10.10
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
 	github.com/anchore/stereoscope v0.0.0-20200706164556-7cf39d7f4639
+	github.com/mholt/archiver/v3 v3.5.1
 	//github.com/ignore/this v9.9.9  // indirect
 	github.com/bmatcuk/doublestar v1.3.1  // indirect
 	github.com/go-test/deep v1.0.6  // a comment
 )
 
 replace github.com/bmatcuk/doublestar => github.com/bmatcuk/doublestar v8.8.8
+
+replace github.com/mholt/archiver/v3 v3.5.1 => github.com/anchore/archiver/v3 v3.5.2
 
 exclude github.com/adrg/xdg v0.2.1


### PR DESCRIPTION
When the goModCataloger processes a Replace directive it currently adds the new package to the resulting package list, but does not remove the old one unless the path is unchanged.

Based on an existing comment in the code, removing the old one seems to be the intended behavior, and results in a more expected end-result, so this does so.