### PR TITLE
Performance: Use file indexer when scanning with file source

### DIFF
--- a/syft/internal/fileresolver/file_indexer.go
+++ b/syft/internal/fileresolver/file_indexer.go
@@ -1,0 +1,223 @@
+package fileresolver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/stereoscope/pkg/filetree"
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/internal/windows"
+	"github.com/wagoodman/go-progress"
+)
+
+type fileIndexer struct {
+	path              string
+	base              string
+	pathIndexVisitors []PathIndexVisitor
+	errPaths          map[string]error
+	tree              filetree.ReadWriter
+	index             filetree.Index
+}
+
+func newFileIndexer(path, base string, visitors ...PathIndexVisitor) *fileIndexer {
+	i := &fileIndexer{
+		path:  path,
+		base:  base,
+		tree:  filetree.New(),
+		index: filetree.NewIndex(),
+		pathIndexVisitors: append(
+			[]PathIndexVisitor{
+				requireFileInfo,
+				disallowByFileType,
+				skipPathsByMountTypeAndName(path),
+			},
+			visitors...,
+		),
+		errPaths: make(map[string]error),
+	}
+
+	return i
+}
+
+// Build the indexer
+func (r *fileIndexer) build() (filetree.Reader, filetree.IndexReader, error) {
+	return r.tree, r.index, index(r.path, r.indexPath)
+}
+
+// Index file at the given path
+// A file indexer simply indexes the file and its directory.
+func index(path string, indexer func(string, *progress.Stage) error) error {
+	// We want to index the file at the provided path and its parent directory.
+	// We need to probably check that we have file access
+	// We also need to determine what to do when the file itself is a symlink.
+	stager, prog := indexingProgress(path)
+	defer prog.SetCompleted()
+
+	err := indexer(path, stager)
+	if err != nil {
+		return fmt.Errorf("unable to index filesystem path=%q: %w", path, err)
+	}
+
+	return nil
+}
+
+// indexPath will index the file at the provided path as well as its parent directory.
+// It expects path to be a file, not a directory.
+// If a directory is provided then an error will be returned. Additionally, any IO or
+// permissions errors on the file at path or its parent directory will return an error.
+// Filter functions provided to the indexer are honoured, so if the path provided (or its parent
+// directory) is filtered by a filter function, an error is returned.
+func (r *fileIndexer) indexPath(path string, stager *progress.Stage) error {
+	log.WithFields("path", path).Trace("indexing file path")
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	// Protect against callers trying to call file_indexer with directories
+	fi, err := os.Stat(absPath)
+	// The directory indexer ignores stat errors, however this file indexer won't ignore them
+	if err != nil {
+		return fmt.Errorf("unable to stat path=%q: %w", path, err)
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("unable to index file, given path was a directory=%q", path)
+	}
+
+	absSymlinkFreeFilePath, err := absoluteSymlinkFreePathToFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Now index the file and its parent directory
+	// We try to index the parent directory first, because if the parent directory
+	// is ignored by any filter function, then we must ensure we also ignore the file.
+	absSymlinkFreeParent, err := absoluteSymlinkFreePathToParent(absSymlinkFreeFilePath)
+	if err != nil {
+		return err
+	}
+	parentFi, err := os.Stat(absSymlinkFreeParent)
+	if err != nil {
+		return fmt.Errorf("unable to stat parent of file=%q: %w", absSymlinkFreeParent, err)
+	}
+
+	stager.Current = absSymlinkFreeParent
+	indexParentErr := r.filterAndIndex(absSymlinkFreeParent, parentFi)
+	if indexParentErr != nil {
+		return indexParentErr
+	}
+
+	// We have indexed the parent successfully, now attempt to index the file.
+	stager.Current = absSymlinkFreeFilePath
+	indexFileErr := r.filterAndIndex(absSymlinkFreeFilePath, fi)
+	if indexFileErr != nil {
+		return indexFileErr
+	}
+
+	return nil
+}
+
+func (r *fileIndexer) filterAndIndex(path string, info os.FileInfo) error {
+	// check if any of the filters want us to ignore this path
+	for _, filterFn := range r.pathIndexVisitors {
+		if filterFn == nil {
+			continue
+		}
+
+		if filterErr := filterFn(r.base, path, info, nil); filterErr != nil {
+			// A filter function wants us to ignore this path, honour it
+			return filterErr
+		}
+	}
+
+	// here we check to see if we need to normalize paths to posix on the way in coming from windows
+	if windows.HostRunningOnWindows() {
+		path = windows.ToPosix(path)
+	}
+
+	err := r.addPathToIndex(path, info)
+	// If we hit file access errors, isFileAccessErr will handle logging & adding
+	// the path to the errPaths map.
+	// While the directory_indexer does not let these cause the indexer to throw
+	// we will here, as not having access to the file we index for a file source
+	// probably makes the file source creation useless? I need to check with Syft maintainers.
+	// This also poses the question, is errPaths worthwhile for file_indexer?
+	if r.isFileAccessErr(path, err) {
+		return err
+	}
+
+	return nil
+}
+
+// Add path to index. File indexer doesn't need to support symlink, as we should have abs symlink free path.
+// If we somehow get a symlink here, report as an error.
+func (r *fileIndexer) addPathToIndex(path string, info os.FileInfo) error {
+	switch t := file.TypeFromMode(info.Mode()); t {
+	case file.TypeDirectory:
+		return r.addDirectoryToIndex(path, info)
+	case file.TypeRegular:
+		return r.addFileToIndex(path, info)
+	default:
+		return fmt.Errorf("unsupported file type: %s", t)
+	}
+}
+
+func (r *fileIndexer) addDirectoryToIndex(path string, info os.FileInfo) error {
+	ref, err := r.tree.AddDir(file.Path(path))
+	if err != nil {
+		return err
+	}
+
+	metadata := file.NewMetadataFromPath(path, info)
+	r.index.Add(*ref, metadata)
+
+	return nil
+}
+
+func (r *fileIndexer) addFileToIndex(path string, info os.FileInfo) error {
+	ref, err := r.tree.AddFile(file.Path(path))
+	if err != nil {
+		return err
+	}
+
+	metadata := file.NewMetadataFromPath(path, info)
+	r.index.Add(*ref, metadata)
+
+	return nil
+}
+
+// Get absolute symlink free path to parent of the file
+func absoluteSymlinkFreePathToParent(path string) (string, error) {
+	absFilePath, err := absoluteSymlinkFreePathToFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Dir(absFilePath), nil
+}
+
+// Get absolute symlink free path to the file
+func absoluteSymlinkFreePathToFile(path string) (string, error) {
+	absAnalysisPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("unable to get absolute path for analysis path=%q: %w", path, err)
+	}
+	dereferencedAbsAnalysisPath, err := filepath.EvalSymlinks(absAnalysisPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to get absolute path for analysis path=%q: %w", path, err)
+	}
+	return dereferencedAbsAnalysisPath, nil
+}
+
+func (r *fileIndexer) isFileAccessErr(path string, err error) bool {
+	// don't allow for errors to stop indexing, keep track of the paths and continue.
+	if err != nil {
+		log.Warnf("unable to access path=%q: %+v", path, err)
+		r.errPaths[path] = err
+		return true
+	}
+	return false
+}

