### PR TITLE
Add version 3 support for swift package manager of the resolved files

### DIFF
--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -78,12 +78,12 @@ from-images:
     paths:
       - /usr/local/go/bin/go
 
-  # - version: 1.5.14
-  #   images:
-  #     - ref: haproxy:1.5.14@sha256:3d57e3921cc84e860f764e863ce729dd0765e3d28d444775127bc42d68f98e10
-  #       platform: linux/amd64
-  #   paths:
-  #     - /usr/local/sbin/haproxy
+  - version: 1.5.14
+    images:
+      - ref: haproxy:1.5.14@sha256:3d57e3921cc84e860f764e863ce729dd0765e3d28d444775127bc42d68f98e10
+        platform: linux/amd64
+    paths:
+      - /usr/local/sbin/haproxy
 
   - version: 1.8.22
     images:
@@ -395,12 +395,12 @@ from-images:
     paths:
       - /usr/local/bin/wp
 
-  # - version: 1.9.3p551
-  #   images:
-  #     - ref: ruby:1.9.3-p551@sha256:56b4a74e4fc2492b3b857bc94454dfa910f61e823a4bfab275d279bfa218eb05
-  #       platform: linux/amd64
-  #   paths:
-  #     - /usr/local/bin/ruby
+  - version: 1.9.3p551
+    images:
+      - ref: ruby:1.9.3-p551@sha256:56b4a74e4fc2492b3b857bc94454dfa910f61e823a4bfab275d279bfa218eb05
+        platform: linux/amd64
+    paths:
+      - /usr/local/bin/ruby
 
   - name: rust-libstd
     version: 1.50.0

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -78,12 +78,12 @@ from-images:
     paths:
       - /usr/local/go/bin/go
 
-  - version: 1.5.14
-    images:
-      - ref: haproxy:1.5.14@sha256:3d57e3921cc84e860f764e863ce729dd0765e3d28d444775127bc42d68f98e10
-        platform: linux/amd64
-    paths:
-      - /usr/local/sbin/haproxy
+  # - version: 1.5.14
+  #   images:
+  #     - ref: haproxy:1.5.14@sha256:3d57e3921cc84e860f764e863ce729dd0765e3d28d444775127bc42d68f98e10
+  #       platform: linux/amd64
+  #   paths:
+  #     - /usr/local/sbin/haproxy
 
   - version: 1.8.22
     images:
@@ -395,12 +395,12 @@ from-images:
     paths:
       - /usr/local/bin/wp
 
-  - version: 1.9.3p551
-    images:
-      - ref: ruby:1.9.3-p551@sha256:56b4a74e4fc2492b3b857bc94454dfa910f61e823a4bfab275d279bfa218eb05
-        platform: linux/amd64
-    paths:
-      - /usr/local/bin/ruby
+  # - version: 1.9.3p551
+  #   images:
+  #     - ref: ruby:1.9.3-p551@sha256:56b4a74e4fc2492b3b857bc94454dfa910f61e823a4bfab275d279bfa218eb05
+  #       platform: linux/amd64
+  #   paths:
+  #     - /usr/local/bin/ruby
 
   - name: rust-libstd
     version: 1.50.0

--- a/syft/pkg/cataloger/swift/parse_package_resolved.go
+++ b/syft/pkg/cataloger/swift/parse_package_resolved.go
@@ -45,6 +45,11 @@ type packagePinsV2 struct {
 	State    packageState `json:"state"`
 }
 
