### PR TITLE
fix: don't use licensecheck's builtin scanner

### DIFF
--- a/internal/licenses/parser.go
+++ b/internal/licenses/parser.go
@@ -22,7 +22,13 @@ func Parse(reader io.Reader, l file.Location) (licenses []pkg.License, err error
 	if err != nil {
 		return nil, err
 	}
-	cov := licensecheck.Scan(contents)
+
+	scanner, err := licensecheck.NewScanner(licensecheck.BuiltinLicenses())
+	if err != nil {
+		return nil, err
+	}
+
+	cov := scanner.Scan(contents)
 	if cov.Percent < coverageThreshold {
 		// unknown or no licenses here?
 		return licenses, nil


### PR DESCRIPTION
The built-in scanner is never cleaned, so it leaks memory