### PR TITLE
3030 license declared spdx correction

### DIFF
--- a/syft/format/common/spdxhelpers/to_format_model.go
+++ b/syft/format/common/spdxhelpers/to_format_model.go
@@ -725,7 +725,7 @@ func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 			if l.Value != "" {
 				licenses[l.ID] = l
 			}
-			if l.ID != "" && isSingularLicenseRef(l.ID) {
+			if l.ID != "" && isLicenseRef(l.ID) {
 				licenses[l.ID] = l
 			}
 		}
@@ -733,7 +733,7 @@ func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 			if l.Value != "" {
 				licenses[l.ID] = l
 			}
-			if l.ID != "" && isSingularLicenseRef(l.ID) {
+			if l.ID != "" && isLicenseRef(l.ID) {
 				licenses[l.ID] = l
 			}
 		}
@@ -762,13 +762,12 @@ func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 	return result
 }
 
-// isSingularLicenseRef checks if the string is a singular LicenseRef-* identifier
-func isSingularLicenseRef(s string) bool {
-	// Regular expression to match LicenseRef-* format (case-sensitive)
-	re := regexp.MustCompile(`^LicenseRef-[A-Za-z0-9_-]+$`)
+var LicenseRefRegEx = regexp.MustCompile(`^LicenseRef-[A-Za-z0-9_-]+$`)
 
+// isSingularLicenseRef checks if the string is a singular LicenseRef-* identifier
+func isLicenseRef(s string) bool {
 	// Match the input string against the regex
-	return re.MatchString(s)
+	return LicenseRefRegEx.MatchString(s)
 }
 
 // TODO: handle SPDX excludes file case

--- a/syft/format/common/spdxhelpers/to_format_model.go
+++ b/syft/format/common/spdxhelpers/to_format_model.go
@@ -762,12 +762,12 @@ func toOtherLicenses(catalog *pkg.Collection) []*spdx.OtherLicense {
 	return result
 }
 
-var LicenseRefRegEx = regexp.MustCompile(`^LicenseRef-[A-Za-z0-9_-]+$`)
+var licenseRefRegEx = regexp.MustCompile(`^LicenseRef-[A-Za-z0-9_-]+$`)
 
 // isSingularLicenseRef checks if the string is a singular LicenseRef-* identifier
 func isLicenseRef(s string) bool {
 	// Match the input string against the regex
-	return LicenseRefRegEx.MatchString(s)
+	return licenseRefRegEx.MatchString(s)
 }
 
 // TODO: handle SPDX excludes file case

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -753,6 +753,29 @@ func Test_OtherLicenses(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "LicenseRef as a valid spdx expression",
+			pkg: pkg.Package{
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicense("LicenseRef-Fedora-Public-Domain"),
+				),
+			},
+			expected: []*spdx.OtherLicense{
+				{
+					LicenseIdentifier: "LicenseRef-Fedora-Public-Domain",
+					ExtractedText:     "Fedora-Public-Domain",
+				},
+			},
+		},
+		{
+			name: "LicenseRef as a valid spdx expression does not otherize compound spdx expressions",
+			pkg: pkg.Package{
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicense("(MIT AND LicenseRef-Fedora-Public-Domain)"),
+				),
+			},
+			expected: nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Description

The syft format helpers for spdx currently treat `License-Ref-*` as a valid spdx expression. This causes our selection on `l.Value` to be partially incorrect when trying to add licenses to the `hasExtractedLicensingInfos` in the spdx document.

This change updates the spdx helpers so that singular `License-Ref` candidates are added to this section.

- Fixes #3030

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
