### PR TITLE
fix: Add set ID to dotnet (lock) packages

### DIFF
--- a/syft/pkg/cataloger/dotnet/parse_dotnet_packages_lock.go
+++ b/syft/pkg/cataloger/dotnet/parse_dotnet_packages_lock.go
@@ -123,7 +123,7 @@ func newDotnetPackagesLockPackage(name string, dep dotnetPackagesLockDep, locati
 		Type:        dep.Type,
 	}
 
-	return &pkg.Package{
+	p := &pkg.Package{
 		Name:      name,
 		Version:   dep.Resolved,
 		Type:      pkg.DotnetPkg,
@@ -132,6 +132,10 @@ func newDotnetPackagesLockPackage(name string, dep dotnetPackagesLockDep, locati
 		Language:  pkg.Dotnet,
 		PURL:      packagesLockPackageURL(name, dep.Resolved),
 	}
+
+	p.SetID()
+
+	return p
 }
 
 func packagesLockPackageURL(name, version string) string {


### PR DESCRIPTION

# Add set ID to dotnet packages

## Description

This PR updates the `.NET` package parsing logic to set the package ID explicitly. This change ensures consistent package identification and improves downstream processing.
I noticed the issue is the source of some relations missing from the model.

### Changes:
- Added `SetID()` call to `newDotnetPackagesLockPackage`
- Ensured the `Package` object includes an explicit ID assignment

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc.)
- [ ] Performance (makes Syft run faster or use less memory)

## Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
