### PR TITLE
feat: purl-list format

### DIFF
--- a/cmd/syft/internal/options/output.go
+++ b/cmd/syft/internal/options/output.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/format/cyclonedxxml"
 	"github.com/anchore/syft/syft/format/github"
+	"github.com/anchore/syft/syft/format/purls"
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/format/spdxtagvalue"
 	"github.com/anchore/syft/syft/format/syftjson"
@@ -127,6 +128,7 @@ func supportedIDs() []sbom.FormatID {
 		table.ID,
 		text.ID,
 		template.ID,
+		purls.ID,
 
 		// encoders that support multiple versions
 		cyclonedxxml.ID,

--- a/syft/format/common/spdxhelpers/to_syft_model.go
+++ b/syft/format/common/spdxhelpers/to_syft_model.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/format/internal"
 	"github.com/anchore/syft/syft/format/internal/spdxutil/helpers"
 	"github.com/anchore/syft/syft/license"
 	"github.com/anchore/syft/syft/linux"
@@ -509,6 +510,10 @@ func toSyftPackage(p *spdx.Package) pkg.Package {
 		Metadata: extractMetadata(p, info),
 	}
 
+	err := internal.Backfill(sP)
+	if err != nil {
+		log.WithFields("package", sP, "error", err).Debug("unable to backfill package")
+	}
 	sP.SetID()
 
 	return *sP

--- a/syft/format/decoders.go
+++ b/syft/format/decoders.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/format/cyclonedxxml"
+	"github.com/anchore/syft/syft/format/purls"
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/format/spdxtagvalue"
 	"github.com/anchore/syft/syft/format/syftjson"
@@ -24,6 +25,7 @@ func Decoders() []sbom.FormatDecoder {
 		cyclonedxjson.NewFormatDecoder(),
 		spdxtagvalue.NewFormatDecoder(),
 		spdxjson.NewFormatDecoder(),
+		purls.NewFormatDecoder(),
 	}
 }
 

--- a/syft/format/decoders_collection.go
+++ b/syft/format/decoders_collection.go
@@ -34,6 +34,10 @@ func (c *DecoderCollection) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, stri
 
 	var bestID sbom.FormatID
 	for _, d := range c.decoders {
+		_, err = reader.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("unable to seek to start of SBOM: %w", err)
+		}
 		id, version := d.Identify(reader)
 		if id == "" || version == "" {
 			if id != "" {
@@ -42,6 +46,10 @@ func (c *DecoderCollection) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, stri
 			continue
 		}
 
+		_, err = reader.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, "", "", fmt.Errorf("unable to seek to start of SBOM: %w", err)
+		}
 		return d.Decode(reader)
 	}
 
