### PR TITLE
fix: packages with empty name

### DIFF
--- a/syft/pkg/cataloger/kernel/parse_linux_kernel_file.go
+++ b/syft/pkg/cataloger/kernel/parse_linux_kernel_file.go
@@ -35,12 +35,14 @@ func parseLinuxKernelFile(_ context.Context, _ file.Resolver, _ *generic.Environ
 		return nil, nil, nil
 	}
 
-	return []pkg.Package{
-		newLinuxKernelPackage(
-			metadata,
-			reader.Location,
-		),
-	}, nil, nil
+	p := newLinuxKernelPackage(
+		metadata,
+		reader.Location,
+	)
+	if pkg.IsValid(&p) {
+		return []pkg.Package{p}, nil, nil
+	}
+	return []pkg.Package{}, nil, nil
 }
 
 func parseLinuxKernelMetadata(magicType []string) (p pkg.LinuxKernel) {

--- a/syft/pkg/cataloger/kernel/parse_linux_kernel_module_file.go
+++ b/syft/pkg/cataloger/kernel/parse_linux_kernel_module_file.go
@@ -30,12 +30,14 @@ func parseLinuxKernelModuleFile(_ context.Context, _ file.Resolver, _ *generic.E
 
 	metadata.Path = reader.Location.RealPath
 
-	return []pkg.Package{
-		newLinuxKernelModulePackage(
-			*metadata,
-			reader.Location,
-		),
-	}, nil, nil
+	p := newLinuxKernelModulePackage(
+		*metadata,
+		reader.Location,
+	)
+	if pkg.IsValid(&p) {
+		return []pkg.Package{p}, nil, nil
+	}
+	return []pkg.Package{}, nil, nil
 }
 
 func parseLinuxKernelModuleMetadata(r unionreader.UnionReader) (p *pkg.LinuxKernelModule, err error) {

--- a/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
+++ b/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
@@ -42,13 +42,14 @@ func parseGemFileLockEntries(_ context.Context, _ file.Resolver, _ *generic.Envi
 			if len(candidate) != 2 {
 				continue
 			}
-			pkgs = append(pkgs,
-				newGemfileLockPackage(
-					candidate[0],
-					strings.Trim(candidate[1], "()"),
-					reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
-				),
+			p := newGemfileLockPackage(
+				candidate[0],
+				strings.Trim(candidate[1], "()"),
+				reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 			)
+			if pkg.IsValid(&p) {
+				pkgs = append(pkgs, p)
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/syft/pkg/cataloger/ruby/parse_gemspec.go
+++ b/syft/pkg/cataloger/ruby/parse_gemspec.go
@@ -102,13 +102,13 @@ func parseGemSpecEntries(_ context.Context, _ file.Resolver, _ *generic.Environm
 			return nil, nil, fmt.Errorf("unable to decode gem metadata: %w", err)
 		}
 
-		pkgs = append(
-			pkgs,
-			newGemspecPackage(
-				metadata,
-				reader.Location,
-			),
+		p := newGemspecPackage(
+			metadata,
+			reader.Location,
 		)
+		if pkg.IsValid(&p) {
+			pkgs = append(pkgs, p)
+		}
 	}
 
 	return pkgs, nil, nil


### PR DESCRIPTION
the problem we faced:
Some packages did not have a name.
The pkg has already the function valid, but that is not everywhere used. This commit adds the validation only for catalogers we have seen the error.