### PR TITLE
docs: document test commands

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -227,6 +227,16 @@ rough outline how that works:
 
 ## Testing
 
+### Testing commands
+
+* `make help` shows a list of available commands
+* `make unit`, `make integration`, `make cli`, and `make acceptance` run those test suites (see below)
+* `make test` runs all those tests (and is therefore pretty slow)
+* `make fixtures` clears and re-fetches all test fixtures.
+* `go test ./syft/pkg/` for example can test particular packages, assuming fixtures are already made
+* `make clean-cache` cleans all test cache. Note that subsequent test runs will be slower after this
+
+
 ### Levels of testing
 
 - `unit`: The default level of test which is distributed throughout the repo are unit tests. Any `_test.go` file that 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -224,7 +224,7 @@ tasks:
       - "go run -race cmd/syft/main.go alpine:latest"
 
   validate-cyclonedx-schema:
-    desc: Run integration tests
+    desc: Validate that Syft produces valid CycloneDX documents
     cmds:
       - "cd schema/cyclonedx && make"
 


### PR DESCRIPTION
So that contributors can quickly figure out how to run tests.

# Description

We had an issue where a user was stuck because they didn't know how to clean the test cache in an old workspace, which made me realize we had some commands that weren't documented in DEVELOPING.md

- Fixes #3809

## Type of change

- [x] Documentation (updates the documentation)


