### PR TITLE
chore(ci): fix composite GitHub action path in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directory: "/.github/actions/boostrap"
+    directory: "/.github/actions/bootstrap"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Description

Fixes a typo in the dependabot config which was preventing automated updates to the composite bootstrap action definition.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
