### PR TITLE
Annotate visible/hidden paths when all-layers scope

### DIFF
--- a/syft/internal/fileresolver/container_image_all_layers.go
+++ b/syft/internal/fileresolver/container_image_all_layers.go
@@ -16,8 +16,9 @@ var _ file.Resolver = (*ContainerImageAllLayers)(nil)
 
 // ContainerImageAllLayers implements path and content access for the AllLayers source option for container image data sources.
 type ContainerImageAllLayers struct {
-	img    *image.Image
-	layers []int
+	img            *image.Image
+	layers         []int
+	markVisibility bool
 }
 
 // NewFromContainerImageAllLayers returns a new resolver from the perspective of all image layers for the given image.
@@ -33,6 +34,10 @@ func NewFromContainerImageAllLayers(img *image.Image) (*ContainerImageAllLayers,
 	return &ContainerImageAllLayers{
 		img:    img,
 		layers: layers,
+		// This is the entrypoint for the user-facing implementation, which should always annotate locations.
+		// We have other resolvers that use this implementation that are already responsible
+		// for marking visibility, so we don't need to do it all of the time (a small performance optimization).
+		markVisibility: true,
 	}, nil
 }
 
@@ -112,7 +117,9 @@ func (r *ContainerImageAllLayers) FilesByPath(paths ...string) ([]file.Location,
 				return nil, err
 			}
 			for _, result := range results {
-				uniqueLocations = append(uniqueLocations, file.NewLocationFromImage(path, result, r.img))
+				l := file.NewLocationFromImage(path, result, r.img)
+				r.annotateLocation(&l)
+				uniqueLocations = append(uniqueLocations, l)
 			}
 		}
 	}
@@ -156,7 +163,9 @@ func (r *ContainerImageAllLayers) FilesByGlob(patterns ...string) ([]file.Locati
 					return nil, err
 				}
 				for _, refResult := range refResults {
-					uniqueLocations = append(uniqueLocations, file.NewLocationFromImage(string(result.RequestPath), refResult, r.img))
+					l := file.NewLocationFromImage(string(result.RequestPath), refResult, r.img)
+					r.annotateLocation(&l)
+					uniqueLocations = append(uniqueLocations, l)
 				}
 			}
 		}
@@ -172,7 +181,7 @@ func (r *ContainerImageAllLayers) RelativeFileByPath(location file.Location, pat
 
 	exists, relativeRef, err := layer.SquashedTree.File(stereoscopeFile.Path(path), filetree.FollowBasenameLinks)
 	if err != nil {
-		log.Errorf("failed to find path=%q in squash: %+w", path, err)
+		log.Errorf("failed to find path=%q in squash: %+v", path, err)
 		return nil
 	}
 	if !exists && !relativeRef.HasReference() {
@@ -180,6 +189,7 @@ func (r *ContainerImageAllLayers) RelativeFileByPath(location file.Location, pat
 	}
 
 	relativeLocation := file.NewLocationFromImage(path, *relativeRef.Reference, r.img)
+	r.annotateLocation(&relativeLocation)
 
 	return &relativeLocation
 }
@@ -228,7 +238,9 @@ func (r *ContainerImageAllLayers) FilesByMIMEType(types ...string) ([]file.Locat
 				return nil, err
 			}
 			for _, refResult := range refResults {
-				uniqueLocations = append(uniqueLocations, file.NewLocationFromImage(string(ref.RequestPath), refResult, r.img))
+				l := file.NewLocationFromImage(string(ref.RequestPath), refResult, r.img)
+				r.annotateLocation(&l)
+				uniqueLocations = append(uniqueLocations, l)
 			}
 		}
 	}
