### PR TITLE
fix: include CPEs with Maven groupId as vendor

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -203,6 +203,8 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:nexus:nexus:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:sonatype:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:sonatype:nexus:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.sonatype.nexus:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.sonatype.nexus:nexus:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -371,6 +373,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:cloudbees:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:com.cloudbees.jenkins.plugins:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -394,6 +397,8 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:something:something:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:something:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:io.jenkins.plugins.name.something:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:io.jenkins.plugins.name.something:something:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -413,6 +418,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			expected: []string{
 				"cpe:2.3:a:name:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:io.jenkins.plugins:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -434,6 +440,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:io.jenkins-ci.plugins:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -455,6 +462,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jenkins-ci:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins:name:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins_ci:name:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.jenkins-ci.plugins:name:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -489,6 +497,9 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jira_client_core:jira-client-core:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jira_client_core:jira:3.2:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jira_client_core:jira_client_core:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.atlassian.jira:jira:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.atlassian.jira:jira_client_core:3.2:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.atlassian.jira:jira-client-core:3.2:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -521,6 +532,8 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jenkins:cloudbees_installation_manager:2.89.0.33:*:*:*:*:*:*:*",
 				"cpe:2.3:a:modules:cloudbees-installation-manager:2.89.0.33:*:*:*:*:*:*:*",
 				"cpe:2.3:a:modules:cloudbees_installation_manager:2.89.0.33:*:*:*:*:*:*:*",
+				"cpe:2.3:a:com.cloudbees.jenkins.modules:cloudbees_installation_manager:2.89.0.33:*:*:*:*:*:*:*",
+				"cpe:2.3:a:com.cloudbees.jenkins.modules:cloudbees-installation-manager:2.89.0.33:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -594,6 +607,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jenkins:handlebars:3.0.8:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins_ci:handlebars:3.0.8:*:*:*:*:*:*:*",
 				"cpe:2.3:a:ui:handlebars:3.0.8:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.jenkins-ci.ui:handlebars:3.0.8:*:*:*:*:*:*:*",
 			},
 		},
 		{
@@ -631,6 +645,8 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:jenkins:active_directory:2.25.1:*:*:*:*:*:*:*", // important!
 				"cpe:2.3:a:jenkins_ci:active-directory:2.25.1:*:*:*:*:*:*:*",
 				"cpe:2.3:a:jenkins_ci:active_directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.jenkins-ci.plugins:active-directory:2.25.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:org.jenkins-ci.plugins:active_directory:2.25.1:*:*:*:*:*:*:*",
 			},
 		},
 		{

--- a/syft/pkg/cataloger/internal/cpegenerate/java.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java.go
@@ -98,6 +98,13 @@ func vendorsFromJavaManifestNames(p pkg.Package) fieldCandidateSet {
 func vendorsFromGroupIDs(groupIDs []string) fieldCandidateSet {
 	vendors := newFieldCandidateSet()
 	for _, groupID := range groupIDs {
+		// always include the groupId as a vendor -- the Grype database may include alternate matches with these
+		vendors.add(fieldCandidate{
+			value:                       groupID,
+			disallowSubSelections:       true,
+			disallowDelimiterVariations: true,
+		})
+
 		for i, field := range strings.Split(groupID, ".") {
 			field = strings.TrimSpace(field)
 

--- a/syft/pkg/cataloger/internal/cpegenerate/java_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_test.go
@@ -139,7 +139,7 @@ func Test_vendorsFromGroupIDs(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.groupID, func(t *testing.T) {
-			assert.ElementsMatch(t, test.expected, vendorsFromGroupIDs([]string{test.groupID}).values(), "different vendors")
+			assert.ElementsMatch(t, append(test.expected, test.groupID), vendorsFromGroupIDs([]string{test.groupID}).values(), "different vendors")
 		})
 	}
 }


### PR DESCRIPTION
This PR adds Maven `groupId` as an explicit vendor to include when creating CPEs.

Fixes #3042 