### PR TITLE
fix: stop omitting redundantly parenthesized licenses in CDX formatter

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
@@ -164,6 +164,29 @@ func Test_encodeLicense(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "single parenthesized SPDX expression",
+			input: pkg.Package{
+				Licenses: pkg.NewLicenseSet(pkg.NewLicensesFromValues("(MIT OR Apache-2.0)")...),
+			},
+			expected: &cyclonedx.Licenses{
+				{
+					Expression: "MIT OR Apache-2.0",
+				},
+			},
+		},
+		{
+			name: "single license AND to parenthesized SPDX expression",
+			// (LGPL-3.0-or-later OR GPL-2.0-or-later OR (LGPL-3.0-or-later AND GPL-2.0-or-later)) AND GFDL-1.3-invariants-or-later
+			input: pkg.Package{
+				Licenses: pkg.NewLicenseSet(pkg.NewLicensesFromValues("(LGPL-3.0-or-later OR GPL-2.0-or-later OR (LGPL-3.0-or-later AND GPL-2.0-or-later)) AND GFDL-1.3-invariants-or-later")...),
+			},
+			expected: &cyclonedx.Licenses{
+				{
+					Expression: "(LGPL-3.0-or-later OR GPL-2.0-or-later OR (LGPL-3.0-or-later AND GPL-2.0-or-later)) AND GFDL-1.3-invariants-or-later",
+				},
+			},
+		},
 		// TODO: do we drop the non SPDX ID license and do a single expression
 		// OR do we keep the non SPDX ID license and do multiple licenses where the complex
 		// expressions are set as the NAME field?

--- a/syft/license/license_test.go
+++ b/syft/license/license_test.go
@@ -21,6 +21,11 @@ func TestParseExpression(t *testing.T) {
 			want:       "MIT OR Apache-2.0",
 		},
 		{
+			name:       "accept redundant parentheses",
+			expression: "(MIT OR Apache-2.0)",
+			want:       "(MIT OR Apache-2.0)",
+		},
+		{
 			name:       "Invalid SPDX expression returns error",
 			expression: "MIT OR Apache-2.0 OR invalid",
 			want:       "",


### PR DESCRIPTION
Previously, a bug in the formatter would cause SPDX expressions that were surrounded in redundant parentheses to be dropped instead of normalized.

# Description

- Fixes # https://github.com/anchore/syft/issues/3441

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
