### PR TITLE
Consider DLL claims for dependencies of .NET packages from deps.json

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -170,6 +170,7 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 		Dotnet: dotnet.DefaultCatalogerConfig().
 			WithDepPackagesMustHaveDLL(cfg.Dotnet.DepPackagesMustHaveDLL).
 			WithDepPackagesMustClaimDLL(cfg.Dotnet.DepPackagesMustClaimDLL).
+			WithDLLClaimsPropagateToParents(cfg.Dotnet.DLLClaimsPropagateToParents).
 			WithRelaxDLLClaimsWhenBundlingDetected(cfg.Dotnet.RelaxDLLClaimsWhenBundlingDetected),
 		Golang: golang.DefaultCatalogerConfig().
 			WithSearchLocalModCacheLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Go, task.Golang), cfg.Golang.SearchLocalModCacheLicenses)).

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -170,7 +170,7 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 		Dotnet: dotnet.DefaultCatalogerConfig().
 			WithDepPackagesMustHaveDLL(cfg.Dotnet.DepPackagesMustHaveDLL).
 			WithDepPackagesMustClaimDLL(cfg.Dotnet.DepPackagesMustClaimDLL).
-			WithDLLClaimsPropagateToParents(cfg.Dotnet.DLLClaimsPropagateToParents).
+			WithPropagateDLLClaimsToParents(cfg.Dotnet.PropagateDLLClaimsToParents).
 			WithRelaxDLLClaimsWhenBundlingDetected(cfg.Dotnet.RelaxDLLClaimsWhenBundlingDetected),
 		Golang: golang.DefaultCatalogerConfig().
 			WithSearchLocalModCacheLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Go, task.Golang), cfg.Golang.SearchLocalModCacheLicenses)).

--- a/cmd/syft/internal/options/dotnet.go
+++ b/cmd/syft/internal/options/dotnet.go
@@ -10,7 +10,7 @@ type dotnetConfig struct {
 
 	DepPackagesMustClaimDLL bool `mapstructure:"dep-packages-must-claim-dll" json:"dep-packages-must-claim-dll" yaml:"dep-packages-must-claim-dll"`
 
-	DLLClaimsPropagateToParents bool `mapstructure:"dll-claims-propagate-to-parents" json:"dll-claims-propagate-to-parents" yaml:"dll-claims-propagate-to-parents"`
+	PropagateDLLClaimsToParents bool `mapstructure:"propagate-dll-claims-to-parents" json:"propagate-dll-claims-to-parents" yaml:"propagate-dll-claims-to-parents"`
 
 	RelaxDLLClaimsWhenBundlingDetected bool `mapstructure:"relax-dll-claims-when-bundling-detected" json:"relax-dll-claims-when-bundling-detected" yaml:"relax-dll-claims-when-bundling-detected"`
 }
@@ -22,7 +22,7 @@ var _ interface {
 func (o *dotnetConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&o.DepPackagesMustHaveDLL, `only keep dep.json packages which an executable on disk is found. The package is also included if a DLL is found for any child package, even if the package itself does not have a DLL.`)
 	descriptions.Add(&o.DepPackagesMustClaimDLL, `only keep dep.json packages which have a runtime/resource DLL claimed in the deps.json targets section (but not necessarily found on disk). The package is also included if any child package claims a DLL, even if the package itself does not claim a DLL.`)
-	descriptions.Add(&o.DLLClaimsPropagateToParents, `treat DLL claims or on-disk evidence for child packages as DLL claims or on-disk evidence for any parent package`)
+	descriptions.Add(&o.PropagateDLLClaimsToParents, `treat DLL claims or on-disk evidence for child packages as DLL claims or on-disk evidence for any parent package`)
 	descriptions.Add(&o.RelaxDLLClaimsWhenBundlingDetected, `show all packages from the deps.json if bundling tooling is present as a dependency (e.g. ILRepack)`)
 }
 
@@ -31,7 +31,7 @@ func defaultDotnetConfig() dotnetConfig {
 	return dotnetConfig{
 		DepPackagesMustHaveDLL:             def.DepPackagesMustHaveDLL,
 		DepPackagesMustClaimDLL:            def.DepPackagesMustClaimDLL,
-		DLLClaimsPropagateToParents:        def.DLLClaimsPropagateToParents,
+		PropagateDLLClaimsToParents:        def.PropagateDLLClaimsToParents,
 		RelaxDLLClaimsWhenBundlingDetected: def.RelaxDLLClaimsWhenBundlingDetected,
 	}
 }

--- a/cmd/syft/internal/options/dotnet.go
+++ b/cmd/syft/internal/options/dotnet.go
@@ -10,6 +10,8 @@ type dotnetConfig struct {
 
 	DepPackagesMustClaimDLL bool `mapstructure:"dep-packages-must-claim-dll" json:"dep-packages-must-claim-dll" yaml:"dep-packages-must-claim-dll"`
 
+	DLLClaimsPropagateToParents bool `mapstructure:"dll-claims-propagate-to-parents" json:"dll-claims-propagate-to-parents" yaml:"dll-claims-propagate-to-parents"`
+
 	RelaxDLLClaimsWhenBundlingDetected bool `mapstructure:"relax-dll-claims-when-bundling-detected" json:"relax-dll-claims-when-bundling-detected" yaml:"relax-dll-claims-when-bundling-detected"`
 }
 
@@ -20,6 +22,7 @@ var _ interface {
 func (o *dotnetConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&o.DepPackagesMustHaveDLL, `only keep dep.json packages which an executable on disk is found. The package is also included if a DLL is found for any child package, even if the package itself does not have a DLL.`)
 	descriptions.Add(&o.DepPackagesMustClaimDLL, `only keep dep.json packages which have a runtime/resource DLL claimed in the deps.json targets section (but not necessarily found on disk). The package is also included if any child package claims a DLL, even if the package itself does not claim a DLL.`)
+	descriptions.Add(&o.DLLClaimsPropagateToParents, `treat DLL claims or on-disk evidence for child packages as DLL claims or on-disk evidence for any parent package`)
 	descriptions.Add(&o.RelaxDLLClaimsWhenBundlingDetected, `show all packages from the deps.json if bundling tooling is present as a dependency (e.g. ILRepack)`)
 }
 
@@ -28,6 +31,7 @@ func defaultDotnetConfig() dotnetConfig {
 	return dotnetConfig{
 		DepPackagesMustHaveDLL:             def.DepPackagesMustHaveDLL,
 		DepPackagesMustClaimDLL:            def.DepPackagesMustClaimDLL,
+		DLLClaimsPropagateToParents:        def.DLLClaimsPropagateToParents,
 		RelaxDLLClaimsWhenBundlingDetected: def.RelaxDLLClaimsWhenBundlingDetected,
 	}
 }

--- a/cmd/syft/internal/options/dotnet.go
+++ b/cmd/syft/internal/options/dotnet.go
@@ -18,8 +18,8 @@ var _ interface {
 } = (*dotnetConfig)(nil)
 
 func (o *dotnetConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
-	descriptions.Add(&o.DepPackagesMustHaveDLL, `only keep dep.json packages which an executable on disk can be found for`)
-	descriptions.Add(&o.DepPackagesMustClaimDLL, `only keep dep.json packages which have a runtime/resource DLL claimed in the deps.json targets section (but not necessarily found on disk)`)
+	descriptions.Add(&o.DepPackagesMustHaveDLL, `only keep dep.json packages which an executable on disk is found. The package is also included if a DLL is found for any child package, even if the package itself does not have a DLL.`)
+	descriptions.Add(&o.DepPackagesMustClaimDLL, `only keep dep.json packages which have a runtime/resource DLL claimed in the deps.json targets section (but not necessarily found on disk). The package is also included if any child package claims a DLL, even if the package itself does not claim a DLL.`)
 	descriptions.Add(&o.RelaxDLLClaimsWhenBundlingDetected, `show all packages from the deps.json if bundling tooling is present as a dependency (e.g. ILRepack)`)
 }
 

--- a/internal/licenses/context_test.go
+++ b/internal/licenses/context_test.go
@@ -2,8 +2,9 @@ package licenses
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetContextLicenseScanner(t *testing.T) {

--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -1,9 +1,9 @@
 package dotnet
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/syft/syft/artifact"
@@ -118,6 +118,10 @@ func TestCataloger(t *testing.T) {
 		"Humanizer @ 2.14.1 (/app/dotnetapp.deps.json)",
 	}
 	net8AppExpectedDepPkgs = append(net8AppExpectedDepPkgs, net8AppExpectedDepPkgsWithoutUnpairedDlls...)
+
+	var net8AppExpectedDepPkgsWithRuntime []string
+	net8AppExpectedDepPkgsWithRuntime = append(net8AppExpectedDepPkgsWithRuntime, net8AppExpectedDepPkgs...)
+	net8AppExpectedDepPkgsWithRuntime = append(net8AppExpectedDepPkgsWithRuntime, "Microsoft.NETCore.App.Runtime.linux-x64 @ 8.0.14 (/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/Microsoft.NETCore.App.deps.json)")
 
 	// app binaries (always dlls)
 	net8AppBinaryOnlyPkgs := []string{
@@ -280,11 +284,17 @@ func TestCataloger(t *testing.T) {
 	net8AppDepOnlyRelationships = append(net8AppDepOnlyRelationships, net8AppDepOnlyRelationshipsWithoutHumanizer...)
 	net8AppDepOnlyRelationships = append(net8AppDepOnlyRelationships, humanizerToAppDepsRelationship)
 
+	var net8AppDepOnlyRelationshipsWithRuntime []string
+	net8AppDepOnlyRelationshipsWithRuntime = append(net8AppDepOnlyRelationshipsWithRuntime, net8AppDepOnlyRelationships...)
+	net8AppDepOnlyRelationshipsWithRuntime = append(net8AppDepOnlyRelationshipsWithRuntime,
+		"Microsoft.NETCore.App.Runtime.linux-x64 @ 8.0.14 (/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/Microsoft.NETCore.App.deps.json) [dependency-of] dotnetapp @ 1.0.0 (/app/dotnetapp.deps.json)",
+	)
+
 	var net8AppExpectedDepRelationships []string
 	net8AppExpectedDepRelationships = append(net8AppExpectedDepRelationships, net8AppDepOnlyRelationships...)
 
 	var net8AppExpectedDepSelfContainedPkgs []string
-	net8AppExpectedDepSelfContainedPkgs = append(net8AppExpectedDepSelfContainedPkgs, net8AppExpectedDepPkgsWithoutUnpairedDlls...)
+	net8AppExpectedDepSelfContainedPkgs = append(net8AppExpectedDepSelfContainedPkgs, net8AppExpectedDepPkgs...)
 	net8AppExpectedDepSelfContainedPkgs = append(net8AppExpectedDepSelfContainedPkgs,
 		// add the CLR runtime packages...
 		"runtimepack.Microsoft.NETCore.App.Runtime.win-x64 @ 8.0.14 (/app/dotnetapp.deps.json)",
@@ -298,7 +308,7 @@ func TestCataloger(t *testing.T) {
 	)
 
 	var net8AppExpectedDepSelfContainedRelationships []string
-	net8AppExpectedDepSelfContainedRelationships = append(net8AppExpectedDepSelfContainedRelationships, net8AppDepOnlyRelationshipsWithoutHumanizer...)
+	net8AppExpectedDepSelfContainedRelationships = append(net8AppExpectedDepSelfContainedRelationships, net8AppDepOnlyRelationships...)
 	net8AppExpectedDepSelfContainedRelationships = append(net8AppExpectedDepSelfContainedRelationships,
 		// add the CLR runtime relationships...
 		"runtimepack.Microsoft.NETCore.App.Runtime.win-x64 @ 8.0.14 (/app/dotnetapp.deps.json) [dependency-of] dotnetapp @ 1.0.0 (/app/dotnetapp.deps.json)",
@@ -706,36 +716,20 @@ func TestCataloger(t *testing.T) {
 			assertion:    assertAllDepEntriesWithoutExecutables,
 		},
 		{
-			name:      "combined cataloger",
-			fixture:   "image-net8-app",
-			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
-
-			// if we don't care about DLL claims in the deps.json, then this is right
-			//expectedPkgs: net8AppExpectedDepPkgs,
-			//expectedRels: net8AppExpectedDepRelationships,
-
-			// we care about DLL claims in the deps.json, so the main application inherits all relationships to/from humanizer
-			expectedPkgs: net8AppExpectedDepPkgsWithoutUnpairedDlls,
-			expectedRels: replaceAll(net8AppDepOnlyRelationshipsWithoutHumanizer, "Humanizer @ 2.14.1", "dotnetapp @ 1.0.0"),
-
-			assertion: assertAlmostAllDepEntriesWithExecutables, // important! this is what makes this case different from the previous one... dep entries have attached executables
+			name:         "combined cataloger",
+			fixture:      "image-net8-app",
+			cataloger:    NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
+			expectedPkgs: net8AppExpectedDepPkgs,
+			expectedRels: net8AppDepOnlyRelationships,
+			assertion:    assertAlmostAllDepEntriesWithExecutables, // important! this is what makes this case different from the previous one... dep entries have attached executables
 		},
 		{
-			name:      "combined cataloger (with runtime)",
-			fixture:   "image-net8-app-with-runtime",
-			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
-			expectedPkgs: func() []string {
-				pkgs := net8AppExpectedDepPkgsWithoutUnpairedDlls
-				pkgs = append(pkgs, "Microsoft.NETCore.App.Runtime.linux-x64 @ 8.0.14 (/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/Microsoft.NETCore.App.deps.json)")
-				return pkgs
-			}(),
-			expectedRels: func() []string {
-				x := replaceAll(net8AppDepOnlyRelationshipsWithoutHumanizer, "Humanizer @ 2.14.1", "dotnetapp @ 1.0.0")
-				// the main application should also have a relationship to the runtime package
-				x = append(x, "Microsoft.NETCore.App.Runtime.linux-x64 @ 8.0.14 (/usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.14/Microsoft.NETCore.App.deps.json) [dependency-of] dotnetapp @ 1.0.0 (/app/dotnetapp.deps.json)")
-				return x
-			}(),
-			assertion: assertAccurateNetRuntimePackage,
+			name:         "combined cataloger (with runtime)",
+			fixture:      "image-net8-app-with-runtime",
+			cataloger:    NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
+			expectedPkgs: net8AppExpectedDepPkgsWithRuntime,
+			expectedRels: net8AppDepOnlyRelationshipsWithRuntime,
+			assertion:    assertAccurateNetRuntimePackage,
 		},
 		{
 			name:      "combined cataloger (with runtime, no deps.json anywhere)",
@@ -923,11 +917,7 @@ func TestCataloger(t *testing.T) {
 			fixture:      "image-net8-app-self-contained",
 			cataloger:    NewDotnetDepsCataloger(),
 			expectedPkgs: net8AppExpectedDepsSelfContainedPkgs,
-			expectedRels: func() []string {
-				x := net8AppExpectedDepSelfContainedRelationships
-				x = append(x, humanizerToAppDepsRelationship)
-				return x
-			}(),
+			expectedRels: net8AppExpectedDepSelfContainedRelationships,
 		},
 		{
 			name:      "combined cataloger (self-contained)",
@@ -935,13 +925,8 @@ func TestCataloger(t *testing.T) {
 			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
 			// we care about DLL claims in the deps.json, so the main application inherits all relationships to/from humarizer
 			expectedPkgs: net8AppExpectedDepSelfContainedPkgs,
-			expectedRels: func() []string {
-				x := replaceAll(net8AppExpectedDepSelfContainedRelationships, "Humanizer @ 2.14.1", "dotnetapp @ 1.0.0")
-				// the main application also has a dependency on the runtime package
-				x = append(x, "runtimepack.Microsoft.NETCore.App.Runtime.win-x64 @ 8.0.14 (/app/dotnetapp.deps.json) [dependency-of] dotnetapp @ 1.0.0 (/app/dotnetapp.deps.json)")
-				return x
-			}(),
-			assertion: assertAccurateNetRuntimePackage,
+			expectedRels: net8AppExpectedDepSelfContainedRelationships,
+			assertion:    assertAccurateNetRuntimePackage,
 		},
 		{
 			name:      "pe cataloger (self-contained)",
@@ -1004,6 +989,8 @@ func TestCataloger(t *testing.T) {
 			fixture:   "image-net2-app",
 			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
 			expectedPkgs: []string{
+				"Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
+				"Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
 				"Serilog @ 2.10.0 (/app/helloworld.deps.json)",
 				"Serilog.Sinks.Console @ 4.0.1 (/app/helloworld.deps.json)",
 				"helloworld @ 1.0.0 (/app/helloworld.deps.json)",
@@ -1011,10 +998,13 @@ func TestCataloger(t *testing.T) {
 				"runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)", // a compile target reference
 			},
 			expectedRels: []string{
+				"Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json) [dependency-of] Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
 				"Serilog @ 2.10.0 (/app/helloworld.deps.json) [dependency-of] Serilog.Sinks.Console @ 4.0.1 (/app/helloworld.deps.json)",
 				"Serilog @ 2.10.0 (/app/helloworld.deps.json) [dependency-of] helloworld @ 1.0.0 (/app/helloworld.deps.json)",
 				"Serilog.Sinks.Console @ 4.0.1 (/app/helloworld.deps.json) [dependency-of] helloworld @ 1.0.0 (/app/helloworld.deps.json)",
+				"runtime.linux-x64.Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json) [dependency-of] Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
 				"runtime.linux-x64.Microsoft.NETCore.App @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json) [dependency-of] helloworld @ 1.0.0 (/app/helloworld.deps.json)",
+				"runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json) [dependency-of] Microsoft.NETCore.DotNetHostPolicy @ 2.2.8 (/usr/share/dotnet/shared/Microsoft.NETCore.App/2.2.8/Microsoft.NETCore.App.deps.json)",
 			},
 			assertion: assertAccurateNetRuntimePackage,
 		},
@@ -1074,17 +1064,29 @@ func TestDotnetDepsCataloger_regressions(t *testing.T) {
 			},
 		},
 		{
-			name:      "compile target reference",
+			name:      "indirect packages references",
 			fixture:   "image-net8-compile-target",
 			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
 			assertion: func(t *testing.T, pkgs []pkg.Package, relationships []artifact.Relationship) {
-				// ensure we find the DotNetNuke.Core package (which is using the compile target reference)
+
+				expected := strset.New(
+					"DotNetNuke.Core", // uses a compile target reference in the deps.json
+					"Umbraco.Cms",     // this is the parent of other packages which do have DLLs included (even though it does not have any DLLs)
+				)
+				notExpected := strset.New(
+					"StyleCop.Analyzers",     // this is a development tool
+					"Microsoft.NET.Test.Sdk", // this is a development tool
+				)
 				for _, p := range pkgs {
-					if p.Name == "DotNetNuke.Core" {
-						return
+					expected.Remove(p.Name)
+					if notExpected.Has(p.Name) {
+						t.Errorf("unexpected package: %s", p.Name)
 					}
 				}
-				t.Error("expected to find DotNetNuke.Core package")
+				if expected.IsEmpty() {
+					return
+				}
+				t.Errorf("missing packages: %s", expected.List())
 			},
 		},
 	}
@@ -1474,12 +1476,4 @@ func extractMatchingPackage(t *testing.T, name string, pkgs []pkg.Package) pkg.P
 	}
 	t.Fatalf("expected to find package %s", name)
 	return pkg.Package{}
-}
-
-func replaceAll(ss []string, find, replace string) []string {
-	var results []string
-	for _, s := range ss {
-		results = append(results, strings.ReplaceAll(s, find, replace))
-	}
-	return results
 }

--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -1101,7 +1101,7 @@ func TestDotnetDepsCataloger_regressions(t *testing.T) {
 		{
 			name:      "not propagating claims",
 			fixture:   "image-net8-compile-target",
-			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig().WithDLLClaimsPropagateToParents(false)),
+			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig().WithPropagateDLLClaimsToParents(false)),
 			assertion: assertPackages(
 				[]string{
 					"DotNetNuke.Core", // uses a compile target reference in the deps.json
@@ -1121,7 +1121,7 @@ func TestDotnetDepsCataloger_regressions(t *testing.T) {
 			cataloger: NewDotnetDepsBinaryCataloger(CatalogerConfig{
 				DepPackagesMustHaveDLL:             false,
 				DepPackagesMustClaimDLL:            false,
-				DLLClaimsPropagateToParents:        false,
+				PropagateDLLClaimsToParents:        false,
 				RelaxDLLClaimsWhenBundlingDetected: false,
 			}),
 			assertion: assertPackages(

--- a/syft/pkg/cataloger/dotnet/config.go
+++ b/syft/pkg/cataloger/dotnet/config.go
@@ -8,8 +8,8 @@ type CatalogerConfig struct {
 	// This does not require such claimed DLLs to exist on disk. The behavior of this
 	DepPackagesMustClaimDLL bool `mapstructure:"dep-packages-must-claim-dll" json:"dep-packages-must-claim-dll" yaml:"dep-packages-must-claim-dll"`
 
-	// DLLClaimsPropagateToParents allows for deps.json packages to be included if any child (transitive) package claims a DLL. This applies to both the claims configuration and evidence-on-disk configurations.
-	DLLClaimsPropagateToParents bool `mapstructure:"dll-claims-propagate-to-parents" json:"dll-claims-propagate-to-parents" yaml:"dll-claims-propagate-to-parents"`
+	// PropagateDLLClaimsToParents allows for deps.json packages to be included if any child (transitive) package claims a DLL. This applies to both the claims configuration and evidence-on-disk configurations.
+	PropagateDLLClaimsToParents bool `mapstructure:"propagate-dll-claims-to-parents" json:"propagate-dll-claims-to-parents" yaml:"propagate-dll-claims-to-parents"`
 
 	// RelaxDLLClaimsWhenBundlingDetected will look for indications of IL bundle tooling via deps.json package names
 	// and, if found (and this config option is enabled), will relax the DepPackagesMustClaimDLL value to `false` only in those cases.
@@ -31,8 +31,8 @@ func (c CatalogerConfig) WithRelaxDLLClaimsWhenBundlingDetected(relax bool) Cata
 	return c
 }
 
-func (c CatalogerConfig) WithDLLClaimsPropagateToParents(propagate bool) CatalogerConfig {
-	c.DLLClaimsPropagateToParents = propagate
+func (c CatalogerConfig) WithPropagateDLLClaimsToParents(propagate bool) CatalogerConfig {
+	c.PropagateDLLClaimsToParents = propagate
 	return c
 }
 
@@ -40,7 +40,7 @@ func DefaultCatalogerConfig() CatalogerConfig {
 	return CatalogerConfig{
 		DepPackagesMustHaveDLL:             false,
 		DepPackagesMustClaimDLL:            true,
-		DLLClaimsPropagateToParents:        true,
+		PropagateDLLClaimsToParents:        true,
 		RelaxDLLClaimsWhenBundlingDetected: true,
 	}
 }

--- a/syft/pkg/cataloger/dotnet/config.go
+++ b/syft/pkg/cataloger/dotnet/config.go
@@ -8,6 +8,9 @@ type CatalogerConfig struct {
 	// This does not require such claimed DLLs to exist on disk. The behavior of this
 	DepPackagesMustClaimDLL bool `mapstructure:"dep-packages-must-claim-dll" json:"dep-packages-must-claim-dll" yaml:"dep-packages-must-claim-dll"`
 
+	// DLLClaimsPropagateToParents allows for deps.json packages to be included if any child (transitive) package claims a DLL. This applies to both the claims configuration and evidence-on-disk configurations.
+	DLLClaimsPropagateToParents bool `mapstructure:"dll-claims-propagate-to-parents" json:"dll-claims-propagate-to-parents" yaml:"dll-claims-propagate-to-parents"`
+
 	// RelaxDLLClaimsWhenBundlingDetected will look for indications of IL bundle tooling via deps.json package names
 	// and, if found (and this config option is enabled), will relax the DepPackagesMustClaimDLL value to `false` only in those cases.
 	RelaxDLLClaimsWhenBundlingDetected bool `mapstructure:"relax-dll-claims-when-bundling-detected" json:"relax-dll-claims-when-bundling-detected" yaml:"relax-dll-claims-when-bundling-detected"`
@@ -28,10 +31,16 @@ func (c CatalogerConfig) WithRelaxDLLClaimsWhenBundlingDetected(relax bool) Cata
 	return c
 }
 
+func (c CatalogerConfig) WithDLLClaimsPropagateToParents(propagate bool) CatalogerConfig {
+	c.DLLClaimsPropagateToParents = propagate
+	return c
+}
+
 func DefaultCatalogerConfig() CatalogerConfig {
 	return CatalogerConfig{
 		DepPackagesMustHaveDLL:             false,
 		DepPackagesMustClaimDLL:            true,
+		DLLClaimsPropagateToParents:        true,
 		RelaxDLLClaimsWhenBundlingDetected: true,
 	}
 }

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -268,14 +268,14 @@ func packagesFromLogicalDepsJSON(doc logicalDepsJSON, config CatalogerConfig) (*
 			continue
 		}
 		lp := doc.PackagesByNameVersion[nameVersion]
-		if config.DepPackagesMustHaveDLL && !lp.FoundDLLs() {
+		if config.DepPackagesMustHaveDLL && !lp.FoundDLLs(config.DLLClaimsPropagateToParents) {
 			// could not find a paired DLL and the user required this...
 			skippedDepPkgs[nameVersion] = lp
 			continue
 		}
 
 		// check to see if we should skip this package because it does not claim a DLL (or has not dependency that claims a DLL)
-		if config.DepPackagesMustClaimDLL && !lp.ClaimsDLLs() {
+		if config.DepPackagesMustClaimDLL && !lp.ClaimsDLLs(config.DLLClaimsPropagateToParents) {
 			if config.RelaxDLLClaimsWhenBundlingDetected && !doc.BundlingDetected || !config.RelaxDLLClaimsWhenBundlingDetected {
 				// could not find a runtime or resource path and the user required this...
 				// and there is no evidence of a bundler in the dependencies (e.g. ILRepack)

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -111,7 +111,7 @@ func (c depsBinaryCataloger) Catalog(_ context.Context, resolver file.Resolver) 
 		runtimePkgs = append(runtimePkgs, &rtp)
 	}
 
-	// create a relationship from every runtime package to every root package
+	// create a relationship from every runtime package to every root package...
 	for _, root := range roots {
 		for _, runtimePkg := range runtimePkgs {
 			relationships = append(relationships, artifact.Relationship{
@@ -122,7 +122,8 @@ func (c depsBinaryCataloger) Catalog(_ context.Context, resolver file.Resolver) 
 		}
 	}
 
-	return pkgs, relationships, unknowns
+	// in the process of creating root-to-runtime relationships, we may have created duplicate relationships. Use the relationship index to deduplicate.
+	return pkgs, relationship.NewIndex(relationships...).All(), unknowns
 }
 
 var runtimeDLLPathPattern = regexp.MustCompile(`/Microsoft\.NETCore\.App/(?P<version>\d+\.\d+\.\d+)/[^/]+\.dll`)
@@ -267,15 +268,14 @@ func packagesFromLogicalDepsJSON(doc logicalDepsJSON, config CatalogerConfig) (*
 			continue
 		}
 		lp := doc.PackagesByNameVersion[nameVersion]
-		if config.DepPackagesMustHaveDLL && len(lp.Executables) == 0 {
+		if config.DepPackagesMustHaveDLL && !lp.FoundDLLs() {
 			// could not find a paired DLL and the user required this...
 			skippedDepPkgs[nameVersion] = lp
 			continue
 		}
 
-		claimsDLLs := len(lp.RuntimePathsByRelativeDLLPath) > 0 || len(lp.ResourcePathsByRelativeDLLPath) > 0 || len(lp.CompilePathsByRelativeDLLPath) > 0 || len(lp.NativePaths.List()) > 0
-
-		if config.DepPackagesMustClaimDLL && !claimsDLLs {
+		// check to see if we should skip this package because it does not claim a DLL (or has not dependency that claims a DLL)
+		if config.DepPackagesMustClaimDLL && !lp.ClaimsDLLs() {
 			if config.RelaxDLLClaimsWhenBundlingDetected && !doc.BundlingDetected || !config.RelaxDLLClaimsWhenBundlingDetected {
 				// could not find a runtime or resource path and the user required this...
 				// and there is no evidence of a bundler in the dependencies (e.g. ILRepack)

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -268,14 +268,14 @@ func packagesFromLogicalDepsJSON(doc logicalDepsJSON, config CatalogerConfig) (*
 			continue
 		}
 		lp := doc.PackagesByNameVersion[nameVersion]
-		if config.DepPackagesMustHaveDLL && !lp.FoundDLLs(config.DLLClaimsPropagateToParents) {
+		if config.DepPackagesMustHaveDLL && !lp.FoundDLLs(config.PropagateDLLClaimsToParents) {
 			// could not find a paired DLL and the user required this...
 			skippedDepPkgs[nameVersion] = lp
 			continue
 		}
 
 		// check to see if we should skip this package because it does not claim a DLL (or has not dependency that claims a DLL)
-		if config.DepPackagesMustClaimDLL && !lp.ClaimsDLLs(config.DLLClaimsPropagateToParents) {
+		if config.DepPackagesMustClaimDLL && !lp.ClaimsDLLs(config.PropagateDLLClaimsToParents) {
 			if config.RelaxDLLClaimsWhenBundlingDetected && !doc.BundlingDetected || !config.RelaxDLLClaimsWhenBundlingDetected {
 				// could not find a runtime or resource path and the user required this...
 				// and there is no evidence of a bundler in the dependencies (e.g. ILRepack)

--- a/syft/pkg/cataloger/dotnet/deps_json.go
+++ b/syft/pkg/cataloger/dotnet/deps_json.go
@@ -84,6 +84,12 @@ type logicalDepsJSONPackage struct {
 	Targets     *depsTarget
 	Library     *depsLibrary
 
+	// anyChildClaimsDLLs is a flag that indicates if any of the children of this package claim a DLL associated with them in the deps.json.
+	anyChildClaimsDLLs bool
+
+	// anyChildHasDLLs is a flag that indicates if any of the children of this package have a DLL associated with them (found on disk).
+	anyChildHasDLLs bool
+
 	// RuntimePathsByRelativeDLLPath is a map of the relative path to the DLL relative to the deps.json file
 	// to the target path as described in the deps.json target entry under "runtime".
 	RuntimePathsByRelativeDLLPath map[string]string
@@ -105,6 +111,27 @@ type logicalDepsJSONPackage struct {
 	// and not something that is found in the deps.json file. This allows us to associate the PE files with this package
 	// based on the relative path to the DLL.
 	Executables []logicalPE
+}
+
+func (l *logicalDepsJSONPackage) dependencyNameVersions() []string {
+	if l.Targets == nil {
+		return nil
+	}
+	var results []string
+	for name, version := range l.Targets.Dependencies {
+		results = append(results, createNameAndVersion(name, version))
+	}
+	return results
+}
+
+// ClaimsDLLs indicates if this package has any DLLs associated with it (directly or indirectly with a dependency).
+func (l *logicalDepsJSONPackage) ClaimsDLLs() bool {
+	selfClaim := len(l.RuntimePathsByRelativeDLLPath) > 0 || len(l.ResourcePathsByRelativeDLLPath) > 0 || len(l.CompilePathsByRelativeDLLPath) > 0 || len(l.NativePaths.List()) > 0
+	return selfClaim || l.anyChildClaimsDLLs
+}
+
+func (l *logicalDepsJSONPackage) FoundDLLs() bool {
+	return len(l.Executables) > 0 || l.anyChildHasDLLs
 }
 
 type logicalDepsJSON struct {
@@ -199,6 +226,8 @@ func getLogicalDepsJSON(deps depsJSON) logicalDepsJSON {
 		if !bundlingDetected && knownBundlers.Has(name) {
 			bundlingDetected = true
 		}
+		p.anyChildClaimsDLLs = searchForDLLClaims(packageMap, p.dependencyNameVersions()...)
+		p.anyChildHasDLLs = searchForDLLEvidence(packageMap, p.dependencyNameVersions()...)
 		packages[p.NameVersion] = *p
 	}
 
@@ -209,6 +238,47 @@ func getLogicalDepsJSON(deps depsJSON) logicalDepsJSON {
 		PackageNameVersions:   nameVersions,
 		BundlingDetected:      bundlingDetected,
 	}
+}
+
+type visitorFunc func(p *logicalDepsJSONPackage) bool
+
+// searchForDLLEvidence recursively searches for executables found for any of the given nameVersions and children recursively.
+func searchForDLLEvidence(packageMap map[string]*logicalDepsJSONPackage, nameVersions ...string) bool {
+	return traverseDependencies(packageMap, func(p *logicalDepsJSONPackage) bool {
+		return p.FoundDLLs()
+	}, nameVersions...)
+}
+
+// searchForDLLClaims recursively searches for DLL claims in the deps.json for any of the given nameVersions and children recursively.
+func searchForDLLClaims(packageMap map[string]*logicalDepsJSONPackage, nameVersions ...string) bool {
+	return traverseDependencies(packageMap, func(p *logicalDepsJSONPackage) bool {
+		return p.ClaimsDLLs()
+	}, nameVersions...)
+}
+
+func traverseDependencies(packageMap map[string]*logicalDepsJSONPackage, visitor visitorFunc, nameVersions ...string) bool {
+	if len(nameVersions) == 0 {
+		return false
+	}
+
+	for _, nameVersion := range nameVersions {
+		if p, ok := packageMap[nameVersion]; ok {
+			if visitor(p) {
+				return true
+			}
+
+			var children []string
+			for name, version := range p.Targets.Dependencies {
+				children = append(children, createNameAndVersion(name, version))
+			}
+
+			if traverseDependencies(packageMap, visitor, children...) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 var libPathPattern = regexp.MustCompile(`^(?:runtimes/[^/]+/)?lib/net[^/]+/(?P<targetPath>.+)`)

--- a/syft/pkg/cataloger/dotnet/package.go
+++ b/syft/pkg/cataloger/dotnet/package.go
@@ -196,9 +196,8 @@ func extractNameAndVersion(nameVersion string) (name, version string) {
 	return
 }
 
-func createNameAndVersion(name, version string) (nameVersion string) {
-	nameVersion = fmt.Sprintf("%s/%s", name, version)
-	return
+func createNameAndVersion(name, version string) string {
+	return fmt.Sprintf("%s/%s", name, version)
 }
 
 func packageURL(m pkg.DotnetDepsEntry) string {

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
@@ -8,8 +8,10 @@ RUN dotnet restore -r $RUNTIME
 COPY src/*.cs .
 RUN dotnet publish -c Release -r $RUNTIME --self-contained false -o /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
-WORKDIR /app
-COPY --from=build /app .
+# note: we're not using a runtime here to make testing easier... so you cannot run this container and expect it to work
+# we do this to keep the test assertions small since the don't want to include the several other runtime packages
+FROM busybox:latest
 
-ENTRYPOINT ["dotnet", "HelloWorld.dll"]
+WORKDIR /app
+
+COPY --from=build /app .

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/Dockerfile
@@ -6,13 +6,10 @@ COPY src/helloworld.csproj .
 RUN dotnet restore -r $RUNTIME
 
 COPY src/*.cs .
+RUN dotnet publish -c Release -r $RUNTIME --self-contained false -o /app
 
-RUN dotnet publish -c Release --no-restore -o /app
-
-# note: we're not using a runtime here to make testing easier... so you cannot run this container and expect it to work
-# we do this to keep the test assertions small since the don't want to include the several other runtime packages
-FROM busybox:latest
-
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS runtime
 WORKDIR /app
-
 COPY --from=build /app .
+
+ENTRYPOINT ["dotnet", "HelloWorld.dll"]

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/Program.cs
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
 
 namespace HelloWorld
 {
@@ -6,7 +8,22 @@ namespace HelloWorld
     {
         public static void Main(string[] args)
         {
-                Console.WriteLine("Hello World!");
+            var builder = WebApplication.CreateBuilder(args);
+            var app = builder.Build();
+
+            // configure the HTTP request pipeline
+            if (!app.Environment.IsDevelopment())
+            {
+                app.UseExceptionHandler("/Error");
+            }
+
+            // enable serving static files (including jQuery)
+            app.UseStaticFiles();
+
+            app.MapGet("/", () => "Hello World!");
+
+            Console.WriteLine("Application starting...");
+            app.Run();
         }
     }
 }

--- a/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/helloworld.csproj
+++ b/syft/pkg/cataloger/dotnet/test-fixtures/image-net8-compile-target/src/helloworld.csproj
@@ -8,17 +8,51 @@
 
   <ItemGroup>
     <PackageReference Include="DotNetNuke.Core" Version="9.9.1"/>
+
+    <!-- jQuery wraps the javascript library, so no DLLs -->
     <PackageReference Include="jQuery" Version="3.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.2.0" />
+
+    <!-- ChakraCore is an open source Javascript engine with a C API -->
     <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Nuget.CommandLine is a command line tool for managing NuGet packages -->
     <PackageReference Include="Nuget.CommandLine" Version="6.3.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Umbraco.Cms has dependencies with software, but itself has no DLLs -->
     <PackageReference Include="Umbraco.Cms" Version="11.3.0" />
+
+    <!-- For code analysis/style checking, only needed during development -->
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
+
+    <!-- For unit testing, only needed during development -->
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" Condition="'$(Configuration)' == 'Debug'" PrivateAssets="All" />
+
   </ItemGroup>
+
+  <!-- create directories if they don't exist -->
+  <Target Name="CreateWwwroot" BeforeTargets="PrepareForPublish">
+    <MakeDir Directories="$(PublishDir)wwwroot\lib\jquery" />
+  </Target>
+
+  <!-- explicitly copy jQuery files during publish phase -->
+  <Target Name="CopyJQueryToPublishOutput" AfterTargets="CreateWwwroot" BeforeTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <!-- find jQuery files in the packages folder -->
+      <JQueryFiles Include="$(NuGetPackageRoot)\jquery\3.4.1\Content\Scripts\*.js" />
+
+      <!-- add these to the publish output -->
+      <ResolvedFileToPublish Include="@(JQueryFiles)">
+        <RelativePath>wwwroot\lib\jquery\%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
This augments the .NET cataloger to include packages that themselves do not claim any DLLs but have dependencies that do have DLLs, which is a common convention for larger nuget package groups (for example [Humanizer](https://www.nuget.org/packages/humanizer/) and [Umbraco.Cms](https://www.nuget.org/packages/Umbraco.Cms/15.4.0-rc2)). This logic now applies to both the DLL claims configuration option as well as DLL existence configuration option. A new configurable has been added to control this behavior:

```
dotnet:
  # treat DLL claims or on-disk evidence for child packages as DLL claims or on-disk evidence for any parent package (env: SYFT_DOTNET_PROPAGATE_DLL_CLAIMS_TO_PARENTS)
  propagate-dll-claims-to-parents: true
```


## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## PR Stack
- https://github.com/anchore/syft/pull/3821