@@ -65,6 +73,10 @@ func (c *DecoderCollection) Identify(r io.Reader) (sbom.FormatID, string) {
 	}
 
 	for _, d := range c.decoders {
+		_, err = reader.Seek(0, io.SeekStart)
+		if err != nil {
+			log.Debugf("unable to seek to start of SBOM: %v", err)
+		}
 		id, version := d.Identify(reader)
 		if id != "" && version != "" {
 			return id, version

--- a/syft/format/encoders.go
+++ b/syft/format/encoders.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anchore/syft/syft/format/cyclonedxjson"
 	"github.com/anchore/syft/syft/format/cyclonedxxml"
 	"github.com/anchore/syft/syft/format/github"
+	"github.com/anchore/syft/syft/format/purls"
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/format/spdxtagvalue"
 	"github.com/anchore/syft/syft/format/syftjson"
@@ -62,6 +63,7 @@ func (o EncodersConfig) Encoders() ([]sbom.FormatEncoder, error) {
 	l.addWithErr(syftjson.ID)(o.syftJSONEncoders())
 	l.add(table.ID)(table.NewFormatEncoder())
 	l.add(text.ID)(text.NewFormatEncoder())
+	l.add(purls.ID)(purls.NewFormatEncoder())
 	l.add(github.ID)(github.NewFormatEncoder())
 	l.addWithErr(cyclonedxxml.ID)(o.cyclonedxXMLEncoders())
 	l.addWithErr(cyclonedxjson.ID)(o.cyclonedxJSONEncoders())

--- a/syft/format/internal/backfill.go
+++ b/syft/format/internal/backfill.go
@@ -1,0 +1,95 @@
+package internal
+
+import (
+	"fmt"
+
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+// Backfill takes all information present in the package and attempts to fill in any missing information
+// from any available sources, such as the Metadata and PURL.
+//
+// Backfill does not call p.SetID(), but this needs to be called later to ensure it's up to date
+func Backfill(p *pkg.Package) error {
+	if p.PURL == "" {
+		return nil
+	}
+	var errs error
+	pu, err := packageurl.FromString(p.PURL)
+	if err != nil {
+		errs = fmt.Errorf("unable to parse purl: %s: %w", p.PURL, err)
+	} else {
+		if p.Type == "" {
+			setTypeFromPurl(p)
+		}
+		if p.Language == "" {
+			setLanguageFromPurl(p)
+		}
+		if p.Name == "" {
+			setNameFromPurl(p, pu)
+		}
+		if p.Version == "" {
+			setVersionFromPurl(p, pu)
+		}
+		if p.Language == pkg.Java {
+			setJavaMetadataFromPurl(p, pu)
+		}
+	}
+	return errs
+}
+
+func setTypeFromPurl(p *pkg.Package) {
+	if p.Type == "" {
+		p.Type = pkg.TypeFromPURL(p.PURL)
+	}
+}
+
+func setLanguageFromPurl(p *pkg.Package) {
+	if p.Language == "" {
+		p.Language = pkg.LanguageFromPURL(p.PURL)
+	}
+}
+
+func setJavaMetadataFromPurl(p *pkg.Package, pu packageurl.PackageURL) {
+	if p.Type != pkg.JavaPkg {
+		return
+	}
+	if pu.Namespace != "" {
+		javaMetadata := &pkg.JavaArchive{}
+		if p.Metadata != nil {
+			javaMetadata, _ = p.Metadata.(*pkg.JavaArchive)
+		} else {
+			p.Metadata = javaMetadata
+		}
+		if javaMetadata != nil {
+			props := javaMetadata.PomProperties
+			if props == nil {
+				props = &pkg.JavaPomProperties{}
+				javaMetadata.PomProperties = props
+			}
+			// capture the group id from the purl if it is not already set
+			if props.ArtifactID == "" {
+				props.ArtifactID = pu.Name
+			}
+			if props.GroupID == "" {
+				props.GroupID = pu.Namespace
+			}
+			if props.Version == "" {
+				props.Version = pu.Version
+			}
+		}
+	}
+}
+
+func setVersionFromPurl(p *pkg.Package, pu packageurl.PackageURL) {
+	if p.Version == "" {
+		p.Version = pu.Version
+	}
+}
+
+func setNameFromPurl(p *pkg.Package, pu packageurl.PackageURL) {
+	if p.Name == "" {
+		p.Name = pu.Name
+	}
+}

--- a/syft/format/internal/backfill_test.go
+++ b/syft/format/internal/backfill_test.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func Test_Backfill(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       pkg.Package
+		expected pkg.Package
+		wantErr  require.ErrorAssertionFunc
+	}{
+		{
+			name: "npm type",
+			in: pkg.Package{
+				PURL: "pkg:npm/test@3.0.0",
+			},
+			expected: pkg.Package{
+				PURL:     "pkg:npm/test@3.0.0",
+				Type:     pkg.NpmPkg,
+				Language: pkg.JavaScript,
+				Name:     "test",
+				Version:  "3.0.0",
+			},
+		},
+		{
+			name: "java type",
+			in: pkg.Package{
+				PURL: "pkg:maven/org.apache/some-thing@1.2.3",
+			},
+			expected: pkg.Package{
+				PURL:     "pkg:maven/org.apache/some-thing@1.2.3",
+				Type:     pkg.JavaPkg,
+				Language: pkg.Java,
+				Name:     "some-thing",
+				Version:  "1.2.3",
+				Metadata: &pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "org.apache",
+						ArtifactID: "some-thing",
+						Version:    "1.2.3",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Backfill(&tt.in)
+			if tt.wantErr == nil {
+				tt.wantErr = require.NoError
+			}
+			tt.wantErr(t, err)
+			tt.in.OverrideID("")
+			require.Equal(t, tt.expected, tt.in)
+		})
+	}
+}

--- a/syft/format/internal/cyclonedxutil/decoder.go
+++ b/syft/format/internal/cyclonedxutil/decoder.go
@@ -1,12 +1,9 @@
 package cyclonedxutil
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/CycloneDX/cyclonedx-go"
-
-	"github.com/anchore/syft/syft/format/internal/stream"
 )
 
 type Decoder struct {
@@ -20,19 +17,10 @@ func NewDecoder(format cyclonedx.BOMFileFormat) Decoder {
 }
 
 func (d Decoder) Decode(r io.Reader) (*cyclonedx.BOM, error) {
-	reader, err := stream.SeekableReader(r)
-	if err != nil {
-		return nil, err
-	}
-
 	doc := &cyclonedx.BOM{
 		Components: &[]cyclonedx.Component{},
 	}
-	if _, err := reader.Seek(0, io.SeekStart); err != nil {
-		return nil, fmt.Errorf("unable to seek to start of CycloneDX SBOM: %w", err)
-	}
-
-	err = cyclonedx.NewBOMDecoder(reader, d.format).Decode(doc)
+	err := cyclonedx.NewBOMDecoder(r, d.format).Decode(doc)
 	if err != nil {
 		return nil, err
 	}

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -6,7 +6,9 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/format/internal"
 	"github.com/anchore/syft/syft/internal/packagemetadata"
 	"github.com/anchore/syft/syft/pkg"
 )
@@ -98,13 +100,11 @@ func decodeComponent(c *cyclonedx.Component) *pkg.Package {
 
 	p.Metadata = decodePackageMetadata(values, c, metadataType)
 
-	if p.Type == "" {
-		p.Type = pkg.TypeFromPURL(p.PURL)
+	err := internal.Backfill(p)
+	if err != nil {
+		log.WithFields("package", p, "error", err).Debug("unable to backfill package")
 	}
-
-	if p.Language == "" {
-		p.Language = pkg.LanguageFromPURL(p.PURL)
-	}
+	p.SetID()
 
 	return p
 }

--- a/syft/format/purls/decoder.go
+++ b/syft/format/purls/decoder.go
@@ -1,0 +1,82 @@
+package purls
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/format/internal"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
+)
+
+var _ sbom.FormatDecoder = (*decoder)(nil)
+
+type decoder struct{}
+
+func NewFormatDecoder() sbom.FormatDecoder {
+	return decoder{}
+}
+
+func (d decoder) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) {
+	s, err := toSyftModel(r)
+	return s, ID, version, err
+}
+
+func (d decoder) Identify(r io.Reader) (sbom.FormatID, string) {
+	buf := [4]byte{}
+	bufs := buf[:]
+	_, _ = r.Read(bufs)
+	if string(bufs) == "pkg:" {
+		return ID, version
+	}
+	log.Warnf("unable to identify purls format: %s", string(bufs))
+	return "", ""
+}
+
+func toSyftModel(r io.Reader) (*sbom.SBOM, error) {
+	var errs []error
+	pkgs := pkg.NewCollection()
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		purl, err := packageurl.FromString(line)
+		if err != nil {
+			log.WithFields("error", err, "line", line).Debug("unable to parse purl")
+			continue
+		}
+		p := pkg.Package{
+			Name:    purl.Name,
+			Version: purl.Version,
+			PURL:    line,
+		}
+
+		err = internal.Backfill(&p)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		p.SetID()
+		pkgs.Add(p)
+	}
+
+	return &sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages:     pkgs,
+			FileMetadata: map[file.Coordinates]file.Metadata{},
+			FileDigests:  map[file.Coordinates][]file.Digest{},
+			FileContents: map[file.Coordinates]string{},
+			FileLicenses: map[file.Coordinates][]file.License{},
+			Executables:  map[file.Coordinates]file.Executable{},
+		},
+		Source:     source.Description{},
+		Descriptor: sbom.Descriptor{},
+	}, errors.Join(errs...)
+}

