### PR TITLE
Close sqlite driver after testing sqlite availability

### DIFF
--- a/syft/pkg/cataloger/redhat/cataloger.go
+++ b/syft/pkg/cataloger/redhat/cataloger.go
@@ -48,6 +48,10 @@ func NewArchiveCataloger() pkg.Cataloger {
 }
 
 func isSqliteDriverAvailable() bool {
-	_, err := sql.Open("sqlite", ":memory:")
-	return err == nil
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		return false
+	}
+	_ = db.Close()
+	return true
 }


### PR DESCRIPTION
For long running programs, opening a sql connection without closing it will cause go routine leaks.  Close sql driver after testing sqlite availability.