### PR TITLE
chore: make fixes field in PR template match auto-close regex

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ or link to an issue where this is explained.
 
 <!-- If this completes an issue, please include: -->
 
-- Fixes #
+- Fixes
 
 ## Type of change
 


### PR DESCRIPTION
Previously, if filling out this template, someone pasted a PR link after "Fixes #", the issue wouldn't automatically close, probably because the extra "#" confused the auto-close regex.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

