### PR TITLE
Fix namespace value for OpenSUSE distros

### DIFF
--- a/syft/pkg/cataloger/redhat/package.go
+++ b/syft/pkg/cataloger/redhat/package.go
@@ -92,6 +92,9 @@ func packageURL(name, arch string, epoch *int, srpm string, version, release str
 	if namespace == "rhel" {
 		namespace = "redhat"
 	}
+	if strings.HasPrefix(namespace, "opensuse") {
+		namespace = "opensuse"
+	}
 
 	qualifiers := map[string]string{}
 


### PR DESCRIPTION
# Description

Instead of namespacing them to the specific distro version, such as Leap or Tumbleweed, the namespace value is set to the vendor itself: "opensuse".

This change is similar to that made in https://github.com/anchore/syft/pull/2914.

<!-- If this completes an issue, please include: -->

- Fixes #3534

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