@@ -243,10 +255,12 @@ func (r *ContainerImageAllLayers) AllLocations(ctx context.Context) <-chan file.
 		for _, layerIdx := range r.layers {
 			tree := r.img.Layers[layerIdx].Tree
 			for _, ref := range tree.AllFiles(stereoscopeFile.AllTypes()...) {
+				l := file.NewLocationFromImage(string(ref.RealPath), ref, r.img)
+				r.annotateLocation(&l)
 				select {
 				case <-ctx.Done():
 					return
-				case results <- file.NewLocationFromImage(string(ref.RealPath), ref, r.img):
+				case results <- l:
 					continue
 				}
 			}
@@ -257,4 +271,37 @@ func (r *ContainerImageAllLayers) AllLocations(ctx context.Context) <-chan file.
 
 func (r *ContainerImageAllLayers) FileMetadataByLocation(location file.Location) (file.Metadata, error) {
 	return fileMetadataByLocation(r.img, location)
+}
+
+func (r *ContainerImageAllLayers) annotateLocation(l *file.Location) {
+	if !r.markVisibility || l == nil {
+		return
+	}
+
+	givenRef := l.Reference()
+	annotation := file.VisibleAnnotation
+
+	// if we find a location for a path that matches the query (e.g. **/node_modules) but is not present in the squashed tree, skip it
+	ref, err := r.img.SquashedSearchContext.SearchByPath(l.RealPath, filetree.DoNotFollowDeadBasenameLinks)
+	if err != nil || !ref.HasReference() {
+		annotation = file.HiddenAnnotation
+	} else if ref.ID() != givenRef.ID() {
+		// we may have the path in the squashed tree, but this must not be in the same layer
+		annotation = file.HiddenAnnotation
+	}
+
+	// not only should the real path to the file exist, but the way we took to get there should also exist
+	// (e.g. if we are looking for /etc/passwd, but the real path is /etc/passwd -> /etc/passwd-1, then we should
+	// make certain that /etc/passwd-1 exists)
+	if annotation == file.VisibleAnnotation && l.AccessPath != "" {
+		ref, err := r.img.SquashedSearchContext.SearchByPath(l.AccessPath, filetree.DoNotFollowDeadBasenameLinks)
+		if err != nil || !ref.HasReference() {
+			annotation = file.HiddenAnnotation
+		} else if ref.ID() != givenRef.ID() {
+			// we may have the path in the squashed tree, but this must not be in the same layer
+			annotation = file.HiddenAnnotation
+		}
+	}
+
+	l.Annotations[file.VisibleAnnotationKey] = annotation
 }

--- a/syft/internal/fileresolver/container_image_deep_squash.go
+++ b/syft/internal/fileresolver/container_image_deep_squash.go
@@ -31,6 +31,9 @@ func NewFromContainerImageDeepSquash(img *image.Image) (*ContainerImageDeepSquas
 		return nil, err
 	}
 
+	// we will do the work here to mark visibility with results from two resolvers (don't do the work twice!)
+	allLayers.markVisibility = false
+
 	return &ContainerImageDeepSquash{
 		squashed:  squashed,
 		allLayers: allLayers,


### PR DESCRIPTION
#3138 added the concept of annotating locations raised up from a `file.Resolver` with `visible=true` or `visible=false` for any location returned so we can discover packages which have been deleted in higher layers or are otherwise hidden. That PR added a new `file.Resolver` to take advantage of this new capability, this PR extends these kinds of annotations to the `all-layers` file resolver (there are no other file resolvers this makes sense to also apply this to).

Here's an example of the changes for a single package in an alpine image where multiple `apk add` commands were performed each in their own `RUN` line in the Dockerfile:

```
$ syft myimage:latest -s all-layers | jq '.artifacts[] | select(.name == "alpine-release").locations'
```
```json
[
  {
    "path": "/lib/apk/db/installed",
    "layerID": "sha256:02b7b5e2cb1b34e0ed386a34b364f52eaf770e524e120055bdd642e104dce1cd",
    "accessPath": "/lib/apk/db/installed",
    "annotations": {
      "evidence": "primary",
      "visible": "false"
    }
  },
  {
    "path": "/lib/apk/db/installed",
    "layerID": "sha256:a16e98724c05975ee8c40d8fe389c3481373d34ab20a1cf52ea2accc43f71f4c",
    "accessPath": "/lib/apk/db/installed",
    "annotations": {
      "evidence": "primary",
      "visible": "false"
    }
  },
  {
    "path": "/lib/apk/db/installed",
    "layerID": "sha256:eeb7e34dc34ae12fe9df0056d36f9620970ed15c30271462be4dffdef4fc69d2",
    "accessPath": "/lib/apk/db/installed",
    "annotations": {
      "evidence": "primary",
      "visible": "true"
    }
  },
  {
    "path": "/lib/apk/db/installed",
    "layerID": "sha256:ff1223b81bbf3c1c3ffc402947f2a9dfdcf789f9c6acdd36a9d9e60e7c650aa8",
    "accessPath": "/lib/apk/db/installed",
    "annotations": {
      "evidence": "primary",
      "visible": "false"
    }
  }
]
```

Follow-up to #3138

This does not "fix" #1818 as that issue describes adding an indication on the package and not constituent locations on the package like done in this PR.

## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
