### PR TITLE
chore: fix failing python relationship test

### DIFF
--- a/syft/pkg/cataloger/python/cataloger_test.go
+++ b/syft/pkg/cataloger/python/cataloger_test.go
@@ -643,7 +643,7 @@ func Test_PackageCataloger_SitePackageRelationships(t *testing.T) {
 				// Note: we'll only see new relationships, so any relationship where there is at least one new player (in FROM or TO)
 				"blessed @ 1.20.0 (/usr/local/lib/python3.9/dist-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",      // note: depends on global site package!
 				"python-editor @ 1.0.4 (/usr/local/lib/python3.9/dist-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)", // note: depends on global site package!
-				"readchar @ 4.1.0 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",
+				"readchar @ 4.2.0 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",
 				"soupsieve @ 2.3 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] beautifulsoup4 @ 4.10.0 (/app/project1/venv/lib/python3.9/site-packages)",
 
 				// project 2 virtual env

--- a/syft/pkg/cataloger/python/test-fixtures/image-multi-site-package/Dockerfile
+++ b/syft/pkg/cataloger/python/test-fixtures/image-multi-site-package/Dockerfile
@@ -17,7 +17,7 @@ RUN python3.9 -m pip install requests==2.25.0 certifi==2020.12.5 chardet==3.0.4 
 RUN python3.8 -m pip install click==8.0.2 beautifulsoup4==4.9.2 soupsieve==2.2.0 requests==2.25.0
 RUN python3.8 -m pip install runs==1.2.2 xmod==1.8.1 # partial dependencies for inquirer in project2 (which is a red herring)
 RUN python3.8 -m pip install requests==2.25.0 certifi==2020.12.5 chardet==3.0.4 idna==2.10 urllib3==1.26.18 # total dependencies for requests
-RUN python3.8 -m pip install readchar==4.1.0
+RUN python3.8 -m pip install readchar==4.2.0
 
 # create directories for the two projects
 RUN mkdir -p /app/project1 /app/project2


### PR DESCRIPTION
[readchar 4.2.0](https://pypi.org/project/readchar/) was released Aug 11, and seems to be picked up by the python relationship test when we have a 4.1.0 in site packages; this PR updates the test to account for the new version.