--- a/syft/internal/fileresolver/file_indexer_test.go
+++ b/syft/internal/fileresolver/file_indexer_test.go
@@ -1,0 +1,103 @@
+package fileresolver
+
+import (
+	"github.com/anchore/stereoscope/pkg/file"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+)
+
+// - Verify that both the parent and the path are indexed
+func Test_index(t *testing.T) {
+	testPath := "test-fixtures/system_paths/target/home/place"
+	indexer := newFileIndexer(testPath, "", make([]PathIndexVisitor, 0)...)
+	tree, index, err := indexer.build()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "has path",
+			path: "test-fixtures/system_paths/target/home/place",
+		},
+		{
+			name: "has parent dir",
+			path: "test-fixtures/system_paths/target/home",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info, err := os.Stat(test.path)
+			assert.NoError(t, err)
+
+			// note: the index uses absolute paths, so assertions MUST keep this in mind
+			cwd, err := os.Getwd()
+			require.NoError(t, err)
+
+			p := file.Path(path.Join(cwd, test.path))
+			assert.Equal(t, true, tree.HasPath(p))
+			exists, ref, err := tree.File(p)
+			assert.Equal(t, true, exists)
+			if assert.NoError(t, err) {
+				return
+			}
+
+			entry, err := index.Get(*ref.Reference)
+			require.NoError(t, err)
+			assert.Equal(t, info.Mode(), entry.Mode)
+		})
+	}
+
+}
+
+// - Verify that directories are rejected
+func Test_indexRejectsDirectory(t *testing.T) {
+	dirPath := "test-fixtures/system_paths/target/home"
+	indexer := newFileIndexer(dirPath, "", make([]PathIndexVisitor, 0)...)
+	_, _, err := indexer.build()
+	require.Error(t, err)
+}
+
+// - Verify ignores if filterAndIndex sets up a filter for the filepath
+func Test_ignoresPathIfFiltered(t *testing.T) {
+	testPath := "test-fixtures/system_paths/target/home/place"
+	cwd, cwdErr := os.Getwd()
+	require.NoError(t, cwdErr)
+	ignorePath := path.Join(cwd, testPath)
+	filterFn := func(_, path string, _ os.FileInfo, _ error) error {
+		if path == ignorePath {
+			return ErrSkipPath
+		}
+
+		return nil
+	}
+	indexer := newFileIndexer(testPath, "", filterFn)
+	_, _, err := indexer.build()
+	require.Error(t, err)
+}
+
+// - Verify ignores if filterAndIndex sets up a filter for the directory
+func Test_ignoresPathIfParentFiltered(t *testing.T) {
+	testPath := "test-fixtures/system_paths/target/home/place"
+	parentPath := "test-fixtures/system_paths/target/home"
+
+	cwd, cwdErr := os.Getwd()
+	require.NoError(t, cwdErr)
+	ignorePath := path.Join(cwd, parentPath)
+	filterFn := func(_, path string, _ os.FileInfo, _ error) error {
+		if path == ignorePath {
+			return fs.SkipDir
+		}
+
+		return nil
+	}
+	indexer := newFileIndexer(testPath, "", filterFn)
+	_, _, err := indexer.build()
+	require.Error(t, err)
+}

