### PR TITLE
Swap centos images for rocky

### DIFF
--- a/cmd/syft/internal/test/integration/test-fixtures/image-pkg-coverage/pkgs/var/lib/rpm/generate-fixture.sh
+++ b/cmd/syft/internal/test/integration/test-fixtures/image-pkg-coverage/pkgs/var/lib/rpm/generate-fixture.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-docker create --name generate-rpmdb-fixture centos:latest sh -c 'tail -f /dev/null'
+docker create --name generate-rpmdb-fixture rockylinux:9 sh -c 'tail -f /dev/null'
 
 function cleanup {
   docker kill generate-rpmdb-fixture

--- a/test/compare/rpm.sh
+++ b/test/compare/rpm.sh
@@ -37,7 +37,7 @@ docker run --rm \
     -v ${WORK_DIR}:${WORK_DIR} \
     -e SYFT_CHECK_FOR_APP_UPDATE=0 \
     -w /src \
-    centos:latest \
+    rockylinux:9 \
         /bin/bash -x -c "\
             rpm -ivh ${DISTDIR}/syft_*_linux_amd64.rpm && \
             syft version && \


### PR DESCRIPTION
We're seeing acceptance tests that rely on centos:latest starting to fail. This PR moves us away from using centos:latest and rockylinux instead.