### PR TITLE
Empty source during decoding an SBOM document should not be fatal

### DIFF
--- a/syft/format/syftjson/model/source.go
+++ b/syft/format/syftjson/model/source.go
@@ -58,7 +58,8 @@ func (s *Source) UnmarshalJSON(b []byte) error {
 func unpackSrcMetadata(s *Source, unpacker sourceUnpacker) error {
 	rt := sourcemetadata.ReflectTypeFromJSONName(s.Type)
 	if rt == nil {
-		return fmt.Errorf("unable to find source metadata type=%q", s.Type)
+		// in cases where we are converting from an SBOM without any source information, we don't want this to be fatal
+		return nil
 	}
 
 	val := reflect.New(rt).Interface()

--- a/syft/format/syftjson/model/source_test.go
+++ b/syft/format/syftjson/model/source_test.go
@@ -23,6 +23,15 @@ func TestSource_UnmarshalJSON(t *testing.T) {
 		wantErr  require.ErrorAssertionFunc
 	}{
 		{
+			name: "empty",
+			input: []byte(`{
+				"id": "",
+				"type": "",
+				"metadata": null
+			}`),
+			expected: &Source{},
+		},
+		{
 			name: "directory",
 			input: []byte(`{
 				"id": "foobar",


### PR DESCRIPTION
When decoding an SBOM document that does not have a source or primary purpose package there we should still allow for the decoding to continue without error; today we get this:
```
[0000] ERROR failed to catalog: unable to decode sbom: unable to decode syft-json document: unable to find source metadata type=""
```

With this fix the decoding would be allowed to continue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
