### PR TITLE
fix: add nil check to cyclonedx toBomProperties

### DIFF
--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -211,6 +211,12 @@ func toBomProperties(srcMetadata source.Description) *[]cyclonedx.Property {
 	metadata, ok := srcMetadata.Metadata.(source.ImageMetadata)
 	if ok {
 		props := helpers.EncodeProperties(metadata.Labels, "syft:image:labels")
+		// return nil if props is nil to avoid creating a pointer to a nil slice,
+		// which results in a null JSON value that does not comply with the CycloneDX schema.
+		// https://github.com/anchore/grype/issues/1759
+		if props == nil {
+			return nil
+		}
 		return &props
 	}
 	return nil

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -236,6 +236,53 @@ func Test_toBomDescriptor(t *testing.T) {
 	}
 }
 
+func Test_toBomProperties(t *testing.T) {
+	tests := []struct {
+		name        string
+		srcMetadata source.Description
+		props       *[]cyclonedx.Property
+	}{
+		{
+			name: "ImageMetadata without labels",
+			srcMetadata: source.Description{
+				Metadata: source.ImageMetadata{
+					Labels: map[string]string{},
+				},
+			},
+			props: nil,
+		},
+		{
+			name: "ImageMetadata with labels",
+			srcMetadata: source.Description{
+				Metadata: source.ImageMetadata{
+					Labels: map[string]string{
+						"label1": "value1",
+						"label2": "value2",
+					},
+				},
+			},
+			props: &[]cyclonedx.Property{
+				{Name: "syft:image:labels:label1", Value: "value1"},
+				{Name: "syft:image:labels:label2", Value: "value2"},
+			},
+		},
+		{
+			name: "not ImageMetadata",
+			srcMetadata: source.Description{
+				Metadata: source.FileMetadata{},
+			},
+			props: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			props := toBomProperties(test.srcMetadata)
+			require.Equal(t, test.props, props)
+		})
+	}
+}
+
 func Test_toOsComponent(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fixes https://github.com/anchore/grype/issues/1759

This PR ensures that `toBomProperties` returns `nil` for images that do not have labels. When an image does not have any labels, `EncodeProperties` returns a `nil` slice and `toBomProperties` then returns a pointer to that `nil` slice (`&props`), resulting in a non-compliant `null` JSON value.

SBOMs generated by syft do not appear to be affected since this code is not in the call path, so it only affects grype as a caller of this code.