### PR TITLE
Map the downloadLocation field for PHP Composer packages

### DIFF
--- a/syft/format/internal/spdxutil/helpers/download_location.go
+++ b/syft/format/internal/spdxutil/helpers/download_location.go
@@ -22,6 +22,10 @@ func DownloadLocation(p pkg.Package) string {
 			return NoneIfEmpty(metadata.URL)
 		case pkg.NpmPackageLockEntry:
 			return NoneIfEmpty(metadata.Resolved)
+		case pkg.PhpComposerLockEntry:
+			return NoneIfEmpty(metadata.Dist.URL)
+		case pkg.PhpComposerInstalledEntry:
+			return NoneIfEmpty(metadata.Dist.URL)
 		}
 	}
 	return NOASSERTION

--- a/syft/format/internal/spdxutil/helpers/download_location_test.go
+++ b/syft/format/internal/spdxutil/helpers/download_location_test.go
@@ -64,6 +64,50 @@ func Test_DownloadLocation(t *testing.T) {
 			},
 			expected: NONE,
 		},
+		{
+			name: "from php installed.json",
+			input: pkg.Package{
+				Metadata: pkg.PhpComposerInstalledEntry{
+					Dist: pkg.PhpComposerExternalReference{
+						URL: "http://package-lock.test",
+					},
+				},
+			},
+			expected: "http://package-lock.test",
+		},
+		{
+			name: "empty",
+			input: pkg.Package{
+				Metadata: pkg.PhpComposerInstalledEntry{
+					Dist: pkg.PhpComposerExternalReference{
+						URL: "",
+					},
+				},
+			},
+			expected: "NONE",
+		},
+		{
+			name: "from php composer.lock",
+			input: pkg.Package{
+				Metadata: pkg.PhpComposerLockEntry{
+					Dist: pkg.PhpComposerExternalReference{
+						URL: "http://package-lock.test",
+					},
+				},
+			},
+			expected: "http://package-lock.test",
+		},
+		{
+			name: "empty",
+			input: pkg.Package{
+				Metadata: pkg.PhpComposerLockEntry{
+					Dist: pkg.PhpComposerExternalReference{
+						URL: "",
+					},
+				},
+			},
+			expected: "NONE",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Php Composer (via `composer.lock` or `installed.json`) have `NOASSERTION` for `downloadLocation` even though the data is captured. This provides the mapping for those packages