### PR TITLE
PE cataloger should consider compile target paths from deps.json

### DIFF
--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -1035,7 +1035,7 @@ func TestCataloger(t *testing.T) {
 	}
 }
 
-func TestDotnetDepsCataloger_problemCases(t *testing.T) {
+func TestDotnetDepsCataloger_regressions(t *testing.T) {
 	cases := []struct {
 		name      string
 		fixture   string
@@ -1070,6 +1070,20 @@ func TestDotnetDepsCataloger_problemCases(t *testing.T) {
 				}
 
 				pkgtest.AssertPackagesEqualIgnoreLayers(t, expected, actual)
+			},
+		},
+		{
+			name:      "compile target reference",
+			fixture:   "image-net8-compile-target",
+			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
+			assertion: func(t *testing.T, pkgs []pkg.Package, relationships []artifact.Relationship) {
+				// ensure we find the DotNetNuke.Core package (which is using the compile target reference)
+				for _, p := range pkgs {
+					if p.Name == "DotNetNuke.Core" {
+						return
+					}
+				}
+				t.Error("expected to find DotNetNuke.Core package")
 			},
 		},
 	}

--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -1008,6 +1008,7 @@ func TestCataloger(t *testing.T) {
 				"Serilog.Sinks.Console @ 4.0.1 (/app/helloworld.deps.json)",
 				"helloworld @ 1.0.0 (/app/helloworld.deps.json)",
 				"runtime.linux-x64.Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
+				"runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)", // a compile target reference
 			},
 			expectedRels: []string{
 				"Serilog @ 2.10.0 (/app/helloworld.deps.json) [dependency-of] Serilog.Sinks.Console @ 4.0.1 (/app/helloworld.deps.json)",

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -204,6 +204,14 @@ func attachAssociatedExecutables(dep *logicalDepsJSON, pe logicalPE) bool {
 			continue
 		}
 
+		if targetPath, ok := p.CompilePathsByRelativeDLLPath[relativeDllPath]; ok {
+			pe.TargetPath = targetPath
+			p.Executables = append(p.Executables, pe)
+			dep.PackagesByNameVersion[key] = p // update the map with the modified package
+			found = true
+			continue
+		}
+
 		if p.NativePaths.Has(relativeDllPath) {
 			pe.TargetPath = relativeDllPath
 			p.Executables = append(p.Executables, pe)
@@ -265,7 +273,7 @@ func packagesFromLogicalDepsJSON(doc logicalDepsJSON, config CatalogerConfig) (*
 			continue
 		}
 
-		claimsDLLs := len(lp.RuntimePathsByRelativeDLLPath) > 0 || len(lp.ResourcePathsByRelativeDLLPath) > 0
+		claimsDLLs := len(lp.RuntimePathsByRelativeDLLPath) > 0 || len(lp.ResourcePathsByRelativeDLLPath) > 0 || len(lp.CompilePathsByRelativeDLLPath) > 0 || len(lp.NativePaths.List()) > 0
 
 		if config.DepPackagesMustClaimDLL && !claimsDLLs {
 			if config.RelaxDLLClaimsWhenBundlingDetected && !doc.BundlingDetected || !config.RelaxDLLClaimsWhenBundlingDetected {

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/.gitignore
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/.gitignore
@@ -1,0 +1,2 @@
+/app
+/extract.sh

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
@@ -9,7 +9,8 @@ COPY src/*.cs .
 
 RUN dotnet publish -c Release --no-restore -o /app
 
-# note: we're not using a runtime here to make testing easier... but this functionally will not work if this was a produciton app
+# note: we're not using a runtime here to make testing easier... so you cannot run this container and expect it to work
+# we do this to keep the test assertions small since the don't want to include the several other runtime packages
 FROM busybox:latest
 
 WORKDIR /app

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine@sha256:3f93439f47fea888d94e6e228d0d0de841f4122ef46f8bfd04f8bd78cbce7ddb AS build
+ARG RUNTIME=win-x64
+WORKDIR /src
+
+COPY src/helloworld.csproj .
+RUN dotnet restore -r $RUNTIME
+
+COPY src/*.cs .
+
+RUN dotnet publish -c Release --no-restore -o /app
+
+# note: we're not using a runtime here to make testing easier... but this functionally will not work if this was a produciton app
+FROM busybox:latest
+
+WORKDIR /app
+
+COPY --from=build /app .

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/Program.cs
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace HelloWorld
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+                Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/helloworld.csproj
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/helloworld.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DotNetNuke.Core" Version="9.9.1"/>
+    <PackageReference Include="jQuery" Version="3.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Nuget.CommandLine" Version="6.3.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Umbraco.Cms" Version="11.3.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Today the PE cataloger considers the `runtime`, `resources`, and `native` target types within a deps.json file, however, the `compile` type is not considered:

>  If a given dependency is only listed for compilation, then its runtime, resources and native properties is omitted. Similarly if the dependency is only listed for runtime, then its compile property is omitted.

Per the [.NET CLI documentation](https://github.com/dotnet/cli/blob/v3.1.426/Documentation/specs/runtime-configuration-file.md).

This mirrors the same logic applied to the runtime and resources type to the compile type, allowing us to pair up deps.json entries that look like this with the DLLs they reference:
```json
... 
"DotNetNuke.Core/9.9.1": {
  "dependencies": {
    "DotNetNuke.DependencyInjection": "9.9.1"
  },
  "compile": {
    "lib/net45/DotNetNuke.dll": {},
    "lib/net45/Microsoft.ApplicationBlocks.Data.dll": {}
  }
},
...
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