--- a/syft/internal/fileresolver/file_test.go
+++ b/syft/internal/fileresolver/file_test.go
@@ -1,0 +1,269 @@
+package fileresolver
+
+import (
+	"context"
+	stereoscopeFile "github.com/anchore/stereoscope/pkg/file"
+	"github.com/anchore/syft/syft/file"
+	"github.com/google/go-cmp/cmp"
+	"github.com/scylladb/go-set/strset"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestFileResolver_FilesByPath(t *testing.T) {
+	tests := []struct {
+		description        string
+		filePath           string // relative to cwd
+		fileByPathInput    string
+		expectedRealPath   string
+		expectedAccessPath string
+		cwd                string
+	}{
+		{
+			description:        "Finds file if searched by filepath",
+			filePath:           "./test-fixtures/req-resp/path/to/the/file.txt",
+			fileByPathInput:    "file.txt",
+			expectedRealPath:   "/file.txt",
+			expectedAccessPath: "/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			parentPath, err := absoluteSymlinkFreePathToParent(tt.filePath)
+			require.NoError(t, err)
+			require.NotNil(t, parentPath)
+
+			resolver, err := NewFromFile(parentPath, tt.filePath)
+			require.NoError(t, err)
+			require.NotNil(t, resolver)
+
+			refs, err := resolver.FilesByPath(tt.fileByPathInput)
+			require.NoError(t, err)
+			if tt.expectedRealPath == "" {
+				require.Empty(t, refs)
+				return
+			}
+			require.Len(t, refs, 1)
+			assert.Equal(t, tt.expectedRealPath, refs[0].RealPath, "real path different")
+			assert.Equal(t, tt.expectedAccessPath, refs[0].AccessPath, "virtual path different")
+		})
+	}
+}
+
+// Test mutliple files by path -> Maybe not necessary for us here?
+func TestFileResolver_MultipleFilesByPath(t *testing.T) {
+	tests := []struct {
+		description string
+		input       []string
+		refCount    int
+	}{
+		{
+			description: "finds file ",
+			input:       []string{"file.txt"},
+			refCount:    1,
+		},
+		{
+			description: "skip non-existing files",
+			input:       []string{"file.txt", "bogus.txt"},
+			refCount:    1,
+		},
+		{
+			description: "does not return anything for non-existing files",
+			input:       []string{"non-existing/bogus.txt", "another-bogus.txt"},
+			refCount:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			filePath := "./test-fixtures/req-resp/path/to/the/file.txt"
+			parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+			require.NoError(t, err)
+			require.NotNil(t, parentPath)
+
+			resolver, err := NewFromFile(parentPath, filePath)
+			assert.NoError(t, err)
+			refs, err := resolver.FilesByPath(tt.input...)
+			assert.NoError(t, err)
+
+			if len(refs) != tt.refCount {
+				t.Errorf("unexpected number of refs: %d != %d", len(refs), tt.refCount)
+			}
+		})
+	}
+}
+
+func TestFileResolver_FilesByGlob(t *testing.T) {
+	filePath := "./test-fixtures/req-resp/path/to/the/file.txt"
+	parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, parentPath)
+
+	resolver, err := NewFromFile(parentPath, filePath)
+	assert.NoError(t, err)
+	refs, err := resolver.FilesByGlob("*.txt")
+	assert.NoError(t, err)
+
+	assert.Len(t, refs, 1)
+}
+
+func Test_fileResolver_FilesByMIMEType(t *testing.T) {
+	tests := []struct {
+		fixturePath   string
+		mimeType      string
+		expectedPaths *strset.Set
+	}{
+		{
+			fixturePath:   "./test-fixtures/image-simple/file-1.txt",
+			mimeType:      "text/plain",
+			expectedPaths: strset.New("/file-1.txt"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.fixturePath, func(t *testing.T) {
+			filePath := "./test-fixtures/image-simple/file-1.txt"
+			parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+			require.NoError(t, err)
+			require.NotNil(t, parentPath)
+
+			resolver, err := NewFromFile(parentPath, filePath)
+			assert.NoError(t, err)
+			locations, err := resolver.FilesByMIMEType(test.mimeType)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedPaths.Size(), len(locations))
+			for _, l := range locations {
+				assert.True(t, test.expectedPaths.Has(l.RealPath), "does not have path %q", l.RealPath)
+			}
+		})
+	}
+}
+
+func Test_fileResolver_FileContentsByLocation(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	filePath := "./test-fixtures/image-simple/file-1.txt"
+	parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, parentPath)
+
+	r, err := NewFromFile(parentPath, filePath)
+	require.NoError(t, err)
+
+	exists, existingPath, err := r.tree.File(stereoscopeFile.Path(filepath.Join(cwd, "test-fixtures/image-simple/file-1.txt")))
+	require.True(t, exists)
+	require.NoError(t, err)
+	require.True(t, existingPath.HasReference())
+
+	tests := []struct {
+		name     string
+		location file.Location
+		expects  string
+		err      bool
+	}{
+		{
+			name:     "use file reference for content requests",
+			location: file.NewLocationFromDirectory("some/place", *existingPath.Reference),
+			expects:  "this file has contents",
+		},
+		{
+			name:     "error on empty file reference",
+			location: file.NewLocationFromDirectory("doesn't matter", stereoscopeFile.Reference{}),
+			err:      true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			actual, err := r.FileContentsByLocation(test.location)
+			if test.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if test.expects != "" {
+				b, err := io.ReadAll(actual)
+				require.NoError(t, err)
+				assert.Equal(t, test.expects, string(b))
+			}
+		})
+	}
+}
+
+func TestFileResolver_AllLocations_errorOnDirRequest(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	filePath := "./test-fixtures/system_paths/target/home/place"
+	parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, parentPath)
+	resolver, err := NewFromFile(parentPath, filePath)
+	require.NoError(t, err)
+
+	var dirLoc *file.Location
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	for loc := range resolver.AllLocations(ctx) {
+		entry, err := resolver.index.Get(loc.Reference())
+		require.NoError(t, err)
+		if entry.Metadata.IsDir() {
+			dirLoc = &loc
+			break
+		}
+	}
+
+	require.NotNil(t, dirLoc)
+
+	reader, err := resolver.FileContentsByLocation(*dirLoc)
+	require.Error(t, err)
+	require.Nil(t, reader)
+}
+
+func TestFileResolver_AllLocations(t *testing.T) {
+	// Verify both the parent and the file itself are indexed
+	filePath := "./test-fixtures/system_paths/target/home/place"
+	parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, parentPath)
+	resolver, err := NewFromFile(parentPath, filePath)
+	require.NoError(t, err)
+
+	paths := strset.New()
+	for loc := range resolver.AllLocations(context.Background()) {
+		paths.Add(loc.RealPath)
+	}
+	expected := []string{
+		"/place",
+		"", // This is how we see the parent dir, since we're resolving wrt the parent directory.
+	}
+
+	pathsList := paths.List()
+	sort.Strings(pathsList)
+
+	assert.ElementsMatchf(t, expected, pathsList, "expected all paths to be indexed, but found different paths: \n%s", cmp.Diff(expected, paths.List()))
+}
+
+func Test_AllLocationsDoesNotLeakGoRoutine(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	filePath := "./test-fixtures/system_paths/target/home/place"
+	parentPath, err := absoluteSymlinkFreePathToParent(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, parentPath)
+	resolver, err := NewFromFile(parentPath, filePath)
+	require.NoError(t, err)
+
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	for range resolver.AllLocations(ctx) {
+		break
+	}
+	cancel()
+}


