### PR TITLE
Do not use hashes for SPDX license names/expressions

### DIFF
--- a/syft/format/internal/spdxutil/helpers/license.go
+++ b/syft/format/internal/spdxutil/helpers/license.go
@@ -94,7 +94,7 @@ func generateLicenseID(l pkg.License) string {
 		return l.SPDXExpression
 	}
 	if l.Value != "" {
-		return licenseSum(l.Value)
+		return spdxlicense.LicenseRefPrefix + SanitizeElementID(l.Value)
 	}
 	return licenseSum(l.FullText)
 }

--- a/syft/format/internal/spdxutil/helpers/license_test.go
+++ b/syft/format/internal/spdxutil/helpers/license_test.go
@@ -105,6 +105,58 @@ func Test_License(t *testing.T) {
 	}
 }
 
+func TestGenerateLicenseID(t *testing.T) {
+	tests := []struct {
+		name     string
+		license  pkg.License
+		expected string
+	}{
+		{
+			name: "SPDX expression is preferred",
+			license: pkg.License{
+				SPDXExpression: "Apache-2.0",
+				Value:          "SomeValue",
+				FullText:       "Some text",
+			},
+			expected: "Apache-2.0",
+		},
+		{
+			name: "Uses value if no SPDX expression",
+			license: pkg.License{
+				Value: "MIT",
+			},
+			expected: spdxlicense.LicenseRefPrefix + "MIT",
+		},
+		{
+			name: "Long value is sanitized correctly",
+			license: pkg.License{
+				Value: "LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL",
+			},
+			expected: spdxlicense.LicenseRefPrefix +
+				"LGPLv2--and-LGPLv2--with-exceptions-and-GPLv2--and-GPLv2--with-exceptions-and-BSD-and-Inner-Net-and-ISC-and-Public-Domain-and-GFDL",
+		},
+		{
+			name: "Uses hash of fullText when nothing else is provided",
+			license: pkg.License{
+				FullText: "This is a very long custom license text that should be hashed because it's more than 64 characters long.",
+			},
+			expected: "", // We'll verify it starts with the correct prefix
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := generateLicenseID(tt.license)
+			if tt.expected == "" {
+				assert.True(t, len(id) > len(spdxlicense.LicenseRefPrefix))
+				assert.Contains(t, id, spdxlicense.LicenseRefPrefix)
+			} else {
+				assert.Equal(t, tt.expected, id)
+			}
+		})
+	}
+}
+
 func Test_joinLicenses(t *testing.T) {
 	tests := []struct {
 		name string

--- a/syft/format/internal/spdxutil/helpers/spdxid.go
+++ b/syft/format/internal/spdxutil/helpers/spdxid.go
@@ -8,6 +8,7 @@ var expr = regexp.MustCompile("[^a-zA-Z0-9.-]")
 
 // SPDX spec says SPDXID must be:
 // "SPDXRef-"[idstring] where [idstring] is a unique string containing letters, numbers, ., and/or -
+// https://spdx.github.io/spdx-spec/v2.3/snippet-information/
 func SanitizeElementID(id string) string {
 	return expr.ReplaceAllString(id, "-")
 }


### PR DESCRIPTION
This PR takes the recent full text license work and updates how we're interpreting the `value` field when converting to spdx. Given that we no longer worry about `fullText` being included in this field, `value` is now treated like Expressions when calculating the ID for SPDX licenses in the format helpers.

This means longer `value` that exceeded 64 characters in length do not lose information when being set to the SPDX license ID. We previously because `value` was a dump for both full text and anything NOT valid spdx expressions.

- Fixes #3780

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
