### PR TITLE
fix: malformed pom.xml may cause recursive loop

### DIFF
--- a/syft/pkg/cataloger/java/internal/maven/test-fixtures/local/circular-1/pom.xml
+++ b/syft/pkg/cataloger/java/internal/maven/test-fixtures/local/circular-1/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+
+  <parent>
+    <groupId>my.org</groupId>
+    <artifactId>circular</artifactId>
+    <version>1.2.3</version>
+  </parent>
+</project>

--- a/syft/pkg/cataloger/java/internal/maven/test-fixtures/local/circular-2/pom.xml
+++ b/syft/pkg/cataloger/java/internal/maven/test-fixtures/local/circular-2/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>something</artifactId>
+  <version>${unresolvable}</version>
+
+  <parent>
+    <groupId>my.org</groupId>
+    <artifactId>circular</artifactId>
+    <version>1.2.3</version>
+  </parent>
+</project>

--- a/syft/pkg/cataloger/java/internal/maven/test-fixtures/maven-repo/my/org/circular/1.2.3/circular-1.2.3.pom
+++ b/syft/pkg/cataloger/java/internal/maven/test-fixtures/maven-repo/my/org/circular/1.2.3/circular-1.2.3.pom
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>circular</artifactId>
+  <version>1.2.3</version>
+
+  <parent>
+    <groupId>my.org</groupId>
+    <artifactId>circular</artifactId>
+    <version>1.2.3</version>
+  </parent>
+</project>


### PR DESCRIPTION
# Description

This PR corrects a case where certain malformed pom.xml files could cause an infinite loop.

This was reported [on Discourse](https://anchorecommunity.discourse.group/t/syft-process-getting-hung/197)

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
