### PR TITLE
fix: read only single package.json or package-lock.json document

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_package_json.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json.go
@@ -55,21 +55,17 @@ func parsePackageJSON(_ context.Context, _ file.Resolver, _ *generic.Environment
 	var pkgs []pkg.Package
 	dec := json.NewDecoder(reader)
 
-	for {
-		var p packageJSON
-		if err := dec.Decode(&p); errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse package.json file: %w", err)
-		}
-
-		// always create a package, regardless of having a valid name and/or version,
-		// a compliance filter later will remove these packages based on compliance rules
-		pkgs = append(
-			pkgs,
-			newPackageJSONPackage(p, reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-		)
+	var p packageJSON
+	if err := dec.Decode(&p); err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, fmt.Errorf("failed to parse package.json file: %w", err)
 	}
+
+	// always create a package, regardless of having a valid name and/or version,
+	// a compliance filter later will remove these packages based on compliance rules
+	pkgs = append(
+		pkgs,
+		newPackageJSONPackage(p, reader.Location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+	)
 
 	pkg.Sort(pkgs)
 

--- a/syft/pkg/cataloger/javascript/parse_package_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock.go
@@ -66,12 +66,8 @@ func (a genericPackageLockAdapter) parsePackageLock(_ context.Context, resolver 
 	dec := json.NewDecoder(reader)
 
 	var lock packageLock
-	for {
-		if err := dec.Decode(&lock); errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse package-lock.json file: %w", err)
-		}
+	if err := dec.Decode(&lock); err != nil && !errors.Is(err, io.EOF) {
+		return nil, nil, fmt.Errorf("failed to parse package-lock.json file: %w", err)
 	}
 
 	if lock.LockfileVersion == 1 {


### PR DESCRIPTION
Previously, this used a for loop over a json decoder, reading N package.json objects from a file stream. Because a single file stream containing the JSON for more than one package.json is unexpected, and because on some filesystems the loop failed to exit, instead read a single package.json object from the decoder.

On some Singularity images, this is causes problems because the decoder never encounters an EOF, and instead just keeps adding the same package forever, leading to eventual OOM. This is probably a bug in the underlying singularity (or its underlying squashFS) library, but I haven't been able to find it. I didn't see a reason we permit a given file to have more than one complete package.json or package-lock.json in it, so this change seemed simplest. Open to feedback, and happy to keep digging into squashFS

Fixes #3651 

Manual testing (image is downloaded and unzipped from the onedrive link on #3651)

On `main`, the following command runs out of memory and crashes the system or is killed by OOM killer, depending on how the system responds to runaway processes. On this branch, it produces the following output:

``` sh
$ go run ./cmd/syft -vv --override-default-catalogers javascript-package-cataloger ~/work/investigations/syft3651/tf1_11_0_Created.sif
... snip ...
[0183] DEBUG executable cataloger processed 1886 files
[0183]  INFO task completed elapsed=33.361242625s task=file-executable-cataloger
[0183]  INFO task completed elapsed=1.77725ms task=relationships-cataloger
[0183]  INFO task completed elapsed=658.708µs task=unknowns-labeler
NAME                                 VERSION  TYPE
@jupyter-widgets/jupyterlab-manager  3.1.11   npm   (+1 duplicate)
@jupyterlab/application-top          3.2.9    npm   (+2 duplicates)
@jupyterlab/mock-consumer            3.2.9    npm
@jupyterlab/mock-extension           3.2.9    npm
@jupyterlab/mock-incompat            0.1.0    npm
@jupyterlab/mock-mime-extension      0.3.0    npm
@jupyterlab/mock-package             0.1.0    npm
@jupyterlab/mock-provider            3.2.9    npm
@jupyterlab/mock-token               3.2.9    npm
test-hyphens                         3.0.2    npm
test-hyphens-underscore              3.0.2    npm
test_no_hyphens                      3.0.2    npm

```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions `syft ghost:latest` returns same set of packages on latest and on this change.
- [ ] I have added comments to my code, particularly in hard-to-understand sections - functions were already under test, and change is no-op for normal file systems.
