### PR TITLE
fix: make caching options more explicit

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -36,7 +36,8 @@ func GetManager() Manager {
 	return manager
 }
 
-// SetManager sets the global cache manager, which is used to instantiate all caches
+// SetManager sets the global cache manager, which is used to instantiate all caches.
+// Setting this to nil disables caching.
 func SetManager(m Manager) {
 	if m == nil {
 		manager = &bypassedCache{}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -10,7 +11,17 @@ func Test_SetManager(t *testing.T) {
 	original := GetManager()
 	defer SetManager(original)
 
+	SetManager(nil)
+
+	require.NotNil(t, GetManager())
+	require.IsType(t, &bypassedCache{}, GetManager())
+
 	SetManager(NewInMemory(0))
+
+	require.NotNil(t, GetManager())
+	require.IsType(t, &bypassedCache{}, GetManager())
+
+	SetManager(NewInMemory(1 * time.Hour))
 
 	require.NotNil(t, GetManager())
 	require.IsType(t, &filesystemCache{}, GetManager())

--- a/internal/cache/memory.go
+++ b/internal/cache/memory.go
@@ -8,6 +8,9 @@ import (
 
 // NewInMemory returns an in-memory only cache manager
 func NewInMemory(ttl time.Duration) Manager {
+	if ttl <= 0 {
+		return &bypassedCache{}
+	}
 	return &filesystemCache{
 		dir: "",
 		fs:  afero.NewMemMapFs(),


### PR DESCRIPTION
This PR makes the caching behavior a bit more logical and explicit for different values:

* TTL of <= 0 disable caching entirely
* Dir of empty string (`''`) results in an in-memory only cache