### PR TITLE
Location order on packages should consider evidence annotations when sorting

### DIFF
--- a/internal/cmptest/license.go
+++ b/internal/cmptest/license.go
@@ -10,20 +10,17 @@ import (
 type LicenseComparer func(x, y pkg.License) bool
 
 func DefaultLicenseComparer(x, y pkg.License) bool {
-	return cmp.Equal(x, y, cmp.Comparer(DefaultLocationComparer), cmp.Comparer(
-		func(x, y file.LocationSet) bool {
-			xs := x.ToSlice()
-			ys := y.ToSlice()
-			if len(xs) != len(ys) {
-				return false
-			}
-			for i, xe := range xs {
-				ye := ys[i]
-				if !DefaultLocationComparer(xe, ye) {
-					return false
-				}
-			}
-			return true
-		},
-	))
+	return cmp.Equal(
+		x, y,
+		cmp.Comparer(DefaultLocationComparer),
+		cmp.Comparer(buildSetComparer[file.Location, file.LocationSet](DefaultLocationComparer)),
+	)
+}
+
+func LicenseComparerWithoutLocationLayer(x, y pkg.License) bool {
+	return cmp.Equal(
+		x, y,
+		cmp.Comparer(LocationComparerWithoutLayer),
+		cmp.Comparer(buildSetComparer[file.Location, file.LocationSet](LocationComparerWithoutLayer)),
+	)
 }

--- a/internal/cmptest/location.go
+++ b/internal/cmptest/location.go
@@ -11,3 +11,7 @@ type LocationComparer func(x, y file.Location) bool
 func DefaultLocationComparer(x, y file.Location) bool {
 	return cmp.Equal(x.Coordinates, y.Coordinates) && cmp.Equal(x.AccessPath, y.AccessPath)
 }
+
+func LocationComparerWithoutLayer(x, y file.Location) bool {
+	return cmp.Equal(x.Coordinates.RealPath, y.Coordinates.RealPath) && cmp.Equal(x.AccessPath, y.AccessPath)
+}

--- a/internal/cmptest/set.go
+++ b/internal/cmptest/set.go
@@ -1,0 +1,24 @@
+package cmptest
+
+type slicer[T any] interface {
+	ToSlice() []T
+}
+
+func buildSetComparer[T any, S slicer[T]](l func(x, y T) bool) func(x, y S) bool {
+	return func(x, y S) bool {
+		xs := x.ToSlice()
+		ys := y.ToSlice()
+
+		if len(xs) != len(ys) {
+			return false
+		}
+		for i, xe := range xs {
+			ye := ys[i]
+			if !l(xe, ye) {
+				return false
+			}
+		}
+
+		return true
+	}
+}

--- a/internal/evidence/constants.go
+++ b/internal/evidence/constants.go
@@ -1,0 +1,9 @@
+package evidence
+
+// this package exists so that the file package can reference package evidence in tests without creating a circular dependency.
+
+const (
+	AnnotationKey        = "evidence"
+	PrimaryAnnotation    = "primary"
+	SupportingAnnotation = "supporting"
+)

--- a/internal/relationship/by_file_ownership_test.go
+++ b/internal/relationship/by_file_ownership_test.go
@@ -145,7 +145,7 @@ func TestOwnershipByFilesRelationship(t *testing.T) {
 			assert.Len(t, relationships, len(expectedRelations))
 			for idx, expectedRelationship := range expectedRelations {
 				actualRelationship := relationships[idx]
-				if d := cmp.Diff(expectedRelationship, actualRelationship, cmptest.DefaultCommonOptions()...); d != "" {
+				if d := cmp.Diff(expectedRelationship, actualRelationship, cmptest.DefaultOptions()...); d != "" {
 					t.Errorf("unexpected relationship (-want, +got): %s", d)
 				}
 			}

--- a/syft/file/location_set_test.go
+++ b/syft/file/location_set_test.go
@@ -1,15 +1,17 @@
 package file
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/internal/evidence"
 	"github.com/anchore/syft/syft/artifact"
 )
 
-func TestLocationSet(t *testing.T) {
+func TestLocationSet_SortPaths(t *testing.T) {
 
 	etcHostsLinkVar := Location{
 		LocationData: LocationData{
@@ -89,6 +91,117 @@ func TestLocationSet(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			set := NewLocationSet(test.input...)
 			assert.Equal(t, test.expected, set.ToSlice())
+		})
+	}
+}
+
+func TestLocationSet_SortEvidence(t *testing.T) {
+	primaryEvidence := map[string]string{evidence.AnnotationKey: evidence.PrimaryAnnotation}
+	secondaryEvidence := map[string]string{evidence.AnnotationKey: evidence.SupportingAnnotation}
+
+	binPrimary := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/bin",
+				FileSystemID: "a",
+			},
+			AccessPath: "/usr/bin",
+		},
+		LocationMetadata: LocationMetadata{
+			Annotations: primaryEvidence,
+		},
+	}
+
+	binSecondary := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/bin",
+				FileSystemID: "a",
+			},
+			AccessPath: "/usr/bin",
+		},
+		LocationMetadata: LocationMetadata{
+			Annotations: secondaryEvidence,
+		},
+	}
+
+	binNoEvidence := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/bin",
+				FileSystemID: "a",
+			},
+			AccessPath: "/usr/bin",
+		},
+	}
+
+	etcHostsPrimary := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/etc/hosts",
+				FileSystemID: "a",
+			},
+			AccessPath: "/var/etc/hosts",
+		},
+		LocationMetadata: LocationMetadata{
+			Annotations: primaryEvidence,
+		},
+	}
+
+	etcHostsSecondary := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/etc/hosts",
+				FileSystemID: "a",
+			},
+			AccessPath: "/var/etc/hosts",
+		},
+		LocationMetadata: LocationMetadata{
+			Annotations: secondaryEvidence,
+		},
+	}
+
+	etcHostsNoEvidence := Location{
+		LocationData: LocationData{
+			Coordinates: Coordinates{
+				RealPath:     "/etc/hosts",
+				FileSystemID: "a",
+			},
+			AccessPath: "/var/etc/hosts",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		input    []Location
+		expected []Location
+	}{
+		{
+			name: "sort primary, secondary, tertiary, no evidence",
+			input: []Location{
+				binNoEvidence, binPrimary, binSecondary,
+			},
+			expected: []Location{
+				binPrimary, binSecondary, binNoEvidence,
+			},
+		},
+		{
+			name: "sort by evidence, then path",
+			input: []Location{
+				etcHostsNoEvidence, etcHostsSecondary,
+				binSecondary, binNoEvidence,
+				binPrimary, etcHostsPrimary,
+			},
+			expected: []Location{
+				binPrimary, etcHostsPrimary, binSecondary, etcHostsSecondary, binNoEvidence, etcHostsNoEvidence,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sort.Sort(Locations(test.input))
+			assert.Equal(t, test.expected, test.input)
 		})
 	}
 }

