### PR TITLE
Issue #3143 – fixed format conversion docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+change
 <p align="center">
     <img src="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png" width="271" alt="Cute pink owl syft logo">
 </p>

--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ Where the `formats` available are:
 
 Note that flags using the @<version> can be used for earlier versions of each specification as well.
 
+## Format conversion (experimental)
+The ability to convert existing SBOMs means you can create SBOMs in different formats quickly, without the need to regenerate the SBOM from scratch, which may take significantly more time.
+
+```sh
+syft convert [SOURCE-SBOM] -o [FORMAT] [flags]
+```
+
+This feature is experimental and data might be lost when converting formats. Packages are the main SBOM component easily transferable across formats, whereas files and relationships, as well as other information Syft doesn't support, are more likely to be lost.
+We support formats with wide community usage AND good encode/decode support by Syft. The supported formats are:
+- Syft JSON (```-o syft-json```)
+- SPDX 2.2 JSON (```-o spdx-json```)
+- SPDX 2.2 tag-value (```-o spdx-tag-value```)
+- CycloneDX 1.4 JSON (```-o cyclonedx-json```)
+- CycloneDX 1.4 XML (```-o cyclonedx-xml```)
+Conversion example:
+
+```sh
+syft convert img.syft.json -o spdx-json                      # convert a syft SBOM to spdx-json, output goes to stdout
+syft convert img.syft.json -o cyclonedx-json=img.cdx.json    # convert a syft SBOM to CycloneDX, output is written to the file img.cdx.json
+syft convert - -o spdx-json                                  # convert an SBOM from STDIN to spdx-json
+```
+
 ### Supported Ecosystems
 
 - Alpine (apk)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-change
 <p align="center">
     <img src="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png" width="271" alt="Cute pink owl syft logo">
 </p>

--- a/cmd/syft/internal/commands/convert.go
+++ b/cmd/syft/internal/commands/convert.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	convertExample = `  {{.appName}} {{.command}} img.syft.json -o spdx-json                      convert a syft SBOM to spdx-json, output goes to stdout
-  {{.appName}} {{.command}} img.syft.json -o cyclonedx-json=img.cdx.json    convert a syft SBOM to CycloneDX, output is written to the file "img.cdx.json""
+  {{.appName}} {{.command}} img.syft.json -o cyclonedx-json=img.cdx.json    convert a syft SBOM to CycloneDX, output is written to the file "img.cdx.json"
   {{.appName}} {{.command}} - -o spdx-json                                  convert an SBOM from STDIN to spdx-json
 `
 )
@@ -39,7 +39,7 @@ func Convert(app clio.Application) *cobra.Command {
 	return app.SetupCommand(&cobra.Command{
 		Use:   "convert [SOURCE-SBOM] -o [FORMAT]",
 		Short: "Convert between SBOM formats",
-		Long:  "[Experimental] Convert SBOM files to, and from, SPDX, CycloneDX and Syft's format. For more info about data loss between formats see https://github.com/anchore/syft#format-conversion-experimental",
+		Long:  "[Experimental] Convert SBOM files to, and from, SPDX, CycloneDX and Syft's format. For more info about data loss between formats see https://github.com/anchore/syft/tree/main?tab=readme-ov-file#format-conversion-experimental",
 		Example: internal.Tprintf(convertExample, map[string]interface{}{
 			"appName": id.Name,
 			"command": "convert",


### PR DESCRIPTION
# Description

Brought back the `Format conversion` documentation. The documentation of this feature was removed in commit 49c458b (May 20th, 2024) and was supposed to appear in the repository's wiki.

- Fixes #3143

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
