### PR TITLE
fix: stop some log.Warn spam due parsing an empty string as a CPE

### DIFF
--- a/syft/pkg/cataloger/binary/elf_package.go
+++ b/syft/pkg/cataloger/binary/elf_package.go
@@ -31,9 +31,12 @@ func packageURL(metadata elfBinaryPackageNotes) string {
 	osVersion := metadata.OSVersion
 
 	var atts cpe.Attributes
-	atts, err := cpe.NewAttributes(metadata.OSCPE)
-	if err != nil {
-		log.WithFields("error", err).Warn("unable to parse cpe attributes for elf binary package")
+	if metadata.OSCPE != "" {
+		var cpeErr error
+		atts, cpeErr = cpe.NewAttributes(metadata.OSCPE)
+		if cpeErr != nil {
+			log.WithFields("error", cpeErr).Warn("unable to parse cpe attributes for elf binary package")
+		}
 	}
 	// only "upgrade" the OS information if there is something more specific to use in it's place
 	if os == "" && osVersion == "" || os == "" && atts.Version != "" || atts.Product != "" && osVersion == "" {


### PR DESCRIPTION
# Description

https://github.com/anchore/syft/pull/2762 fixed a small bug where creating a CPE would sometimes return a nil error even though it failed. However, this resulted in some needlessly noisy logs. Clean up some of this logging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior - no behavior change
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
