### PR TITLE
Don't cleanup cache in forks

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -206,7 +206,7 @@ jobs:
 
   Cleanup-Cache:
     name: "Cleanup snapshot cache"
-    if: always()
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-20.04
     permissions:
       actions: write


### PR DESCRIPTION
Follow up from #3190 , we should not be deleting caches from forks