### PR TITLE
chore: update executor back to default of not bubbling errors to main flow

### DIFF
--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -73,7 +73,7 @@ func (p *Executor) Execute(ctx context.Context, resolver file.Resolver, s sbomsy
 						prog.SetError(err)
 					})
 				}
-			
+
 				prog.Increment()
 			}
 		}()

--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"sync"
 	"time"
 
@@ -84,7 +85,13 @@ func appendUnknowns(builder sbomsync.Builder, taskName string, unknowns []unknow
 				if sb.Artifacts.Unknowns == nil {
 					sb.Artifacts.Unknowns = map[file.Coordinates][]string{}
 				}
-				sb.Artifacts.Unknowns[u.Coordinates] = append(sb.Artifacts.Unknowns[u.Coordinates], formatUnknown(u.Reason.Error(), taskName))
+				unknownText := formatUnknown(u.Reason.Error(), taskName)
+				existing := sb.Artifacts.Unknowns[u.Coordinates]
+				// don't include duplicate unknowns
+				if slices.Contains(existing, unknownText) {
+					continue
+				}
+				sb.Artifacts.Unknowns[u.Coordinates] = append(existing, unknownText)
 			}
 		})
 	}

--- a/internal/task/executor.go
+++ b/internal/task/executor.go
@@ -81,7 +81,7 @@ func (p *Executor) Execute(ctx context.Context, resolver file.Resolver, s sbomsy
 
 	wg.Wait()
 
-	return nil
+	return errs
 }
 
 func appendUnknowns(builder sbomsync.Builder, taskName string, unknowns []unknown.CoordinateError) {

--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -103,6 +103,9 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 		t := bus.StartCatalogerTask(info, -1, "")
 
 		pkgs, relationships, err := c.Catalog(ctx, resolver)
+		if err != nil {
+			return fmt.Errorf("unable to catalog packages with %q: %w", catalogerName, err)
+		}
 
 		log.WithFields("cataloger", catalogerName).Debugf("discovered %d packages", len(pkgs))
 
@@ -117,7 +120,7 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 		t.SetCompleted()
 		log.WithFields("name", catalogerName).Trace("package cataloger completed")
 
-		return err
+		return nil
 	}
 	tags = append(tags, pkgcataloging.PackageTag)
 

--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -103,9 +103,6 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 		t := bus.StartCatalogerTask(info, -1, "")
 
 		pkgs, relationships, err := c.Catalog(ctx, resolver)
-		if err != nil {
-			return fmt.Errorf("unable to catalog packages with %q: %w", catalogerName, err)
-		}
 
 		log.WithFields("cataloger", catalogerName).Debugf("discovered %d packages", len(pkgs))
 
@@ -120,7 +117,7 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 		t.SetCompleted()
 		log.WithFields("name", catalogerName).Trace("package cataloger completed")
 
-		return nil
+		return err
 	}
 	tags = append(tags, pkgcataloging.PackageTag)
 

--- a/internal/unknown/path_error.go
+++ b/internal/unknown/path_error.go
@@ -1,0 +1,33 @@
+package unknown
+
+import (
+	"regexp"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/file"
+)
+
+var pathErrorRegex = regexp.MustCompile(`.*path="([^"]+)".*`)
+
+// ProcessPathErrors replaces "path" errors returned from the file.Resolver into unknowns,
+// and warn logs non-unknown errors, returning only the unknown errors
+func ProcessPathErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+	errText := err.Error()
+	if pathErrorRegex.MatchString(errText) {
+		foundPath := pathErrorRegex.ReplaceAllString(err.Error(), "$1")
+		if foundPath != "" {
+			return New(file.NewLocation(foundPath), err)
+		}
+	}
+	unknowns, remainingErrors := ExtractCoordinateErrors(err)
+	log.Warn(remainingErrors)
+
+	var out []error
+	for _, u := range unknowns {
+		out = append(out, &u)
+	}
+	return Join(out...)
+}