+type packageResolvedV3 struct {
+	packageResolvedV2
+	OriginHash string `json:"originHash"`
+}
+
 type packagePin struct {
 	Identity string
 	Location string
@@ -123,6 +128,24 @@ func pinsForVersion(data map[string]interface{}, version float64) ([]packagePin,
 		}
 	case 2:
 		t := packageResolvedV2{}
+		jsonString, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		parseErr := json.Unmarshal(jsonString, &t)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		for _, pin := range t.Pins {
+			genericPins = append(genericPins, packagePin{
+				pin.Identity,
+				pin.Location,
+				pin.State.Revision,
+				pin.State.Version,
+			})
+		}
+	case 3:
+		t := packageResolvedV3{}
 		jsonString, err := json.Marshal(data)
 		if err != nil {
 			return nil, err

--- a/syft/pkg/cataloger/swift/parse_package_resolved.go
+++ b/syft/pkg/cataloger/swift/parse_package_resolved.go
@@ -45,11 +45,6 @@ type packagePinsV2 struct {
 	State    packageState `json:"state"`
 }
 
-type packageResolvedV3 struct {
-	packageResolvedV2
-	OriginHash string `json:"originHash"`
-}
-
 type packagePin struct {
 	Identity string
 	Location string
@@ -126,26 +121,8 @@ func pinsForVersion(data map[string]interface{}, version float64) ([]packagePin,
 				pin.State.Version,
 			})
 		}
-	case 2:
+	case 2, 3:
 		t := packageResolvedV2{}
-		jsonString, err := json.Marshal(data)
-		if err != nil {
-			return nil, err
-		}
-		parseErr := json.Unmarshal(jsonString, &t)
-		if parseErr != nil {
-			return nil, parseErr
-		}
-		for _, pin := range t.Pins {
-			genericPins = append(genericPins, packagePin{
-				pin.Identity,
-				pin.Location,
-				pin.State.Revision,
-				pin.State.Version,
-			})
-		}
-	case 3:
-		t := packageResolvedV3{}
 		jsonString, err := json.Marshal(data)
 		if err != nil {
 			return nil, err

--- a/syft/pkg/cataloger/swift/parse_package_resolved_test.go
+++ b/syft/pkg/cataloger/swift/parse_package_resolved_test.go
@@ -80,6 +80,40 @@ func TestParsePackageResolved(t *testing.T) {
 	pkgtest.TestFileParser(t, fixture, parsePackageResolved, expectedPkgs, expectedRelationships)
 }
 
+func TestParsePackageResolvedV3(t *testing.T) {
+	fixture := "test-fixtures/PackageV3.resolved"
+	locations := file.NewLocationSet(file.NewLocation(fixture))
+	expectedPkgs := []pkg.Package{
+		{
+			Name:      "swift-mmio",
+			Version:   "",
+			PURL:      "pkg:swift/github.com/apple/swift-mmio/swift-mmio",
+			Locations: locations,
+			Language:  pkg.Swift,
+			Type:      pkg.SwiftPkg,
+			Metadata: pkg.SwiftPackageManagerResolvedEntry{
+				Revision: "80c109b87511041338a4d8d88064088c8dfc079b",
+			},
+		},
+		{
+			Name:      "swift-syntax",
+			Version:   "509.1.1",
+			PURL:      "pkg:swift/github.com/apple/swift-syntax.git/swift-syntax@509.1.1",
+			Locations: locations,
+			Language:  pkg.Swift,
+			Type:      pkg.SwiftPkg,
+			Metadata: pkg.SwiftPackageManagerResolvedEntry{
+				Revision: "64889f0c732f210a935a0ad7cda38f77f876262d",
+			},
+		},
+	}
+
+	// TODO: no relationships are under test yet
+	var expectedRelationships []artifact.Relationship
+
+	pkgtest.TestFileParser(t, fixture, parsePackageResolved, expectedPkgs, expectedRelationships)
+}
+
 func TestParsePackageResolved_empty(t *testing.T) {
 	// regression for https://github.com/anchore/syft/issues/2225
 	fixture := "test-fixtures/empty-packages.resolved"

--- a/syft/pkg/cataloger/swift/test-fixtures/PackageV3.resolved
+++ b/syft/pkg/cataloger/swift/test-fixtures/PackageV3.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "ea83017c944c7850b8f60207e6143eb17cb6b5e6b734b3fa08787a5d920dba7b",
+  "pins" : [
+    {
+      "identity" : "swift-mmio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-mmio",
+      "state" : {
+        "branch" : "swift-embedded-examples",
+        "revision" : "80c109b87511041338a4d8d88064088c8dfc079b"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
Add version 3 support for swift package manager of the resolved files, add test coverage for v3 support as well.

This is a fix for : https://github.com/anchore/syft/issues/2759