### PR TITLE
fix: use official CPE for linux kernel

### DIFF
--- a/syft/pkg/cataloger/kernel/cataloger_test.go
+++ b/syft/pkg/cataloger/kernel/cataloger_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
@@ -22,6 +23,7 @@ func Test_KernelCataloger(t *testing.T) {
 		),
 		Type: pkg.LinuxKernelPkg,
 		PURL: "pkg:generic/linux-kernel@6.0.7-301.fc37.x86_64",
+		CPEs: []cpe.CPE{cpe.Must("cpe:2.3:o:linux:linux_kernel:6.0.7-301.fc37.x86_64:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource)},
 		Metadata: pkg.LinuxKernel{
 			Name:            "",
 			Architecture:    "x86",

--- a/syft/pkg/cataloger/kernel/package.go
+++ b/syft/pkg/cataloger/kernel/package.go
@@ -4,11 +4,25 @@ import (
 	"strings"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 )
 
 const linuxKernelPackageName = "linux-kernel"
+
+func createLinuxKernelCPEs(version string) []cpe.CPE {
+	c := cpe.NewWithAny()
+	c.Part = "o"
+	c.Product = "linux_kernel"
+	c.Vendor = "linux"
+	c.Version = version
+	if cpe.ValidateString(c.String()) != nil {
+		return nil
+	}
+
+	return []cpe.CPE{{Attributes: c, Source: cpe.NVDDictionaryLookupSource}}
+}
 
 func newLinuxKernelPackage(metadata pkg.LinuxKernel, archiveLocation file.Location) pkg.Package {
 	p := pkg.Package{
@@ -18,6 +32,7 @@ func newLinuxKernelPackage(metadata pkg.LinuxKernel, archiveLocation file.Locati
 		PURL:      packageURL(linuxKernelPackageName, metadata.Version),
 		Type:      pkg.LinuxKernelPkg,
 		Metadata:  metadata,
+		CPEs:      createLinuxKernelCPEs(metadata.Version),
 	}
 
 	p.SetID()


### PR DESCRIPTION
# Description

Uses the official cpe `cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*` for the `linux-kernel-cataloger` so that downstream vulnerability matching will function for those building a grype database with operating system type CPEs included