### PR TITLE
docs: clearer deprecation message for --file

### DIFF
--- a/cmd/syft/internal/options/output_file.go
+++ b/cmd/syft/internal/options/output_file.go
@@ -28,7 +28,7 @@ func (o *OutputFile) AddFlags(flags clio.FlagSet) {
 
 		if pfp, ok := flags.(fangs.PFlagSetProvider); ok {
 			flagSet := pfp.PFlagSet()
-			flagSet.Lookup("file").Deprecated = "use: output"
+			flagSet.Lookup("file").Deprecated = "use: --output FORMAT=PATH"
 		}
 	}
 }


### PR DESCRIPTION
It's not clear to users that they shoudl use --output FORMAT=PATH instead of --file. Directly suggest the FORMAT=PATH syntax.

# Description

Just a docs improvement, made after [this very reasonable question](https://anchorecommunity.discourse.group/t/how-to-specify-file-name-if-flag-is-depreciated/169?u=willmurphy)

## Type of change

- [x] Documentation (updates the documentation)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Manual testing

``` sh
❯ go run ./cmd/syft -o json --file /tmp/syft.json busybox:latest
Flag --file has been deprecated, use: --output FORMAT=PATH
```
