### PR TITLE
chore: disable line wrapping glow output

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -581,7 +581,7 @@ tasks:
       - "{{ .NEXT_VERSION }}"
     cmds:
       - "{{ .TOOL_DIR }}/chronicle -vv -n --version-file {{ .NEXT_VERSION }} > {{ .CHANGELOG }}"
-      - "{{ .TOOL_DIR }}/glow {{ .CHANGELOG }}"
+      - "{{ .TOOL_DIR }}/glow -w 0 {{ .CHANGELOG }}"
 
 
   ## Release targets #################################


### PR DESCRIPTION
This PR disables line wrapping of glow output during `make release`. When line wrap is enabled, many of the URLs are split across lines, making it more difficult to copy/paste output or follow the links to clean up the issue labels.