### PR TITLE
Handle GOEXPERIMENTs in go version

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -3,5 +3,5 @@ package internal
 const (
 	// JSONSchemaVersion is the current schema version output by the JSON encoder
 	// This is roughly following the "SchemaVer" guidelines for versioning the JSON schema. Please see schema/json/README.md for details on how to increment.
-	JSONSchemaVersion = "16.0.11"
+	JSONSchemaVersion = "16.0.12"
 )

--- a/schema/json/README.md
+++ b/schema/json/README.md
@@ -22,7 +22,7 @@ Given a version number format `MODEL.REVISION.ADDITION`:
 
 ## Adding a New `pkg.*Metadata` Type
 
-When adding a new `pkg.*Metadata` that is assigned to the `pkg.Package.Metadata` struct field you must add a test case to `test/integration/catalog_packages_cases_test.go` that exercises the new package type with the new metadata.
+When adding a new `pkg.*Metadata` that is assigned to the `pkg.Package.Metadata` struct field you must add a test case to `cmd/syft/internal/test/integration/catalog_packages_cases_test.go` that exercises the new package type with the new metadata.
 
 Additionally it is important to generate a new JSON schema since the `pkg.Package.Metadata` field is covered by the schema.
 

--- a/schema/json/schema-16.0.12.json
+++ b/schema/json/schema-16.0.12.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "anchore.io/schema/syft/json/16.0.10/document",
+  "$id": "anchore.io/schema/syft/json/16.0.12/document",
   "$ref": "#/$defs/Document",
   "$defs": {
     "AlpmDbEntry": {
@@ -866,6 +866,12 @@
           "type": "string"
         },
         "goCryptoSettings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "goExperiments": {
           "items": {
             "type": "string"
           },
@@ -1973,6 +1979,21 @@
         },
         "directUrlOrigin": {
           "$ref": "#/$defs/PythonDirectURLOriginInfo"
+        },
+        "requiresPython": {
+          "type": "string"
+        },
+        "requiresDist": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "providesExtra": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object",

