### PR TITLE
chore: pin fedora image for elf binary test

### DIFF
--- a/syft/pkg/cataloger/binary/elf_package_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/elf_package_cataloger_test.go
@@ -70,8 +70,8 @@ func Test_ELF_Package_Cataloger(t *testing.T) {
 			expected: []pkg.Package{
 				{
 					Name:    "coreutils",
-					Version: "9.5-1.fc41",
-					PURL:    "pkg:rpm/fedora/coreutils@9.5-1.fc41?distro=fedora-40",
+					Version: "9.5-3.fc41",
+					PURL:    "pkg:rpm/fedora/coreutils@9.5-3.fc41?distro=fedora-40",
 					Locations: file.NewLocationSet(
 						file.NewLocation("/sha256sum").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 						file.NewLocation("/sha1sum").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),

--- a/syft/pkg/cataloger/binary/test-fixtures/image-fedora-64bit/Dockerfile
+++ b/syft/pkg/cataloger/binary/test-fixtures/image-fedora-64bit/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 fedora:41 as build
+FROM --platform=linux/amd64 fedora:41@sha256:c05bf79137835bf5c521c58f8252d6031780ae865a0379ab57f412e0ac6b42aa as build
 
 FROM scratch
 COPY --from=build /bin/sha256sum /sha256sum


### PR DESCRIPTION
This PR just pins the fedora:41 image used for an ELF binary test