### PR TITLE
feat: add options for cataloging full licenses

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -158,9 +158,9 @@ func (cfg Catalog) ToFilesConfig() filecataloging.Config {
 
 func (cfg Catalog) ToLicenseConfig() cataloging.LicenseConfig {
 	return cataloging.LicenseConfig{
-		IncludeFullText:             cfg.License.IncludeFullText,
-		IncludeUnkownLicenseContent: cfg.License.IncludeUnknownLicenseContent,
-		Coverage:                    cfg.License.LicenseCoverage,
+		IncludeFullText:              cfg.License.IncludeFullText,
+		IncludeUnknownLicenseContent: cfg.License.IncludeUnknownLicenseContent,
+		Coverage:                     cfg.License.LicenseCoverage,
 	}
 }
 

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -158,6 +158,7 @@ func (cfg Catalog) ToFilesConfig() filecataloging.Config {
 
 func (cfg Catalog) ToLicenseConfig() cataloging.LicenseConfig {
 	return cataloging.LicenseConfig{
+		IncludeFullText:             cfg.License.IncludeFullText,
 		IncludeUnkownLicenseContent: cfg.License.IncludeUnknownLicenseContent,
 		Coverage:                    cfg.License.LicenseCoverage,
 	}

--- a/cmd/syft/internal/options/license.go
+++ b/cmd/syft/internal/options/license.go
@@ -5,6 +5,7 @@ import (
 )
 
 type licenseConfig struct {
+	IncludeFullText              bool    `yaml:"include-full-text" json:"include-full-text" mapstructure:"include-full-text"`
 	IncludeUnknownLicenseContent bool    `yaml:"include-unknown-license-content" json:"include-unknown-license-content" mapstructure:"include-unknown-license-content"`
 	LicenseCoverage              float64 `yaml:"license-coverage" json:"license-coverage" mapstructure:"license-coverage"`
 }
@@ -14,6 +15,7 @@ var _ interface {
 } = (*licenseConfig)(nil)
 
 func (o *licenseConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
+	descriptions.Add(&o.IncludeFullText, `include the content of a license in the SBOM for all cases where a cataloger has license content access`)
 	descriptions.Add(&o.IncludeUnknownLicenseContent, `include the content of a license in the SBOM when syft
 cannot determine a valid SPDX ID for the given license`)
 	descriptions.Add(&o.LicenseCoverage, `adjust the percent as a fraction of the total text, in normalized words, that
@@ -22,6 +24,7 @@ matches any valid license for the given inputs, expressed as a percentage across
 
 func defaultLicenseConfig() licenseConfig {
 	return licenseConfig{
+		IncludeFullText:              false,
 		IncludeUnknownLicenseContent: false,
 		LicenseCoverage:              75,
 	}

--- a/internal/licenses/context_test.go
+++ b/internal/licenses/context_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSetContextLicenseScanner(t *testing.T) {
-	scanner := testScanner(true)
+	scanner := testScanner(true, false)
 	ctx := context.Background()
 	ctx = SetContextLicenseScanner(ctx, scanner)
 
@@ -20,7 +20,7 @@ func TestSetContextLicenseScanner(t *testing.T) {
 }
 
 func TestIsContextLicenseScannerSet(t *testing.T) {
-	scanner := testScanner(true)
+	scanner := testScanner(true, false)
 	ctx := context.Background()
 	require.False(t, IsContextLicenseScannerSet(ctx))
 
@@ -30,7 +30,7 @@ func TestIsContextLicenseScannerSet(t *testing.T) {
 
 func TestContextLicenseScanner(t *testing.T) {
 	t.Run("with scanner", func(t *testing.T) {
-		scanner := testScanner(true)
+		scanner := testScanner(true, false)
 		ctx := SetContextLicenseScanner(context.Background(), scanner)
 		s, err := ContextLicenseScanner(ctx)
 		if err != nil || s != scanner {

--- a/internal/licenses/scanner.go
+++ b/internal/licenses/scanner.go
@@ -15,6 +15,7 @@ import (
 const (
 	DefaultCoverageThreshold     = 75 // determined by experimentation
 	DefaultIncludeLicenseContent = false
+	DefaultIncludeFullText       = false
 )
 
 type Scanner interface {

--- a/internal/licenses/scanner.go
+++ b/internal/licenses/scanner.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	DefaultCoverageThreshold     = 75 // determined by experimentation
-	DefaultIncludeLicenseContent = false
-	DefaultIncludeFullText       = false
+	DefaultCoverageThreshold            = 75 // determined by experimentation
+	DefaultIncludeUnknownLicenseContent = false
+	DefaultIncludeFullText              = false
 )
 
 type Scanner interface {
@@ -27,15 +27,17 @@ type Scanner interface {
 var _ Scanner = (*scanner)(nil)
 
 type scanner struct {
-	coverageThreshold     float64 // between 0 and 100
-	includeLicenseContent bool
-	scanner               func([]byte) licensecheck.Coverage
+	coverageThreshold            float64 // between 0 and 100
+	includeUnknownLicenseContent bool
+	includeFullText              bool
+	scanner                      func([]byte) licensecheck.Coverage
 }
 
 type ScannerConfig struct {
-	CoverageThreshold     float64
-	IncludeLicenseContent bool
-	Scanner               func([]byte) licensecheck.Coverage
+	CoverageThreshold            float64
+	IncludeUnknownLicenseContent bool
+	IncludeFullText              bool
+	Scanner                      func([]byte) licensecheck.Coverage
 }
 
 type Option func(*scanner)
@@ -46,9 +48,15 @@ func WithCoverage(coverage float64) Option {
 	}
 }
 
-func WithIncludeLicenseContent(includeLicenseContent bool) Option {
+func WithIncludeUnknownLicenseContent(includeUnknownLicenseContent bool) Option {
 	return func(s *scanner) {
-		s.includeLicenseContent = includeLicenseContent
+		s.includeUnknownLicenseContent = includeUnknownLicenseContent
+	}
+}
+
+func WithIncludeFullText(includeFullText bool) Option {
+	return func(s *scanner) {
+		s.includeFullText = includeFullText
 	}
 }
 
@@ -60,9 +68,10 @@ func NewDefaultScanner(o ...Option) (Scanner, error) {
 		return nil, fmt.Errorf("unable to create default license scanner: %w", err)
 	}
 	newScanner := &scanner{
-		coverageThreshold:     DefaultCoverageThreshold,
-		includeLicenseContent: DefaultIncludeLicenseContent,
-		scanner:               s.Scan,
+		coverageThreshold:            DefaultCoverageThreshold,
+		includeUnknownLicenseContent: DefaultIncludeUnknownLicenseContent,
+		includeFullText:              DefaultIncludeFullText,
+		scanner:                      s.Scan,
 	}
 
 	for _, opt := range o {
@@ -79,8 +88,9 @@ func NewScanner(c *ScannerConfig) (Scanner, error) {
 	}
 
 	return &scanner{
-		coverageThreshold:     c.CoverageThreshold,
-		includeLicenseContent: c.IncludeLicenseContent,
-		scanner:               c.Scanner,
+		coverageThreshold:            c.CoverageThreshold,
+		includeFullText:              c.IncludeFullText,
+		includeUnknownLicenseContent: c.IncludeUnknownLicenseContent,
+		scanner:                      c.Scanner,
 	}, nil
 }

--- a/internal/licenses/scanner_test.go
+++ b/internal/licenses/scanner_test.go
@@ -45,7 +45,7 @@ func TestIdentifyLicenseIDs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			content, err := os.ReadFile(test.in)
 			require.NoError(t, err)
-			ids, content, err := testScanner(false).IdentifyLicenseIDs(context.TODO(), bytes.NewReader(content))
+			ids, content, err := testScanner(false, false).IdentifyLicenseIDs(context.TODO(), bytes.NewReader(content))
 			if test.expected.yieldError {
 				require.Error(t, err)
 			} else {
@@ -66,11 +66,12 @@ func TestIdentifyLicenseIDs(t *testing.T) {
 	}
 }
 
-func testScanner(includeLicenseContent bool) Scanner {
+func testScanner(includeUnknownLicenseContent, includeFullText bool) Scanner {
 	return &scanner{
-		coverageThreshold:     DefaultCoverageThreshold,
-		includeLicenseContent: includeLicenseContent,
-		scanner:               licensecheck.Scan,
+		coverageThreshold:            DefaultCoverageThreshold,
+		includeUnknownLicenseContent: includeUnknownLicenseContent,
+		includeFullText:              includeFullText,
+		scanner:                      licensecheck.Scan,
 	}
 }
 

--- a/syft/cataloging/license.go
+++ b/syft/cataloging/license.go
@@ -3,12 +3,14 @@ package cataloging
 import "github.com/anchore/syft/internal/licenses"
 
 type LicenseConfig struct {
+	IncludeFullText             bool    `json:"include-full-text" yaml:"include-full-text" mapstructure:"include-full-text"`
 	IncludeUnkownLicenseContent bool    `json:"include-unknown-license-content" yaml:"include-unknown-license-content" mapstructure:"include-unknown-license-content"`
 	Coverage                    float64 `json:"coverage" yaml:"coverage" mapstructure:"coverage"`
 }
 
 func DefaultLicenseConfig() LicenseConfig {
 	return LicenseConfig{
+		IncludeFullText:             licenses.DefaultIncludeFullText,
 		IncludeUnkownLicenseContent: licenses.DefaultIncludeLicenseContent,
 		Coverage:                    licenses.DefaultCoverageThreshold,
 	}

--- a/syft/cataloging/license.go
+++ b/syft/cataloging/license.go
@@ -3,15 +3,15 @@ package cataloging
 import "github.com/anchore/syft/internal/licenses"
 
 type LicenseConfig struct {
-	IncludeFullText             bool    `json:"include-full-text" yaml:"include-full-text" mapstructure:"include-full-text"`
-	IncludeUnkownLicenseContent bool    `json:"include-unknown-license-content" yaml:"include-unknown-license-content" mapstructure:"include-unknown-license-content"`
-	Coverage                    float64 `json:"coverage" yaml:"coverage" mapstructure:"coverage"`
+	IncludeFullText              bool    `json:"include-full-text" yaml:"include-full-text" mapstructure:"include-full-text"`
+	IncludeUnknownLicenseContent bool    `json:"include-unknown-license-content" yaml:"include-unknown-license-content" mapstructure:"include-unknown-license-content"`
+	Coverage                     float64 `json:"coverage" yaml:"coverage" mapstructure:"coverage"`
 }
 
 func DefaultLicenseConfig() LicenseConfig {
 	return LicenseConfig{
-		IncludeFullText:             licenses.DefaultIncludeFullText,
-		IncludeUnkownLicenseContent: licenses.DefaultIncludeLicenseContent,
-		Coverage:                    licenses.DefaultCoverageThreshold,
+		IncludeFullText:              licenses.DefaultIncludeFullText,
+		IncludeUnknownLicenseContent: licenses.DefaultIncludeUnknownLicenseContent,
+		Coverage:                     licenses.DefaultCoverageThreshold,
 	}
 }

--- a/syft/create_sbom.go
+++ b/syft/create_sbom.go
@@ -107,9 +107,9 @@ func setupContext(ctx context.Context, cfg *CreateSBOMConfig) (context.Context, 
 // SetContextLicenseScanner creates and sets a license scanner
 // on the provided context using the provided license config.
 func SetContextLicenseScanner(ctx context.Context, cfg cataloging.LicenseConfig) (context.Context, error) {
-	// inject a single license scanner and content config for all package cataloging tasks into context
 	licenseScanner, err := licenses.NewDefaultScanner(
-		licenses.WithIncludeLicenseContent(cfg.IncludeUnkownLicenseContent),
+		licenses.WithIncludeFullText(cfg.IncludeFullText),
+		licenses.WithIncludeUnknownLicenseContent(cfg.IncludeUnknownLicenseContent),
 		licenses.WithCoverage(cfg.Coverage),
 	)
 	if err != nil {

--- a/syft/pkg/license.go
+++ b/syft/pkg/license.go
@@ -69,8 +69,25 @@ func (l Licenses) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
 }
 
+// NewLicense returns a license for the provided value with a declared type
 func NewLicense(value string) License {
 	return NewLicenseFromType(value, license.Declared)
+}
+
+func NewLicenseFromFullText(id string, fullText string, location file.Location, t license.Type) License {
+	spdxExpression, err := license.ParseExpression(id)
+	if err != nil {
+		log.WithFields("error", err, "expression", id).Trace("unable to parse license expression")
+	}
+
+	l := License{
+		SPDXExpression: spdxExpression,
+		Value:          id,
+		FullText:       fullText,
+		Type:           t,
+	}
+	l.Locations.Add(location)
+	return l
 }
 
 func NewLicenseFromType(value string, t license.Type) License {


### PR DESCRIPTION
# Description

This PR adds the option for users to configure syft to return the full text of licenses it comes across during scanning.
Currently, syft can be configured to return the `contents` for licenses that do not return a valid SPDX ID. This PR adds an additional config option called `include-full-text`.

By default syft does not return any contents of any license in any SBOM.

If a user sets `include-unknown-license-content` then syft will ONLY include content when an SPDX license ID cannot be determined. 

If a user sets `include-full-text` then syft will include content for all license objects it returns.
NOTE: this config option can lead to very large SBOM. 

Imagine a license file where multiple ID are extracted from the same text. Each ID would lead to a separate license being created. Each license would have the content from that file included in the final SBOM.

- Fixes

#3088 

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (updates the documentation)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