--- a/schema/json/schema-latest.json
+++ b/schema/json/schema-latest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "anchore.io/schema/syft/json/16.0.11/document",
+  "$id": "anchore.io/schema/syft/json/16.0.12/document",
   "$ref": "#/$defs/Document",
   "$defs": {
     "AlpmDbEntry": {
@@ -866,6 +866,12 @@
           "type": "string"
         },
         "goCryptoSettings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "goExperiments": {
           "items": {
             "type": "string"
           },

--- a/syft/pkg/cataloger/golang/package.go
+++ b/syft/pkg/cataloger/golang/package.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
-func (c *goBinaryCataloger) newGoBinaryPackage(resolver file.Resolver, dep *debug.Module, mainModule, goVersion, architecture string, buildSettings pkg.KeyValues, cryptoSettings []string, locations ...file.Location) pkg.Package {
+func (c *goBinaryCataloger) newGoBinaryPackage(resolver file.Resolver, dep *debug.Module, mainModule, goVersion, architecture string, buildSettings pkg.KeyValues, cryptoSettings, experiments []string, locations ...file.Location) pkg.Package {
 	if dep.Replace != nil {
 		dep = dep.Replace
 	}
@@ -35,6 +35,7 @@ func (c *goBinaryCataloger) newGoBinaryPackage(resolver file.Resolver, dep *debu
 			BuildSettings:     buildSettings,
 			MainModule:        mainModule,
 			GoCryptoSettings:  cryptoSettings,
+			GoExperiments:     experiments,
 		},
 	}
 

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -908,6 +908,44 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "parse a mod with go experiments",
+			mod: &extendedBuildInfo{
+				BuildInfo: &debug.BuildInfo{
+					GoVersion: "go1.22.2 X:nocoverageredesign,noallocheaders,noexectracer2",
+					Main:      debug.Module{Path: "github.com/anchore/syft", Version: "(devel)"},
+					Settings: []debug.BuildSetting{
+						{Key: "GOARCH", Value: archDetails},
+						{Key: "GOOS", Value: "darwin"},
+						{Key: "GOAMD64", Value: "v1"},
+					},
+				},
+				cryptoSettings: nil,
+				arch:           archDetails,
+			},
+			expected: []pkg.Package{{
+				Name:     "github.com/anchore/syft",
+				Language: pkg.Go,
+				Type:     pkg.GoModulePkg,
+				Version:  "(devel)",
+				PURL:     "pkg:golang/github.com/anchore/syft@(devel)",
+				Locations: file.NewLocationSet(
+					file.NewLocationFromCoordinates(
+						file.Coordinates{
+							RealPath:     "/a-path",
+							FileSystemID: "layer-id",
+						},
+					).WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+				),
+				Metadata: pkg.GolangBinaryBuildinfoEntry{
+					GoCompiledVersion: "go1.22.2",
+					Architecture:      archDetails,
+					BuildSettings:     defaultBuildSettings,
+					MainModule:        "github.com/anchore/syft",
+					GoExperiments:     []string{"nocoverageredesign", "noallocheaders", "noexectracer2"},
+				},
+			}},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/golang.go
+++ b/syft/pkg/golang.go
@@ -8,6 +8,7 @@ type GolangBinaryBuildinfoEntry struct {
 	H1Digest          string    `json:"h1Digest,omitempty" cyclonedx:"h1Digest"`
 	MainModule        string    `json:"mainModule,omitempty" cyclonedx:"mainModule"`
 	GoCryptoSettings  []string  `json:"goCryptoSettings,omitempty" cyclonedx:"goCryptoSettings"`
+	GoExperiments     []string  `json:"goExperiments,omitempty" cyclonedx:"goExperiments"`
 }
 
 // GolangModuleEntry represents all captured data for a Golang source scan with go.mod/go.sum


### PR DESCRIPTION
See https://github.com/anchore/grype/issues/1851 for more context.

I was originally going to put this into [`scanFile`](https://github.com/anchore/syft/blob/3023a5a7bc870f70a3dd24213d795516288ca0df/syft/pkg/cataloger/golang/scan_binary.go#L22), but the existing tests made it a little easier to test if I did it in `parse_go_binary.go` instead.

I've also tested this manually, before:
```
$ git checkout main && go install ./cmd/syft && syft ghcr.io/projectcontour/contour | grep stdlib
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
 ✔ Loaded image                                                                                                                                                                                                         ghcr.io/projectcontour/contour:latest
 ✔ Parsed image                                                                                                                                                                       sha256:3538357182affbd790c9ecaffc62c3022d8e2cc46816eaa8a8fb8acb1a82ad8b
 ✔ Cataloged contents                                                                                                                                                                        bd7b5d7ab8063fa560c1164fbfea7cb4d6b90cc61b534bc2720f34f80d18db18
   ├── ✔ Packages                        [73 packages]
   └── ✔ Executables                     [1 executables]
stdlib                                              go1.22.2 X:nocoverageredesign,noallocheaders,noexectracer2  go-module
```

And after:
```
$ git checkout go-experiments && go install ./cmd/syft && syft ghcr.io/projectcontour/contour | grep stdlib
Switched to branch 'go-experiments'
 ✔ Loaded image                                                                                                                                                                                                         ghcr.io/projectcontour/contour:latest
 ✔ Parsed image                                                                                                                                                                       sha256:3538357182affbd790c9ecaffc62c3022d8e2cc46816eaa8a8fb8acb1a82ad8b
 ✔ Cataloged contents                                                                                                                                                                        bd7b5d7ab8063fa560c1164fbfea7cb4d6b90cc61b534bc2720f34f80d18db18
   ├── ✔ Packages                        [73 packages]
   └── ✔ Executables                     [1 executables]
stdlib                                              go1.22.2                               go-module
```

I can also confirm that after modifying `grype` to use my branch, it no longer emits a warning:

```
$ git diff | head
diff --git a/go.mod b/go.mod
index 4116608..2852d36 100644
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/anchore/grype

 go 1.21.1

+replace github.com/anchore/syft => ../syft
+

$ grype ghcr.io/projectcontour/contour
 ✔ Vulnerability DB                [updated]
 ✔ Loaded image                                                                                                                                                                                                         ghcr.io/projectcontour/contour:latest
 ✔ Parsed image                                                                                                                                                                       sha256:3538357182affbd790c9ecaffc62c3022d8e2cc46816eaa8a8fb8acb1a82ad8b
 ✔ Cataloged contents                                                                                                                                                                        bd7b5d7ab8063fa560c1164fbfea7cb4d6b90cc61b534bc2720f34f80d18db18
   ├── ✔ Packages                        [73 packages]
   └── ✔ Executables                     [1 executables]
 ✔ Scanned for vulnerabilities     [2 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   0 fixed, 2 not-fixed, 0 ignored
NAME    INSTALLED  FIXED-IN  TYPE       VULNERABILITY   SEVERITY
stdlib  go1.22.2             go-module  CVE-2024-24788  Unknown
stdlib  go1.22.2             go-module  CVE-2024-24787  Unknown
```

Interestingly, `grype` still picks up these CVEs even without my change, so maybe this warning isn't all that necessary? I don't have a super firm grasp on how this works.
 
```
$ git checkout -- . && go install ./cmd/grype && grype ghcr.io/projectcontour/contour
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                                                                                         ghcr.io/projectcontour/contour:latest
 ✔ Parsed image                                                                                                                                                                       sha256:3538357182affbd790c9ecaffc62c3022d8e2cc46816eaa8a8fb8acb1a82ad8b
 ✔ Cataloged contents                                                                                                                                                                        bd7b5d7ab8063fa560c1164fbfea7cb4d6b90cc61b534bc2720f34f80d18db18
   ├── ✔ Packages                        [73 packages]
   └── ✔ Executables                     [1 executables]
 ✔ Scanned for vulnerabilities     [2 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible (2 unknown)
   └── by status:   0 fixed, 2 not-fixed, 0 ignored
[0000]  WARN could not match by package language (package=Pkg(type=go-module, name=stdlib, version=go1.22.2 X:nocoverageredesign,noallocheaders,noexectracer2, upstreams=0)): matcher failed to parse version pkg="stdlib" ver="go1.22.2 X:nocoverageredesign,n
NAME    INSTALLED                                                   FIXED-IN  TYPE       VULNERABILITY   SEVERITY
stdlib  go1.22.2 X:nocoverageredesign,noallocheaders,noexectracer2            go-module  CVE-2024-24788  Unknown
stdlib  go1.22.2 X:nocoverageredesign,noallocheaders,noexectracer2            go-module  CVE-2024-24787  Unknown