### PR TITLE
python-cataloger: fix normalization test

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -54,9 +54,9 @@ func TestParseRequirementsTxt(t *testing.T) {
 			},
 		},
 		{
-			Name:      "dots-._allowed",
+			Name:      "dots-allowed",
 			Version:   "1.0.0",
-			PURL:      "pkg:pypi/dots-._allowed@1.0.0",
+			PURL:      "pkg:pypi/dots-allowed@1.0.0",
 			Locations: locations,
 			Language:  pkg.Python,
 			Type:      pkg.PythonPkg,


### PR DESCRIPTION
Fixes the normalization in the test case introduced in https://github.com/anchore/syft/pull/3070