### PR TITLE
feat: add binary classifiers for avahi, syslog-ng, openssh

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1105,6 +1105,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "curl/8.9.1/linux-amd64",
+			expected: pkg.Package{
+				Name:      "curl",
+				Version:   "8.9.1",
+				Type:      "binary",
+				PURL:      "pkg:generic/curl@8.9.1",
+				Locations: locations("curl"),
+				Metadata:  metadata("curl-binary"),
+			},
+		},
+		{
 			logicalFixture: "lighttpd/1.4.76/linux-amd64",
 			expected: pkg.Package{
 				Name:      "lighttpd",

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1192,6 +1192,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("jq-binary"),
 			},
 		},
+		{
+			logicalFixture: "openssh/9.3/linux-amd64",
+			expected: pkg.Package{
+				Name:      "openssh",
+				Version:   "9.3",
+				Type:      "binary",
+				PURL:      "pkg:generic/openssh@9.3",
+				Locations: locations("ssh"),
+				Metadata:  metadata("openssh-binary"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1214,6 +1214,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("syslog-ng-binary"),
 			},
 		},
+		{
+			logicalFixture: "avahi/0.8/linux-amd64",
+			expected: pkg.Package{
+				Name:      "avahi",
+				Version:   "0.8",
+				Type:      "binary",
+				PURL:      "pkg:generic/avahi@0.8",
+				Locations: locations("avahi-browse"),
+				Metadata:  metadata("avahi-binary"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1138,17 +1138,6 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
-			logicalFixture: "zstd/1.5.6/linux-amd64",
-			expected: pkg.Package{
-				Name:      "zstd",
-				Version:   "1.5.6",
-				Type:      "binary",
-				PURL:      "pkg:generic/zstd@1.5.6",
-				Locations: locations("zstd"),
-				Metadata:  metadata("zstd-binary"),
-			},
-		},
-		{
 			logicalFixture: "xz/5.6.2/linux-amd64",
 			expected: pkg.Package{
 				Name:      "xz",

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1203,6 +1203,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("openssh-binary"),
 			},
 		},
+		{
+			logicalFixture: "syslog-ng/4.7.1/linux-amd64",
+			expected: pkg.Package{
+				Name:      "syslog-ng",
+				Version:   "4.7.1",
+				Type:      "binary",
+				PURL:      "pkg:generic/syslog-ng@4.7.1",
+				Locations: locations("syslog-ng"),
+				Metadata:  metadata("syslog-ng-binary"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -674,6 +674,16 @@ func DefaultClassifiers() []Classifier {
 			PURL:    mustPURL("pkg:generic/syslog-ng@version"),
 			CPEs:    singleCPE("cpe:2.3:a:oneidentity:syslog-ng:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "avahi-binary",
+			FileGlob: "**/avahi-browse",
+			EvidenceMatcher: FileContentsVersionMatcher(
+				`\x00\x25s (?P<version>[0-9]+\.[0-9]+)\x0a\x00`,
+			),
+			Package: "avahi",
+			PURL:    mustPURL("pkg:generic/avahi@version"),
+			CPEs:    singleCPE("cpe:2.3:a:avahi:avahi:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 }
 

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -664,6 +664,16 @@ func DefaultClassifiers() []Classifier {
 			PURL:    mustPURL("pkg:generic/openssh@version"),
 			CPEs:    singleCPE("cpe:2.3:a:openbsd:openssh:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "syslog-ng-binary",
+			FileGlob: "**/syslog-ng",
+			EvidenceMatcher: FileContentsVersionMatcher(
+				`\x00syslog-ng [0-9] \((?P<version>[0-9]+\.[0-9]+\.[0-9]+)\)`,
+			),
+			Package: "syslog-ng",
+			PURL:    mustPURL("pkg:generic/syslog-ng@version"),
+			CPEs:    singleCPE("cpe:2.3:a:oneidentity:syslog-ng:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 }
 

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -654,6 +654,16 @@ func DefaultClassifiers() []Classifier {
 			PURL:    mustPURL("pkg:generic/jq@version"),
 			CPEs:    singleCPE("cpe:2.3:a:jqlang:jq:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "openssh-binary",
+			FileGlob: "**/ssh",
+			EvidenceMatcher: FileContentsVersionMatcher(
+				`\x00OpenSSH_(?P<version>[0-9]+\.[0-9]+)(p[0-9])?\x00`,
+			),
+			Package: "openssh",
+			PURL:    mustPURL("pkg:generic/openssh@version"),
+			CPEs:    singleCPE("cpe:2.3:a:openbsd:openssh:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 }
 

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -679,3 +679,11 @@ from-images:
         platform: linux/amd64
     paths:
       - /usr/local/bin/jq
+
+  - name: openssh
+    version: 9.3
+    images:
+      - ref: finalgene/openssh:9.1@sha256:0272f8e6ef6344eafc71c2dfb53ba8397ff47d7cf2e46c5c46c5f269e41d19e8
+        platform: linux/amd64
+    paths:
+      - /usr/bin/ssh

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -687,3 +687,11 @@ from-images:
         platform: linux/amd64
     paths:
       - /usr/bin/ssh
+
+  - name: syslog-ng
+    version: 4.7.1
+    images:
+      - ref: linuxserver/syslog-ng:4.7.1@sha256:c995ed807bafc61972c486a4a876589df214dc34f4caf2e329bb6ef6bcf12639
+        platform: linux/amd64
+    paths:
+      - /usr/sbin/syslog-ng

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -695,3 +695,11 @@ from-images:
         platform: linux/amd64
     paths:
       - /usr/sbin/syslog-ng
+
+  - name: avahi
+    version: 0.8
+    images:
+      - ref: ydkn/avahi:latest@sha256:0df3de700d2b12f9bc3a4be6b49e04865bd0f92b992c287021c582c9ca90e535
+        platform: linux/amd64
+    paths:
+      - /usr/bin/avahi-browse


### PR DESCRIPTION
Additionly:
- Add test for the binary curl cataloger (added here: https://github.com/anchore/syft/commit/cff9d494df431d8ef15c56f72a494bcd0aacfbd0)
- Remove duplicate binary cataloger (accidentally added here: [6a95a5f2](https://github.com/anchore/syft/commit/6a95a5f2ed9ea35c8a718de859d9bf171854c5d5#diff-b7627d804c9423f6bc9957300413ed29e7e985dbd1a1b1b113eb341c5641944dR1108))
