### PR TITLE
add log time of task

### DIFF
--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -72,6 +72,6 @@ func runTaskSafely(ctx context.Context, t Task, resolver file.Resolver, s sbomsy
 
 	start := time.Now()
 	res := t.Execute(ctx, resolver, s)
-	log.Tracef("task name: %s time to execute: %v", t.Name(), time.Since(start))
+	log.WithFields("task", t.Name(), "elapsed", time.Since(start))
 	return res
 }

--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"time"
 
+	"github.com/anchore/syft/internal/log"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/anchore/syft/internal/sbomsync"
@@ -68,5 +70,8 @@ func runTaskSafely(ctx context.Context, t Task, resolver file.Resolver, s sbomsy
 		}
 	}()
 
-	return t.Execute(ctx, resolver, s)
+	start := time.Now()
+	res := t.Execute(ctx, resolver, s)
+	log.Debugf("task name: %s time to execute: %v", t.Name(), time.Since(start))
+	return res
 }

--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -72,6 +72,6 @@ func runTaskSafely(ctx context.Context, t Task, resolver file.Resolver, s sbomsy
 
 	start := time.Now()
 	res := t.Execute(ctx, resolver, s)
-	log.WithFields("task", t.Name(), "elapsed", time.Since(start))
+	log.WithFields("task", t.Name(), "elapsed", time.Since(start)).Info("task completed")
 	return res
 }

--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -72,6 +72,6 @@ func runTaskSafely(ctx context.Context, t Task, resolver file.Resolver, s sbomsy
 
 	start := time.Now()
 	res := t.Execute(ctx, resolver, s)
-	log.Debugf("task name: %s time to execute: %v", t.Name(), time.Since(start))
+	log.Tracef("task name: %s time to execute: %v", t.Name(), time.Since(start))
 	return res
 }


### PR DESCRIPTION
knowing how much a task took in syft can be useful
in this PR we add a log which specifies the time a task took.
closes - https://github.com/anchore/syft/issues/2723