### PR TITLE
update ruby classifier

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -852,6 +852,60 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 		},
 		{
 			// note: dynamic (non-snippet) test case
+			name:           "positive-ruby-3.4.0-dev",
+			logicalFixture: "ruby-shared-libs/3.4.0-dev/linux-amd64",
+			expected: pkg.Package{
+				Name:      "ruby",
+				Version:   "3.4.0dev",
+				Type:      "binary",
+				PURL:      "pkg:generic/ruby@3.4.0dev",
+				Locations: locations("ruby", "libruby.so.3.4.0"),
+				Metadata: pkg.BinarySignature{
+					Matches: []pkg.ClassifierMatch{
+						match("ruby-binary", "ruby"),
+						match("ruby-binary", "libruby.so.3.4.0"),
+					},
+				},
+			},
+		},
+		{
+			// note: dynamic (non-snippet) test case
+			name:           "positive-ruby-3.4.0-preview1",
+			logicalFixture: "ruby-shared-libs/3.4.0-preview1/linux-amd64",
+			expected: pkg.Package{
+				Name:      "ruby",
+				Version:   "3.4.0preview1",
+				Type:      "binary",
+				PURL:      "pkg:generic/ruby@3.4.0preview1",
+				Locations: locations("ruby", "libruby.so.3.4.0"),
+				Metadata: pkg.BinarySignature{
+					Matches: []pkg.ClassifierMatch{
+						match("ruby-binary", "ruby"),
+						match("ruby-binary", "libruby.so.3.4.0"),
+					},
+				},
+			},
+		},
+		{
+			// note: dynamic (non-snippet) test case
+			name:           "positive-ruby-3.3.0-rc1",
+			logicalFixture: "ruby-shared-libs/3.3.0-rc1/linux-amd64",
+			expected: pkg.Package{
+				Name:      "ruby",
+				Version:   "3.3.0rc1",
+				Type:      "binary",
+				PURL:      "pkg:generic/ruby@3.3.0rc1",
+				Locations: locations("ruby", "libruby.so.3.3.0"),
+				Metadata: pkg.BinarySignature{
+					Matches: []pkg.ClassifierMatch{
+						match("ruby-binary", "ruby"),
+						match("ruby-binary", "libruby.so.3.3.0"),
+					},
+				},
+			},
+		},
+		{
+			// note: dynamic (non-snippet) test case
 			logicalFixture: "ruby-bullseye-shared-libs/2.7.7/linux-amd64",
 			expected: pkg.Package{
 				Name:      "ruby",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -666,6 +666,9 @@ var libpythonMatcher = fileNameTemplateVersionMatcher(
 )
 
 var rubyMatcher = FileContentsVersionMatcher(
+	// ruby 3.4.0dev (2024-09-15T01:06:11Z master 532af89e3b) [x86_64-linux]
+	// ruby 3.4.0preview1 (2024-05-16 master 9d69619623) [x86_64-linux]
+	// ruby 3.3.0rc1 (2023-12-11 master a49643340e) [x86_64-linux]
 	// ruby 3.2.1 (2023-02-08 revision 31819e82c8) [x86_64-linux]
 	// ruby 2.7.7p221 (2022-11-24 revision 168ec2b1e5) [x86_64-linux]
-	`(?m)ruby (?P<version>[0-9]+\.[0-9]+\.[0-9]+(p[0-9]+)?) `)
+	`(?m)ruby (?P<version>[0-9]+\.[0-9]+\.[0-9]+((p|preview|rc|dev)[0-9]*)?) `)

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -564,6 +564,36 @@ from-images:
       - /usr/local/lib/libruby.so.2.7
 
   - name: ruby-shared-libs
+    version: 3.4.0-dev
+    images:
+      - ref: rubylang/ruby:master-dev-nightly-20240804-focal@sha256:b5fe8b9ac1e9638a4b08bda6a6343082a07623d1c01926e637eb4bbbbf159409
+        platform: linux/amd64
+    paths:
+      - /usr/local/bin/ruby
+      - /usr/local/lib/libruby.so.3.4.0
+      - /usr/local/lib/libruby.so.3.4
+
+  - name: ruby-shared-libs
+    version: 3.4.0-preview1
+    images:
+      - ref: ruby:3.4.0-preview1@sha256:88cad31539e1a4ab987ac4b00c45b86d8346c25e3b08ac647ccccfb21cee5890
+        platform: linux/amd64
+    paths:
+      - /usr/local/bin/ruby
+      - /usr/local/lib/libruby.so.3.4.0
+      - /usr/local/lib/libruby.so.3.4
+
+  - name: ruby-shared-libs
+    version: 3.3.0-rc1
+    images:
+      - ref: ruby:3.3.0-rc1@sha256:453c8bbb9b4e3b04b94ba58db77b648222f3c92936dc12b5ae96df48076c106b
+        platform: linux/amd64
+    paths:
+      - /usr/local/bin/ruby
+      - /usr/local/lib/libruby.so.3.3.0
+      - /usr/local/lib/libruby.so.3.3
+
+  - name: ruby-shared-libs
     version: 2.6.10
     images:
       - ref: ruby:2.6.10@sha256:771a810704167e55da8a19970c5dfa6eb795dfee32547adffa29ea72703f7243


### PR DESCRIPTION
This PR updates a binary cataloger for ruby
Fixes #3238
Fixes #3239

```
$ go run cmd/syft/main.go -q ruby:3.4-rc | grep 'ruby '
ruby                          3.4.0preview1                   binary

$ go run cmd/syft/main.go -q ruby:3.3.0-rc1 | grep 'ruby '
ruby                          3.3.0rc1                        binary

$ go run cmd/syft/main.go -q rubylang/ruby:master-jammy | grep 'ruby '
ruby                 3.4.0dev                                 binary
```