### PR TITLE
fix: stop panicking on "devel" version go stdlib

### DIFF
--- a/syft/pkg/cataloger/golang/stdlib_package.go
+++ b/syft/pkg/cataloger/golang/stdlib_package.go
@@ -33,10 +33,11 @@ func stdlibPackageAndRelationships(pkgs []pkg.Package) ([]pkg.Package, []artifac
 			}
 
 			stdLibPkg := newGoStdLib(mValue.GoCompiledVersion, goPkg.Locations)
-			if stdLibPkg != nil {
-				goCompilerPkgs = append(goCompilerPkgs, *stdLibPkg)
-				totalLocations.Add(location)
+			if stdLibPkg == nil {
+				continue
 			}
+			goCompilerPkgs = append(goCompilerPkgs, *stdLibPkg)
+			totalLocations.Add(location)
 
 			relationships = append(relationships, artifact.Relationship{
 				From: *stdLibPkg,

--- a/syft/pkg/cataloger/golang/stdlib_package_test.go
+++ b/syft/pkg/cataloger/golang/stdlib_package_test.go
@@ -68,6 +68,22 @@ func Test_stdlibPackageAndRelationships(t *testing.T) {
 			wantPkgs: 1,
 			wantRels: 1,
 		},
+		{
+			name: "go binary package with devel stdlib",
+			pkgs: []pkg.Package{
+				{
+					Name:      "github.com/something/go",
+					Version:   "1.0.0",
+					Locations: file.NewLocationSet(file.NewLocation("/bin/my-app")),
+					Metadata: pkg.GolangBinaryBuildinfoEntry{
+						GoCompiledVersion: "devel",
+						MainModule:        "github.com/something/go",
+					},
+				},
+			},
+			wantPkgs: 0,
+			wantRels: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Previously, if a Go binary was cataloged with build info indicating that the go compiler version used was "deve", syft would panic on a nil pointer dereference. Instead, skip creating a Go stdlib reference and relationship for such a package.

Fixes #3037 