### PR TITLE
update traefik classifier for linux/arm/v6, linux/riscv64

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -205,6 +205,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "traefik/3.0.4/linux-riscv64",
+			expected: pkg.Package{
+				Name:      "traefik",
+				Version:   "3.0.4",
+				Type:      "binary",
+				PURL:      "pkg:generic/traefik@3.0.4",
+				Locations: locations("traefik"),
+				Metadata:  metadata("traefik-binary"),
+			},
+		},
+		{
 			logicalFixture: "memcached/1.6.18/linux-amd64",
 			expected: pkg.Package{
 				Name:      "memcached",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -263,7 +263,8 @@ func DefaultClassifiers() []Classifier {
 			EvidenceMatcher: FileContentsVersionMatcher(
 				// [NUL]v1.7.34[NUL]
 				// [NUL]2.9.6[NUL]
-				`(?m)(\x00|\x{FFFD})v?(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]|-beta[0-9]|-rc[0-9])?)\x00`),
+				// 3.0.4[NUL]
+				`(?m)(\x00|\x{FFFD})?v?(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]|-beta[0-9]|-rc[0-9])?)\x00`),
 			Package: "traefik",
 			PURL:    mustPURL("pkg:generic/traefik@version"),
 			CPEs:    singleCPE("cpe:2.3:a:traefik:traefik:*:*:*:*:*:*:*:*"),

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -448,6 +448,12 @@ from-images:
     paths:
       - /usr/local/bin/traefik
 
+  - version: 3.0.4
+    images:
+      - ref: traefik:3.0.4@sha256:12a7cc4232b5b7fe027673da8c096144525f59a8eabc87e52260aac0ec5a1219
+        platform: linux/riscv64
+    paths:
+      - /usr/local/bin/traefik
 
   # from the original dynamic fixtures...
 


### PR DESCRIPTION
This PR updates a binary cataloger for traefik
Fixes #3038

```
$ go run cmd/syft/main.go -q library/traefik:3.0 --platform linux/arm/v6 | grep traefik
github.com/traefik/grpc-web                                                           v0.16.0                                go-module
github.com/traefik/paerser                                                            v0.2.0                                 go-module
github.com/traefik/traefik/v3                                                         v0.0.0-20240702134203-d42e75bb2eab     go-module
github.com/traefik/yaegi                                                              v0.16.1                                go-module
traefik                                                                               3.0.4                                  binary
```

```
$ go run cmd/syft/main.go -q library/traefik:3.0 --platform linux/riscv64 | grep traefik
github.com/traefik/grpc-web                                                           v0.16.0                                go-module
github.com/traefik/paerser                                                            v0.2.0                                 go-module
github.com/traefik/traefik/v3                                                         v0.0.0-20240702134203-d42e75bb2eab     go-module
github.com/traefik/yaegi                                                              v0.16.1                                go-module
traefik                                                                               3.0.4                                  binary
```

```
$ go run cmd/syft/main.go -q library/traefik:2.11 --platform linux/arm/v6 | grep traefik
github.com/traefik/paerser                                                            v0.2.0                                       go-module
github.com/traefik/traefik/v2                                                         v0.0.0-20240702122203-927f0bc01a78           go-module
github.com/traefik/yaegi                                                              v0.16.1                                      go-module
traefik                                                                               2.11.6                                       binary
```

```
$ go run cmd/syft/main.go -q library/traefik:2.11 --platform linux/riscv64 | grep traefik
github.com/traefik/paerser                                                            v0.2.0                                       go-module
github.com/traefik/traefik/v2                                                         v0.0.0-20240702122203-927f0bc01a78           go-module
github.com/traefik/yaegi                                                              v0.16.1                                      go-module
traefik                                                                               2.11.6                                       binary
```