### PR TITLE
chore: replace all shorthand tags of mapstruct -> mapstructure

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_package_json.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json.go
@@ -36,9 +36,9 @@ type packageJSON struct {
 }
 
 type author struct {
-	Name  string `json:"name" mapstruct:"name"`
-	Email string `json:"email" mapstruct:"email"`
-	URL   string `json:"url" mapstruct:"url"`
+	Name  string `json:"name" mapstructure:"name"`
+	Email string `json:"email" mapstructure:"email"`
+	URL   string `json:"url" mapstructure:"url"`
 }
 
 type repository struct {

--- a/syft/pkg/python.go
+++ b/syft/pkg/python.go
@@ -13,18 +13,18 @@ var _ FileOwner = (*PythonPackage)(nil)
 // Historically these were defined in PEPs 345, 314, and 241, but have been superseded by PEP 566. This means that this
 // struct can (partially) express at least versions 1.0, 1.1, 1.2, 2.1, 2.2, and 2.3 of the metadata format.
 type PythonPackage struct {
-	Name                 string                     `json:"name" mapstruct:"Name"`
-	Version              string                     `json:"version" mapstruct:"Version"`
-	Author               string                     `json:"author" mapstruct:"Author"`
-	AuthorEmail          string                     `json:"authorEmail" mapstruct:"Authoremail"`
-	Platform             string                     `json:"platform" mapstruct:"Platform"`
+	Name                 string                     `json:"name" mapstructure:"Name"`
+	Version              string                     `json:"version" mapstructure:"Version"`
+	Author               string                     `json:"author" mapstructure:"Author"`
+	AuthorEmail          string                     `json:"authorEmail" mapstructure:"Authoremail"`
+	Platform             string                     `json:"platform" mapstructure:"Platform"`
 	Files                []PythonFileRecord         `json:"files,omitempty"`
 	SitePackagesRootPath string                     `json:"sitePackagesRootPath"`
 	TopLevelPackages     []string                   `json:"topLevelPackages,omitempty"`
 	DirectURLOrigin      *PythonDirectURLOriginInfo `json:"directUrlOrigin,omitempty"`
-	RequiresPython       string                     `json:"requiresPython,omitempty" mapstruct:"RequiresPython"`
-	RequiresDist         []string                   `json:"requiresDist,omitempty" mapstruct:"RequiresDist"`
-	ProvidesExtra        []string                   `json:"providesExtra,omitempty" mapstruct:"ProvidesExtra"`
+	RequiresPython       string                     `json:"requiresPython,omitempty" mapstructure:"RequiresPython"`
+	RequiresDist         []string                   `json:"requiresDist,omitempty" mapstructure:"RequiresDist"`
+	ProvidesExtra        []string                   `json:"providesExtra,omitempty" mapstructure:"ProvidesExtra"`
 }
 
 // PythonFileDigest represents the file metadata for a single file attributed to a python package.
@@ -86,9 +86,9 @@ type PythonPoetryLockExtraEntry struct {
 
 // PythonRequirementsEntry represents a single entry within a [*-]requirements.txt file.
 type PythonRequirementsEntry struct {
-	Name              string   `json:"name" mapstruct:"Name"`
-	Extras            []string `json:"extras,omitempty" mapstruct:"Extras"`
-	VersionConstraint string   `json:"versionConstraint" mapstruct:"VersionConstraint"`
-	URL               string   `json:"url,omitempty" mapstruct:"URL"`
-	Markers           string   `json:"markers,omitempty" mapstruct:"Markers"`
+	Name              string   `json:"name" mapstructure:"Name"`
+	Extras            []string `json:"extras,omitempty" mapstructure:"Extras"`
+	VersionConstraint string   `json:"versionConstraint" mapstructure:"VersionConstraint"`
+	URL               string   `json:"url,omitempty" mapstructure:"URL"`
+	Markers           string   `json:"markers,omitempty" mapstructure:"Markers"`
 }

--- a/syft/pkg/swipl.go
+++ b/syft/pkg/swipl.go
@@ -3,10 +3,10 @@ package pkg
 type SwiplPackEntry struct {
 	Name          string   `toml:"name" json:"name"`
 	Version       string   `toml:"version" json:"version"`
-	Author        string   `json:"author" mapstruct:"Author"`
-	AuthorEmail   string   `json:"authorEmail" mapstruct:"Authoremail"`
+	Author        string   `json:"author" mapstructure:"Author"`
+	AuthorEmail   string   `json:"authorEmail" mapstructure:"Authoremail"`
 	Packager      string   `json:"packager" mapstructure:"Packager"`
-	PackagerEmail string   `json:"packagerEmail" mapstruct:"Packageremail"`
+	PackagerEmail string   `json:"packagerEmail" mapstructure:"Packageremail"`
 	Homepage      string   `json:"homepage"`
 	Dependencies  []string `toml:"dependencies" json:"dependencies"`
 }


### PR DESCRIPTION
# Description

When doing https://github.com/anchore/syft/pull/3631 I noticed that syft had some incorrect tags for map-structure that might have been auto completed incorrectly in prior PR. This PR updates the struct tags to use the correct `mapstructure` 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)