### PR TITLE
Add compliance policy for empty name and version

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -37,6 +37,7 @@ type Catalog struct {
 	Scope             string              `yaml:"scope" json:"scope" mapstructure:"scope"`
 	Parallelism       int                 `yaml:"parallelism" json:"parallelism" mapstructure:"parallelism"` // the number of catalog workers to run in parallel
 	Relationships     relationshipsConfig `yaml:"relationships" json:"relationships" mapstructure:"relationships"`
+	Compliance        complianceConfig    `yaml:"compliance" json:"compliance" mapstructure:"compliance"`
 	Enrich            []string            `yaml:"enrich" json:"enrich" mapstructure:"enrich"`
 
 	// ecosystem-specific cataloger configuration
@@ -62,6 +63,7 @@ var _ interface {
 
 func DefaultCatalog() Catalog {
 	return Catalog{
+		Compliance:    defaultComplianceConfig(),
 		Scope:         source.SquashedScope.String(),
 		Package:       defaultPackageConfig(),
 		LinuxKernel:   defaultLinuxKernelConfig(),
@@ -79,6 +81,7 @@ func (cfg Catalog) ToSBOMConfig(id clio.Identification) *syft.CreateSBOMConfig {
 		WithTool(id.Name, id.Version).
 		WithParallelism(cfg.Parallelism).
 		WithRelationshipsConfig(cfg.ToRelationshipsConfig()).
+		WithComplianceConfig(cfg.ToComplianceConfig()).
 		WithSearchConfig(cfg.ToSearchConfig()).
 		WithPackagesConfig(cfg.ToPackagesConfig()).
 		WithFilesConfig(cfg.ToFilesConfig()).
@@ -101,6 +104,13 @@ func (cfg Catalog) ToRelationshipsConfig() cataloging.RelationshipsConfig {
 		PackageFileOwnershipOverlap: cfg.Relationships.PackageFileOwnershipOverlap,
 		// note: this option was surfaced in the syft application configuration before this relationships section was added
 		ExcludeBinaryPackagesWithFileOwnershipOverlap: cfg.Package.ExcludeBinaryOverlapByOwnership,
+	}
+}
+
+func (cfg Catalog) ToComplianceConfig() cataloging.ComplianceConfig {
+	return cataloging.ComplianceConfig{
+		MissingName:    cfg.Compliance.MissingName,
+		MissingVersion: cfg.Compliance.MissingVersion,
 	}
 }
 

--- a/cmd/syft/internal/options/compliance.go
+++ b/cmd/syft/internal/options/compliance.go
@@ -1,0 +1,35 @@
+package options
+
+import (
+	"github.com/anchore/fangs"
+	"github.com/anchore/syft/syft/cataloging"
+)
+
+var (
+	_ fangs.FieldDescriber = (*complianceConfig)(nil)
+	_ fangs.PostLoader     = (*complianceConfig)(nil)
+)
+
+type complianceConfig struct {
+	MissingName    cataloging.ComplianceAction `mapstructure:"missing-name" json:"missing-name" yaml:"missing-name"`
+	MissingVersion cataloging.ComplianceAction `mapstructure:"missing-version" json:"missing-version" yaml:"missing-version"`
+}
+
+func defaultComplianceConfig() complianceConfig {
+	def := cataloging.DefaultComplianceConfig()
+	return complianceConfig{
+		MissingName:    def.MissingName,
+		MissingVersion: def.MissingVersion,
+	}
+}
+
+func (r *complianceConfig) DescribeFields(descriptions fangs.FieldDescriptionSet) {
+	descriptions.Add(&r.MissingName, "action to take when a package is missing a name")
+	descriptions.Add(&r.MissingVersion, "action to take when a package is missing a version")
+}
+
+func (r *complianceConfig) PostLoad() error {
+	r.MissingName = r.MissingName.Parse()
+	r.MissingVersion = r.MissingVersion.Parse()
+	return nil
+}

--- a/internal/relationship/index.go
+++ b/internal/relationship/index.go
@@ -68,6 +68,18 @@ func (i *Index) Add(relationships ...artifact.Relationship) {
 	}
 }
 
+func (i *Index) Remove(id artifact.ID) {
+	delete(i.fromID, id)
+	delete(i.toID, id)
+	for idx := 0; idx < len(i.all); {
+		if i.all[idx].from == id || i.all[idx].to == id {
+			i.all = append(i.all[:idx], i.all[idx+1:]...)
+		} else {
+			idx++
+		}
+	}
+}
+
 // From returns all relationships from the given identifiable, with specified types
 func (i *Index) From(identifiable artifact.Identifiable, types ...artifact.RelationshipType) []artifact.Relationship {
 	return toSortedSlice(fromMapped(i.fromID, identifiable), types)

--- a/internal/relationship/index.go
+++ b/internal/relationship/index.go
@@ -17,20 +17,16 @@ type Index struct {
 
 // NewIndex returns a new relationship Index
 func NewIndex(relationships ...artifact.Relationship) *Index {
-	out := Index{}
+	out := Index{
+		fromID: make(map[artifact.ID]*mappedRelationships),
+		toID:   make(map[artifact.ID]*mappedRelationships),
+	}
 	out.Add(relationships...)
 	return &out
 }
 
 // Add adds all the given relationships to the index, without adding duplicates
 func (i *Index) Add(relationships ...artifact.Relationship) {
-	if i.fromID == nil {
-		i.fromID = map[artifact.ID]*mappedRelationships{}
-	}
-	if i.toID == nil {
-		i.toID = map[artifact.ID]*mappedRelationships{}
-	}
-
 	// store appropriate indexes for stable ordering to minimize ID() calls
 	for _, r := range relationships {
 		// prevent duplicates
@@ -71,6 +67,7 @@ func (i *Index) Add(relationships ...artifact.Relationship) {
 func (i *Index) Remove(id artifact.ID) {
 	delete(i.fromID, id)
 	delete(i.toID, id)
+
 	for idx := 0; idx < len(i.all); {
 		if i.all[idx].from == id || i.all[idx].to == id {
 			i.all = append(i.all[:idx], i.all[idx+1:]...)
@@ -78,6 +75,26 @@ func (i *Index) Remove(id artifact.ID) {
 			idx++
 		}
 	}
+}
+
+func (i *Index) Replace(ogID artifact.ID, replacement artifact.Identifiable) {
+	for _, mapped := range fromMappedByID(i.fromID, ogID) {
+		i.Add(artifact.Relationship{
+			From: replacement,
+			To:   mapped.relationship.To,
+			Type: mapped.relationship.Type,
+		})
+	}
+
+	for _, mapped := range fromMappedByID(i.toID, ogID) {
+		i.Add(artifact.Relationship{
+			From: mapped.relationship.From,
+			To:   replacement,
+			Type: mapped.relationship.Type,
+		})
+	}
+
+	i.Remove(ogID)
 }
 
 // From returns all relationships from the given identifiable, with specified types
@@ -122,10 +139,17 @@ func (i *Index) All(types ...artifact.RelationshipType) []artifact.Relationship 
 }
 
 func fromMapped(idMap map[artifact.ID]*mappedRelationships, identifiable artifact.Identifiable) []*sortableRelationship {
-	if identifiable == nil || idMap == nil {
+	if identifiable == nil {
 		return nil
 	}
-	mapped := idMap[identifiable.ID()]
+	return fromMappedByID(idMap, identifiable.ID())
+}
+
+func fromMappedByID(idMap map[artifact.ID]*mappedRelationships, id artifact.ID) []*sortableRelationship {
+	if idMap == nil {
+		return nil
+	}
+	mapped := idMap[id]
 	if mapped == nil {
 		return nil
 	}

--- a/internal/task/package_task_factory_test.go
+++ b/internal/task/package_task_factory_test.go
@@ -4,8 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cpe"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
 )
 
 func Test_hasAuthoritativeCPE(t *testing.T) {
@@ -52,4 +57,96 @@ func Test_hasAuthoritativeCPE(t *testing.T) {
 			assert.Equal(t, tt.want, hasAuthoritativeCPE(tt.cpes))
 		})
 	}
+}
+
+func TestApplyCompliance(t *testing.T) {
+	p1 := pkg.Package{Name: "pkg-1", Version: "1.0"}
+	p2 := pkg.Package{Name: "", Version: "1.0"}   // missing name
+	p3 := pkg.Package{Name: "pkg-3", Version: ""} // missing version
+	p4 := pkg.Package{Name: "pkg-4", Version: ""} // missing version
+	c1 := file.Coordinates{RealPath: "/coords/1"}
+	c2 := file.Coordinates{RealPath: "/coords/2"}
+
+	for _, p := range []*pkg.Package{&p1, &p2, &p3, &p4} {
+		p.SetID()
+	}
+
+	r1 := artifact.Relationship{
+		From: p1,
+		To:   c1,
+		Type: artifact.ContainsRelationship,
+	}
+	r2 := artifact.Relationship{
+		From: p2,
+		To:   c2,
+		Type: artifact.ContainsRelationship,
+	}
+
+	cfg := cataloging.ComplianceConfig{
+		MissingName:    cataloging.ComplianceActionDrop,
+		MissingVersion: cataloging.ComplianceActionWarn,
+	}
+
+	remainingPkgs, remainingRels, err := applyCompliance(cfg, "test-cataloger", []pkg.Package{p1, p2, p3, p4}, []artifact.Relationship{r1, r2})
+	require.NoError(t, err)
+
+	// p2 should be dropped because it has a missing name, p3 and p4 should pass with a warning for the missing version
+	assert.Len(t, remainingPkgs, 3) // p1, p3, p4 should remain
+	assert.Len(t, remainingRels, 1) // only r1 should remain (relationship involving p1)
+}
+
+func TestFilterNonCompliantPackages(t *testing.T) {
+	p1 := pkg.Package{Name: "pkg-1", Version: "1.0"}
+	p2 := pkg.Package{Name: "", Version: "1.0"}   // missing name
+	p3 := pkg.Package{Name: "pkg-3", Version: ""} // missing version
+
+	for _, p := range []*pkg.Package{&p1, &p2, &p3} {
+		p.SetID()
+	}
+
+	cfg := cataloging.ComplianceConfig{
+		MissingName:    cataloging.ComplianceActionDrop,
+		MissingVersion: cataloging.ComplianceActionWarn,
+	}
+
+	remainingPkgs, droppedPkgs, err := filterNonCompliantPackages([]pkg.Package{p1, p2, p3}, cfg)
+	require.NoError(t, err)
+
+	// p2 should be dropped because it has a missing name
+	assert.Len(t, remainingPkgs, 2)
+	assert.Len(t, droppedPkgs, 1)
+	assert.Equal(t, p2, droppedPkgs[0])
+}
+
+func TestApplyComplianceRules_DropAndStub(t *testing.T) {
+	p := pkg.Package{Name: "", Version: ""}
+	p.SetID()
+
+	cfg := cataloging.ComplianceConfig{
+		MissingName:    cataloging.ComplianceActionDrop,
+		MissingVersion: cataloging.ComplianceActionStub,
+	}
+
+	errNonCompliant := cataloging.NewErrNonCompliantPackages()
+
+	isCompliant := applyComplianceRules(&p, cfg, errNonCompliant)
+
+	// the package should be dropped due to missing name (drop action) and its version should be stubbed
+	assert.False(t, isCompliant)
+	assert.Equal(t, cataloging.UnknownStubValue, p.Version)
+}
+
+func TestApplyComplianceRules_Fail(t *testing.T) {
+	p1 := pkg.Package{Name: "", Version: "1.0"} // missing name
+	p1.SetID()
+
+	cfg := cataloging.ComplianceConfig{
+		MissingName: cataloging.ComplianceActionFail,
+	}
+
+	errNonCompliant := cataloging.NewErrNonCompliantPackages()
+	isCompliant := applyComplianceRules(&p1, cfg, errNonCompliant)
+
+	assert.False(t, isCompliant)
+	assert.Contains(t, errNonCompliant.NonCompliantPackageLocations, "unknown")
 }

--- a/syft/cataloging/compliance.go
+++ b/syft/cataloging/compliance.go
@@ -53,7 +53,7 @@ func DefaultComplianceConfig() ComplianceConfig {
 	// Note: name and version are required minimum SBOM elements by NTIA, thus should be the API default
 	return ComplianceConfig{
 		MissingName:    ComplianceActionDrop,
-		MissingVersion: ComplianceActionDrop,
+		MissingVersion: ComplianceActionStub,
 	}
 }
 

--- a/syft/cataloging/compliance.go
+++ b/syft/cataloging/compliance.go
@@ -1,44 +1,14 @@
 package cataloging
 
 import (
-	"sort"
 	"strings"
 )
 
 const (
 	ComplianceActionKeep ComplianceAction = "keep"
-	ComplianceActionWarn ComplianceAction = "warn"
 	ComplianceActionDrop ComplianceAction = "drop"
-	ComplianceActionFail ComplianceAction = "fail"
 	ComplianceActionStub ComplianceAction = "stub"
 )
-
-type ErrNonCompliantPackages struct {
-	NonCompliantPackageLocations map[string][]string
-}
-
-func NewErrNonCompliantPackages() *ErrNonCompliantPackages {
-	return &ErrNonCompliantPackages{
-		NonCompliantPackageLocations: make(map[string][]string),
-	}
-}
-
-func (e *ErrNonCompliantPackages) AddInfo(location, info, note string) {
-	e.NonCompliantPackageLocations[location] = append(e.NonCompliantPackageLocations[location], note+": "+info)
-}
-
-func (e ErrNonCompliantPackages) Error() string {
-	var reasons []string
-	for location, infos := range e.NonCompliantPackageLocations {
-		for _, info := range infos {
-			reasons = append(reasons, location+": "+info)
-		}
-	}
-
-	sort.Strings(reasons)
-
-	return "non-compliant packages: " + strings.Join(reasons, "\n")
-}
 
 const UnknownStubValue = "UNKNOWN"
 
@@ -68,14 +38,10 @@ func (c ComplianceAction) Parse() ComplianceAction {
 	switch strings.ToLower(string(c)) {
 	case string(ComplianceActionKeep), "include":
 		return ComplianceActionKeep
-	case string(ComplianceActionWarn), "warning":
-		return ComplianceActionWarn
 	case string(ComplianceActionDrop), "exclude":
 		return ComplianceActionDrop
-	case string(ComplianceActionFail), "error":
-		return ComplianceActionFail
 	case string(ComplianceActionStub), "replace":
 		return ComplianceActionStub
 	}
-	return ComplianceActionWarn
+	return ComplianceActionKeep
 }

--- a/syft/cataloging/compliance.go
+++ b/syft/cataloging/compliance.go
@@ -1,0 +1,81 @@
+package cataloging
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	ComplianceActionKeep ComplianceAction = "keep"
+	ComplianceActionWarn ComplianceAction = "warn"
+	ComplianceActionDrop ComplianceAction = "drop"
+	ComplianceActionFail ComplianceAction = "fail"
+	ComplianceActionStub ComplianceAction = "stub"
+)
+
+type ErrNonCompliantPackages struct {
+	NonCompliantPackageLocations map[string][]string
+}
+
+func NewErrNonCompliantPackages() *ErrNonCompliantPackages {
+	return &ErrNonCompliantPackages{
+		NonCompliantPackageLocations: make(map[string][]string),
+	}
+}
+
+func (e *ErrNonCompliantPackages) AddInfo(location, info, note string) {
+	e.NonCompliantPackageLocations[location] = append(e.NonCompliantPackageLocations[location], note+": "+info)
+}
+
+func (e ErrNonCompliantPackages) Error() string {
+	var reasons []string
+	for location, infos := range e.NonCompliantPackageLocations {
+		for _, info := range infos {
+			reasons = append(reasons, location+": "+info)
+		}
+	}
+
+	sort.Strings(reasons)
+
+	return "non-compliant packages: " + strings.Join(reasons, "\n")
+}
+
+const UnknownStubValue = "UNKNOWN"
+
+type ComplianceAction string
+
+type ComplianceConfig struct {
+	MissingName    ComplianceAction `yaml:"missing-name" json:"missing-name" mapstructure:"missing-name"`
+	MissingVersion ComplianceAction `yaml:"missing-version" json:"missing-version" mapstructure:"missing-version"`
+}
+
+func DefaultComplianceConfig() ComplianceConfig {
+	// Note: name and version are required minimum SBOM elements by NTIA, thus should be the API default
+	return ComplianceConfig{
+		MissingName:    ComplianceActionDrop,
+		MissingVersion: ComplianceActionDrop,
+	}
+}
+
+func (c ComplianceConfig) Parse() ComplianceConfig {
+	return ComplianceConfig{
+		MissingName:    c.MissingName.Parse(),
+		MissingVersion: c.MissingVersion.Parse(),
+	}
+}
+
+func (c ComplianceAction) Parse() ComplianceAction {
+	switch strings.ToLower(string(c)) {
+	case string(ComplianceActionKeep), "include":
+		return ComplianceActionKeep
+	case string(ComplianceActionWarn), "warning":
+		return ComplianceActionWarn
+	case string(ComplianceActionDrop), "exclude":
+		return ComplianceActionDrop
+	case string(ComplianceActionFail), "error":
+		return ComplianceActionFail
+	case string(ComplianceActionStub), "replace":
+		return ComplianceActionStub
+	}
+	return ComplianceActionWarn
+}

--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -19,6 +19,7 @@ import (
 // CreateSBOMConfig specifies all parameters needed for creating an SBOM.
 type CreateSBOMConfig struct {
 	// required configuration input to specify how cataloging should be performed
+	Compliance         cataloging.ComplianceConfig
 	Search             cataloging.SearchConfig
 	Relationships      cataloging.RelationshipsConfig
 	DataGeneration     cataloging.DataGenerationConfig
@@ -38,6 +39,7 @@ type CreateSBOMConfig struct {
 
 func DefaultCreateSBOMConfig() *CreateSBOMConfig {
 	return &CreateSBOMConfig{
+		Compliance:           cataloging.DefaultComplianceConfig(),
 		Search:               cataloging.DefaultSearchConfig(),
 		Relationships:        cataloging.DefaultRelationshipsConfig(),
 		DataGeneration:       cataloging.DefaultDataGenerationConfig(),
@@ -90,6 +92,12 @@ func (c *CreateSBOMConfig) WithParallelism(p int) *CreateSBOMConfig {
 		p = 1
 	}
 	c.Parallelism = p
+	return c
+}
+
+// WithComplianceConfig allows for setting the specific compliance configuration for cataloging.
+func (c *CreateSBOMConfig) WithComplianceConfig(cfg cataloging.ComplianceConfig) *CreateSBOMConfig {
+	c.Compliance = cfg
 	return c
 }
 
@@ -225,6 +233,7 @@ func (c *CreateSBOMConfig) packageTasks(src source.Description) ([]task.Task, *t
 		RelationshipsConfig:  c.Relationships,
 		DataGenerationConfig: c.DataGeneration,
 		PackagesConfig:       c.Packages,
+		ComplianceConfig:     c.Compliance,
 	}
 
 	persistentTasks, selectableTasks, err := c.allPackageTasks(cfg)

--- a/syft/pkg/cataloger/ocaml/parse_opam_test.go
+++ b/syft/pkg/cataloger/ocaml/parse_opam_test.go
@@ -3,11 +3,12 @@ package ocaml
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParseOpamPackage(t *testing.T) {


### PR DESCRIPTION
Adds a new compliance configuration to handle what to do when there is a missing name or version:

```yaml
compliance:
  # action to take when a package is missing a name (env: SYFT_COMPLIANCE_MISSING_NAME)
  missing-name: 'drop'
  
  # action to take when a package is missing a version (env: SYFT_COMPLIANCE_MISSING_VERSION)
  missing-version: 'stub'
```

Above are the default values, but the possible values a user can put in are:
- `keep`, add a trace log but the non-compliant package is still added to the SBOM
- `drop`, exclude the package from results, add a debug log
- `stub`, replace the non-compliant empty value with `UNKNOWN`

Open questions:
1. configuration-wise should this land within the `pkgcataloging` package? (instead of the `cataloging` package?)

Closes #2132 
Closes #2652 
Closes #2038 
Closes #2039 
