### PR TITLE
lighttpd and proftpd binarie detection added

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -544,6 +544,16 @@ func DefaultClassifiers() []Classifier {
 			PURL:    mustPURL("pkg:generic/curl@version"),
 			CPEs:    singleCPE("cpe:2.3:a:haxx:curl:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "lighttpd-binary",
+			FileGlob: "**/lighttpd",
+			EvidenceMatcher: FileContentsVersionMatcher(
+				`lighttpd/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+			),
+			Package: "lighttpd",
+			PURL:    mustPURL("pkg:generic/lighttpd@version"),
+			CPEs:    singleCPE("cpe:2.3:a:lighttpd:lighttpd:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 }
 

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -554,6 +554,16 @@ func DefaultClassifiers() []Classifier {
 			PURL:    mustPURL("pkg:generic/lighttpd@version"),
 			CPEs:    singleCPE("cpe:2.3:a:lighttpd:lighttpd:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "proftpd-binary",
+			FileGlob: "**/proftpd",
+			EvidenceMatcher: FileContentsVersionMatcher(
+				`ProFTPD Version (?P<version>[0-9]+\.[0-9]+\.[0-9]+[a-z]?)`,
+			),
+			Package: "proftpd",
+			PURL:    mustPURL("pkg:generic/proftpd@version"),
+			CPEs:    singleCPE("cpe:2.3:a:proftpd:proftpd:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 }
 

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -594,3 +594,10 @@ from-images:
     paths:
       - /usr/bin/curl
 
+  - name: lighttpd
+    version: 1.4.76
+    images:
+      - ref: jitesoft/lighttpd:1.4.76-cgi@sha256:f5d4500bfb992a20ca39369ae1ca1d8a7a9463bb8c59ee8dd85ddb6d96fc9fc1
+        platform: linux/amd64
+    paths:
+      - /usr/local/sbin/lighttpd

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -601,3 +601,11 @@ from-images:
         platform: linux/amd64
     paths:
       - /usr/local/sbin/lighttpd
+
+  - name: proftpd
+    version: 1.3.8b
+    images:
+      - ref: mekayelanik/proftpd-server-alpine:1.3.8b-r2@sha256:a1ef73a2de04999e53bf728b548ef9922febab8f5709037e40e0141cedcd66db
+        platform: linux/amd64
+    paths:
+      - /usr/sbin/proftpd


### PR DESCRIPTION
lighttpd and proftpd added to the binary classifiers.

```
lighttpd-binary regex: 'lighttpd/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)'
lighttpd-binary cpe: 'cpe:2.3:a:lighttpd:lighttpd:*:*:*:*:*:*:*:*'

proftpd-binary regex: 'ProFTPD Version (?P<version>[0-9]+\.[0-9]+\.[0-9]+[a-z]?)'
proftpd-binary cpe: 'cpe:2.3:a:proftpd:proftpd:*:*:*:*:*:*:*:*'
```