### PR TITLE
Expose option to scan without indexing 

### DIFF
--- a/cmd/syft/internal/commands/scan.go
+++ b/cmd/syft/internal/commands/scan.go
@@ -224,7 +224,8 @@ func getSource(ctx context.Context, opts *options.Catalog, userInput string, sou
 		}).
 		WithBasePath(opts.Source.BasePath).
 		WithSources(sources...).
-		WithDefaultImagePullSource(opts.Source.Image.DefaultPullSource)
+		WithDefaultImagePullSource(opts.Source.Image.DefaultPullSource).
+		WithUnindexed(opts.Unindexed)
 
 	var err error
 	var platform *image.Platform

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -53,6 +53,7 @@ type Catalog struct {
 	Platform   string         `yaml:"platform" json:"platform" mapstructure:"platform"`
 	Source     sourceConfig   `yaml:"source" json:"source" mapstructure:"source"`
 	Exclusions []string       `yaml:"exclude" json:"exclude" mapstructure:"exclude"`
+	Unindexed  bool           `yaml:"unindexed" json:"unindexed" mapstructure:"unindexed"`
 
 	// configuration for inclusion of unknown information within elements
 	Unknowns unknownsConfig `yaml:"unknowns" mapstructure:"unknowns"`
@@ -228,6 +229,9 @@ func (cfg *Catalog) AddFlags(flags clio.FlagSet) {
 
 	flags.StringVarP(&cfg.Source.BasePath, "base-path", "",
 		"base directory for scanning, no links will be followed above this directory, and all paths will be reported relative to this directory")
+
+	flags.BoolVarP(&cfg.Unindexed, "unindexed", "",
+		"whether to index the file system or not, indexing can improve scan times but incurs a memory overhead, default false.")
 }
 
 func (cfg *Catalog) DescribeFields(descriptions fangs.FieldDescriptionSet) {

--- a/syft/get_source_config.go
+++ b/syft/get_source_config.go
@@ -26,6 +26,11 @@ func (c *GetSourceConfig) WithAlias(alias source.Alias) *GetSourceConfig {
 	return c
 }
 
+func (c *GetSourceConfig) WithUnindexed(unindexed bool) *GetSourceConfig {
+	c.SourceProviderConfig = c.SourceProviderConfig.WithUnindexed(unindexed)
+	return c
+}
+
 func (c *GetSourceConfig) WithRegistryOptions(registryOptions *image.RegistryOptions) *GetSourceConfig {
 	c.SourceProviderConfig = c.SourceProviderConfig.WithRegistryOptions(registryOptions)
 	return c

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -18,30 +18,33 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/afero"
 
+	stereoscopeFile "github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"
+	syftFile "github.com/anchore/syft/syft/file"
 )
 
-var _ file.Resolver = (*UnindexedDirectory)(nil)
-var _ file.WritableResolver = (*UnindexedDirectory)(nil)
+var _ syftFile.Resolver = (*UnindexedDirectory)(nil)
+var _ syftFile.WritableResolver = (*UnindexedDirectory)(nil)
 
 type UnindexedDirectory struct {
-	ls   afero.Lstater
-	lr   afero.LinkReader
-	base string
-	dir  string
-	fs   afero.Fs
+	ls          afero.Lstater
+	lr          afero.LinkReader
+	base        string
+	dir         string
+	fs          afero.Fs
+	pathFilters []PathIndexVisitor
 }
 
-func NewFromUnindexedDirectory(dir string) file.WritableResolver {
+func NewFromUnindexedDirectory(dir string) syftFile.WritableResolver {
 	return NewFromUnindexedDirectoryFS(afero.NewOsFs(), dir, "")
 }
 
-func NewFromRootedUnindexedDirectory(dir string, base string) file.WritableResolver {
-	return NewFromUnindexedDirectoryFS(afero.NewOsFs(), dir, base)
+func NewFromRootedUnindexedDirectory(dir string, base string, pathVisitors ...PathIndexVisitor) syftFile.WritableResolver {
+	return NewFromUnindexedDirectoryFS(afero.NewOsFs(), dir, base, pathVisitors...)
 }
 
-func NewFromUnindexedDirectoryFS(fs afero.Fs, dir string, base string) file.WritableResolver {
+func NewFromUnindexedDirectoryFS(fs afero.Fs, dir string, base string, pathVisitors ...PathIndexVisitor) syftFile.WritableResolver {
 	ls, ok := fs.(afero.Lstater)
 	if !ok {
 		panic(fmt.Sprintf("unable to get afero.Lstater interface from: %+v", fs))
@@ -70,15 +73,16 @@ func NewFromUnindexedDirectoryFS(fs afero.Fs, dir string, base string) file.Writ
 		}
 	}
 	return UnindexedDirectory{
-		base: base,
-		dir:  dir,
-		fs:   fs,
-		ls:   ls,
-		lr:   lr,
+		base:        base,
+		dir:         dir,
+		fs:          fs,
+		ls:          ls,
+		lr:          lr,
+		pathFilters: pathVisitors,
 	}
 }
 
-func (u UnindexedDirectory) FileContentsByLocation(location file.Location) (io.ReadCloser, error) {
+func (u UnindexedDirectory) FileContentsByLocation(location syftFile.Location) (io.ReadCloser, error) {
 	p := u.absPath(u.scrubInputPath(location.RealPath))
 	f, err := u.fs.Open(p)
 	if err != nil {
@@ -149,11 +153,11 @@ func (u UnindexedDirectory) absPath(p string) string {
 
 // - full symlink resolution should be performed on all requests
 // - only returns locations to files (NOT directories)
-func (u UnindexedDirectory) FilesByPath(paths ...string) (out []file.Location, _ error) {
+func (u UnindexedDirectory) FilesByPath(paths ...string) (out []syftFile.Location, _ error) {
 	return u.filesByPath(true, false, paths...)
 }
 
-func (u UnindexedDirectory) filesByPath(resolveLinks bool, includeDirs bool, paths ...string) (out []file.Location, _ error) {
+func (u UnindexedDirectory) filesByPath(resolveLinks bool, includeDirs bool, paths ...string) (out []syftFile.Location, _ error) {
 	// sort here for stable output
 	sort.Strings(paths)
 nextPath:
@@ -183,11 +187,11 @@ nextPath:
 // - full symlink resolution should be performed on all requests
 // - if multiple paths to the same file are found, the best single match should be returned
 // - only returns locations to files (NOT directories)
-func (u UnindexedDirectory) FilesByGlob(patterns ...string) (out []file.Location, _ error) {
+func (u UnindexedDirectory) FilesByGlob(patterns ...string) (out []syftFile.Location, _ error) {
 	return u.filesByGlob(true, false, patterns...)
 }
 
-func (u UnindexedDirectory) filesByGlob(resolveLinks bool, includeDirs bool, patterns ...string) (out []file.Location, _ error) {
+func (u UnindexedDirectory) filesByGlob(resolveLinks bool, includeDirs bool, patterns ...string) (out []syftFile.Location, _ error) {
 	f := unindexedDirectoryResolverFS{
 		u: u,
 	}
@@ -206,13 +210,62 @@ func (u UnindexedDirectory) filesByGlob(resolveLinks bool, includeDirs bool, pat
 	return u.filesByPath(resolveLinks, includeDirs, paths...)
 }
 
-func (u UnindexedDirectory) FilesByMIMEType(_ ...string) ([]file.Location, error) {
-	panic("FilesByMIMEType unsupported")
+// FilesByMIMEType fetches all of the files which match the provided MIME types.
+// This requires walking the filetree from u.base and checking the MIME type of each file we encounter
+// Handling of errors while walking is ignored unless a filterFn wants the directory to be skipped.
+func (u UnindexedDirectory) FilesByMIMEType(types ...string) ([]syftFile.Location, error) {
+	uniqueLocations := make([]file.Location, 0)
+	// TODO: For now we use afero.Walk here to walk the entire dir tree, but we know that when a single directory
+	// contains many files this will cause us to run OOM due to how Golang provides lexical ordering guarantees by reading the entire dir into memory..
+	// That can be fixed by using a custom walk func that uses Readdir(N) where N >=1 so that the entire directory isn't read into
+	// memory each time...
+
+	err := afero.Walk(u.fs, u.absPath(u.base), func(p string, fi fs.FileInfo, walkErr error) error {
+		// Tidy the path, same as AllLocations
+		p = strings.TrimPrefix(p, u.dir)
+		if p == "" {
+			return nil
+		}
+		p = strings.TrimPrefix(p, "/")
+		// Ignore any path for which a filter function returns true
+		for _, filterFn := range u.pathFilters {
+			if filterFn == nil {
+				continue
+			}
+
+			if filterErr := filterFn(u.base, p, fi, walkErr); filterErr != nil {
+				if errors.Is(filterErr, fs.SkipDir) {
+					// signal to walk() to skip this directory entirely (even if we're processing a file)
+					return filterErr
+				}
+				// skip this path but don't affect walk() trajectory
+				return nil
+			}
+		}
+
+		// If we get here, then the MIME type of the file should be checked
+		mimeType := stereoscopeFile.NewMetadataFromPath(p, fi).MIMEType
+		for _, mType := range types {
+			if mimeType == mType {
+				uniqueLocations = append(uniqueLocations, syftFile.NewLocation(p))
+			}
+		}
+
+		// Continue to walk()
+		return nil
+	})
+
+	if err != nil {
+		log.Debug(err)
+		return nil, err
+	}
+
+	return uniqueLocations, nil
 }
 
 // RelativeFileByPath fetches a single file at the given path relative to the layer squash of the given reference.
 // This is helpful when attempting to find a file that is in the same layer or lower as another file.
-func (u UnindexedDirectory) RelativeFileByPath(l file.Location, p string) *file.Location {
+func (u UnindexedDirectory) RelativeFileByPath(l syftFile.Location, p string) *syftFile.Location {
 	p = path.Clean(path.Join(l.RealPath, p))
 	locs, err := u.filesByPath(true, false, p)
 	if err != nil || len(locs) == 0 {
@@ -228,8 +281,8 @@ func (u UnindexedDirectory) RelativeFileByPath(l file.Location, p string) *file.
 
 // - NO symlink resolution should be performed on results
 // - returns locations for any file or directory
-func (u UnindexedDirectory) AllLocations(ctx context.Context) <-chan file.Location {
-	out := make(chan file.Location)
+func (u UnindexedDirectory) AllLocations(ctx context.Context) <-chan syftFile.Location {
+	out := make(chan syftFile.Location)
 	errWalkCanceled := fmt.Errorf("walk canceled")
 	go func() {
 		defer close(out)
@@ -240,7 +293,7 @@ func (u UnindexedDirectory) AllLocations(ctx context.Context) <-chan file.Locati
 			}
 			p = strings.TrimPrefix(p, "/")
 			select {
-			case out <- file.NewLocation(p):
+			case out <- syftFile.NewLocation(p):
 				return nil
 			case <-ctx.Done():
 				return errWalkCanceled
@@ -253,11 +306,18 @@ func (u UnindexedDirectory) AllLocations(ctx context.Context) <-chan file.Locati
 	return out
 }
 
-func (u UnindexedDirectory) FileMetadataByLocation(_ file.Location) (file.Metadata, error) {
-	panic("FileMetadataByLocation unsupported")
+func (u UnindexedDirectory) FileMetadataByLocation(loc syftFile.Location) (syftFile.Metadata, error) {
+	p := u.absPath(u.scrubInputPath(loc.RealPath))
+	finfo, err := u.fs.Stat(p)
+	if err != nil {
+		return syftFile.Metadata{}, err
+	}
+
+	metadata := stereoscopeFile.NewMetadataFromPath(p, finfo)
+	return metadata, nil
 }
 
-func (u UnindexedDirectory) Write(location file.Location, reader io.Reader) error {
+func (u UnindexedDirectory) Write(location syftFile.Location, reader io.Reader) error {
 	filePath := location.RealPath
 	if path.IsAbs(filePath) {
 		filePath = filePath[1:]
@@ -266,7 +326,7 @@ func (u UnindexedDirectory) Write(location file.Location, reader io.Reader) erro
 	return afero.WriteReader(u.fs, absPath, reader)
 }
 
-func (u UnindexedDirectory) newLocation(filePath string, resolveLinks bool) *file.Location {
+func (u UnindexedDirectory) newLocation(filePath string, resolveLinks bool) *syftFile.Location {
 	filePath = path.Clean(filePath)
 
 	virtualPath := filePath
@@ -287,7 +347,7 @@ func (u UnindexedDirectory) newLocation(filePath string, resolveLinks bool) *fil
 		}
 	}
 
-	l := file.NewVirtualLocation(realPath, virtualPath)
+	l := syftFile.NewVirtualLocation(realPath, virtualPath)
 	return &l
 }
 

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -221,12 +221,6 @@ func (u UnindexedDirectory) FilesByMIMEType(types ...string) ([]syftFile.Locatio
 	// memory each time...
 
 	err := afero.Walk(u.fs, u.absPath(u.base), func(p string, fi fs.FileInfo, walkErr error) error {
-		// Tidy the path, same as AllLocations
-		p = strings.TrimPrefix(p, u.dir)
-		if p == "" {
-			return nil
-		}
-		p = strings.TrimPrefix(p, "/")
 		// Ignore any path for which a filter function returns true
 		for _, filterFn := range u.pathFilters {
 			if filterFn == nil {
@@ -247,6 +241,12 @@ func (u UnindexedDirectory) FilesByMIMEType(types ...string) ([]syftFile.Locatio
 		mimeType := stereoscopeFile.NewMetadataFromPath(p, fi).MIMEType
 		for _, mType := range types {
 			if mimeType == mType {
+				// Tidy the path, same as AllLocations
+				p = strings.TrimPrefix(p, u.dir)
+				if p == "" {
+					return nil
+				}
+				p = strings.TrimPrefix(p, "/")
 				uniqueLocations = append(uniqueLocations, syftFile.NewLocation(p))
 			}
 		}

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -20,7 +20,6 @@ import (
 
 	stereoscopeFile "github.com/anchore/stereoscope/pkg/file"
 	"github.com/anchore/syft/internal/log"
-	"github.com/anchore/syft/syft/file"
 	syftFile "github.com/anchore/syft/syft/file"
 )
 
@@ -214,7 +213,7 @@ func (u UnindexedDirectory) filesByGlob(resolveLinks bool, includeDirs bool, pat
 // This requires walking the filetree from u.base and checking the MIME type of each file we encounter
 // Handling of errors while walking is ignored unless a filterFn wants the directory to be skipped.
 func (u UnindexedDirectory) FilesByMIMEType(types ...string) ([]syftFile.Location, error) {
-	uniqueLocations := make([]file.Location, 0)
+	uniqueLocations := make([]syftFile.Location, 0)
 	// TODO: For now we use afero.Walk here to walk the entire dir tree, but we know that when a single directory
 	// contains many files this will cause us to run OOM due to how Golang provides lexical ordering guarantees by reading the entire dir into memory..
 	// That can be fixed by using a custom walk func that uses Readdir(N) where N >=1 so that the entire directory isn't read into

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -265,7 +265,7 @@ func (u UnindexedDirectory) FilesByMIMEType(types ...string) ([]syftFile.Locatio
 // RelativeFileByPath fetches a single file at the given path relative to the layer squash of the given reference.
 // This is helpful when attempting to find a file that is in the same layer or lower as another file.
 func (u UnindexedDirectory) RelativeFileByPath(l syftFile.Location, p string) *syftFile.Location {
-	p = path.Clean(path.Join(l.RealPath, p))
+	p = path.Clean(p)
 	locs, err := u.filesByPath(true, false, p)
 	if err != nil || len(locs) == 0 {
 		return nil

--- a/syft/internal/fileresolver/unindexed_directory_test.go
+++ b/syft/internal/fileresolver/unindexed_directory_test.go
@@ -1271,6 +1271,31 @@ func Test_WritableUnindexedDirectoryResolver(t *testing.T) {
 	require.Equal(t, c, string(bytes))
 }
 
+func Test_UnindexedDirectoryResolver_FilesByMIMEType(t *testing.T) {
+	tests := []struct {
+		fixturePath   string
+		mimeType      string
+		expectedPaths *strset.Set
+	}{
+		{
+			fixturePath:   "./test-fixtures/image-simple",
+			mimeType:      "text/plain",
+			expectedPaths: strset.New("file-1.txt", "file-2.txt", "target/really/nested/file-3.txt", "Dockerfile"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.fixturePath, func(t *testing.T) {
+			resolver := NewFromUnindexedDirectory(test.fixturePath)
+			locations, err := resolver.FilesByMIMEType(test.mimeType)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedPaths.Size(), len(locations))
+			for _, l := range locations {
+				assert.True(t, test.expectedPaths.Has(l.RealPath), "does not have path %q", l.RealPath)
+			}
+		})
+	}
+}
+
 func testWithTimeout(t *testing.T, timeout time.Duration, test func(*testing.T)) {
 	done := make(chan bool)
 	go func() {

--- a/syft/internal/fileresolver/unindexed_directory_test.go
+++ b/syft/internal/fileresolver/unindexed_directory_test.go
@@ -1296,6 +1296,30 @@ func Test_UnindexedDirectoryResolver_FilesByMIMEType(t *testing.T) {
 	}
 }
 
+func Test_UnindexedDirectoryResolver_RelativeFileByPath(t *testing.T) {
+	cases := []struct {
+		name       string
+		root       string
+		searchFile string
+		expected   *strset.Set
+	}{
+		{
+			name:       "should find nested file from root",
+			root:       "./test-fixtures/image-simple",
+			searchFile: "target/really/nested/file-3.txt",
+			expected:   strset.New("file-3.txt"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resolver := NewFromUnindexedDirectory(c.root)
+			rootLoc := file.NewLocation(c.root)
+			loc := resolver.RelativeFileByPath(rootLoc, c.searchFile)
+			assert.True(t, c.expected.Has(loc.Coordinates.RealPath), "does not have path %q", loc.RealPath)
+		})
+	}
+}
+
 func testWithTimeout(t *testing.T, timeout time.Duration, test func(*testing.T)) {
 	done := make(chan bool)
 	go func() {

--- a/syft/source/directorysource/directory_source_provider.go
+++ b/syft/source/directorysource/directory_source_provider.go
@@ -10,20 +10,22 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-func NewSourceProvider(path string, exclude source.ExcludeConfig, alias source.Alias, basePath string) source.Provider {
+func NewSourceProvider(path string, exclude source.ExcludeConfig, alias source.Alias, basePath string, unindexed bool) source.Provider {
 	return &directorySourceProvider{
-		path:     path,
-		basePath: basePath,
-		exclude:  exclude,
-		alias:    alias,
+		path:      path,
+		basePath:  basePath,
+		exclude:   exclude,
+		alias:     alias,
+		unindexed: unindexed,
 	}
 }
 
 type directorySourceProvider struct {
-	path     string
-	basePath string
-	exclude  source.ExcludeConfig
-	alias    source.Alias
+	path      string
+	basePath  string
+	exclude   source.ExcludeConfig
+	alias     source.Alias
+	unindexed bool
 }
 
 func (l directorySourceProvider) Name() string {
@@ -48,10 +50,11 @@ func (l directorySourceProvider) Provide(_ context.Context) (source.Source, erro
 
 	return New(
 		Config{
-			Path:    location,
-			Base:    basePath(l.basePath, location),
-			Exclude: l.exclude,
-			Alias:   l.alias,
+			Path:      location,
+			Base:      basePath(l.basePath, location),
+			Exclude:   l.exclude,
+			Alias:     l.alias,
+			Unindexed: l.unindexed,
 		},
 	)
 }

--- a/syft/source/directorysource/directory_source_test.go
+++ b/syft/source/directorysource/directory_source_test.go
@@ -85,6 +85,25 @@ func TestNewFromDirectory(t *testing.T) {
 	}
 }
 
+func Test_NewFromDirectory_Unindexed(t *testing.T) {
+	testutil.Chdir(t, "..") // run with source/test-fixtures
+
+	cfg := Config{
+		Path:      "test-fixtures",
+		Unindexed: true,
+	}
+
+	src, err := New(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, src.Close())
+	})
+
+	resolver, err := src.FileResolver("")
+	require.NoError(t, err)
+	require.IsType(t, fileresolver.UnindexedDirectory{}, resolver)
+}
+
 func Test_DirectorySource_FilesByGlob(t *testing.T) {
 	testutil.Chdir(t, "..") // run with source/test-fixtures
 

--- a/syft/source/sourceproviders/source_provider_config.go
+++ b/syft/source/sourceproviders/source_provider_config.go
@@ -15,10 +15,16 @@ type Config struct {
 	Exclude          source.ExcludeConfig
 	DigestAlgorithms []crypto.Hash
 	BasePath         string
+	Unindexed        bool
 }
 
 func (c *Config) WithAlias(alias source.Alias) *Config {
 	c.Alias = alias
+	return c
+}
+
+func (c *Config) WithUnindexed(unindexed bool) *Config {
+	c.Unindexed = unindexed
 	return c
 }
 

--- a/syft/source/sourceproviders/source_providers.go
+++ b/syft/source/sourceproviders/source_providers.go
@@ -27,7 +27,7 @@ func All(userInput string, cfg *Config) []collections.TaggedValue[source.Provide
 		// --from file, dir, oci-archive, etc.
 		Join(stereoscopeProviders.Select(FileTag, DirTag)...).
 		Join(tagProvider(filesource.NewSourceProvider(userInput, cfg.Exclude, cfg.DigestAlgorithms, cfg.Alias), FileTag)).
-		Join(tagProvider(directorysource.NewSourceProvider(userInput, cfg.Exclude, cfg.Alias, cfg.BasePath), DirTag)).
+		Join(tagProvider(directorysource.NewSourceProvider(userInput, cfg.Exclude, cfg.Alias, cfg.BasePath, cfg.Unindexed), DirTag)).
 
 		// --from docker, registry, etc.
 		Join(stereoscopeProviders.Select(PullTag)...)


### PR DESCRIPTION
# Description

There was some discussion recently regarding supporting scanning without indexing in this [issue](https://github.com/anchore/syft/issues/3145)

In that issue, the main complaint is related to the **time** taken to scan.

The most promising solution presented was:
```
[most promising] Allow the user to opt into non-** globs only and use the unindexed resolver. We'd want to be able to be loud in terms of logging/UI when a ** glob is used when in an "unindexed" mode. This has a few variants, such as:
a. for select catalogers (primarily OS ones) have hard coded absolute paths to common DB locations (inflexible but simple)
b. expose glob-level configuration for all catalogers, allowing the user to extend or override the globs that are searched for (flexible but potentially dangerous)
```

However, on memory constrained systems with large disks, file system indexing can use considerable memory. 

I am raising this PR as I'd like to propose exposing the unindexed resolver, as a form of preferring slower scan times in favour of lower memory usage. 

As a result, I would like to propose getting this change in without the added complexity of `Allow the user to opt into non-** globs`. Perhaps adding that is a reasonable next step as part of a follow up PR?

This does not necessarily fix https://github.com/anchore/syft/issues/3145 as it will not improve their scan times, however it will allow for reduced memory imapct on memory constrained systems.

As part of this change, I've changed the behaviour of `RelativeFileByPath` and added a unit test, the existing implementation didn't seem to work. When `package.go::fetchMd5Contents` ran with the unindexed resolver it did not resolve correctly because the `location` field passed into the function points at the DPKG `status` file, so the existing code which tried to do `path.Clean(path.Join(l.RealPath, p))` wound up trying to join something like `/var/lib/dpkg/status` with `/info` to search `/var/ib/dpkg/status/info` which is incorrect as we want `/var/lib/dpkg/info`.

One other thing I've noticed while testing this change is that I get more 'location' files for DPKG than the indexed resolver, however I'm not sure this is a bug, perhaps there is a bug with the existing indexed resolver?

With the indexed resolver, I get these locations for one of my DPKG artifacts:
```
      "locations": [
        {
          "path": "var/lib/dpkg/info/acpid.conffiles",
          "accessPath": "var/lib/dpkg/info/acpid.conffiles",
          "annotations": {
            "evidence": "supporting"
          }
        },
        {
          "path": "var/lib/dpkg/info/acpid.md5sums",
          "accessPath": "var/lib/dpkg/info/acpid.md5sums",
          "annotations": {
            "evidence": "supporting"
          }
        },
        {
          "path": "var/lib/dpkg/status",
          "accessPath": "var/lib/dpkg/status",
          "annotations": {
            "evidence": "primary"
          }
        }
      ],
```

With the unindexed resolver, I get these locations for the same DPKG artifact:
```
      "locations": [
        {
          "path": "var/lib/dpkg/info/acpid.conffiles",
          "accessPath": "var/lib/dpkg/info/acpid.conffiles",
          "annotations": {
            "evidence": "supporting"
          }
        },
        {
          "path": "var/lib/dpkg/info/acpid.list",
          "accessPath": "var/lib/dpkg/info/acpid.list"
        },
        {
          "path": "var/lib/dpkg/info/acpid.md5sums",
          "accessPath": "var/lib/dpkg/info/acpid.md5sums",
          "annotations": {
            "evidence": "supporting"
          }
        },
        {
          "path": "var/lib/dpkg/info/acpid.postinst",
          "accessPath": "var/lib/dpkg/info/acpid.postinst"
        },
        {
          "path": "var/lib/dpkg/info/acpid.postrm",
          "accessPath": "var/lib/dpkg/info/acpid.postrm"
        },
        {
          "path": "var/lib/dpkg/info/acpid.preinst",
          "accessPath": "var/lib/dpkg/info/acpid.preinst"
        },
        {
          "path": "var/lib/dpkg/info/acpid.prerm",
          "accessPath": "var/lib/dpkg/info/acpid.prerm"
        },
        {
          "path": "var/lib/dpkg/status",
          "accessPath": "var/lib/dpkg/status",
          "annotations": {
            "evidence": "primary"
          }
        }
      ],
```

The difference in behaviour relates to `parse_dpkg_db.go::findDpkgInfoFiles` and this call in particular:
```go
        // look for /var/lib/dpkg/info/NAME.*
	locations, err := resolver.FilesByGlob(path.Join(searchPath, name+".*"))
```

Here we pass something like:
- searchPath = `/var/lib/dpkg/info/`
- name + .* = `acpid.*`

Giving us a `FilesByGlob` path of `var/lib/dpkg/info/acpid.*`

On my system, I believe we should be matching all of these:
```
$ find ./var/lib/dpkg/info -name 'acpid.*'
./var/lib/dpkg/info/acpid.postinst
./var/lib/dpkg/info/acpid.md5sums
./var/lib/dpkg/info/acpid.postrm
./var/lib/dpkg/info/acpid.prerm
./var/lib/dpkg/info/acpid.preinst
./var/lib/dpkg/info/acpid.conffiles
./var/lib/dpkg/info/acpid.list
```

However, with the indexed directory resolver the pattern `var/lib/dpkg/info/acpid.*` gets converted in the `r.chroot.ToNativeGlob(pattern)` call to `/var/lib/dpkg/info/acpid./*` which returns no matches. This explains why the indexed resolver doesn't find locations like `acpid.prerm` in the output. The `md5sums` and `conffiles` are found by `package.go::fetchMd5Contents` and `package.go::fetchConffileContents` respectively and they use `RelativeFileByPath` which explains why they still work.

Maybe I'm unclear on what `FilesByGlob` _should_ be returning here, and perhaps the issue is with the existing unindexed_directory impl, but I'd like to get some clarification on what we expect the behaviour to be here.

## Type of change
<!-- Delete any that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:
- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections