### PR TITLE
(feat): support skipping archive extraction with file source

### DIFF
--- a/syft/source/filesource/file_source.go
+++ b/syft/source/filesource/file_source.go
@@ -26,10 +26,11 @@ import (
 var _ source.Source = (*fileSource)(nil)
 
 type Config struct {
-	Path             string
-	Exclude          source.ExcludeConfig
-	DigestAlgorithms []crypto.Hash
-	Alias            source.Alias
+	Path               string
+	Exclude            source.ExcludeConfig
+	DigestAlgorithms   []crypto.Hash
+	Alias              source.Alias
+	SkipExtractArchive bool
 }
 
 type fileSource struct {
@@ -58,7 +59,7 @@ func New(cfg Config) (source.Source, error) {
 		return nil, fmt.Errorf("given path is a directory: %q", cfg.Path)
 	}
 
-	analysisPath, cleanupFn := fileAnalysisPath(cfg.Path)
+	analysisPath, cleanupFn := fileAnalysisPath(cfg.Path, cfg.SkipExtractArchive)
 
 	var digests []file.Digest
 	if len(cfg.DigestAlgorithms) > 0 {
@@ -206,9 +207,15 @@ func (s *fileSource) Close() error {
 
 // fileAnalysisPath returns the path given, or in the case the path is an archive, the location where the archive
 // contents have been made available. A cleanup function is provided for any temp files created (if any).
-func fileAnalysisPath(path string) (string, func() error) {
-	var analysisPath = path
+// Users can disable unpacking archives, allowing individual cataloguers to extract them instead (where
+// supported)
+func fileAnalysisPath(path string, skipExtractArchive bool) (string, func() error) {
 	var cleanupFn = func() error { return nil }
+	var analysisPath = path
+
+	if skipExtractArchive {
+		return analysisPath, cleanupFn
+	}
 
 	// if the given file is an archive (as indicated by the file extension and not MIME type) then unarchive it and
 	// use the contents as the source. Note: this does NOT recursively unarchive contents, only the given path is

--- a/syft/source/filesource/file_source_test.go
+++ b/syft/source/filesource/file_source_test.go
@@ -99,13 +99,14 @@ func TestNewFromFile_WithArchive(t *testing.T) {
 	testutil.Chdir(t, "..") // run with source/test-fixtures
 
 	testCases := []struct {
-		desc       string
-		input      string
-		expString  string
-		inputPaths []string
-		expRefs    int
-		layer2     bool
-		contents   string
+		desc               string
+		input              string
+		expString          string
+		inputPaths         []string
+		expRefs            int
+		layer2             bool
+		contents           string
+		skipExtractArchive bool
 	}{
 		{
 			desc:       "path detected",
@@ -121,14 +122,25 @@ func TestNewFromFile_WithArchive(t *testing.T) {
 			layer2:     true,
 			contents:   "Another .vimrc file",
 		},
+		{
+			desc:               "skip extract archive",
+			input:              "test-fixtures/path-detected",
+			inputPaths:         []string{"/.vimrc"},
+			expRefs:            0,
+			layer2:             false,
+			skipExtractArchive: true,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(test.desc, func(t *testing.T) {
 			archivePath := setupArchiveTest(t, test.input, test.layer2)
 
-			src, err := New(Config{
-				Path: archivePath,
-			})
+			cfg := Config{
+				Path:               archivePath,
+				SkipExtractArchive: test.skipExtractArchive,
+			}
+
+			src, err := New(cfg)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, src.Close())


### PR DESCRIPTION
# Description

Currently when an archive file is scanned with a file source, the archive is extracted before scanning

This is different from the default behavior when an archive file is encountered via directory source, in that case archives are only extracted when deemed necessary by catalogers (ie the java archive cataloguer)

As a Syft library user, when scanning with file source I would like the option to skip extracting archives and instead allow cataloguers decide whether to extract them. 

I've added `SkipExtractArchive` to the filesource Config here, and by default it will be `false` so all existing users will be unaffected.

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
