### PR TITLE
Go source cataloger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	github.com/adrg/xdg v0.5.3
 	github.com/magiconair/properties v1.8.7
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/tools v0.23.0
 )
 
 require (

--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -84,6 +84,11 @@ func DefaultPackageTaskFactories() PackageTaskFactories {
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Go, Golang, "gomod",
 		),
+		newPackageTaskFactory(
+			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
+				return golang.NewGoModuleSourceFileCataloger(cfg.PackagesConfig.Golang)
+			},
+			pkgcataloging.InstalledTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Go, Golang, "gosource"),
 		newSimplePackageTaskFactory(java.NewGradleLockfileCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Java, "gradle"),
 		newPackageTaskFactory(
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {

--- a/syft/pkg/cataloger/golang/cataloger.go
+++ b/syft/pkg/cataloger/golang/cataloger.go
@@ -39,6 +39,6 @@ func NewGoModuleBinaryCataloger(opts CatalogerConfig) pkg.Cataloger {
 // to extract the module name and then searches all direct and transitive dependencies
 // for the given module source tree
 func NewGoModuleSourceFileCataloger(opts CatalogerConfig) pkg.Cataloger {
-	return generic.NewCataloger(modFileCatalogerName).
+	return generic.NewCataloger(sourceFileCatalogerName).
 		WithParserByGlobs(newGoModSourceCataloger(opts).parseGoModFile, "**/go.mod")
 }

--- a/syft/pkg/cataloger/golang/cataloger.go
+++ b/syft/pkg/cataloger/golang/cataloger.go
@@ -14,8 +14,9 @@ import (
 var versionCandidateGroups = regexp.MustCompile(`(?P<version>\d+(\.\d+)?(\.\d+)?)(?P<candidate>\w*)`)
 
 const (
-	modFileCatalogerName = "go-module-file-cataloger"
-	binaryCatalogerName  = "go-module-binary-cataloger"
+	modFileCatalogerName    = "go-module-file-cataloger"
+	binaryCatalogerName     = "go-module-binary-cataloger"
+	sourceFileCatalogerName = "go-module-source-file-cataloger"
 )
 
 // NewGoModuleFileCataloger returns a new cataloger object that searches within go.mod files.
@@ -32,4 +33,12 @@ func NewGoModuleBinaryCataloger(opts CatalogerConfig) pkg.Cataloger {
 			mimetype.ExecutableMIMETypeSet.List()...,
 		).
 		WithProcessors(stdlibProcessor)
+}
+
+// NewGoModuleSourceFileCataloger returns a new cataloger object that uses the go.mod file
+// to extract the module name and then searches all direct and transitive dependencies
+// for the given module source tree
+func NewGoModuleSourceFileCataloger(opts CatalogerConfig) pkg.Cataloger {
+	return generic.NewCataloger(modFileCatalogerName).
+		WithParserByGlobs(newGoModSourceCataloger(opts).parseGoModFile, "**/go.mod")
 }

--- a/syft/pkg/golang.go
+++ b/syft/pkg/golang.go
@@ -1,5 +1,10 @@
 package pkg
 
+import (
+	"golang.org/x/tools/go/packages"
+	"time"
+)
+
 // GolangBinaryBuildinfoEntry represents all captured data for a Golang binary
 type GolangBinaryBuildinfoEntry struct {
 	BuildSettings     KeyValues `json:"goBuildSettings,omitempty" cyclonedx:"goBuildSettings"`
@@ -14,4 +19,18 @@ type GolangBinaryBuildinfoEntry struct {
 // GolangModuleEntry represents all captured data for a Golang source scan with go.mod/go.sum
 type GolangModuleEntry struct {
 	H1Digest string `json:"h1Digest,omitempty" cyclonedx:"h1Digest"`
+}
+
+// GolangModuleEntryMetadata represetns all captured data from the golang.org/x/tools/go/packages package
+// when scanning a golang source directory for direct and indirect dependencies
+type GolangModuleEntryMetadata struct {
+	Path      string           // module path
+	Version   string           // module version
+	Replace   *packages.Module // replaced by this module
+	Time      *time.Time       // time version was created
+	Main      bool             // is this the main module?
+	Indirect  bool             // is this module only an indirect dependency of main module?
+	Dir       string           // directory holding files for this module, if any
+	GoMod     string           // path to go.mod file used when loading this module, if any
+	GoVersion string           // go version used in module
 }


### PR DESCRIPTION
# Description

This PR adds a new directory source cataloger that goes beyond reading declarations from the `go.mod` file.

The `go-module-source-file-cataloger` uses the `golang.org/x/tools/go/packages` library to read the "main" module from detected `go.mod` files. It then uses this main module information to load all the `root` packages for a given main module. The tool chain then visits all the packages in the import graph whose roots are packages in the discovered `root` packages.

This PR is currently WIP and needs further discussion around the following sections:
- The first draft of what relationships we want to surface from this cataloger should be included as none are implemented at the moment.
- License inclusion needs to be added. There is a good example in the `go-licenses` open source program at how to do this.

- Fixes #3451 

## Type of change

<!-- Delete any that are not relevant -->

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