--- a/syft/format/purls/decoder_test.go
+++ b/syft/format/purls/decoder_test.go
@@ -1,0 +1,103 @@
+package purls
+
+import (
+	"bytes"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/internal/cmptest"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func TestDecoder_Decode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []pkg.Package
+	}{
+		{
+			name:  "basic",
+			input: `pkg:generic/some-package@1.2.3`,
+			expected: []pkg.Package{
+				{
+					Name:    "some-package",
+					Type:    pkg.UnknownPkg,
+					Version: "1.2.3",
+					PURL:    "pkg:generic/some-package@1.2.3",
+				},
+			},
+		},
+		{
+			name:  "npm",
+			input: `pkg:npm/some-package@1.2.3`,
+			expected: []pkg.Package{
+				{
+					Name:     "some-package",
+					Type:     pkg.NpmPkg,
+					Language: pkg.JavaScript,
+					Version:  "1.2.3",
+					PURL:     "pkg:npm/some-package@1.2.3",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dec := NewFormatDecoder()
+			got, _, _, err := dec.Decode(strings.NewReader(test.input))
+			require.NoError(t, err)
+
+			if diff := cmp.Diff(test.expected, got.Artifacts.Packages.Sorted(), cmptest.DefaultOptions()...); diff != "" {
+				t.Errorf("expected packages (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_DecodeEncodeCycle(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "basic",
+			input: "pkg:generic/some-package@1.2.3",
+		},
+		{
+			name:  "multiple",
+			input: "pkg:generic/pkg1\npkg:generic/pkg2\n\npkg:npm/@vercel/ncc@2.9.5",
+		},
+		{
+			name:  "java",
+			input: "pkg:maven/org.apache/some-thing@4.11.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dec := NewFormatDecoder()
+			decodedSBOM, _, _, err := dec.Decode(strings.NewReader(tt.input))
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			enc := NewFormatEncoder()
+			require.NoError(t, enc.Encode(&buf, *decodedSBOM))
+
+			in := strings.TrimSpace(regexp.MustCompile(`\s+`).ReplaceAllString(tt.input, "\n"))
+			parts := strings.Split(in, "\n")
+			slices.Sort(parts)
+			in = strings.Join(parts, "\n")
+
+			parts = strings.Split(strings.TrimSpace(buf.String()), "\n")
+			slices.Sort(parts)
+			got := strings.Join(parts, "\n")
+			require.Equal(t, in, got)
+		})
+	}
+}

--- a/syft/format/purls/encoder.go
+++ b/syft/format/purls/encoder.go
@@ -1,0 +1,62 @@
+package purls
+
+import (
+	"io"
+	"strings"
+
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+const ID sbom.FormatID = "purl-list"
+const version = "1"
+
+type encoder struct {
+}
+
+func NewFormatEncoder() sbom.FormatEncoder {
+	return encoder{}
+}
+
+func (e encoder) ID() sbom.FormatID {
+	return ID
+}
+
+func (e encoder) Aliases() []string {
+	return []string{
+		"purl",
+		"purls",
+	}
+}
+
+func (e encoder) Version() string {
+	return sbom.AnyVersion
+}
+
+func (e encoder) Encode(writer io.Writer, s sbom.SBOM) error {
+	output := strset.New()
+	for _, p := range s.Artifacts.Packages.Sorted() {
+		purl := strings.TrimSpace(p.PURL)
+		if purl == "" || output.Has(purl) {
+			continue
+		}
+		// ensure syft doesn't output invalid PURLs in this format
+		_, err := packageurl.FromString(purl)
+		if err != nil {
+			log.Debugf("invalid purl: %q", purl)
+			continue
+		}
+		_, err = writer.Write([]byte(purl))
+		if err != nil {
+			return err
+		}
+		_, err = writer.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/syft/format/purls/encoder_test.go
+++ b/syft/format/purls/encoder_test.go
@@ -1,0 +1,46 @@
+package purls
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/anchore/syft/syft/format/internal/testutil"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+var updateSnapshot = flag.Bool("update-purl-list", false, "update the *.golden files for purl-list format")
+
+func Test_Encoder(t *testing.T) {
+	pkgs := []pkg.Package{
+		{
+			Name:     "npmtest",
+			Version:  "1.5.1",
+			Type:     pkg.NpmPkg,
+			Language: pkg.JavaScript,
+			PURL:     "pkg:npm/npmtest@1.0.0",
+		},
+		{
+			Name:     "javatest",
+			Version:  "0.30.1",
+			Type:     pkg.JavaPkg,
+			Language: pkg.Java,
+			PURL:     "pkg:maven/org.apache/javatest@0.30.1",
+		},
+		{
+			Type: pkg.UnknownPkg,
+			PURL: "pkg:generic/generic@1.0.0",
+		},
+	}
+	testutil.AssertEncoderAgainstGoldenSnapshot(t,
+		testutil.EncoderSnapshotTestConfig{
+			Subject: sbom.SBOM{Artifacts: sbom.Artifacts{
+				Packages: pkg.NewCollection(pkgs...),
+			}},
+			Format:                      NewFormatEncoder(),
+			UpdateSnapshot:              *updateSnapshot,
+			PersistRedactionsInSnapshot: true,
+			IsJSON:                      false,
+		},
+	)
+}

--- a/syft/format/purls/test-fixtures/snapshot/Test_Encoder.golden
+++ b/syft/format/purls/test-fixtures/snapshot/Test_Encoder.golden
@@ -1,0 +1,3 @@
+pkg:generic/generic@1.0.0
+pkg:maven/org.apache/javatest@0.30.1
+pkg:npm/npmtest@1.0.0

--- a/syft/format/spdxtagvalue/decoder.go
+++ b/syft/format/spdxtagvalue/decoder.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spdx/tools-golang/tagvalue"
 
-	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/format/common/spdxhelpers"
 	"github.com/anchore/syft/syft/format/internal/stream"
 	"github.com/anchore/syft/syft/sbom"
@@ -57,22 +56,12 @@ func (d decoder) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) 
 }
 
 func (d decoder) Identify(r io.Reader) (sbom.FormatID, string) {
-	reader, err := stream.SeekableReader(r)
-	if err != nil {
-		return "", ""
-	}
-
-	if _, err := reader.Seek(0, io.SeekStart); err != nil {
-		log.Debugf("unable to seek to start of SPDX Tag-Value SBOM: %+v", err)
-		return "", ""
-	}
-
 	// Example document
 	// SPDXVersion: SPDX-2.3
 	// DataLicense: CC0-1.0
 	// SPDXID: SPDXRef-DOCUMENT
 
-	scanner := bufio.NewScanner(reader)
+	scanner := bufio.NewScanner(r)
 	scanner.Split(bufio.ScanLines)
 
 	var id sbom.FormatID

--- a/syft/format/syftjson/decoder.go
+++ b/syft/format/syftjson/decoder.go
@@ -53,24 +53,14 @@ func (d decoder) Decode(r io.Reader) (*sbom.SBOM, sbom.FormatID, string, error) 
 }
 
 func (d decoder) Identify(r io.Reader) (sbom.FormatID, string) {
-	reader, err := stream.SeekableReader(r)
-	if err != nil {
-		return "", ""
-	}
-
-	if _, err := reader.Seek(0, io.SeekStart); err != nil {
-		log.Debugf("unable to seek to start of Syft JSON SBOM: %+v", err)
-		return "", ""
-	}
-
 	type Document struct {
 		Schema model.Schema `json:"schema"`
 	}
 
-	dec := json.NewDecoder(reader)
+	dec := json.NewDecoder(r)
 
 	var doc Document
-	if err = dec.Decode(&doc); err != nil {
+	if err := dec.Decode(&doc); err != nil {
 		// maybe not json? maybe not valid? doesn't matter, we won't process it.
 		return "", ""
 	}


### PR DESCRIPTION
# Description

This PR adds a `purl-list` format (with aliases: `purl` and `purls`). This allows a user to export and by association convert to and from a list of PURLs.

Additionally, after reading an SBOM, formats are able to "enhance" Syft package data from information in the PURL if the data isn't present in the package. For example: a `maven` PURL includes the GroupID, something like: `pkg:maven/org.apache/something`, but this GroupID was not being mapped to the internal data location for GroupID which could result in false positives in Grype. This happens for PURL input as well as other formats including SPDX and CycloneDX in order to improve support for SBOMs created with tools other than Syft.

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
