### PR TITLE
Suppress "file already closed" errors

### DIFF
--- a/internal/err_helper.go
+++ b/internal/err_helper.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 
 	"github.com/anchore/syft/internal/log"
@@ -12,6 +13,10 @@ import (
 // CloseAndLogError closes the given io.Closer and reports any errors found as a warning in the log
 func CloseAndLogError(closer io.Closer, location string) {
 	if err := closer.Close(); err != nil {
+		// suppress "file already closed" log messages
+		if errors.Is(err, fs.ErrClosed) {
+			return
+		}
 		log.Debugf("unable to close file for location=%q: %+v", location, err)
 	}
 }


### PR DESCRIPTION
# Description

When scanning a sif image I see many lines showing `file already closed`

```
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/fused_conv/python/ops/_fused_conv2d_bias_activation_op.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/hadoop/_dataset_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/ignite/_ignite_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/image/python/ops/_distort_image_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/image/python/ops/_image_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/image/python/ops/_single_image_random_dot_stereograms.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/input_pipeline/python/ops/_input_pipeline_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0419] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/kafka/_dataset_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0420] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/kinesis/_dataset_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0420] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/layers/python/ops/_sparse_feature_cross_op.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
[0420] DEBUG unable to close file for location="/usr/local/lib/python3.6/dist-packages/tensorflow_core/contrib/libsvm/python/ops/_libsvm_ops.so": close /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/stereoscope-3851921087/-2735928573/sha256:01819dea9081a6007328ed242e79efa451cdca6573359cbf8d52eb83cdf4815b: file already closed
```

This is noisy and unnecessary information (since with stereoscope it is safe to close files more than once).


## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
