### PR TITLE
feat:parse golang test binaries and resolve deps

### DIFF
--- a/examples/create_simple_sbom/main.go
+++ b/examples/create_simple_sbom/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-const defaultImage = "alpine:3.19"
+const defaultImage = "./syft/syft.test"
 
 func main() {
 	// automagically get a source.Source for arbitrary string input

--- a/examples/create_simple_sbom/main.go
+++ b/examples/create_simple_sbom/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/anchore/syft/syft/source"
 )
 
-const defaultImage = "./syft/syft.test"
+const defaultImage = "alpine:3.19"
 
 func main() {
 	// automagically get a source.Source for arbitrary string input

--- a/syft/artifact/relationship.go
+++ b/syft/artifact/relationship.go
@@ -21,6 +21,9 @@ const (
 
 	// DescribedByRelationship is a proxy for the SPDX 2.2.2 DESCRIBED_BY relationship.
 	DescribedByRelationship RelationshipType = "described-by"
+
+	// TestDependencyOfRelationship is a proxy for the SPDX 2.2 TEST_DEPENDENCY_OF relationship.
+	TestDependencyOfRelationship RelationshipType = "test-dependency-of"
 )
 
 func AllRelationshipTypes() []RelationshipType {

--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -84,14 +84,14 @@ func (c *goBinaryCataloger) parseGoBinary(ctx context.Context, resolver file.Res
 		if btyp == devBinaryType {
 			mainPkg, depPkgs = c.buildGoPkgInfo(ctx, licenseScanner, resolver, reader.Location, mod, mod.arch, unionReader)
 			if mainPkg != nil {
-				pkgs = append(pkgs, *mainPkg)
 				rels = createModuleRelationships(*mainPkg, depPkgs)
+				pkgs = append(pkgs, *mainPkg)
 			}
 		} else {
 			mainPkg, depPkgs = c.buildGoTestPkgInfo(ctx, licenseScanner, resolver, reader.Location, mod, mod.sym, mod.arch, unionReader)
 			if mainPkg != nil {
-				pkgs = append(pkgs, *mainPkg)
 				rels = createModuleTestRelationships(*mainPkg, depPkgs)
+				pkgs = append(pkgs, *mainPkg)
 			}
 		}
 		pkgs = append(pkgs, depPkgs...)

--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -74,7 +74,7 @@ func (c *goBinaryCataloger) parseGoBinary(ctx context.Context, resolver file.Res
 	}
 	defer internal.CloseAndLogError(reader.ReadCloser, reader.RealPath)
 
-	mods, btype, errs := c.scanFile(reader.Location, unionReader)
+	mods, btype, errs := scanFile(reader.Location, unionReader)
 
 	var rels []artifact.Relationship
 	for _, mod := range mods {

--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -74,14 +74,14 @@ func (c *goBinaryCataloger) parseGoBinary(ctx context.Context, resolver file.Res
 	}
 	defer internal.CloseAndLogError(reader.ReadCloser, reader.RealPath)
 
-	mods, btype, errs := scanFile(reader.Location, unionReader)
+	mods, btype, errs := c.scanFile(reader.Location, unionReader)
 
 	var rels []artifact.Relationship
 	for _, mod := range mods {
 		var depPkgs []pkg.Package
 		mainPkg, depPkgs := c.buildGoPkgInfo(ctx, licenseScanner, resolver, reader.Location, mod, mod.arch, unionReader)
 		if mainPkg != nil {
-			if btype == DevBinaryType {
+			if btype == devBinaryType {
 				rels = createModuleRelationships(*mainPkg, depPkgs)
 			} else {
 				rels = createModuleTestRelationships(*mainPkg, depPkgs)

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -4,12 +4,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"debug/elf"
 	"errors"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1065,6 +1067,188 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				pkgs = append(pkgs, *mainPkg)
 			}
 			require.Len(t, pkgs, len(test.expected))
+			for i, p := range pkgs {
+				pkgtest.AssertPackagesEqual(t, test.expected[i], p)
+			}
+		})
+	}
+}
+
+func TestTestGoPkgSymbols(t *testing.T) {
+	const (
+		goCompiledVersion = "1.18"
+		archDetails       = "amd64"
+	)
+	locationSet := file.NewLocationSet(
+		file.NewLocationFromCoordinates(
+			file.Coordinates{
+				RealPath:     "/a-path",
+				FileSystemID: "layer-id",
+			},
+		).WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+	)
+
+	sc := &licenses.ScannerConfig{Scanner: licensecheck.Scan, CoverageThreshold: 75}
+	licenseScanner, err := licenses.NewScanner(sc)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		symbols       []elf.Symbol
+		mod           *extendedBuildInfo
+		expected      []pkg.Package
+		binaryContent string
+	}{
+		{
+			name: "a test binary",
+			mod: &extendedBuildInfo{
+				BuildInfo: &debug.BuildInfo{
+					GoVersion: goCompiledVersion,
+					Path:      "command-line-arguments.test",
+					Main:      debug.Module{},
+					Settings: []debug.BuildSetting{
+						{Key: "-buildmode", Value: "exe"},
+						{Key: "-compiler", Value: "gc"},
+						{Key: "CGO_ENABLED", Value: "1"},
+						{Key: "GOARCH", Value: archDetails},
+						{Key: "GOOS", Value: "darwin"},
+						{Key: "GOAMD64", Value: "v1"},
+					},
+					Deps: []*debug.Module{},
+				},
+				arch: archDetails,
+			},
+			symbols: []elf.Symbol{
+				{
+					Name:       "github.com/davecgh/go-spew..gobytes.1",
+					HasVersion: false,
+				},
+				{
+					Name:       "github.com/google/go-cmp/cmp/internal/diff..typeAsserts.0",
+					HasVersion: false,
+				},
+				{
+					Name:       "crypto/internal/fips140/hmac..typeAssert.0",
+					HasVersion: false,
+				},
+				{
+					Name:       "$f32.6258d727",
+					HasVersion: false,
+				},
+				{
+					Name:       "github.com/sirupsen/logrus.isTerminal",
+					HasVersion: false,
+				},
+				{
+					Name:       "vendor/golang.org/x/net/http/httpproxy.cidrMatch.match",
+					HasVersion: false,
+				},
+				{
+					Name:       "testing.mutexProfileFraction",
+					HasVersion: false,
+				},
+				{
+					Name:       "mime.typeFiles",
+					HasVersion: false,
+				},
+			},
+			binaryContent: "",
+			expected: []pkg.Package{
+				{
+					Name:      "command-line-arguments.test",
+					Version:   "(devel)",
+					PURL:      "pkg:golang/command-line-arguments.test@%28devel%29",
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Locations: locationSet,
+					Metadata: pkg.GolangBinaryBuildinfoEntry{
+						GoCompiledVersion: goCompiledVersion,
+						BuildSettings: pkg.KeyValues{
+							{Key: "-buildmode", Value: "exe"},
+							{Key: "-compiler", Value: "gc"},
+							{Key: "CGO_ENABLED", Value: "1"},
+							{Key: "GOARCH", Value: "amd64"},
+							{Key: "GOOS", Value: "darwin"},
+							{Key: "GOAMD64", Value: "v1"},
+						},
+						Architecture: archDetails,
+						H1Digest:     "",
+						MainModule:   "command-line-arguments.test",
+					},
+				},
+				{
+					Name:      "github.com/davecgh/go-spew",
+					Version:   "v1.1.1",
+					PURL:      "pkg:golang/github.com/davecgh/go-spew@v1.1.1",
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Locations: locationSet,
+					Metadata: pkg.GolangBinaryBuildinfoEntry{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						H1Digest:          "h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=",
+						MainModule:        "command-line-arguments.test",
+					},
+				},
+				{
+					Name:      "github.com/google/go-cmp",
+					Version:   "v0.7.0",
+					PURL:      "pkg:golang/github.com/google/go-cmp@v0.7.0",
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Locations: locationSet,
+					Metadata: pkg.GolangBinaryBuildinfoEntry{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						H1Digest:          "h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=",
+						MainModule:        "command-line-arguments.test",
+					},
+				},
+				{
+					Name:      "github.com/sirupsen/logrus",
+					Version:   "v1.9.3",
+					PURL:      "pkg:golang/github.com/sirupsen/logrus@v1.9.3",
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Locations: locationSet,
+					Metadata: pkg.GolangBinaryBuildinfoEntry{
+						GoCompiledVersion: goCompiledVersion,
+						Architecture:      archDetails,
+						H1Digest:          "h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=",
+						MainModule:        "command-line-arguments.test",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for i := range test.expected {
+				p := &test.expected[i]
+				p.SetID()
+			}
+			location := file.NewLocationFromCoordinates(
+				file.Coordinates{
+					RealPath:     "/a-path",
+					FileSystemID: "layer-id",
+				},
+			)
+
+			c := newGoBinaryCataloger(CatalogerConfig{
+				MainModuleVersion: DefaultMainModuleVersionConfig(),
+				LocalModCacheDir:  filepath.Join("./test-fixtures", "mod-cache", "pkg", "mod"),
+			})
+			reader, err := unionreader.GetUnionReader(io.NopCloser(strings.NewReader(test.binaryContent)))
+			require.NoError(t, err)
+			mainPkg, pkgs := c.buildGoTestPkgInfo(context.Background(), licenseScanner, fileresolver.Empty{}, location, test.mod, test.symbols, test.mod.arch, reader)
+			if mainPkg != nil {
+				pkgs = append(pkgs, *mainPkg)
+			}
+			require.Len(t, pkgs, len(test.expected))
+			sort.Slice(pkgs, func(i, j int) bool {
+				return pkgs[i].Name < pkgs[j].Name
+			})
 			for i, p := range pkgs {
 				pkgtest.AssertPackagesEqual(t, test.expected[i], p)
 			}

--- a/syft/pkg/cataloger/golang/scan_binary_test.go
+++ b/syft/pkg/cataloger/golang/scan_binary_test.go
@@ -31,7 +31,7 @@ func Test_getBuildInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBi, err := getBuildInfo(tt.args.r)
+			gotBi, _, err := getBuildInfo(tt.args.r)
 			if !tt.wantErr(t, err, fmt.Sprintf("getBuildInfo(%v)", tt.args.r)) {
 				return
 			}

--- a/syft/pkg/cataloger/golang/scan_binary_test.go
+++ b/syft/pkg/cataloger/golang/scan_binary_test.go
@@ -29,9 +29,10 @@ func Test_getBuildInfo(t *testing.T) {
 			wantErr: assert.Error,
 		},
 	}
+	c := newGoBinaryCataloger(DefaultCatalogerConfig())
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBi, _, err := getBuildInfo(tt.args.r)
+			gotBi, _, err := c.getBuildInfo(tt.args.r)
 			if !tt.wantErr(t, err, fmt.Sprintf("getBuildInfo(%v)", tt.args.r)) {
 				return
 			}

--- a/syft/pkg/cataloger/golang/scan_binary_test.go
+++ b/syft/pkg/cataloger/golang/scan_binary_test.go
@@ -29,10 +29,10 @@ func Test_getBuildInfo(t *testing.T) {
 			wantErr: assert.Error,
 		},
 	}
-	c := newGoBinaryCataloger(DefaultCatalogerConfig())
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotBi, _, err := c.getBuildInfo(tt.args.r)
+			gotBi, err := getBuildInfo(tt.args.r)
 			if !tt.wantErr(t, err, fmt.Sprintf("getBuildInfo(%v)", tt.args.r)) {
 				return
 			}

--- a/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/davecgh/go-spew/@v/v1.1.1.ziphash
+++ b/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/davecgh/go-spew/@v/v1.1.1.ziphash
@@ -1,0 +1,1 @@
+h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/google/go-cmp/@v/v0.7.0.ziphash
+++ b/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/google/go-cmp/@v/v0.7.0.ziphash
@@ -1,0 +1,1 @@
+h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/sirupsen/logrus/@v/v1.9.3.ziphash
+++ b/syft/pkg/cataloger/golang/test-fixtures/mod-cache/pkg/mod/cache/download/github.com/sirupsen/logrus/@v/v1.9.3.ziphash
@@ -1,0 +1,1 @@
+h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=


### PR DESCRIPTION
# Description

I've come up with an elegant solution to the issue: use Go module cache to resolve the dependencies appeared in the test binary. Code formatting and edge case investigation are still required.

P.S. Are there any better or alternative solutions to resolve the deps?

- Fixes #3629 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
