### PR TITLE
Improve subpath to mount matching

### DIFF
--- a/syft/internal/fileresolver/path_skipper.go
+++ b/syft/internal/fileresolver/path_skipper.go
@@ -93,12 +93,13 @@ func (ps pathSkipper) pathIndexVisitor(_ string, givenPath string, _ os.FileInfo
 	for _, mi := range ps.mounts {
 		conditionalPaths, ignorable := ps.ignorableMountTypes[mi.FSType]
 
-		if len(conditionalPaths) == 0 {
-			// Rule 1: ignore any path within a mount point that is of the given filesystem type unconditionally
-			if !containsPath(givenPath, mi.Mountpoint) {
-				continue
-			}
+		// Rule 0: Make sure the given path is within the mount point; if not let the scan continue
+		if !containsPath(givenPath, mi.Mountpoint) {
+			continue
+		}
 
+		// Rule 1: ignore any path within a mount point that is of the given filesystem type unconditionally
+		if len(conditionalPaths) == 0 {
 			if !ignorable {
 				// we've matched on the most specific path at this point, which means we should stop searching
 				// mount points for this path
@@ -151,7 +152,7 @@ func simpleClean(p string) string {
 		return "."
 	}
 	if p == "/" {
-		return "/"
+		return ""
 	}
 	return strings.TrimSuffix(p, "/")
 }

--- a/syft/internal/fileresolver/path_skipper_test.go
+++ b/syft/internal/fileresolver/path_skipper_test.go
@@ -358,6 +358,43 @@ func Test_newPathSkipper(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "buildkit github ubuntu 22.04",
+			root: "/run/src/core/sbom",
+			mounts: []*mountinfo.Info{
+				{Mountpoint: "/", FSType: "overlay"},
+				{Mountpoint: "/proc", FSType: "proc"},
+				{Mountpoint: "/dev", FSType: "tmpfs"},
+				{Mountpoint: "/dev/pts", FSType: "devpts"},
+				{Mountpoint: "/dev/shm", FSType: "tmpfs"},
+				{Mountpoint: "/dev/mqueue", FSType: "mqueue"},
+				{Mountpoint: "/sys", FSType: "sysfs"},
+				{Mountpoint: "/etc/resolv.conf", FSType: "ext4"},
+				{Mountpoint: "/etc/hosts", FSType: "ext4"},
+				{Mountpoint: "/sys/fs/cgroup", FSType: "cgroup2"},
+				{Mountpoint: "/run/out", FSType: "ext4"},
+				{Mountpoint: "/run/src/core/sbom", FSType: "overlay"},
+				{Mountpoint: "/tmp", FSType: "tmpfs"},
+				{Mountpoint: "/dev/otel-grpc.sock", FSType: "overlay"},
+				{Mountpoint: "/proc/bus", FSType: "proc"},
+				{Mountpoint: "/proc/fs", FSType: "proc"},
+				{Mountpoint: "/proc/irq", FSType: "proc"},
+				{Mountpoint: "/proc/sys", FSType: "proc"},
+				{Mountpoint: "/proc/sysrq-trigger", FSType: "proc"},
+				{Mountpoint: "/proc/acpi", FSType: "tmpfs"},
+				{Mountpoint: "/proc/kcore", FSType: "tmpfs"},
+				{Mountpoint: "/proc/keys", FSType: "tmpfs"},
+				{Mountpoint: "/proc/latency_stats", FSType: "tmpfs"},
+				{Mountpoint: "/proc/timer_list", FSType: "tmpfs"},
+				{Mountpoint: "/sys/firmware", FSType: "tmpfs"},
+				{Mountpoint: "/proc/scsi", FSType: "tmpfs"},
+			},
+			want: []expect{
+				{
+					path: "/run/src/core/sbom",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
👋🏽 we are seeing issues when upgrading the `syft-sbom-indexer` to the latest version of Syft running on latest GitHub Action Runner images (ubuntu-22.04). Effectively the recently introduced mount path checking prevents the mounted filesystem to be analysed. We see the following log message in the GHA logs when enabling debug logging:

```
DEBUG ignoring path based on mountpoint filesystem type condition=/run fs=tmpfs mountpoint=/proc/latency_stats path=/run/src/core/sbom
```

We tracked this down to https://github.com/anchore/syft/pull/2918. 

This PR adds a new test mimicking the file mounts as seen on the GitHub Action Runner image for ubuntu-22.04 and changes the code to let the requested path `/run/src/core/sbom` not get blocked. 

Please take a look at this change and let us know what you think? Thank you.