--- a/syft/file/locations.go
+++ b/syft/file/locations.go
@@ -1,5 +1,7 @@
 package file
 
+import "github.com/anchore/syft/internal/evidence"
+
 type Locations []Location
 
 func (l Locations) Len() int {
@@ -7,13 +9,25 @@ func (l Locations) Len() int {
 }
 
 func (l Locations) Less(i, j int) bool {
-	if l[i].RealPath == l[j].RealPath {
-		if l[i].AccessPath == l[j].AccessPath {
-			return l[i].FileSystemID < l[j].FileSystemID
+	liEvidence := l[i].Annotations[evidence.AnnotationKey]
+	ljEvidence := l[j].Annotations[evidence.AnnotationKey]
+	if liEvidence == ljEvidence {
+		if l[i].RealPath == l[j].RealPath {
+			if l[i].AccessPath == l[j].AccessPath {
+				return l[i].FileSystemID < l[j].FileSystemID
+			}
+			return l[i].AccessPath < l[j].AccessPath
 		}
-		return l[i].AccessPath < l[j].AccessPath
+		return l[i].RealPath < l[j].RealPath
 	}
-	return l[i].RealPath < l[j].RealPath
+	if liEvidence == evidence.PrimaryAnnotation {
+		return true
+	}
+	if ljEvidence == evidence.PrimaryAnnotation {
+		return false
+	}
+
+	return liEvidence > ljEvidence
 }
 
 func (l Locations) Swap(i, j int) {

--- a/syft/pkg/cataloger/debian/cataloger_test.go
+++ b/syft/pkg/cataloger/debian/cataloger_test.go
@@ -30,11 +30,11 @@ func TestDpkgCataloger(t *testing.T) {
 						pkg.NewLicenseFromLocations("LGPL-2.1", file.NewLocation("/usr/share/doc/libpam-runtime/copyright")),
 					),
 					Locations: file.NewLocationSet(
-						file.NewLocation("/var/lib/dpkg/status"),
-						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.preinst"),
-						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.md5sums"),
-						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.conffiles"),
-						file.NewLocation("/usr/share/doc/libpam-runtime/copyright"),
+						file.NewLocation("/var/lib/dpkg/status").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.preinst").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
+						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.md5sums").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
+						file.NewLocation("/var/lib/dpkg/info/libpam-runtime.conffiles").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
+						file.NewLocation("/usr/share/doc/libpam-runtime/copyright").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
 					),
 					Type: pkg.DebPkg,
 					Metadata: pkg.DpkgDBEntry{
@@ -104,10 +104,10 @@ func TestDpkgCataloger(t *testing.T) {
 						pkg.NewLicenseFromLocations("GPL-2", file.NewLocation("/usr/share/doc/libsqlite3-0/copyright")),
 					),
 					Locations: file.NewLocationSet(
-						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0"),
-						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0.md5sums"),
-						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0.preinst"),
-						file.NewLocation("/usr/share/doc/libsqlite3-0/copyright"),
+						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0.md5sums").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
+						file.NewLocation("/var/lib/dpkg/status.d/libsqlite3-0.preinst").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
+						file.NewLocation("/usr/share/doc/libsqlite3-0/copyright").WithAnnotation(pkg.EvidenceAnnotationKey, pkg.SupportingEvidenceAnnotation),
 					),
 					Type: pkg.DebPkg,
 					Metadata: pkg.DpkgDBEntry{

--- a/syft/pkg/cataloger/golang/stdlib_package_test.go
+++ b/syft/pkg/cataloger/golang/stdlib_package_test.go
@@ -139,14 +139,14 @@ func Test_stdlibPackageAndRelationships_values(t *testing.T) {
 	require.Len(t, gotPkgs, 1)
 
 	gotPkg := gotPkgs[0]
-	if d := cmp.Diff(expectedPkg, gotPkg, cmptest.DefaultCommonOptions()...); d != "" {
+	if d := cmp.Diff(expectedPkg, gotPkg, cmptest.DefaultOptions()...); d != "" {
 		t.Errorf("unexpected package (-want +got): %s", d)
 	}
 
 	require.Len(t, gotRels, 1)
 	gotRel := gotRels[0]
 
-	if d := cmp.Diff(expectedRel, gotRel, cmptest.DefaultCommonOptions()...); d != "" {
+	if d := cmp.Diff(expectedRel, gotRel, cmptest.DefaultOptions()...); d != "" {
 		t.Errorf("unexpected relationship (-want +got): %s", d)
 	}
 

--- a/syft/pkg/cataloger/python/parse_wheel_egg_metadata_test.go
+++ b/syft/pkg/cataloger/python/parse_wheel_egg_metadata_test.go
@@ -76,7 +76,7 @@ func TestParseWheelEggMetadata(t *testing.T) {
 				t.Fatalf("failed to parse: %+v", err)
 			}
 
-			if d := cmp.Diff(test.ExpectedMetadata, actual, cmptest.DefaultCommonOptions()...); d != "" {
+			if d := cmp.Diff(test.ExpectedMetadata, actual, cmptest.DefaultOptions()...); d != "" {
 				t.Errorf("metadata mismatch (-want +got):\n%s", d)
 			}
 		})

--- a/syft/pkg/evidence.go
+++ b/syft/pkg/evidence.go
@@ -1,7 +1,9 @@
 package pkg
 
+import "github.com/anchore/syft/internal/evidence"
+
 const (
-	EvidenceAnnotationKey        = "evidence"
-	PrimaryEvidenceAnnotation    = "primary"
-	SupportingEvidenceAnnotation = "supporting"
+	EvidenceAnnotationKey        = evidence.AnnotationKey
+	PrimaryEvidenceAnnotation    = evidence.PrimaryAnnotation
+	SupportingEvidenceAnnotation = evidence.SupportingAnnotation
 )


### PR DESCRIPTION
# Description

Today when sorting locations on packages we sort based on the real and access path on these objects. This is almost correct: we should additionally consider first any package annotations that exist (i.e. is this primary evidence or supporting evidence).

This PR adjusts the behavior such that all primary evidence is listed before supporting evidence.

While working on tests for this PR and a soon-to-follow on PR, it made sense to improve some of the `cmptest` options we use around location sets and license sets (which have locations on them and affect comparisons). No functional change was made here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
