### PR TITLE
Support extracting symbols in .dynsym section for GraalVM Native Images

### DIFF
--- a/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
+++ b/syft/pkg/cataloger/java/graalvm_native_image_cataloger.go
@@ -251,11 +251,11 @@ func (ni nativeImageElf) fetchPkgs() (pkgs []pkg.Package, relationships []artifa
 	var sbomLength elf.Symbol
 	var svmVersion elf.Symbol
 
-	si, err := bi.Symbols()
+	si, err := ni.getSymbols()
 	if err != nil {
-		return nil, nil, fmt.Errorf("no symbols found in binary: %w", err)
+		return nil, nil, err
 	}
-	if si == nil {
+	if len(si) == 0 {
 		return nil, nil, errors.New(nativeImageMissingSymbolsError)
 	}
 	for _, s := range si {
@@ -284,6 +284,31 @@ func (ni nativeImageElf) fetchPkgs() (pkgs []pkg.Package, relationships []artifa
 	lengthLocation := sbomLength.Value - dataSectionBase
 
 	return decompressSbom(data, sbomLocation, lengthLocation)
+}
+
+// getSymbols obtains the union of the symbols in the .symtab and .dynsym sections of the ELF file
+func (ni nativeImageElf) getSymbols() ([]elf.Symbol, error) {
+	var symbols []elf.Symbol
+	symsErr := error(nil)
+	dynErr := error(nil)
+
+	if syms, err := ni.file.Symbols(); err == nil {
+		symbols = append(symbols, syms...)
+	} else {
+		symsErr = err
+	}
+
+	if dynSyms, err := ni.file.DynamicSymbols(); err == nil {
+		symbols = append(symbols, dynSyms...)
+	} else {
+		dynErr = err
+	}
+
+	if symsErr != nil && dynErr != nil {
+		return nil, fmt.Errorf("could not retrieve symbols from binary: SHT_SYMTAB error: %v, SHT_DYNSYM error: %v", symsErr, dynErr)
+	}
+
+	return symbols, nil
 }
 
 // fetchPkgs obtains the packages from a Native Image given as a Mach O file.


### PR DESCRIPTION
# Description

This PR adds support for extracting SBOMs embedded in native images where the SBOM symbols are saved in the `.dynsym` section of ELF files. Newer versions of GraalVM Native Image saves the SBOM symbols in the `.dynsym` section while older versions saves them in the `.symtab` section. This PR ensures SBOM extraction works in both cases. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have added unit tests that cover changed behavior*

*No additional tests were added. The new `getSymbols` function is exercised via [TestParseNativeImage that calls fetchPkgs](https://github.com/anchore/syft/blob/e584c9f416028051fbdc80fffda4e624aaed528d/syft/pkg/cataloger/java/graalvm_native_image_cataloger_test.go#L49). This is a negative test testing that an error is thrown when SBOM extraction is attempted on a native image that wasn't created with an embedded SBOM. 

- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
