### PR TITLE
Expanded dpkg cataloger globs to search outside of /var

### DIFF
--- a/syft/pkg/cataloger/debian/cataloger.go
+++ b/syft/pkg/cataloger/debian/cataloger.go
@@ -14,6 +14,6 @@ func NewDBCataloger() pkg.Cataloger {
 	return generic.NewCataloger("dpkg-db-cataloger").
 		// note: these globs have been intentionally split up in order to improve search performance,
 		// please do NOT combine into: "**/var/lib/dpkg/{status,status.d/*}"
-		WithParserByGlobs(parseDpkgDB, "**/var/lib/dpkg/status", "**/var/lib/dpkg/status.d/*", "**/lib/opkg/info/*.control", "**/lib/opkg/status").
+		WithParserByGlobs(parseDpkgDB, "**/lib/dpkg/status", "**/lib/dpkg/status.d/*", "**/lib/opkg/info/*.control", "**/lib/opkg/status").
 		WithProcessors(dependency.Processor(dbEntryDependencySpecifier))
 }

--- a/syft/pkg/cataloger/debian/cataloger_test.go
+++ b/syft/pkg/cataloger/debian/cataloger_test.go
@@ -234,10 +234,12 @@ func TestCataloger_Globs(t *testing.T) {
 			name:    "obtain db status files",
 			fixture: "test-fixtures/glob-paths",
 			expected: []string{
+				"usr/lib/dpkg/status",
 				"var/lib/dpkg/status",
+				"usr/lib/dpkg/status.d/pkg-1.0",
 				"var/lib/dpkg/status.d/pkg-1.0",
-				"usr/lib/opkg/status",
 				"usr/lib/opkg/info/pkg-1.0.control",
+				"usr/lib/opkg/status",
 			},
 		},
 	}

--- a/syft/pkg/cataloger/debian/test-fixtures/glob-paths/usr/lib/dpkg/status
+++ b/syft/pkg/cataloger/debian/test-fixtures/glob-paths/usr/lib/dpkg/status
@@ -1,0 +1,1 @@
+bogus status

--- a/syft/pkg/cataloger/debian/test-fixtures/glob-paths/usr/lib/dpkg/status.d/pkg-1.0
+++ b/syft/pkg/cataloger/debian/test-fixtures/glob-paths/usr/lib/dpkg/status.d/pkg-1.0
@@ -1,0 +1,1 @@
+bogus package


### PR DESCRIPTION
# Description

This expands the globs handled by the debian cataloger to include `dpkg/status` and `dpkg/status.d` files that are found in directories not located under `var`. This has been observed 'in the wild' in several instances, in which case Syft failed to parse the available package information.

- Fixes #2692

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] I have added unit tests that cover changed behavior
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections
