### PR TITLE
Resolve owned file paths when searching for overlaps

### DIFF
--- a/internal/relationship/by_file_ownership.go
+++ b/internal/relationship/by_file_ownership.go
@@ -151,7 +151,6 @@ func allPaths(ownedFilePath string, resolver file.Resolver) []string {
 	for _, loc := range locs {
 		ownedFilePaths.Add(loc.RealPath)
 	}
-	ownedFilePaths.Remove("")
 	return ownedFilePaths.List()
 }
 

--- a/internal/relationship/by_file_ownership.go
+++ b/internal/relationship/by_file_ownership.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
 )
@@ -32,11 +33,11 @@ type ownershipByFilesMetadata struct {
 	Files []string `json:"files"`
 }
 
-func ByFileOwnershipOverlapWorker(accessor sbomsync.Accessor) {
+func ByFileOwnershipOverlapWorker(resolver file.Resolver, accessor sbomsync.Accessor) {
 	var relationships []artifact.Relationship
 
 	accessor.ReadFromSBOM(func(s *sbom.SBOM) {
-		relationships = byFileOwnershipOverlap(s.Artifacts.Packages)
+		relationships = byFileOwnershipOverlap(resolver, s.Artifacts.Packages)
 	})
 
 	accessor.WriteToSBOM(func(s *sbom.SBOM) {
@@ -46,8 +47,8 @@ func ByFileOwnershipOverlapWorker(accessor sbomsync.Accessor) {
 
 // byFileOwnershipOverlap creates a package-to-package relationship based on discovering which packages have
 // evidence locations that overlap with ownership claim from another package's package manager metadata.
-func byFileOwnershipOverlap(catalog *pkg.Collection) []artifact.Relationship {
-	var relationships = findOwnershipByFilesRelationships(catalog)
+func byFileOwnershipOverlap(resolver file.Resolver, catalog *pkg.Collection) []artifact.Relationship {
+	var relationships = findOwnershipByFilesRelationships(resolver, catalog)
 
 	var edges []artifact.Relationship
 	for parentID, children := range relationships {
@@ -84,7 +85,7 @@ func byFileOwnershipOverlap(catalog *pkg.Collection) []artifact.Relationship {
 
 // findOwnershipByFilesRelationships find overlaps in file ownership with a file that defines another package. Specifically, a .Location.Path of
 // a package is found to be owned by another (from the owner's .Metadata.Files[]).
-func findOwnershipByFilesRelationships(catalog *pkg.Collection) map[artifact.ID]map[artifact.ID]*strset.Set {
+func findOwnershipByFilesRelationships(resolver file.Resolver, catalog *pkg.Collection) map[artifact.ID]map[artifact.ID]*strset.Set { //nolint:gocognit
 	var relationships = make(map[artifact.ID]map[artifact.ID]*strset.Set)
 
 	if catalog == nil {
@@ -102,32 +103,56 @@ func findOwnershipByFilesRelationships(catalog *pkg.Collection) map[artifact.ID]
 		if !ok {
 			continue
 		}
-		for _, ownedFilePath := range pkgFileOwner.OwnedFiles() {
-			if matchesAny(ownedFilePath, globsForbiddenFromBeingOwned) {
-				// we skip over known exceptions to file ownership, such as the RPM package owning
-				// the RPM DB path, otherwise the RPM package would "own" all RPMs, which is not intended
-				continue
-			}
 
-			// look for package(s) in the catalog that may be owned by this package and mark the relationship
-			for _, subPackage := range catalog.PackagesByPath(ownedFilePath) {
-				subID := subPackage.ID()
-				if subID == id {
+		for _, ownedFilePath := range pkgFileOwner.OwnedFiles() {
+			// find the first path that results in a hit
+			for _, ownedPath := range allPaths(ownedFilePath, resolver) {
+				if matchesAny(ownedPath, globsForbiddenFromBeingOwned) {
+					// we skip over known exceptions to file ownership, such as the RPM package owning
+					// the RPM DB path, otherwise the RPM package would "own" all RPMs, which is not intended
 					continue
 				}
-				if _, exists := relationships[id]; !exists {
-					relationships[id] = make(map[artifact.ID]*strset.Set)
-				}
 
-				if _, exists := relationships[id][subID]; !exists {
-					relationships[id][subID] = strset.New()
+				// look for package(s) in the catalog that may be owned by this package and mark the relationship
+				for _, subPackage := range catalog.PackagesByPath(ownedPath) {
+					subID := subPackage.ID()
+					if subID == id {
+						continue
+					}
+					if _, exists := relationships[id]; !exists {
+						relationships[id] = make(map[artifact.ID]*strset.Set)
+					}
+
+					if _, exists := relationships[id][subID]; !exists {
+						relationships[id][subID] = strset.New()
+					}
+					relationships[id][subID].Add(ownedPath)
 				}
-				relationships[id][subID].Add(ownedFilePath)
 			}
 		}
 	}
 
 	return relationships
+}
+
+func allPaths(ownedFilePath string, resolver file.Resolver) []string {
+	// though we have a string path, we need to resolve symlinks and other filesystem oddities since we cannot assume this is a real path
+	var locs []file.Location
+	var err error
+	if resolver != nil {
+		locs, err = resolver.FilesByPath(ownedFilePath)
+		if err != nil {
+			log.WithFields("error", err, "path", ownedFilePath).Trace("unable to find path for owned file")
+			locs = nil
+		}
+	}
+
+	ownedFilePaths := strset.New(ownedFilePath)
+	for _, loc := range locs {
+		ownedFilePaths.Add(loc.RealPath)
+	}
+	ownedFilePaths.Remove("")
+	return ownedFilePaths.List()
 }
 
 func matchesAny(s string, globs []string) bool {

--- a/internal/relationship/by_file_ownership_test.go
+++ b/internal/relationship/by_file_ownership_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/syft/internal/cmptest"
 	"github.com/anchore/syft/syft/artifact"
@@ -12,11 +12,29 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
+type mockFR struct {
+	file.Resolver
+	translate map[string]string
+}
+
+func (m mockFR) FilesByPath(paths ...string) ([]file.Location, error) {
+	var results []file.Location
+	for _, p := range paths {
+		tPath, ok := m.translate[p]
+		if !ok {
+			tPath = p
+		}
+		results = append(results, file.NewLocation(tPath))
+	}
+	return results, nil
+}
+
 func TestOwnershipByFilesRelationship(t *testing.T) {
 
 	tests := []struct {
-		name  string
-		setup func(t testing.TB) ([]pkg.Package, []artifact.Relationship)
+		name     string
+		resolver file.Resolver
+		setup    func(t testing.TB) ([]pkg.Package, []artifact.Relationship)
 	}{
 		{
 			name: "owns-by-real-path",
@@ -53,6 +71,75 @@ func TestOwnershipByFilesRelationship(t *testing.T) {
 					Data: ownershipByFilesMetadata{
 						Files: []string{
 							"/d/path",
+						},
+					},
+				}
+
+				return []pkg.Package{parent, child}, []artifact.Relationship{relationship}
+			},
+		},
+		{
+			name: "misses-by-dead-symlink",
+			resolver: mockFR{
+				translate: map[string]string{
+					"/bin/gzip": "", // treat this as a dead symlink
+				},
+			},
+			setup: func(t testing.TB) ([]pkg.Package, []artifact.Relationship) {
+				parent := pkg.Package{
+					Type: pkg.DebPkg,
+					Metadata: pkg.DpkgDBEntry{
+						Files: []pkg.DpkgFileRecord{
+							{Path: "/bin/gzip"}, // this symlinks to gzip via /bin -> /usr/bin
+						},
+					},
+				}
+				parent.SetID()
+
+				child := pkg.Package{
+					Locations: file.NewLocationSet(
+						file.NewVirtualLocation("/usr/bin/gzip", "/usr/bin/gzip"),
+					),
+					Type: pkg.BinaryPkg,
+				}
+				child.SetID()
+
+				return []pkg.Package{parent, child}, nil // importantly, no relationship is expected
+			},
+		},
+		{
+			name: "owns-by-symlink",
+			resolver: mockFR{
+				translate: map[string]string{
+					"/bin/gzip": "/usr/bin/gzip", // if there is a string path of /bin/gzip then return the real path of /usr/bin/gzip
+				},
+			},
+			setup: func(t testing.TB) ([]pkg.Package, []artifact.Relationship) {
+				parent := pkg.Package{
+					Type: pkg.DebPkg,
+					Metadata: pkg.DpkgDBEntry{
+						Files: []pkg.DpkgFileRecord{
+							{Path: "/bin/gzip"}, // this symlinks to gzip via /bin -> /usr/bin
+						},
+					},
+				}
+				parent.SetID()
+
+				child := pkg.Package{
+					Locations: file.NewLocationSet(
+						file.NewVirtualLocation("/usr/bin/gzip", "/usr/bin/gzip"),
+					),
+					Type: pkg.BinaryPkg,
+				}
+				child.SetID()
+
+				relationship := artifact.Relationship{
+					From: parent,
+					To:   child,
+					Type: artifact.OwnershipByFileOverlapRelationship,
+					Data: ownershipByFilesMetadata{
+						Files: []string{
+							"/usr/bin/gzip",
 						},
 					},
 				}
@@ -140,9 +227,9 @@ func TestOwnershipByFilesRelationship(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pkgs, expectedRelations := test.setup(t)
 			c := pkg.NewCollection(pkgs...)
-			relationships := byFileOwnershipOverlap(c)
+			relationships := byFileOwnershipOverlap(test.resolver, c)
 
-			assert.Len(t, relationships, len(expectedRelations))
+			require.Len(t, relationships, len(expectedRelations))
 			for idx, expectedRelationship := range expectedRelations {
 				actualRelationship := relationships[idx]
 				if d := cmp.Diff(expectedRelationship, actualRelationship, cmptest.DefaultOptions()...); d != "" {

--- a/internal/task/relationship_tasks.go
+++ b/internal/task/relationship_tasks.go
@@ -46,7 +46,7 @@ func finalizeRelationships(resolver file.Resolver, builder sbomsync.Builder, cfg
 
 	// add relationships showing packages that are evident by a file which is owned by another package (package-to-package)
 	if cfg.PackageFileOwnershipOverlap {
-		relationship.ByFileOwnershipOverlapWorker(accessor)
+		relationship.ByFileOwnershipOverlapWorker(resolver, accessor)
 	}
 
 	// conditionally remove binary packages based on file ownership overlap relationships found


### PR DESCRIPTION
Today we add relationships between packages that overlap in file ownership, say when the python cataloger finds a package at path `X` and the debian DB cataloger also finds the same package at the same file path `X` --in this case we leave both packages and add a `file-ownership-by-overlap` relationship between them. In the case where the same path conflict occurs and this is between a binary file and a debian package then we remove the binary package altogether.

The problem is that package ownership locations are unresolved strings (copied from the RPM DB or the Dpkg DB, etc) and the package locations are resolved real paths. This can cause issues int he case of https://github.com/anchore/grype/issues/2527 where the debian package writes through the `/bin` symlink to the realpath of `/usr/bin` to drop in the `gzip` binary.

This PR fixes this behavior by just-in-time attempting to resolve any paths from the `FileOwner`

- Fixes related issue https://github.com/anchore/grype/issues/2527

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## TODO
- [x] Check the performance implications of putting path resolutions in the relationship creation path
