### PR TITLE
(fix): delete collection name/type key entries when empty

### DIFF
--- a/syft/pkg/collection.go
+++ b/syft/pkg/collection.go
@@ -201,7 +201,11 @@ func (c *Collection) deleteNameFromIndex(p Package) {
 
 	nameIndex := c.idsByName[p.Name]
 	nameIndex.delete(p.id)
-	c.idsByName[p.Name] = nameIndex
+	if len(nameIndex.slice) == 0 {
+		delete(c.idsByName, p.Name)
+	} else {
+		c.idsByName[p.Name] = nameIndex
+	}
 }
 
 func (c *Collection) deleteTypeFromIndex(p Package) {
@@ -209,7 +213,11 @@ func (c *Collection) deleteTypeFromIndex(p Package) {
 
 	typeIndex := c.idsByType[p.Type]
 	typeIndex.delete(p.id)
-	c.idsByType[p.Type] = typeIndex
+	if len(typeIndex.slice) == 0 {
+		delete(c.idsByType, p.Type)
+	} else {
+		c.idsByType[p.Type] = typeIndex
+	}
 }
 
 func (c *Collection) deletePathsFromIndex(p Package) {

--- a/syft/pkg/collection_test.go
+++ b/syft/pkg/collection_test.go
@@ -184,6 +184,24 @@ func TestCatalogDeleteRemovesPackages(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "delete idsBy key entries when all deleted",
+			pkgs: []Package{
+				{
+					id:      artifact.ID("pkg:deb/debian/1"),
+					Name:    "debian",
+					Version: "1",
+					Type:    DebPkg,
+					Locations: file.NewLocationSet(
+						file.NewVirtualLocation("/c/path", "/another/path1"),
+					),
+				},
+			},
+			deleteIDs: []artifact.ID{
+				artifact.ID("pkg:deb/debian/1"),
+			},
+			expectedIndexes: expectedIndexes{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Description
The collection used to store packages does not delete map keys from the `byName` or `byType` maps when the key's respective slice is emptied.

This is already done for the `byPath` map - this change fixes the `idsByName` and `idsByType` maps

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
