### PR TITLE
Pin golang image version in test fixture

### DIFF
--- a/syft/pkg/cataloger/golang/test-fixtures/image-not-a-module/Dockerfile
+++ b/syft/pkg/cataloger/golang/test-fixtures/image-not-a-module/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.22 AS builder
+FROM --platform=linux/amd64 golang:1.22.4 AS builder
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
This fixes a similar test failure as #2932 due to a drifting golang image version.