### PR TITLE
fix: comma separated selectors in cataloger list command

### DIFF
--- a/cmd/syft/internal/commands/cataloger_list.go
+++ b/cmd/syft/internal/commands/cataloger_list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/anchore/clio"
+	"github.com/anchore/syft/cmd/syft/internal/options"
 	"github.com/anchore/syft/internal/bus"
 	"github.com/anchore/syft/internal/task"
 	"github.com/anchore/syft/syft/cataloging"
@@ -86,11 +87,13 @@ func runCatalogerList(opts *catalogerListOptions) error {
 }
 
 func catalogerListReport(opts *catalogerListOptions, allTaskGroups [][]task.Task) (string, error) {
+	defaultCatalogers := options.Flatten(opts.DefaultCatalogers)
+	selectCatalogers := options.Flatten(opts.SelectCatalogers)
 	selectedTaskGroups, selectionEvidence, err := task.SelectInGroups(
 		allTaskGroups,
 		cataloging.NewSelectionRequest().
-			WithDefaults(opts.DefaultCatalogers...).
-			WithExpression(opts.SelectCatalogers...),
+			WithDefaults(defaultCatalogers...).
+			WithExpression(selectCatalogers...),
 	)
 	if err != nil {
 		return "", fmt.Errorf("unable to select catalogers: %w", err)
@@ -99,7 +102,7 @@ func catalogerListReport(opts *catalogerListOptions, allTaskGroups [][]task.Task
 
 	switch opts.Output {
 	case "json":
-		report, err = renderCatalogerListJSON(flattenTaskGroups(selectedTaskGroups), selectionEvidence, opts.DefaultCatalogers, opts.SelectCatalogers)
+		report, err = renderCatalogerListJSON(flattenTaskGroups(selectedTaskGroups), selectionEvidence, defaultCatalogers, selectCatalogers)
 	case "table", "":
 		if opts.ShowHidden {
 			report = renderCatalogerListTables(allTaskGroups, selectionEvidence)

--- a/cmd/syft/internal/commands/cataloger_list_test.go
+++ b/cmd/syft/internal/commands/cataloger_list_test.go
@@ -184,15 +184,52 @@ Default selections: 1
   • 'image'
 Selection expressions: 6
   • 'b' (intersect)
-  • '-directory' (remove)
   • '-c' (remove)
+  • '-directory' (remove)
   • '-file' (remove)
-  • '+task3' (add)
   • '+file-task1' (add)
+  • '+task3' (add)
 ┌────────────────┬──────────────────┐
 │ FILE CATALOGER │ TAGS             │
 ├────────────────┼──────────────────┤
 │ file-task1     │ file, ft, ft-1-b │
+└────────────────┴──────────────────┘
+┌───────────────────┬────────────────────┐
+│ PACKAGE CATALOGER │ TAGS               │
+├───────────────────┼────────────────────┤
+│ task1             │ 1, a, b, image     │
+│ task3             │ 3, c, d, directory │
+└───────────────────┴────────────────────┘
+`,
+		},
+		{
+			name: "with comma separated expressions, table",
+			options: func() *catalogerListOptions {
+				c := defaultCatalogerListOptions()
+				c.Output = "table"
+				c.DefaultCatalogers = []string{
+					"image,task3,file-task1",
+				}
+				c.SelectCatalogers = []string{
+					"-task2,c,b",
+				}
+				return c
+			}(),
+			want: `
+Default selections: 4
+  • 'file-task1'
+  • 'image'
+  • 'task3'
+  • 'file'
+Selection expressions: 3
+  • 'b' (intersect)
+  • 'c' (intersect)
+  • '-task2' (remove)
+┌────────────────┬──────────────────┐
+│ FILE CATALOGER │ TAGS             │
+├────────────────┼──────────────────┤
+│ file-task1     │ file, ft, ft-1-b │
+│ file-task2     │ file, ft, ft-2-b │
 └────────────────┴──────────────────┘
 ┌───────────────────┬────────────────────┐
 │ PACKAGE CATALOGER │ TAGS               │
@@ -219,7 +256,7 @@ Selection expressions: 6
 				return c
 			}(),
 			want: `
-{"default":["image"],"selection":["-directory","+task3","-c","b"],"catalogers":[{"name":"file-task1","tags":["file"]},{"name":"file-task2","tags":["file"]},{"name":"task1","tags":["b","image"]},{"name":"task3","tags":["task3"]}]}
+{"default":["image"],"selection":["+task3","-c","-directory","b"],"catalogers":[{"name":"file-task1","tags":["file"]},{"name":"file-task2","tags":["file"]},{"name":"task1","tags":["b","image"]},{"name":"task3","tags":["task3"]}]}
 `,
 		},
 	}

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -272,12 +272,12 @@ func (cfg *Catalog) PostLoad() error {
 		return fmt.Errorf("cannot use both 'catalogers' and 'select-catalogers'/'default-catalogers' flags")
 	}
 
-	cfg.From = flatten(cfg.From)
+	cfg.From = Flatten(cfg.From)
 
-	cfg.Catalogers = flatten(cfg.Catalogers)
-	cfg.DefaultCatalogers = flatten(cfg.DefaultCatalogers)
-	cfg.SelectCatalogers = flatten(cfg.SelectCatalogers)
-	cfg.Enrich = flatten(cfg.Enrich)
+	cfg.Catalogers = Flatten(cfg.Catalogers)
+	cfg.DefaultCatalogers = Flatten(cfg.DefaultCatalogers)
+	cfg.SelectCatalogers = Flatten(cfg.SelectCatalogers)
+	cfg.Enrich = Flatten(cfg.Enrich)
 
 	// for backwards compatibility
 	cfg.DefaultCatalogers = append(cfg.DefaultCatalogers, cfg.Catalogers...)
@@ -295,7 +295,7 @@ func (cfg *Catalog) PostLoad() error {
 	return nil
 }
 
-func flatten(commaSeparatedEntries []string) []string {
+func Flatten(commaSeparatedEntries []string) []string {
 	var out []string
 	for _, v := range commaSeparatedEntries {
 		for _, s := range strings.Split(v, ",") {

--- a/cmd/syft/internal/options/catalog_test.go
+++ b/cmd/syft/internal/options/catalog_test.go
@@ -139,7 +139,7 @@ func Test_enrichmentEnabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.directives, func(t *testing.T) {
-			got := enrichmentEnabled(flatten([]string{test.directives}), test.test)
+			got := enrichmentEnabled(Flatten([]string{test.directives}), test.test)
 			assert.Equal(t, test.expected, got)
 		})
 	}


### PR DESCRIPTION
# Description

This PR fixes [an issue that was raised on Discourse](https://anchorecommunity.discourse.group/t/package-detect-binary-not-detect/299/5?u=kzantow) where `cataloger list --override-default-catalogers "go-module-binary-cataloger,go-module-file-cataloger"` would cause an error:
```
[0000] ERROR unable to generate cataloger list report: unable to select catalogers: no cataloger tasks respond to the following selections: go-module-binary-cataloger,go-module-file-cataloger
```

With this change:
```
$ go run ./cmd/syft cataloger list --override-default-catalogers "go-module-binary-cataloger,go-module-file-cataloger"                          
[0000]  WARN adding 'file' tag to the default cataloger selection, to override add '-file' to the cataloger selection request
Default selections: 3
  • 'go-module-binary-cataloger'
  • 'go-module-file-cataloger'
  • 'file'
Selection expressions: 0
┌───────────────────────────┬───────────────────────┐
│ FILE CATALOGER            │ TAGS                  │
├───────────────────────────┼───────────────────────┤
│ file-content-cataloger    │ content, file         │
│ file-digest-cataloger     │ digest, file          │
│ file-executable-cataloger │ binary-metadata, file │
│ file-metadata-cataloger   │ file, file-metadata   │
└───────────────────────────┴───────────────────────┘
┌────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
│ PACKAGE CATALOGER          │ TAGS                                                                      │
├────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
│ go-module-binary-cataloger │ binary, directory, go, golang, gomod, image, installed, language, package │
│ go-module-file-cataloger   │ declared, directory, go, golang, gomod, language, package                 │
└────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘
```

- Fixes #3801

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
