### PR TITLE
feat: update to go 1.24.x

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: true
-    default: "1.23.x"
+    default: "1.24.x"
   go-dependencies:
     description: "Download go dependencies"
     required: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/syft
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
# Description

Update to building with go 1.24.x so that the main module version gets set during `go build`