### PR TITLE
chore: reformat imports

### DIFF
--- a/cmd/syft/internal/options/cache.go
+++ b/cmd/syft/internal/options/cache.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
-	"github.com/anchore/go-homedir"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/internal/cache"
 	"github.com/anchore/syft/internal/log"
 )

--- a/cmd/syft/internal/options/cache_test.go
+++ b/cmd/syft/internal/options/cache_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/adrg/xdg"
-	"github.com/anchore/go-homedir"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/cache"
 )

--- a/cmd/syft/internal/options/output_file.go
+++ b/cmd/syft/internal/options/output_file.go
@@ -3,10 +3,9 @@ package options
 import (
 	"fmt"
 
-	"github.com/anchore/go-homedir"
-
 	"github.com/anchore/clio"
 	"github.com/anchore/fangs"
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/syft/sbom"
 )
 

--- a/cmd/syft/internal/options/writer.go
+++ b/cmd/syft/internal/options/writer.go
@@ -9,10 +9,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/anchore/go-homedir"
 	"github.com/hashicorp/go-multierror"
 	"github.com/scylladb/go-set/strset"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/format"

--- a/cmd/syft/internal/options/writer_test.go
+++ b/cmd/syft/internal/options/writer_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/anchore/go-homedir"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/syft/sbom"
 )
 

--- a/syft/format/template/encoder.go
+++ b/syft/format/template/encoder.go
@@ -11,8 +11,8 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
-	"github.com/anchore/go-homedir"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/syft/format/syftjson"
 	"github.com/anchore/syft/syft/sbom"
 )

--- a/syft/internal/fileresolver/unindexed_directory.go
+++ b/syft/internal/fileresolver/unindexed_directory.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/anchore/go-homedir"
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/spf13/afero"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"
 )

--- a/syft/pkg/cataloger/golang/config.go
+++ b/syft/pkg/cataloger/golang/config.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/anchore/go-homedir"
-
 	"github.com/anchore/syft/internal/log"
 )
 

--- a/syft/pkg/cataloger/golang/config_test.go
+++ b/syft/pkg/cataloger/golang/config_test.go
@@ -4,8 +4,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/anchore/go-homedir"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/go-homedir"
 )
 
 func Test_Config(t *testing.T) {

--- a/syft/pkg/cataloger/java/internal/maven/config.go
+++ b/syft/pkg/cataloger/java/internal/maven/config.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/anchore/go-homedir"
-
 	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/internal/log"
 )

--- a/syft/pkg/cataloger/java/internal/maven/config_test.go
+++ b/syft/pkg/cataloger/java/internal/maven/config_test.go
@@ -5,9 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/anchore/go-homedir"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/internal"
 )
 

--- a/syft/source/directorysource/directory_source_provider.go
+++ b/syft/source/directorysource/directory_source_provider.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/anchore/go-homedir"
 	"github.com/spf13/afero"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/syft/source"
 )
 

--- a/syft/source/filesource/file_source_provider.go
+++ b/syft/source/filesource/file_source_provider.go
@@ -5,9 +5,9 @@ import (
 	"crypto"
 	"fmt"
 
-	"github.com/anchore/go-homedir"
 	"github.com/spf13/afero"
 
+	"github.com/anchore/go-homedir"
 	"github.com/anchore/syft/syft/source"
 )
 


### PR DESCRIPTION
This PR just has changes from `make lint-fix` to avoid conflicts due to formatting in other PRs.