### PR TITLE
chore: build release sbom from go.mod

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,6 +151,7 @@ jobs:
       - uses: anchore/sbom-action@251a468eed47e5082b105c3ba6ee500c0e65a764 #v0.17.6
         continue-on-error: true
         with:
+          file: go.mod
           artifact-name: sbom.spdx.json
 
       - uses: 8398a7/action-slack@28ba43ae48961b90635b50953d216767a6bea486 #v3.16.2


### PR DESCRIPTION
# Description

When generating an SBOM at release time, only target `go.mod`, not entire directory.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
