### PR TITLE
python requirements.txt cataloger: allow dots in python package names

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -26,7 +26,7 @@ const (
 	//      --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65  # some comment
 
 	// namePattern matches: requests[security]
-	namePattern = `(?P<name>\w[\w\[\],\s-_]+)`
+	namePattern = `(?P<name>\w[\w\[\],\s-_\.]+)`
 
 	// versionConstraintPattern matches: == 2.8.*
 	versionConstraintPattern = `(?P<versionConstraint>([^\S\r\n]*[~=>!<]+\s*[0-9a-zA-Z.*]+[^\S\r\n]*,?)+)?(@[^\S\r\n]*(?P<url>[^;]*))?`

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -54,6 +54,18 @@ func TestParseRequirementsTxt(t *testing.T) {
 			},
 		},
 		{
+			Name:      "dots-._allowed",
+			Version:   "1.0.0",
+			PURL:      "pkg:pypi/dots-._allowed@1.0.0",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "dots-._allowed",
+				VersionConstraint: "== 1.0.0",
+			},
+		},
+		{
 			Name:      "argh",
 			Version:   "0.26.2",
 			PURL:      "pkg:pypi/argh@0.26.2",

--- a/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
+++ b/syft/pkg/cataloger/python/test-fixtures/requires/requirements.txt
@@ -8,6 +8,7 @@ bar >= 1.0.0, <= 2.0.0, \
 -r other-requirements.txt
 --requirements super-secretrequirements.txt
 SomeProject ==5.4 ; python_version < '3.8'
+dots-._allowed == 1.0.0
 coverage != 3.5 # Version Exclusion. Anything except version 3.5
 numpyNew; sys_platform == 'win32'
 numpy >= 3.4.1; sys_platform == 'win32'


### PR DESCRIPTION
Its perfectly valid for python packages to have dots in their name
https://packaging.python.org/en/latest/specifications/name-normalization/


It seems like https://github.com/anchore/syft/pull/1966 introduced a regex match which did not include the dot. This results in silently skipping packages with dots in their requirements.txt.

This PR accepts the dot and adds a test.

Noticed this whilst doing https://github.com/anchore/syft/pull/3069 (which does the normalization of the name)

(its possible that this bug may exist in the other parsers but did not investigate that)