### PR DESCRIPTION
# Description
This PR alters `file_source.go` to use a new **file indexer,** rather than the existing **directory indexer**.

Currently, when scanning a non-archive file, file_source.go applies a filter function to the directory indexer such that all files other than the file being scanned and its parent directory are ignored by the directory indexer. See [here](https://github.com/anchore/syft/blob/main/syft/source/filesource/file_source.go#L176-L200).

This approach becomes problematic when the scanned file is inside a directory with a large number of files, for two reasons:

1. Go’s filepath.Walk provides lexical ordering guarantees by reading the entire directory into memory. For sufficiently large containing directories, **scanning a single file takes many GB’s of memory**.
2. The total time to scan the single file also increases wrt the number of files in the containing directory due to the directory walk and the time taken to perform memory allocation etc.

This Pprof shows heap allocation when scanning a file within a directory containing a large number of files, I’m including it here as proof of my root cause analysis
<img width="109" alt="Screenshot 2024-10-15 at 11 45 59" src="https://github.com/user-attachments/assets/5897c63e-7806-4bdc-bdb0-8d4cfccf61a2">

Walking all of the files in the containing directory is redundant when using a file source, since as mentioned above the filter function will ignore everything other than the scanned file and its parent dir.

In this change, I have added a new **file indexer** which should match the existing behaviour of the directory indexer for a single file source. However, instead of walking the file system, it simply makes an attempt to index the containing directory and the file target.

I have also added `file.go` to satisfy the resolver interface when using the file indexer. Much of the functionality matches that of `directory.go` and I would appreciate it if there are any suggestions for improvement here, as I appreciate there's a bit of duplicated code.

The existing `directory.go` has many unit tests to verify behaviour in the event that the directory being walked contains symlinks etc. I have attempted to simplify the unit tests for `file.go` as it does not have to handle all of the complexity that `directory.go` does, but I would really appreciate extra review attention in this area as I may not be aware of all the ways a target for file_source may be defined.

I haven’t got a pprof diagram for the new approach, but memstat profiling has shown O(1) heap use wrt the number of files in the containing directory when using file source as expected.

Additionally, creating a resolver via a file_source is also happening in O(1) time wrt the number of files in the containing directory too. 

## Type of change
- [x] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
