### PR TITLE
Restore log on UI teardown

### DIFF
--- a/cmd/syft/internal/ui/ui.go
+++ b/cmd/syft/internal/ui/ui.go
@@ -78,6 +78,13 @@ func (m *UI) Handle(e partybus.Event) error {
 }
 
 func (m *UI) Teardown(force bool) error {
+	defer func() {
+		// allow for traditional logging to resume now that the UI is shutting down
+		if logWrapper, ok := log.Get().(logger.Controller); ok {
+			logWrapper.SetOutput(m.err)
+		}
+	}()
+
 	if !force {
 		m.handler.Wait()
 		m.program.Quit()


### PR DESCRIPTION
This restores the UI on teardown (note that it is redirected to a buffer on setup). This will now show logging events after the UI has returned screen control.