### PR TITLE
RPM-invalid-cache

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -54,11 +54,11 @@ jobs:
           path: syft/pkg/cataloger/java/test-fixtures/java-builds/packages
           key: ${{ runner.os }}-unit-java-cache-${{ hashFiles( 'syft/pkg/cataloger/java/test-fixtures/java-builds/cache.fingerprint' ) }}
 
-      - name: Restore RPM test-fixture cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
-        with:
-          path: syft/pkg/cataloger/redhat/test-fixtures/rpms
-          key: ${{ runner.os }}-unit-rpm-cache-${{ hashFiles( 'syft/pkg/cataloger/redhat/test-fixtures/rpms.fingerprint' ) }}
+      # - name: Restore RPM test-fixture cache
+      #   uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+      #   with:
+      #     path: syft/pkg/cataloger/redhat/test-fixtures/rpms
+      #     key: ${{ runner.os }}-unit-rpm-cache-${{ hashFiles( 'syft/pkg/cataloger/redhat/test-fixtures/rpms.fingerprint' ) }}
 
       - name: Restore go binary test-fixture cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2

--- a/syft/lib_test.go
+++ b/syft/lib_test.go
@@ -40,4 +40,4 @@ func Test_removeRelationshipsByID(t *testing.T) {
 	}
 
 	require.Equal(t, rel(p3), relationships)
-}
+} 


### PR DESCRIPTION
its look like the rpms in cache have packages and make the UT pass
while if there is no cache, the download RPM is packages