### PR TITLE
Fix: Updated PackageSupplier to type Organization for JAR files

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -111,7 +111,7 @@ tools:
   # used for triggering a release
   - name: gh
     version:
-      want: v2.53.0
+      want: v2.54.0
     method: github-release
     with:
       repo: cli/cli

--- a/syft/format/internal/spdxutil/helpers/originator_supplier.go
+++ b/syft/format/internal/spdxutil/helpers/originator_supplier.go
@@ -56,6 +56,10 @@ func Originator(p pkg.Package) (typ string, author string) { // nolint: funlen
 			if author == "" {
 				author = metadata.Manifest.Main.MustGet("Implementation-Vendor")
 			}
+			// Vendor is specified, hence set 'Organization' as the PackageSupplier
+			if author != "" {
+				typ = orgType
+			}
 		}
 
 	case pkg.LinuxKernelModule:

--- a/syft/format/internal/spdxutil/helpers/originator_supplier_test.go
+++ b/syft/format/internal/spdxutil/helpers/originator_supplier_test.go
@@ -138,8 +138,8 @@ func Test_OriginatorSupplier(t *testing.T) {
 					},
 				},
 			},
-			originator: "Person: auth-spec",
-			supplier:   "Person: auth-spec",
+			originator: "Organization: auth-spec",
+			supplier:   "Organization: auth-spec",
 		},
 		{
 			name: "from java -- fallback to impl vendor in main manifest section",
@@ -155,8 +155,8 @@ func Test_OriginatorSupplier(t *testing.T) {
 					},
 				},
 			},
-			originator: "Person: auth-impl",
-			supplier:   "Person: auth-impl",
+			originator: "Organization: auth-impl",
+			supplier:   "Organization: auth-impl",
 		},
 		{
 			name: "from java -- non-main manifest sections ignored",


### PR DESCRIPTION
**Issue**: 
The PackageSupplier and PackageOriginator are set to type 'Person' for JAR files. For example:
```
PackageName: jackson-annotations
SPDXID: SPDXRef-Package-java-archive-jackson-annotations-55544ed7d2a352e0
PackageVersion: 2.9.10
PackageSupplier: Person: FasterXML
PackageOriginator: Person: FasterXML
```
**Fix**:
Updated to set the type as 'Organization' if vendor is specified in the metadata file of the JAR.

**Result**:
```
PackageName: jackson-annotations
SPDXID: SPDXRef-Package-java-archive-jackson-annotations-55544ed7d2a352e0
PackageVersion: 2.9.10
PackageSupplier: Organization: FasterXML
PackageOriginator: Organization: FasterXML
```

