### PR TITLE
chore: bump packageurl-go with new parsing rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
-	github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f
+	github.com/anchore/packageurl-go v0.1.1-0.20250117185454-edf36a908b10
 	github.com/anchore/stereoscope v0.0.12
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	// we are hinting brotli to latest due to warning when installing archiver v3:

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZVsCYMrIZBpFxwV26CbsuoEh5muXD5I1Ods=
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f h1:dAQPIrQ3a5PBqZeZ+B9NGZsGmodk4NO9OjDIsQmQyQM=
-github.com/anchore/packageurl-go v0.1.1-0.20241018175412-5c22e6360c4f/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
+github.com/anchore/packageurl-go v0.1.1-0.20250117185454-edf36a908b10 h1:zBedM9ZGYbs/61QC4ZOKxtChx5njXKHgHqDeHuUxrTw=
+github.com/anchore/packageurl-go v0.1.1-0.20250117185454-edf36a908b10/go.mod h1:KoYIv7tdP5+CC9VGkeZV4/vGCKsY55VvoG+5dadg4YI=
 github.com/anchore/stereoscope v0.0.12 h1:ovUWeyeZGml6pTGiu/uha/rCbToANFPu+cnhLbeperY=
 github.com/anchore/stereoscope v0.0.12/go.mod h1:cmb/MGya7ccOd6fZZEREuhdSH2kFALBMrkY/66Sfv1o=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -72,7 +72,7 @@ func Test_toFormatModel(t *testing.T) {
 							{
 								Category: "PACKAGE-MANAGER",
 								RefType:  "purl",
-								Locator:  "pkg:oci/alpine@sha256:d34db33f?arch=&tag=latest",
+								Locator:  "pkg:oci/alpine@sha256%3Ad34db33f?arch=&tag=latest",
 							},
 						},
 						PackageSupplier: &spdx.Supplier{

--- a/syft/format/github/test-fixtures/snapshot/TestGithubDirectoryEncoder.golden
+++ b/syft/format/github/test-fixtures/snapshot/TestGithubDirectoryEncoder.golden
@@ -7,7 +7,7 @@
     "version": "v0.42.0-bogus"
   },
   "metadata": {
-    "syft:distro": "pkg:generic/debian@1.2.3?like=like!"
+    "syft:distro": "pkg:generic/debian@1.2.3?like=like%21"
   },
   "manifests": {
     "redacted/some/path/some/path/pkg1": {

--- a/syft/format/github/test-fixtures/snapshot/TestGithubImageEncoder.golden
+++ b/syft/format/github/test-fixtures/snapshot/TestGithubImageEncoder.golden
@@ -7,7 +7,7 @@
     "version": "v0.42.0-bogus"
   },
   "metadata": {
-    "syft:distro": "pkg:generic/debian@1.2.3?like=like!"
+    "syft:distro": "pkg:generic/debian@1.2.3?like=like%21"
   },
   "manifests": {
     "user-image-input:/somefile-1.txt": {

--- a/syft/format/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
+++ b/syft/format/spdxjson/test-fixtures/snapshot/TestSPDXJSONImageEncoder.golden
@@ -81,7 +81,7 @@
     {
      "referenceCategory": "PACKAGE-MANAGER",
      "referenceType": "purl",
-     "referenceLocator": "pkg:oci/user-image-input@sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch="
+     "referenceLocator": "pkg:oci/user-image-input@sha256%3A2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch="
     }
    ],
    "primaryPackagePurpose": "CONTAINER"

--- a/syft/format/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/format/spdxjson/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -81,7 +81,7 @@
     {
      "referenceCategory": "PACKAGE-MANAGER",
      "referenceType": "purl",
-     "referenceLocator": "pkg:oci/user-image-input@sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch="
+     "referenceLocator": "pkg:oci/user-image-input@sha256%3A2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch="
     }
    ],
    "primaryPackagePurpose": "CONTAINER"

--- a/syft/format/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
+++ b/syft/format/spdxtagvalue/test-fixtures/snapshot/TestSPDXRelationshipOrder.golden
@@ -71,7 +71,7 @@ PackageChecksum: SHA256: 2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf4
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-ExternalRef: PACKAGE-MANAGER purl pkg:oci/user-image-input@sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch=
+ExternalRef: PACKAGE-MANAGER purl pkg:oci/user-image-input@sha256%3A2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch=
 
 ##### Package: package-2
 

--- a/syft/format/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
+++ b/syft/format/spdxtagvalue/test-fixtures/snapshot/TestSPDXTagValueImageEncoder.golden
@@ -21,7 +21,7 @@ PackageChecksum: SHA256: 2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf4
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-ExternalRef: PACKAGE-MANAGER purl pkg:oci/user-image-input@sha256:2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch=
+ExternalRef: PACKAGE-MANAGER purl pkg:oci/user-image-input@sha256%3A2731251dc34951c0e50fcc643b4c5f74922dad1a5d98f302b504cf46cd5d9368?arch=
 
 ##### Package: package-2
 

--- a/syft/pkg/cataloger/binary/elf_package_test.go
+++ b/syft/pkg/cataloger/binary/elf_package_test.go
@@ -26,7 +26,7 @@ func Test_packageURL(t *testing.T) {
 					System: "syftsys",
 				},
 			},
