### PR TITLE
Ensure accurate java main artifact name retrieval for multi-JARs and refine fallback approach

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -301,11 +301,17 @@ func (j *archiveParser) guessMainPackageNameAndVersionFromPomInfo(ctx context.Co
 	properties, _ := pomPropertiesByParentPath(j.archivePath, j.location, pomPropertyMatches)
 	projects, _ := pomProjectByParentPath(j.archivePath, j.location, pomMatches)
 
+	// map of all the artifacts in the pom properties, in order to chek exact match with the filename
+	artifactsMap := make(map[string]bool)
+	for _, propertiesObj := range properties {
+		artifactsMap[propertiesObj.ArtifactID] = true
+	}
+
 	parentPaths := maps.Keys(properties)
 	slices.Sort(parentPaths)
 	for _, parentPath := range parentPaths {
 		propertiesObj := properties[parentPath]
-		if artifactIDMatchesFilename(propertiesObj.ArtifactID, j.fileInfo.name) {
+		if artifactIDMatchesFilename(propertiesObj.ArtifactID, j.fileInfo.name, artifactsMap) {
 			pomPropertiesObject = propertiesObj
 			if proj, exists := projects[parentPath]; exists {
 				pomProjectObject = proj
@@ -343,10 +349,15 @@ func (j *archiveParser) guessMainPackageNameAndVersionFromPomInfo(ctx context.Co
 	return name, version, licenses
 }
 
-func artifactIDMatchesFilename(artifactID, fileName string) bool {
+func artifactIDMatchesFilename(artifactID, fileName string, artifactsMap map[string]bool) bool {
 	if artifactID == "" || fileName == "" {
 		return false
 	}
+	// Ensure true is returned when filename matches the artifact ID, prevent random retrieval by checking prefix and suffix
+	if _, exists := artifactsMap[fileName]; exists {
+		return artifactID == fileName
+	}
+	// Use fallback check with suffix and prefix if no POM properties file matches the exact artifact name
 	return strings.HasPrefix(artifactID, fileName) || strings.HasSuffix(fileName, artifactID)
 }
 

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1156,7 +1156,7 @@ func Test_artifactIDMatchesFilename(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, artifactIDMatchesFilename(tt.artifactID, tt.fileName))
+			assert.Equal(t, tt.want, artifactIDMatchesFilename(tt.artifactID, tt.fileName, nil))
 		})
 	}
 }


### PR DESCRIPTION
**Improving Accuracy of Package Name Retrieval in Java Archives**

This section outlines enhancements to accurately retrieve the main package artifact names and their corresponding SHA1 values. It focuses on resolving issues where incorrect package names were being retrieved, especially for JAR files with multiple internal JARs. The improvements include:

- Correctly retrieving the main package name when the main POM file is present.
- Addressing issues with incorrect package names for specific JAR files, such as those containing multiple JARs.
- Ensuring accurate results by checking prefixes and suffixes, with a fallback mechanism if no exact matches are found.