### PR TITLE
[chore] Add mastodon link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
  &nbsp;<a href="https://github.com/anchore/syft" target="_blank"><img alt="GitHub go.mod Go version" src="https://img.shields.io/github/go-mod/go-version/anchore/syft.svg"></a>&nbsp;
  &nbsp;<a href="" target="_blank"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"></a>&nbsp;
  &nbsp;<a href="https://anchore.com/discourse" target="_blank"><img alt="Join our Discourse" src="https://img.shields.io/badge/Discourse-Join-blue?logo=discourse"/></a>&nbsp;
+ &nbsp;<a rel="me" href="https://fosstodon.org/@syft"><img alt="Follow on Mastodon" src="https://img.shields.io/badge/Mastodon-Follow-blue?logoColor=white&logo=mastodon"/></a>&nbsp;
 </p>
 
 ![syft-demo](https://user-images.githubusercontent.com/590471/90277200-2a253000-de33-11ea-893f-32c219eea11a.gif)


### PR DESCRIPTION
Hello friends.

# Description

This follows the same pattern as the other badges at the top of the readme. It adds the mastodon link to the Syft account. 

This also means that the link back here from the Mastodon account's profile page will show as 'Validated' once it lands, which gives the account more authenticity.

<!-- If this completes an issue, please include: -->

- Fixes #

## Type of change

<!-- Delete any that are not relevant -->

- [X] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

None of these apply, I think.

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
