### PR TITLE
Update to latest packageurl-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f
+	github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f
 	github.com/anchore/stereoscope v0.0.5-0.20241015153345-9e57bce5efeb
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	// we are hinting brotli to latest due to warning when installing archiver v3:

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f h1:B/E9ixKNCasntpoch61NDaQyGPDXLEJlL+B9B/PbdbA=
-github.com/anchore/packageurl-go v0.1.1-0.20240507183024-848e011fc24f/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
+github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f h1:dAQPIrQ3a5PBqZeZ+B9NGZsGmodk4NO9OjDIsQmQyQM=
+github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.0.5-0.20241015153345-9e57bce5efeb h1:yCFQfICLjqx2CK7Tjmxb+gj0OlZx1sRKnHOpKF3tsh8=
 github.com/anchore/stereoscope v0.0.5-0.20241015153345-9e57bce5efeb/go.mod h1:pTHFcI/hFgBQ1R1fljEG1WMQavBRjuzgi+sZ4jotwko=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/syft/pkg/cataloger/alpine/package_test.go
+++ b/syft/pkg/cataloger/alpine/package_test.go
@@ -112,7 +112,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:        "alpine",
 				VersionID: "3.4.6",
 			},
-			expected: "pkg:apk/alpine/p@v?arch=a&upstream=origin&distro=alpine-3.4.6",
+			expected: "pkg:apk/alpine/p@v?arch=a&distro=alpine-3.4.6&upstream=origin",
 		},
 		{
 			name: "wolfi distro",

--- a/syft/pkg/cataloger/arch/package_test.go
+++ b/syft/pkg/cataloger/arch/package_test.go
@@ -108,7 +108,7 @@ func Test_PackageURL(t *testing.T) {
 				ID:      "arch",
 				BuildID: "rolling",
 			},
-			expected: "pkg:alpm/arch/p@v?arch=a&upstream=origin&distro=arch-rolling",
+			expected: "pkg:alpm/arch/p@v?arch=a&distro=arch-rolling&upstream=origin",
 		},
 	}
 

--- a/syft/pkg/cataloger/debian/package_test.go
+++ b/syft/pkg/cataloger/debian/package_test.go
@@ -81,7 +81,7 @@ func Test_packageURL(t *testing.T) {
 				Source:  "s",
 				Version: "v",
 			},
-			expected: "pkg:deb/debian/p@v?upstream=s&distro=debian-11",
+			expected: "pkg:deb/debian/p@v?distro=debian-11&upstream=s",
 		},
 		{
 			name: "with upstream qualifier with source pkg name and version info",
@@ -98,7 +98,7 @@ func Test_packageURL(t *testing.T) {
 				Version:       "v",
 				SourceVersion: "2.3",
 			},
-			expected: "pkg:deb/debian/p@v?upstream=s%402.3&distro=debian-11",
+			expected: "pkg:deb/debian/p@v?distro=debian-11&upstream=s%402.3",
 		},
 	}
 

--- a/syft/pkg/cataloger/redhat/package_test.go
+++ b/syft/pkg/cataloger/redhat/package_test.go
@@ -43,7 +43,7 @@ func Test_packageURL(t *testing.T) {
 				Release: "r",
 				Epoch:   intRef(1),
 			},
-			expected: "pkg:rpm/centos/p@v-r?arch=a&epoch=1&distro=centos-7",
+			expected: "pkg:rpm/centos/p@v-r?arch=a&distro=centos-7&epoch=1",
 		},
 		{
 			name: "missing distro",
@@ -67,7 +67,7 @@ func Test_packageURL(t *testing.T) {
 				Release:   "r",
 				SourceRpm: "sourcerpm",
 			},
-			expected: "pkg:rpm/redhat/p@v-r?upstream=sourcerpm&distro=rhel-8.4",
+			expected: "pkg:rpm/redhat/p@v-r?distro=rhel-8.4&upstream=sourcerpm",
 		},
 	}
 

--- a/syft/pkg/language_test.go
+++ b/syft/pkg/language_test.go
@@ -87,7 +87,7 @@ func TestLanguageFromPURL(t *testing.T) {
 			want: Lua,
 		},
 		{
-			purl: "pkg:opam/ocaml-base-compiler@	5.2.0",
+			purl: "pkg:opam/ocaml-base-compiler@5.2.0",
 			want: OCaml,
 		},
 	}


### PR DESCRIPTION
Updates syft to use the latest changes from `anchore/packageurl-go`.
