### PR TITLE
fix: stack overflow in spyingIoReadCloser

### DIFF
--- a/syft/pkg/cataloger/generic/cataloger_test.go
+++ b/syft/pkg/cataloger/generic/cataloger_test.go
@@ -108,7 +108,7 @@ func newSpyReturningFileResolver(s *spyingIoReadCloser, paths ...string) file.Re
 }
 
 func (s *spyingIoReadCloser) Read(p []byte) (n int, err error) {
-	return s.Read(p)
+	return s.rc.Read(p)
 }
 
 func (s *spyingIoReadCloser) Close() error {


### PR DESCRIPTION
# Description

Corrects infinite recursion in test utility.

- Fixes #3379

## Type of change

<!-- Delete any that are not relevant -->

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
