### PR TITLE
fix: improve go binary semver extraction for traefik

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -196,7 +196,7 @@ func (c *goBinaryCataloger) makeGoMainPackage(resolver file.Resolver, mod *exten
 // this is checking for (.L)? because at least one binary seems to have \xA0L preceding the version string, but for some reason
 // this is unable to be matched by the regex here as \x00\xA0L;
 // the only thing that seems to work is to just look for version strings following both \x00 and \x00.L for now
-var semverPattern = regexp.MustCompile(`\x00(.L)?(?P<version>v?(\d+\.\d+\.\d+[-\w]*[+\w]*))\x00`)
+var semverPattern = regexp.MustCompile(`(\x00|\x{FFFD})(.L)?(?P<version>v?(\d+\.\d+\.\d+[-\w]*[+\w]*))\x00`)
 
 func (c *goBinaryCataloger) findMainModuleVersion(metadata *pkg.GolangBinaryBuildinfoEntry, gbs pkg.KeyValues, reader io.ReadSeekCloser) string {
 	vcsVersion, hasVersion := gbs.Get("vcs.revision")

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -1305,6 +1305,14 @@ func Test_extractVersionFromContents(t *testing.T) {
 			contents: strings.NewReader("\x0e\x74\x5a\x3b\x00\x00\xa0\x4cv1.9.5\x00\x00"),
 			want:     "v1.9.5",
 		},
+		{
+			// 06168a34: f98f b0be 332e 312e 3200 0000 636f 6d74  ....3.1.2...comt from /usr/local/bin/traefik
+			// in traefik:v3.1.2@sha256:3f92eba47bd4bfda91d47b72d16fef2d7ae15db61a92b2057cf0cb389f8938f6
+			// TODO: eventually use something for managing snippets, similar to what's used with binary classifier tests
+			name:     "parse traefik version",
+			contents: strings.NewReader("\xf9\x8f\xb0\xbe\x33\x2e\x31\x2e\x32\x00\x00\x00\x63\x6f\x6d\x74"),
+			want:     "3.1.2",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Enhances the go cataloger semver extraction logic to include getting the release version of traefik.  This is based off of the regex pattern that already existed in the [traefik binary classifier](https://github.com/anchore/syft/blob/8095f7b8c14d2b2abf08c9516c7617c08e9fc319/syft/pkg/cataloger/binary/classifiers.go#L278).

The advantage to raising up the release version in the go cataloger rather than just in the binary classifier is that it means the vulnerability matching can take advantage of the GitHub security advisory data for traefik rather than just the NVD CVE entries.  I think this would have prevented https://github.com/anchore/grype/issues/2178 from occurring