### PR TITLE
disable package scan

### DIFF
--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -7,6 +7,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/task"
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/filecataloging"
@@ -267,7 +268,8 @@ func (c *CreateSBOMConfig) packageTasks(src source.Description) ([]task.Task, *t
 	finalTasks = append(finalTasks, persistentTasks...)
 
 	if len(finalTasks) == 0 {
-		return nil, nil, fmt.Errorf("no catalogers selected")
+		log.Warn("no catalogers selected")
+		return finalTasks, &selection, nil
 	}
 
 	return finalTasks, &selection, nil


### PR DESCRIPTION
# Description
this PR enables the way to scan only using files cataloger without package cataloger
related to an older request I've submitted 3128 (link below)
<!-- If this completes an issue, please include: -->

- Fixes #3128

## Type of change

<!-- Delete any that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
