### PR TITLE
fix: use official CPE for curl binary cataloger

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -537,7 +537,7 @@ func DefaultClassifiers() []Classifier {
 			),
 			Package: "curl",
 			PURL:    mustPURL("pkg:generic/curl@version"),
-			CPEs:    singleCPE("cpe:2.3:a:curl:curl:*:*:*:*:*:*:*:*"),
+			CPEs:    singleCPE("cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*"),
 		},
 	}
 }


### PR DESCRIPTION
The official CPE for curl is `cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*`