### PR TITLE
chore: restore ci-check.sh script

### DIFF
--- a/.github/scripts/ci-check.sh
+++ b/.github/scripts/ci-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+red=$(tput setaf 1)
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+# assert we are running in CI (or die!)
+if [[ -z "$CI" ]]; then
+    echo "${bold}${red}This step should ONLY be run in CI. Exiting...${normal}"
+    exit 1
+fi

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -593,16 +593,7 @@ tasks:
   ci-check:
     # desc: "[CI only] Are you in CI?"
     cmds:
-      - cmd: |
-          red=$(tput setaf 1)
-          bold=$(tput bold)
-          normal=$(tput sgr0)
-  
-          # assert we are running in CI (or die!)
-          if [[ -z "$CI" ]]; then
-              echo "${bold}${red}This step should ONLY be run in CI. Exiting...${normal}"
-              exit 1
-          fi
+      - cmd: .github/scripts/ci-check.sh
         silent: true
 
   ci-release:


### PR DESCRIPTION
This PR restores the `ci-check.sh` script used during a release instead of inlined commands.