### PR TITLE
Fix ELF package correlations

### DIFF
--- a/internal/relationship/binary/binary_dependencies.go
+++ b/internal/relationship/binary/binary_dependencies.go
@@ -36,8 +36,7 @@ func generateRelationships(resolver file.Resolver, accessor sbomsync.Accessor, i
 				newRelationships.Add(r)
 			}
 		}
-
-		for _, parentPkg := range s.Artifacts.Packages.Sorted(pkg.BinaryPkg) {
+		for _, parentPkg := range allElfPackages(s) {
 			for _, evidentLocation := range parentPkg.Locations.ToSlice() {
 				if evidentLocation.Annotations[pkg.EvidenceAnnotationKey] != pkg.PrimaryEvidenceAnnotation {
 					continue
@@ -101,7 +100,7 @@ func onlyPrimaryEvidenceLocations(p pkg.Package) []file.Location {
 
 func allElfPackages(s *sbom.SBOM) []pkg.Package {
 	var elfPkgs []pkg.Package
-	for _, p := range s.Artifacts.Packages.Sorted(pkg.BinaryPkg) {
+	for _, p := range s.Artifacts.Packages.Sorted() {
 		if !isElfPackage(p) {
 			continue
 		}


### PR DESCRIPTION
We support a feature where binaries with ELF package notes can be correlated with other packages based on dynamic library requirements on the binary and file ownership information for other system packages. The result is that binaries that have ELF notes "magically" are associated via dependency relationships to RPM/Deb/etc packages that represent the dynamic libraries that the binary uses.

This functionality is currently not working ever since we switched the package type on these ELF packages from `BinaryPkg` to the type that the package claims (e.g. `RpmPkg`). This PR addresses this issue by considering all packages based on the package metadata and not the package type (since an ELF package can be any type).