### PR TITLE
update node classifier to support 6.x

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -158,7 +158,7 @@ func DefaultClassifiers() []Classifier {
 				// [NUL]v0.12.18[NUL]
 				// [NUL]v4.9.1[NUL]
 				// node.js/v22.9.0
-				FileContentsVersionMatcher(`(?m)\x00(node )?v(?P<version>(0|4|5)\.[0-9]+\.[0-9]+)\x00`),
+				FileContentsVersionMatcher(`(?m)\x00(node )?v(?P<version>(0|4|5|6)\.[0-9]+\.[0-9]+)\x00`),
 				FileContentsVersionMatcher(`(?m)node\.js\/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
 			),
 			Package: "node",


### PR DESCRIPTION
Signed-off-by: witchcraze <witchcraze@gmail.com>

# Description

This PR is update of #3284.
Sorry, I missed 6.x series.

- Fixes #3404

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

----

```
$ go run cmd/syft/main.go -q node:6.2.2 | grep 'node '
node                          6.2.2                       binary
$ go run cmd/syft/main.go -q node:6.3.0 | grep 'node '
node                          6.3.0                       binary
$ go run cmd/syft/main.go -q node:6.4.0 | grep 'node '
node                          6.4.0                       binary
$ go run cmd/syft/main.go -q node:6.5.0 | grep 'node '
node                          6.5.0                       binary
$ go run cmd/syft/main.go -q node:6.6.0 | grep 'node '
node                          6.6.0                       binary
$ go run cmd/syft/main.go -q node:6.7.0 | grep 'node '
node                          6.7.0                       binary
$ go run cmd/syft/main.go -q node:6.8.0 | grep 'node '
node                          6.8.0                       binary
$ go run cmd/syft/main.go -q node:6.9.1 | grep 'node '
node                          6.9.1                       binary
$ go run cmd/syft/main.go -q node:6.9.2 | grep 'node '
node                          6.9.2                       binary
$ go run cmd/syft/main.go -q node:6.17 | grep 'node '
node                          6.17.1                          binary
```
