### PR TITLE
Fix: Correct variable names for Conan lock parsing version handling

### DIFF
--- a/syft/pkg/cataloger/cpp/parse_conanlock.go
+++ b/syft/pkg/cataloger/cpp/parse_conanlock.go
@@ -47,14 +47,14 @@ func parseConanLock(_ context.Context, _ file.Resolver, _ *generic.Environment, 
 	// in a second iteration
 	var indexToPkgMap = map[string]pkg.Package{}
 
-	v1Pkgs := handleConanLockV2(cl, reader, indexToPkgMap)
+	v2Pkgs := handleConanLockV2(cl, reader, indexToPkgMap)
 
 	// we do not want to store the index list requires in the conan metadata, because it is not useful to have it in
 	// the SBOM. Instead, we will store it in a map and then use it to build the relationships
 	// maps pkg.ID to a list of indices
 	var parsedPkgRequires = map[artifact.ID][]string{}
 
-	v2Pkgs := handleConanLockV1(cl, reader, parsedPkgRequires, indexToPkgMap)
+	v1Pkgs := handleConanLockV1(cl, reader, parsedPkgRequires, indexToPkgMap)
 
 	var relationships []artifact.Relationship
 	var pkgs []pkg.Package


### PR DESCRIPTION
# Description

This PR fixes incorrect variable naming in the `parseConanLock` function.

- Renamed the result of `handleConanLockV2` from `v1Pkgs` to `v2Pkgs`
- Renamed the result of `handleConanLockV1` from `v2Pkgs` to `v1Pkgs`

These changes improve the clarity of the code and prevent confusion between Conan lock version 1 and version 2 parsing logic.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
