### PR TITLE
3122 valid license url characters

### DIFF
--- a/syft/pkg/license.go
+++ b/syft/pkg/license.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/scylladb/go-set/strset"
 
@@ -112,7 +113,8 @@ func NewLicenseFromURLs(value string, urls ...string) License {
 	s := strset.New()
 	for _, url := range urls {
 		if url != "" {
-			s.Add(url)
+			sanitizedURL := stripUnwantedCharacters(url)
+			s.Add(sanitizedURL)
 		}
 	}
 
@@ -120,6 +122,14 @@ func NewLicenseFromURLs(value string, urls ...string) License {
 	sort.Strings(l.URLs)
 
 	return l
+}
+
+func stripUnwantedCharacters(input string) string {
+	// Remove newline, tab, and other unwanted whitespace characters
+	input = strings.ReplaceAll(input, "\n", "")
+	input = strings.ReplaceAll(input, "\t", "")
+	input = strings.TrimSpace(input) // also trim leading/trailing whitespace
+	return input
 }
 
 func NewLicenseFromFields(value, url string, location *file.Location) License {

--- a/syft/pkg/license.go
+++ b/syft/pkg/license.go
@@ -131,8 +131,6 @@ func NewLicenseFromURLs(value string, urls ...string) License {
 
 func stripUnwantedCharacters(rawURL string) (string, error) {
 	cleanedURL := strings.TrimSpace(rawURL)
-
-	// Step 3: Validate the cleaned URL
 	_, err := url.ParseRequestURI(cleanedURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid URL: %w", err)

--- a/syft/pkg/license.go
+++ b/syft/pkg/license.go
@@ -130,12 +130,7 @@ func NewLicenseFromURLs(value string, urls ...string) License {
 }
 
 func stripUnwantedCharacters(rawURL string) (string, error) {
-	// Step 1: Remove newline and tab characters
-	cleanedURL := strings.ReplaceAll(rawURL, "\n", "")
-	cleanedURL = strings.ReplaceAll(cleanedURL, "\t", "")
-
-	// Step 2: Trim leading/trailing spaces
-	cleanedURL = strings.TrimSpace(cleanedURL)
+	cleanedURL := strings.TrimSpace(rawURL)
 
 	// Step 3: Validate the cleaned URL
 	_, err := url.ParseRequestURI(cleanedURL)

--- a/syft/pkg/license_test.go
+++ b/syft/pkg/license_test.go
@@ -226,3 +226,39 @@ func TestLicense_Merge(t *testing.T) {
 		})
 	}
 }
+
+func TestLicenseConstructors(t *testing.T) {
+	type input struct {
+		value string
+		urls  []string
+	}
+	tests := []struct {
+		name     string
+		input    input
+		expected License
+	}{
+		{
+			name: "License URLs are stripped of newlines and tabs",
+			input: input{
+				value: "New BSD License",
+				urls: []string{
+					`
+						http://user-agent-utils.googlecode.com/svn/trunk/UserAgentUtils/LICENSE.txt
+									
+					`},
+			},
+			expected: License{
+				Value: "New BSD License",
+				Type:  license.Declared,
+				URLs:  []string{"http://user-agent-utils.googlecode.com/svn/trunk/UserAgentUtils/LICENSE.txt"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := NewLicenseFromURLs(test.input.value, test.input.urls...)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR updates the license constructors to strip unwanted characters from URLs in license metadata and make sure all URLs conform to RFC 3987 IRI-reference.

- Fixes #3122

### Fix Validation

- Download .jar file [here](https://repo1.maven.org/maven2/eu/bitwalker/UserAgentUtils/1.21/UserAgentUtils-1.21.jar)
- Run the following command using this branch:
`go run cmd/syft/main.go --output cyclonedx-json=file.json --verbose`

The URL now listed for the `UserAgentUtils` should no longer have special characters in it as listed in the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
