### PR TITLE
Less verbose java logging when non-fatal issues arise

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -58,19 +58,19 @@ type archiveFilename struct {
 
 func getSubexp(matches []string, subexpName string, re *regexp.Regexp, raw string) string {
 	if len(matches) < 1 {
-		log.Warnf("unexpectedly empty matches for archive '%s'", raw)
+		log.Tracef("unexpectedly empty matches for Java archive '%s'", raw)
 		return ""
 	}
 
 	index := re.SubexpIndex(subexpName)
 	if index < 1 {
-		log.Warnf("unexpected index of '%s' capture group for Java archive '%s'", subexpName, raw)
+		log.Tracef("unexpected index of '%s' capture group for Java archive '%s'", subexpName, raw)
 		return ""
 	}
 
 	// Prevent out-of-range panic
 	if len(matches) < index+1 {
-		log.Warnf("no match found for '%s' in '%s'", subexpName, matches[0])
+		log.Tracef("no match found for '%s' in '%s' for Java archive", subexpName, matches[0])
 		return ""
 	}
 


### PR DESCRIPTION
These are technically not warn-worthy events since there is no action for a user to take to remove the warning.