### PR TITLE
Allow for concurrent cataloger parser calls

### DIFF
--- a/cmd/syft/internal/commands/attest.go
+++ b/cmd/syft/internal/commands/attest.go
@@ -13,6 +13,7 @@ import (
 	"github.com/wagoodman/go-progress"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/go-sync"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/syft/cmd/syft/internal/options"
 	"github.com/anchore/syft/cmd/syft/internal/ui"
@@ -251,6 +252,8 @@ func generateSBOMForAttestation(ctx context.Context, id clio.Identification, opt
 	if len(opts.From) > 1 || (len(opts.From) == 1 && opts.From[0] != stereoscope.RegistryTag) {
 		return nil, fmt.Errorf("attest requires use of an OCI registry directly, one or more of the specified sources is unsupported: %v", opts.From)
 	}
+
+	ctx = sync.SetContextExecutor(ctx, sync.NewExecutor(opts.Parallelism))
 
 	src, err := getSource(ctx, opts, userInput, stereoscope.RegistryTag)
 

--- a/cmd/syft/internal/commands/scan.go
+++ b/cmd/syft/internal/commands/scan.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anchore/clio"
 	"github.com/anchore/go-collections"
+	"github.com/anchore/go-sync"
 	"github.com/anchore/stereoscope"
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/cmd/syft/internal/options"
@@ -167,6 +168,8 @@ func validateArgs(cmd *cobra.Command, args []string, error string) error {
 }
 
 func runScan(ctx context.Context, id clio.Identification, opts *scanOptions, userInput string) error {
+	ctx = sync.SetContextExecutor(ctx, sync.NewExecutor(opts.Parallelism))
+
 	writer, err := opts.SBOMWriter()
 	if err != nil {
 		return err

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -72,7 +73,7 @@ func DefaultCatalog() Catalog {
 		File:          defaultFileConfig(),
 		Relationships: defaultRelationshipsConfig(),
 		Source:        defaultSourceConfig(),
-		Parallelism:   1,
+		Parallelism:   runtime.NumCPU() * 3,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/adrg/xdg v0.5.0
+	github.com/anchore/go-sync v0.0.0-20240926143818-0345bfc976f9
 	github.com/magiconair/properties v1.8.7
 	golang.org/x/exp v0.0.0-20231108232855-2478ac86f678
 )

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb h1:iDMnx6LIj
 github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb/go.mod h1:DmTY2Mfcv38hsHbG78xMiTDdxFtkHpgYNVDPsF2TgHk=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
+github.com/anchore/go-sync v0.0.0-20240926143818-0345bfc976f9 h1:CEONkqYICLuKgiIgHIcY9cxSDvQWMtDnIY01HSVCJhc=
+github.com/anchore/go-sync v0.0.0-20240926143818-0345bfc976f9/go.mod h1:43zWHVYBx8GXzjjISSD4rMpACGBpUZmE3Yy+qUNnhn4=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0vW0nnNKJfJieyH/TZ9UYAnTZs5/gHTdAe8=
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=

--- a/syft/file/cataloger/filedigest/cataloger.go
+++ b/syft/file/cataloger/filedigest/cataloger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 
+	"github.com/anchore/go-sync"
 	stereoscopeFile "github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/bus"
@@ -30,6 +31,12 @@ func NewCataloger(hashes []crypto.Hash) *Cataloger {
 	}
 }
 
+type result struct {
+	coordinates file.Coordinates
+	digests     []file.Digest
+	err         error
+}
+
 func (i *Cataloger) Catalog(ctx context.Context, resolver file.Resolver, coordinates ...file.Coordinates) (map[file.Coordinates][]file.Digest, error) {
 	results := make(map[file.Coordinates][]file.Digest)
 	var locations []file.Location
@@ -46,29 +53,22 @@ func (i *Cataloger) Catalog(ctx context.Context, resolver file.Resolver, coordin
 		}
 	}
 
+	exec := sync.ContextExecutor(ctx)
+
+	collector := sync.NewCollector[result](exec)
+
 	prog := catalogingProgress(int64(len(locations)))
 	for _, location := range locations {
-		result, err := i.catalogLocation(resolver, location)
+		collector.Provide(i.run(resolver, location, prog))
+	}
 
-		if errors.Is(err, ErrUndigestableFile) {
+	for _, r := range collector.Collect() {
+		if r.err != nil {
+			log.Warnf("failed to process file %q: %+v", r.coordinates.RealPath, r.err)
 			continue
 		}
 
-		prog.AtomicStage.Set(location.Path())
-
-		if internal.IsErrPathPermission(err) {
-			log.Debugf("file digests cataloger skipping %q: %+v", location.RealPath, err)
-			continue
-		}
-
-		if err != nil {
-			prog.SetError(err)
-			return nil, fmt.Errorf("failed to process file %q: %w", location.RealPath, err)
-		}
-
-		prog.Increment()
-
-		results[location.Coordinates] = result
+		results[r.coordinates] = append(results[r.coordinates], r.digests...)
 	}
 
 	log.Debugf("file digests cataloger processed %d files", prog.Current())
@@ -77,6 +77,42 @@ func (i *Cataloger) Catalog(ctx context.Context, resolver file.Resolver, coordin
 	prog.SetCompleted()
 
 	return results, nil
+}
+
+func (i *Cataloger) run(resolver file.Resolver, location file.Location, prog *monitor.CatalogerTaskProgress) sync.ProviderFunc[result] {
+	return func() result {
+		digests, err := i.catalogLocation(resolver, location)
+
+		if errors.Is(err, ErrUndigestableFile) {
+			return result{
+				coordinates: location.Coordinates,
+			}
+		}
+
+		prog.AtomicStage.Set(location.Path())
+
+		if internal.IsErrPathPermission(err) {
+			log.Debugf("file digests cataloger skipping %q: %+v", location.RealPath, err)
+			return result{
+				coordinates: location.Coordinates,
+			}
+		}
+
+		if err != nil {
+			prog.SetError(err)
+			return result{
+				coordinates: location.Coordinates,
+				err:         fmt.Errorf("failed to process file %q: %w", location.RealPath, err),
+			}
+		}
+
+		prog.Increment()
+		return result{
+			coordinates: location.Coordinates,
+			digests:     digests,
+			err:         err,
+		}
+	}
 }
 
 func (i *Cataloger) catalogLocation(resolver file.Resolver, location file.Location) ([]file.Digest, error) {


### PR DESCRIPTION
Note: uses unmerged changes from go-sync (using go.work locally)