### PR TITLE
fix: Version parse caused by line breaks on different platforms

### DIFF
--- a/syft/pkg/cataloger/cpp/parse_conanfile.go
+++ b/syft/pkg/cataloger/cpp/parse_conanfile.go
@@ -39,7 +39,7 @@ func parseConanfile(_ context.Context, _ file.Resolver, _ *generic.Environment, 
 		}
 
 		m := pkg.ConanfileEntry{
-			Ref: strings.Trim(line, "\n"),
+			Ref: strings.TrimSpace(line),
 		}
 
 		if !inRequirements {


### PR DESCRIPTION
# Description

Under windows platform, `conanfile.txt` has a line break of `\r\n`, so the parsed version number will have '\r', this problem does not exist under unix platform.

- Fixes

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
