### PR TITLE
fix: find bitnami files even when no relationships

### DIFF
--- a/syft/pkg/cataloger/bitnami/cataloger.go
+++ b/syft/pkg/cataloger/bitnami/cataloger.go
@@ -80,6 +80,10 @@ func parseSBOM(_ context.Context, resolver file.Resolver, _ *generic.Environment
 
 		pkgs = append(pkgs, p)
 	}
+	// If there is exactly one package, assume it is the main package
+	if len(pkgs) == 1 && mainPkgID == "" {
+		mainPkgID = pkgs[0].ID()
+	}
 
 	// Resolve all files owned by the main package in the SBOM and update the metadata
 	if mainPkgFiles, err := mainPkgFiles(resolver, reader.Location.RealPath, secondaryPkgsFiles); err == nil {

--- a/syft/pkg/cataloger/bitnami/cataloger_test.go
+++ b/syft/pkg/cataloger/bitnami/cataloger_test.go
@@ -421,6 +421,31 @@ func TestBitnamiCataloger(t *testing.T) {
 		},
 	}
 
+	redisMainPkg := pkg.Package{
+		Name:      "redis",
+		Version:   "7.4.0-0",
+		Type:      pkg.BitnamiPkg,
+		Locations: file.NewLocationSet(file.NewLocation("opt/bitnami/redis/.spdx-redis.spdx")),
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicenseFromType("RSALv2", license.Concluded),
+			pkg.NewLicenseFromType("RSALv2", license.Declared),
+		),
+		FoundBy: catalogerName,
+		PURL:    "pkg:bitnami/redis@7.4.0-0?arch=arm64&distro=debian-12",
+		CPEs: mustCPEs(
+			"cpe:2.3:*:redis:redis:7.4.0:*:*:*:*:*:*:*",
+		),
+		Metadata: &pkg.BitnamiSBOMEntry{
+			Name:         "redis",
+			Version:      "7.4.0",
+			Revision:     "0",
+			Architecture: "arm64",
+			Distro:       "debian-12",
+			Path:         "opt/bitnami/redis",
+			Files:        []string{"opt/bitnami/redis/bin/redis-server"},
+		},
+	}
+
 	tests := []struct {
 		name              string
 		fixture           string
@@ -455,6 +480,12 @@ func TestBitnamiCataloger(t *testing.T) {
 			wantPkgs:          nil,
 			wantRelationships: nil,
 			wantErr:           require.Error,
+		},
+		{
+			name:              "SBOM with no relationships",
+			fixture:           "test-fixtures/no-rel",
+			wantPkgs:          []pkg.Package{redisMainPkg},
+			wantRelationships: nil,
 		},
 	}
 

--- a/syft/pkg/cataloger/bitnami/test-fixtures/no-rel/opt/bitnami/redis/.spdx-redis.spdx
+++ b/syft/pkg/cataloger/bitnami/test-fixtures/no-rel/opt/bitnami/redis/.spdx-redis.spdx
@@ -1,0 +1,38 @@
+{
+  "SPDXID": "SPDXRef-redis",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2024-08-08T11:12:35.680Z",
+    "creators": ["Organization: VMware, Inc."]
+  },
+  "name": "SPDX document for Redis(R) 7.4.0",
+  "dataLicense": "CC0-1.0",
+  "documentDescribes": ["SPDXRef-redis"],
+  "documentNamespace": "redis-7.4.0",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-redis",
+      "name": "redis",
+      "versionInfo": "7.4.0-0",
+      "downloadLocation": "http://download.redis.io/releases/redis-7.4.0.tar.gz",
+      "licenseConcluded": "RSALv2",
+      "licenseDeclared": "RSALv2",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "SECURITY",
+          "referenceType": "cpe23Type",
+          "referenceLocator": "cpe:2.3:*:redis:redis:7.4.0:*:*:*:*:*:*:*"
+        },
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:bitnami/redis@7.4.0-0?arch=arm64&distro=debian-12"
+        }
+      ],
+      "copyrightText": "NOASSERTION"
+    }
+  ],
+  "files": [],
+  "relationships": []
+}

--- a/syft/pkg/cataloger/bitnami/test-fixtures/no-rel/opt/bitnami/redis/bin/redis-server
+++ b/syft/pkg/cataloger/bitnami/test-fixtures/no-rel/opt/bitnami/redis/bin/redis-server
@@ -1,0 +1,1 @@
+test fixture pretending to be redis-server


### PR DESCRIPTION
# Description

The bitnami cataloger assigns files under /opt/bitnami/PACKAGE to be owned by PACKAGE unless they are otherwise owned. Previously, this main package was identified only by relationships, leading to an edge case where if there was a bitnami SBOM with a single package in it, there were no relationships, and so there would be no main package to assign the files to, leading to deduplication failures.

Instead, when encountering a bitnami SBOM with exactly one package in it, assume that package is the main package of that SBOM.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
