### PR TITLE
Trim whitespace from wordpress values

### DIFF
--- a/syft/pkg/cataloger/wordpress/parse_plugin.go
+++ b/syft/pkg/cataloger/wordpress/parse_plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/syft/artifact"
@@ -39,7 +40,6 @@ type pluginData struct {
 
 func parseWordpressPluginFiles(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	var pkgs []pkg.Package
-	var fields = make(map[string]interface{})
 	buffer := make([]byte, contentBufferSize)
 
 	_, err := reader.Read(buffer)
@@ -47,13 +47,7 @@ func parseWordpressPluginFiles(_ context.Context, _ file.Resolver, _ *generic.En
 		return nil, nil, fmt.Errorf("failed to read %s file: %w", reader.Location.Path(), err)
 	}
 
-	fileContent := string(buffer)
-	for field, pattern := range patterns {
-		matchMap := internal.MatchNamedCaptureGroups(pattern, fileContent)
-		if value := matchMap[field]; value != "" {
-			fields[field] = value
-		}
-	}
+	fields := extractFields(string(buffer))
 
 	name, nameOk := fields["name"]
 	version, versionOk := fields["version"]
@@ -95,4 +89,16 @@ func parseWordpressPluginFiles(_ context.Context, _ file.Resolver, _ *generic.En
 	}
 
 	return pkgs, nil, nil
+}
+
+func extractFields(in string) map[string]any {
+	var fields = make(map[string]interface{})
+
+	for field, pattern := range patterns {
+		matchMap := internal.MatchNamedCaptureGroups(pattern, in)
+		if value := matchMap[field]; value != "" {
+			fields[field] = strings.TrimSpace(value)
+		}
+	}
+	return fields
 }

--- a/syft/pkg/cataloger/wordpress/parse_plugin_test.go
+++ b/syft/pkg/cataloger/wordpress/parse_plugin_test.go
@@ -3,6 +3,8 @@ package wordpress
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
@@ -29,4 +31,29 @@ func TestParseWordpressPluginFiles(t *testing.T) {
 	}
 
 	pkgtest.TestFileParser(t, fixture, parseWordpressPluginFiles, []pkg.Package{expectedPkg}, nil)
+}
+
+func Test_extractFields(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]any
+	}{
+		{
+			name: "carriage returns are stripped",
+			in:   "Plugin Name: WP Migration\r\nVersion: 5.3\r\nLicense: GPLv3\r\nAuthor: MonsterInsights\r\nAuthor URI: https://servmask.com/\r\n",
+			want: map[string]any{
+				"name":       "WP Migration",
+				"version":    "5.3",
+				"license":    "GPLv3",
+				"author":     "MonsterInsights",
+				"author_uri": "https://servmask.com/",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractFields(tt.in))
+		})
+	}
 }


### PR DESCRIPTION
It's possible that values being parsed within PHP comments for the wordpress plugin may have whitespace values (e.g. [carriage returns before line endings](https://plugins.trac.wordpress.org/browser/wp-coder/tags/2.5.1/wp-coder.php)). This PR cleans such values before further processing.