-			want: "pkg:generic/syftsys/github.com/anchore/syft@v0.1.0",
+			want: "pkg:generic/syftsys/github.com%2Fanchore%2Fsyft@v0.1.0",
 		},
 		{
 			name: "elf binary package short name",

--- a/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec_lock_test.go
@@ -89,7 +89,7 @@ func TestParsePubspecLock(t *testing.T) {
 		{
 			Name:      "key_binder",
 			Version:   "1.11.20",
-			PURL:      "pkg:pub/key_binder@1.11.20?vcs_url=git%40github.com:Workiva/key_binder.git%403f7b3a6350e73c7dcac45301c0e18fbd42af02f7",
+			PURL:      "pkg:pub/key_binder@1.11.20?vcs_url=git%40github.com%3AWorkiva%2Fkey_binder.git%403f7b3a6350e73c7dcac45301c0e18fbd42af02f7",
 			Locations: fixtureLocationSet,
 			Language:  pkg.Dart,
 			Type:      pkg.DartPubPkg,

--- a/syft/pkg/cataloger/gentoo/cataloger_test.go
+++ b/syft/pkg/cataloger/gentoo/cataloger_test.go
@@ -16,7 +16,7 @@ func TestPortageCataloger(t *testing.T) {
 			Name:    "app-containers/skopeo",
 			Version: "1.5.1",
 			FoundBy: "portage-cataloger",
-			PURL:    "pkg:ebuild/app-containers/skopeo@1.5.1",
+			PURL:    "pkg:ebuild/app-containers%2Fskopeo@1.5.1",
 			Locations: file.NewLocationSet(
 				file.NewLocation("var/db/pkg/app-containers/skopeo-1.5.1/CONTENTS"),
 				file.NewLocation("var/db/pkg/app-containers/skopeo-1.5.1/SIZE"),

--- a/syft/pkg/cataloger/gentoo/purl_test.go
+++ b/syft/pkg/cataloger/gentoo/purl_test.go
@@ -17,7 +17,7 @@ func Test_packageURL(t *testing.T) {
 		{
 			"app-admin/eselect",
 			"1.4.15",
-			"pkg:ebuild/app-admin/eselect@1.4.15",
+			"pkg:ebuild/app-admin%2Feselect@1.4.15",
 		},
 	}
 	for _, tt := range tests {

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -152,7 +152,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 		Language: pkg.Go,
 		Type:     pkg.GoModulePkg,
 		Version:  "(devel)",
-		PURL:     "pkg:golang/github.com/anchore/syft@(devel)",
+		PURL:     "pkg:golang/github.com/anchore/syft@%28devel%29",
 		Locations: file.NewLocationSet(
 			file.NewLocationFromCoordinates(
 				file.Coordinates{
@@ -280,7 +280,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				{
 					Name:     "github.com/a/b/c",
 					Version:  "(devel)",
-					PURL:     "pkg:golang/github.com/a/b@(devel)#c",
+					PURL:     "pkg:golang/github.com/a/b@%28devel%29#c",
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: file.NewLocationSet(
@@ -932,7 +932,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				Language: pkg.Go,
 				Type:     pkg.GoModulePkg,
 				Version:  "(devel)",
-				PURL:     "pkg:golang/github.com/anchore/syft@(devel)",
+				PURL:     "pkg:golang/github.com/anchore/syft@%28devel%29",
 				Locations: file.NewLocationSet(
 					file.NewLocationFromCoordinates(
 						file.Coordinates{

--- a/syft/pkg/cataloger/java/cataloger_test.go
+++ b/syft/pkg/cataloger/java/cataloger_test.go
@@ -157,7 +157,7 @@ func TestJvmDistributionCataloger(t *testing.T) {
 				Licenses:  pkg.NewLicenseSet(),
 				Type:      pkg.BinaryPkg,
 				CPEs:      []cpe.CPE{cpe.Must("cpe:2.3:a:oracle:openjdk:21.0.4:*:*:*:*:*:*:*", cpe.DeclaredSource)},
-				PURL:      "pkg:generic/oracle/openjdk@21.0.4%2B7-LTS?repository_url=https://github.com/adoptium/jdk21u.git",
+				PURL:      "pkg:generic/oracle/openjdk@21.0.4%2B7-LTS?repository_url=https%3A%2F%2Fgithub.com%2Fadoptium%2Fjdk21u.git",
 				Metadata: pkg.JavaVMInstallation{
 					Release: pkg.JavaVMRelease{
 						Implementor:        "Eclipse Adoptium",

--- a/syft/pkg/cataloger/java/parse_jvm_release_test.go
+++ b/syft/pkg/cataloger/java/parse_jvm_release_test.go
@@ -395,7 +395,7 @@ func TestJvmPurl(t *testing.T) {
 			version:      "21.0.4",
 			vendor:       "oracle",
 			product:      "jdk",
-			expectedPURL: "pkg:generic/oracle/jdk@21.0.4?repository_url=https://github.com/adoptium/temurin-build.git",
+			expectedPURL: "pkg:generic/oracle/jdk@21.0.4?repository_url=https%3A%2F%2Fgithub.com%2Fadoptium%2Ftemurin-build.git",
 		},
 		{
 			name: "source repo provided, no build source repo",
@@ -405,7 +405,7 @@ func TestJvmPurl(t *testing.T) {
 			version:      "21.0.4",
 			vendor:       "azul",
 			product:      "zulu",
-			expectedPURL: "pkg:generic/azul/zulu@21.0.4?repository_url=https://github.com/adoptium/jdk21u.git",
+			expectedPURL: "pkg:generic/azul/zulu@21.0.4?repository_url=https%3A%2F%2Fgithub.com%2Fadoptium%2Fjdk21u.git",
 		},
 		{
 			name: "no repository URLs provided",
@@ -425,7 +425,7 @@ func TestJvmPurl(t *testing.T) {
 			version:      "1.8.0_302",
 			vendor:       "oracle",
 			product:      "jre",
-			expectedPURL: "pkg:generic/oracle/jre@1.8.0_302?repository_url=https://github.com/adoptium/jre-repo.git",
+			expectedPURL: "pkg:generic/oracle/jre@1.8.0_302?repository_url=https%3A%2F%2Fgithub.com%2Fadoptium%2Fjre-repo.git",
 		},
 	}
 

--- a/syft/pkg/cataloger/python/cataloger_test.go
+++ b/syft/pkg/cataloger/python/cataloger_test.go
@@ -121,7 +121,7 @@ func Test_PackageCataloger(t *testing.T) {
 			expectedPackage: pkg.Package{
 				Name:     "pygments",
 				Version:  "2.6.1",
-				PURL:     "pkg:pypi/pygments@2.6.1?vcs_url=git%2Bhttps://github.com/python-test/test.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				PURL:     "pkg:pypi/pygments@2.6.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fpython-test%2Ftest.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
 				Licenses: pkg.NewLicenseSet(
@@ -163,7 +163,7 @@ func Test_PackageCataloger(t *testing.T) {
 			expectedPackage: pkg.Package{
 				Name:     "pygments",
 				Version:  "2.6.1",
-				PURL:     "pkg:pypi/pygments@2.6.1?vcs_url=git%2Bhttps://github.com/python-test/test.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				PURL:     "pkg:pypi/pygments@2.6.1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Fpython-test%2Ftest.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				Type:     pkg.PythonPkg,
 				Language: pkg.Python,
 				Licenses: pkg.NewLicenseSet(

--- a/syft/pkg/cataloger/python/package_test.go
+++ b/syft/pkg/cataloger/python/package_test.go
@@ -35,7 +35,7 @@ func Test_packageURL(t *testing.T) {
 					CommitID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				},
 			},
-			want: "pkg:pypi/name@v0.1.0?vcs_url=git%2Bhttps://github.com/test/test.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			want: "pkg:pypi/name@v0.1.0?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com%2Ftest%2Ftest.git%40aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 	}
 	for _, tt := range tests {

--- a/syft/pkg/cataloger/swift/parse_podfile_lock_test.go
+++ b/syft/pkg/cataloger/swift/parse_podfile_lock_test.go
@@ -38,7 +38,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "PINCache/Arc-exception-safe",
 			Version:   "3.0.3",
-			PURL:      "pkg:cocoapods/PINCache/Arc-exception-safe@3.0.3",
+			PURL:      "pkg:cocoapods/PINCache%2FArc-exception-safe@3.0.3",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -49,7 +49,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "PINCache/Core",
 			Version:   "3.0.3",
-			PURL:      "pkg:cocoapods/PINCache/Core@3.0.3",
+			PURL:      "pkg:cocoapods/PINCache%2FCore@3.0.3",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -71,7 +71,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "PINRemoteImage/Core",
 			Version:   "3.0.3",
-			PURL:      "pkg:cocoapods/PINRemoteImage/Core@3.0.3",
+			PURL:      "pkg:cocoapods/PINRemoteImage%2FCore@3.0.3",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -82,7 +82,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "PINRemoteImage/iOS",
 			Version:   "3.0.3",
-			PURL:      "pkg:cocoapods/PINRemoteImage/iOS@3.0.3",
+			PURL:      "pkg:cocoapods/PINRemoteImage%2FiOS@3.0.3",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -93,7 +93,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "PINRemoteImage/PINCache",
 			Version:   "3.0.3",
-			PURL:      "pkg:cocoapods/PINRemoteImage/PINCache@3.0.3",
+			PURL:      "pkg:cocoapods/PINRemoteImage%2FPINCache@3.0.3",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -137,7 +137,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/AssetsLibrary",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/AssetsLibrary@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FAssetsLibrary@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -148,7 +148,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/Core",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/Core@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FCore@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -159,7 +159,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/MapKit",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/MapKit@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FMapKit@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -170,7 +170,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/Photos",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/Photos@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FPhotos@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -181,7 +181,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/PINRemoteImage",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/PINRemoteImage@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FPINRemoteImage@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -192,7 +192,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "Texture/Video",
 			Version:   "3.1.0",
-			PURL:      "pkg:cocoapods/Texture/Video@3.1.0",
+			PURL:      "pkg:cocoapods/Texture%2FVideo@3.1.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -214,7 +214,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "TextureSwiftSupport/Components",
 			Version:   "3.13.0",
-			PURL:      "pkg:cocoapods/TextureSwiftSupport/Components@3.13.0",
+			PURL:      "pkg:cocoapods/TextureSwiftSupport%2FComponents@3.13.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -225,7 +225,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "TextureSwiftSupport/Experiments",
 			Version:   "3.13.0",
-			PURL:      "pkg:cocoapods/TextureSwiftSupport/Experiments@3.13.0",
+			PURL:      "pkg:cocoapods/TextureSwiftSupport%2FExperiments@3.13.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -236,7 +236,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "TextureSwiftSupport/Extensions",
 			Version:   "3.13.0",
-			PURL:      "pkg:cocoapods/TextureSwiftSupport/Extensions@3.13.0",
+			PURL:      "pkg:cocoapods/TextureSwiftSupport%2FExtensions@3.13.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,
@@ -247,7 +247,7 @@ func TestParsePodfileLock(t *testing.T) {
 		{
 			Name:      "TextureSwiftSupport/LayoutSpecBuilders",
 			Version:   "3.13.0",
-			PURL:      "pkg:cocoapods/TextureSwiftSupport/LayoutSpecBuilders@3.13.0",
+			PURL:      "pkg:cocoapods/TextureSwiftSupport%2FLayoutSpecBuilders@3.13.0",
 			Locations: locations,
 			Language:  pkg.Swift,
 			Type:      pkg.CocoapodsPkg,


### PR DESCRIPTION
# Description

This update integrates the purl changes found in: https://github.com/anchore/packageurl-go/pull/23

- Fixes #3577 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
