### PR TITLE
refactor: move license scanner out from internal package

### DIFF
--- a/examples/create_simple_sbom/main.go
+++ b/examples/create_simple_sbom/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/anchore/syft/internal/licenses"
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/syftjson"
@@ -47,7 +48,15 @@ func getSource(input string) source.Source {
 }
 
 func getSBOM(src source.Source) sbom.SBOM {
-	s, err := syft.CreateSBOM(context.Background(), src, nil)
+	ctx := context.Background()
+
+	licenseScanner, err := licenses.NewDefaultScanner(
+		licenses.WithIncludeLicenseContent(licenses.DefaultIncludeLicenseContent),
+		licenses.WithCoverage(licenses.DefaultCoverageThreshold),
+	)
+	scanCtx := licenses.SetContextLicenseScanner(ctx, licenseScanner)
+
+	s, err := syft.CreateSBOM(scanCtx, src, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/licenses/context.go
+++ b/internal/licenses/context.go
@@ -16,3 +16,8 @@ func ContextLicenseScanner(ctx context.Context) (Scanner, error) {
 	}
 	return NewDefaultScanner()
 }
+
+func ContextHasLicenseScanner(ctx context.Context) bool {
+	_, ok := ctx.Value(licenseScannerKey{}).(Scanner)
+	return ok
+}

--- a/syft/create_sbom.go
+++ b/syft/create_sbom.go
@@ -62,15 +62,17 @@ func CreateSBOM(ctx context.Context, src source.Source, cfg *CreateSBOMConfig) (
 		},
 	}
 
-	// inject a single license scanner and content config for all package cataloging tasks into context
-	licenseScanner, err := licenses.NewDefaultScanner(
-		licenses.WithIncludeLicenseContent(cfg.Licenses.IncludeUnkownLicenseContent),
-		licenses.WithCoverage(cfg.Licenses.Coverage),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("could not build licenseScanner for cataloging: %w", err)
+	if !licenses.ContextHasLicenseScanner(ctx) {
+		// inject a single license scanner and content config for all package cataloging tasks into context
+		licenseScanner, err := licenses.NewDefaultScanner(
+			licenses.WithIncludeLicenseContent(cfg.Licenses.IncludeUnkownLicenseContent),
+			licenses.WithCoverage(cfg.Licenses.Coverage),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("could not build licenseScanner for cataloging: %w", err)
+		}
+		ctx = licenses.SetContextLicenseScanner(ctx, licenseScanner)
 	}
-	ctx = licenses.SetContextLicenseScanner(ctx, licenseScanner)
 
 	catalogingProgress := monitorCatalogingTask(src.ID(), taskGroups)
 	packageCatalogingProgress := monitorPackageCatalogingTask()


### PR DESCRIPTION
The goal is to reuse the default license scanner instance, which is set as Context value, between different scans. This is the main use case for Syft running as a daemon that periodically invokes CreateSBOM() method.

Towards: #3705