### PR TITLE
fix: improve mariadb binary classifer to detect older versions

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -351,7 +351,7 @@ func DefaultClassifiers() []Classifier {
 		},
 		{
 			Class:    "mariadb-binary",
-			FileGlob: "**/mariadb",
+			FileGlob: "**/{mariadb,mysql}",
 			EvidenceMatcher: FileContentsVersionMatcher(
 				// 10.6.15-MariaDB
 				`(?m)(?P<version>[0-9]+(\.[0-9]+)?(\.[0-9]+)?(alpha[0-9]|beta[0-9]|rc[0-9])?)-MariaDB`),


### PR DESCRIPTION
# Description

With older versions of mariadb the binary name was `mysql`, so this adjusts the binary classifier to additionally search for the expected version pattern in `mysql` binaries.
