### PR TITLE
Fix: Parse package.json with non-standard fields in 'author' section

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_package_json_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json_test.go
@@ -179,6 +179,27 @@ func TestParsePackageJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-author-non-standard.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocations("Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-author-non-standard.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "npm Inc. (https://www.npmjs.com/)",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-author-non-standard.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-author-non-standard.json
@@ -1,0 +1,16 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": {
+    "name": "npm Inc.",
+    "url": "https://www.npmjs.com/",
+    "organization": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}


### PR DESCRIPTION
Several npm packages, including those within the AWS CDK ecosystem, use non-standard fields within their `package.json` files (e.g., `"organization": true`). This caused parsing errors and excluded these packages from reports.

This fix modifies the JavaScript package cataloger to correctly handle these non-standard fields, ensuring accurate parsing and inclusion of all packages in the report.

`aws-cdk/package.json`:
```
...
"author": {
  "name": "Amazon Web Services",
  "url": "https://aws.amazon.com",
  "organization": true
},
...
```

Scan example before fix:
```
syft scan XXX
 ✔ Parsed image sha256:XXX
 ✔ Cataloged contents XXX
   ├── ✔ Packages                        [1,519 packages]
   ├── ✔ File digests                    [32,435 files]
   ├── ✔ File metadata                   [32,435 locations]
   └── ✔ Executables                     [2,057 executables]
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/node_modules/@aws-cdk/asset-awscli-v1/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/node_modules/@aws-cdk/asset-kubectl-v20/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/node_modules/@aws-cdk/asset-node-proxy-agent-v6/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/node_modules/constructs/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk-lib/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/aws-cdk/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/@aws-cdk/asset-awscli-v1/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/@aws-cdk/asset-kubectl-v20/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/@aws-cdk/asset-node-proxy-agent-v6/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/@aws-cdk/cloud-assembly-schema/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/aws-cdk-lib/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/node_modules/constructs/package.json
[0036]  WARN cataloger failed cataloger=javascript-package-cataloger error=failed to parse package.json file: unable to parse package.json author: json: cannot unmarshal bool into Go value of type string location=/usr/local/lib/node_modules/cdk-nag/package.json
```