--- a/internal/unknown/path_error_test.go
+++ b/internal/unknown/path_error_test.go
@@ -1,0 +1,56 @@
+package unknown
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/file"
+)
+
+func Test_ProcessPathErrors(t *testing.T) {
+	tests := []struct {
+		errorText string
+		expected  error
+	}{
+		{
+			errorText: `prefix path="/var/lib/thing" suffix`,
+			expected: &CoordinateError{
+				Coordinates: file.Coordinates{
+					RealPath: "/var/lib/thing",
+				},
+				Reason: fmt.Errorf(`prefix path="/var/lib/thing" suffix`),
+			},
+		},
+		{
+			errorText: `prefix path="/var/lib/thing"`,
+			expected: &CoordinateError{
+				Coordinates: file.Coordinates{
+					RealPath: "/var/lib/thing",
+				},
+				Reason: fmt.Errorf(`prefix path="/var/lib/thing"`),
+			},
+		},
+		{
+			errorText: `path="/var/lib/thing" suffix`,
+			expected: &CoordinateError{
+				Coordinates: file.Coordinates{
+					RealPath: "/var/lib/thing",
+				},
+				Reason: fmt.Errorf(`path="/var/lib/thing" suffix`),
+			},
+		},
+		{
+			errorText: "all your base are belong to us",
+			expected:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.errorText, func(t *testing.T) {
+			got := ProcessPathErrors(fmt.Errorf("%s", test.errorText))
+			require.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/syft/pkg/cataloger/binary/classifier_cataloger.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger.go
@@ -105,6 +105,7 @@ func catalog(resolver file.Resolver, cls Classifier) (packages []pkg.Package, er
 	var errs error
 	locations, err := resolver.FilesByGlob(cls.FileGlob)
 	if err != nil {
+		err = unknown.ProcessPathErrors(err) // convert any file.Resolver path errors to unknowns with locations
 		return nil, err
 	}
 	for _, location := range locations {

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1667,8 +1667,7 @@ func Test_Cataloger_ResilientToErrors(t *testing.T) {
 	c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 	resolver := &panicyResolver{}
-	_, _, err := c.Catalog(context.Background(), resolver)
-	assert.Error(t, err)
+	_, _, _ = c.Catalog(context.Background(), resolver)
 	assert.True(t, resolver.searchCalled)
 }
 

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1667,7 +1667,8 @@ func Test_Cataloger_ResilientToErrors(t *testing.T) {
 	c := NewClassifierCataloger(DefaultClassifierCatalogerConfig())
 
 	resolver := &panicyResolver{}
-	_, _, _ = c.Catalog(context.Background(), resolver)
+	_, _, err := c.Catalog(context.Background(), resolver)
+	assert.Nil(t, err) // non-coordinate-based FindBy* errors are now logged and not returned
 	assert.True(t, resolver.searchCalled)
 }
 

--- a/test/cli/test-fixtures/image-unknowns/Dockerfile
+++ b/test/cli/test-fixtures/image-unknowns/Dockerfile
@@ -1,3 +1,5 @@
 FROM alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33
 RUN rm -rf /lib/apk/db/installed
 COPY . /home/files
+# add a circular reference that will result in a failure while executing FindByGlob:
+RUN mkdir -p /etc/alternatives && ln -s /etc/alternatives/java2 /etc/alternatives/java && ln -s /etc/alternatives/java /etc/alternatives/java2

--- a/test/cli/unknowns_test.go
+++ b/test/cli/unknowns_test.go
@@ -22,6 +22,7 @@ func Test_Unknowns(t *testing.T) {
 				assertInOutput(`no package identified in executable file`),
 				assertInOutput(`unable to read files from java archive`),
 				assertInOutput(`no package identified in archive`),
+				assertInOutput(`cycle during symlink resolution`),
 				assertSuccessfulReturnCode,
 			},
 		},


### PR DESCRIPTION
# Description

The latest releases of syft saw a change where `err` was returned by the `executor` causing the main control flow to exit on task failure. This PR reverts this change and instead writes the errors to a multi err value which sets prog warnings in the TUI

- Fixes: NO BUG FILED

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

Behavior on latest release:
```
 ✔ Loaded image                                                                                                                                                                                                                        
 ✔ Parsed image                                                                                                                                                                                 
 ⠧ Cataloging contents             ━━━━━━━━━━━━━━━━━━━━                                                                                                                                                
   └── ⠧ Packages                        [302 packages]
failed to run tasks: 1 error occurred:
        * failed to run task: java-binary-openjdk: failed to resolve files by glob (**/java): unable to search by glob="**/java": unable to get ref for path="/etc/alternatives/java": cycle during symlink resolution
java-binary-ibm: failed to resolve files by glob (**/java): unable to search by glob="**/java": unable to get ref for path="/etc/alternatives/java": cycle during symlink resolution
java-binary-oracle: failed to resolve files by glob (**/java): unable to search by glob="**/java": unable to get ref for path="/etc/alternatives/java": cycle during symlink resolution
java-binary-graalvm: failed to resolve files by glob (**/java): unable to search by glob="**/java": unable to get ref for path="/etc/alternatives/java": cycle during symlink resolution
```

Behavior on this PR showing warnings in cataloged contents, but still produces an SBOM
```
 ✔ Loaded image                                                                                                                                                                                                                        
 ✔ Parsed image                                                                                                                                                                                 
 ✘ Cataloged contents                                                                                                                                                                                  
   ├── ✔ Packages                        [296 packages]
   ├── ✔ File digests                    [3,829 files]
   ├── ✔ File metadata                   [3,829 locations]
   └── ✔ Executables                     [998 executables]
NAME                                VERSION                            TYPE
adduser                             3.118ubuntu2                       deb
...
```
