### PR TITLE
Persist artifact ID as supplemental package data

### DIFF
--- a/syft/format/common/spdxhelpers/to_syft_model.go
+++ b/syft/format/common/spdxhelpers/to_syft_model.go
@@ -499,14 +499,15 @@ func extractPkgInfo(p *spdx.Package) pkgInfo {
 func toSyftPackage(p *spdx.Package) pkg.Package {
 	info := extractPkgInfo(p)
 	sP := &pkg.Package{
-		Type:     info.typ,
-		Name:     p.PackageName,
-		Version:  p.PackageVersion,
-		Licenses: pkg.NewLicenseSet(parseSPDXLicenses(p)...),
-		CPEs:     extractCPEs(p),
-		PURL:     purlValue(info.purl),
-		Language: info.lang,
-		Metadata: extractMetadata(p, info),
+		Type:             info.typ,
+		Name:             p.PackageName,
+		Version:          p.PackageVersion,
+		Licenses:         pkg.NewLicenseSet(parseSPDXLicenses(p)...),
+		CPEs:             extractCPEs(p),
+		PURL:             purlValue(info.purl),
+		Language:         info.lang,
+		Metadata:         extractMetadata(p, info),
+		SupplementalData: []any{artifact.ID(p.PackageSPDXIdentifier)},
 	}
 
 	sP.SetID()

--- a/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -17,14 +17,14 @@
       ]
     },
     "component": {
-      "bom-ref":"redacted",
+      "bom-ref": "redacted",
       "type": "file",
       "name": "some/path"
     }
   },
   "components": [
     {
-      "bom-ref":"redacted",
+      "bom-ref": "4dd25c6ee16b729a",
       "type": "library",
       "name": "package-1",
       "version": "1.0.1",
@@ -61,7 +61,7 @@
       ]
     },
     {
-      "bom-ref":"redacted",
+      "bom-ref": "pkg:deb/debian/package-2@2.0.1?package-id=39392bb5e270f669",
       "type": "library",
       "name": "package-2",
       "version": "2.0.1",
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "bom-ref":"redacted",
+      "bom-ref": "os:debian@1.2.3",
       "type": "operating-system",
       "name": "debian",
       "version": "1.2.3",

--- a/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxjson/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -17,7 +17,7 @@
       ]
     },
     "component": {
-      "bom-ref":"redacted",
+      "bom-ref": "redacted",
       "type": "container",
       "name": "user-image-input",
       "version": "sha256:redacted"
@@ -25,7 +25,7 @@
   },
   "components": [
     {
-      "bom-ref":"redacted",
+      "bom-ref": "72567175418f73f8",
       "type": "library",
       "name": "package-1",
       "version": "1.0.1",
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "bom-ref":"redacted",
+      "bom-ref": "pkg:deb/debian/package-2@2.0.1?package-id=4b756c6f6fb127a3",
       "type": "library",
       "name": "package-2",
       "version": "2.0.1",
@@ -100,7 +100,7 @@
       ]
     },
     {
-      "bom-ref":"redacted",
+      "bom-ref": "os:debian@1.2.3",
       "type": "operating-system",
       "name": "debian",
       "version": "1.2.3",

--- a/syft/format/cyclonedxxml/encoder_test.go
+++ b/syft/format/cyclonedxxml/encoder_test.go
@@ -90,16 +90,24 @@ func TestCycloneDxImageEncoder(t *testing.T) {
 func redactor(values ...string) testutil.Redactor {
 	return testutil.NewRedactions().
 		WithValuesRedacted(values...).
+		WithPatternRedactorSpec(
+			testutil.PatternReplacement{
+				// only the source component bom-ref (not package or other component bom-refs)
+				Search:  regexp.MustCompile(`<component bom-ref="(?P<redact>[^"]*)" type="file">`),
+				Groups:  []string{"redact"}, // use the regex to anchore the search, but only replace bytes within the capture group
+				Replace: "redacted",
+			},
+		).
 		WithPatternRedactors(
 			map[string]string{
 				// dates
 				`([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))`: `redacted`,
 
-				// image hashes and BOM refs
+				// image hashes
 				`sha256:[A-Za-z0-9]{64}`: `sha256:redacted`,
 
-				// serial numbers and BOM refs
-				`(serialNumber|bom-ref)="[^"]+"`: `$1="redacted"`,
+				// serial numbers
+				`(serialNumber)="[^"]+"`: `$1="redacted"`,
 			},
 		)
 }

--- a/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -16,7 +16,7 @@
     </component>
   </metadata>
   <components>
-    <component bom-ref="redacted" type="library">
+    <component bom-ref="4dd25c6ee16b729a" type="library">
       <name>package-1</name>
       <version>1.0.1</version>
       <licenses>
@@ -34,7 +34,7 @@
         <property name="syft:location:0:path">/some/path/pkg1</property>
       </properties>
     </component>
-    <component bom-ref="redacted" type="library">
+    <component bom-ref="pkg:deb/debian/package-2@2.0.1?package-id=39392bb5e270f669" type="library">
       <name>package-2</name>
       <version>2.0.1</version>
       <cpe>cpe:2.3:*:some:package:2:*:*:*:*:*:*:*</cpe>
@@ -47,7 +47,7 @@
         <property name="syft:metadata:installedSize">0</property>
       </properties>
     </component>
-    <component bom-ref="redacted" type="operating-system">
+    <component bom-ref="os:debian@1.2.3" type="operating-system">
       <name>debian</name>
       <version>1.2.3</version>
       <description>debian</description>

--- a/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxxml/test-fixtures/snapshot/TestCycloneDxImageEncoder.golden
@@ -11,13 +11,13 @@
         </component>
       </components>
     </tools>
-    <component bom-ref="redacted" type="container">
+    <component bom-ref="f28a4ba3ddfdddad" type="container">
       <name>user-image-input</name>
       <version>sha256:redacted</version>
     </component>
   </metadata>
   <components>
-    <component bom-ref="redacted" type="library">
+    <component bom-ref="72567175418f73f8" type="library">
       <name>package-1</name>
       <version>1.0.1</version>
       <licenses>
@@ -36,7 +36,7 @@
         <property name="syft:location:0:path">/somefile-1.txt</property>
       </properties>
     </component>
-    <component bom-ref="redacted" type="library">
+    <component bom-ref="pkg:deb/debian/package-2@2.0.1?package-id=4b756c6f6fb127a3" type="library">
       <name>package-2</name>
       <version>2.0.1</version>
       <cpe>cpe:2.3:*:some:package:2:*:*:*:*:*:*:*</cpe>
@@ -50,7 +50,7 @@
         <property name="syft:metadata:installedSize">0</property>
       </properties>
     </component>
-    <component bom-ref="redacted" type="operating-system">
+    <component bom-ref="os:debian@1.2.3" type="operating-system">
       <name>debian</name>
       <version>1.2.3</version>
       <description>debian</description>

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -6,6 +6,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 
 	"github.com/anchore/packageurl-go"
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/internal/packagemetadata"
 	"github.com/anchore/syft/syft/pkg"
@@ -84,12 +85,13 @@ func decodeComponent(c *cyclonedx.Component) *pkg.Package {
 	}
 
 	p := &pkg.Package{
-		Name:      c.Name,
-		Version:   c.Version,
-		Locations: decodeLocations(values),
-		Licenses:  pkg.NewLicenseSet(decodeLicenses(c)...),
-		CPEs:      decodeCPEs(c),
-		PURL:      c.PackageURL,
+		Name:             c.Name,
+		Version:          c.Version,
+		Locations:        decodeLocations(values),
+		Licenses:         pkg.NewLicenseSet(decodeLicenses(c)...),
+		CPEs:             decodeCPEs(c),
+		PURL:             c.PackageURL,
+		SupplementalData: []any{artifact.ID(c.BOMRef)},
 	}
 
 	DecodeInto(p, values, "syft:package", CycloneDXFields)

--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -70,7 +70,6 @@ func collectPackages(component *cyclonedx.Component, s *sbom.SBOM, idMap map[str
 		if syftID != "" {
 			idMap[syftID] = p
 		}
-		// TODO there must be a better way than needing to call this manually:
 		p.SetID()
 		s.Artifacts.Packages.Add(*p)
 	}

--- a/syft/pkg/package.go
+++ b/syft/pkg/package.go
@@ -17,17 +17,18 @@ import (
 // Package represents an application or library that has been bundled into a distributable format.
 // TODO: if we ignore FoundBy for ID generation should we merge the field to show it was found in two places?
 type Package struct {
-	id        artifact.ID      `hash:"ignore"`
-	Name      string           // the package name
-	Version   string           // the version of the package
-	FoundBy   string           `hash:"ignore" cyclonedx:"foundBy"` // the specific cataloger that discovered this package
-	Locations file.LocationSet // the locations that lead to the discovery of this package (note: this is not necessarily the locations that make up this package)
-	Licenses  LicenseSet       // licenses discovered with the package metadata
-	Language  Language         `hash:"ignore" cyclonedx:"language"` // the language ecosystem this package belongs to (e.g. JavaScript, Python, etc)
-	Type      Type             `cyclonedx:"type"`                   // the package type (e.g. Npm, Yarn, Python, Rpm, Deb, etc)
-	CPEs      []cpe.CPE        `hash:"ignore"`                      // all possible Common Platform Enumerators (note: this is NOT included in the definition of the ID since all fields on a CPE are derived from other fields)
-	PURL      string           `hash:"ignore"`                      // the Package URL (see https://github.com/package-url/purl-spec)
-	Metadata  interface{}      // additional data found while parsing the package source
+	id               artifact.ID      `hash:"ignore"`
+	Name             string           // the package name
+	Version          string           // the version of the package
+	FoundBy          string           `hash:"ignore" cyclonedx:"foundBy"` // the specific cataloger that discovered this package
+	Locations        file.LocationSet // the locations that lead to the discovery of this package (note: this is not necessarily the locations that make up this package)
+	Licenses         LicenseSet       // licenses discovered with the package metadata
+	Language         Language         `hash:"ignore" cyclonedx:"language"` // the language ecosystem this package belongs to (e.g. JavaScript, Python, etc)
+	Type             Type             `cyclonedx:"type"`                   // the package type (e.g. Npm, Yarn, Python, Rpm, Deb, etc)
+	CPEs             []cpe.CPE        `hash:"ignore"`                      // all possible Common Platform Enumerators (note: this is NOT included in the definition of the ID since all fields on a CPE are derived from other fields)
+	PURL             string           `hash:"ignore"`                      // the Package URL (see https://github.com/package-url/purl-spec)
+	Metadata         any              // additional data found while parsing the package source
+	SupplementalData []any            `hash:"ignore"` // additional data that is not part of the package metadata nor expressed in output formats
 }
 
 func (p *Package) OverrideID(id artifact.ID) {
@@ -35,6 +36,24 @@ func (p *Package) OverrideID(id artifact.ID) {
 }
 
 func (p *Package) SetID() {
+	for _, data := range p.SupplementalData {
+		switch d := data.(type) {
+		case artifact.ID:
+			if d == "" {
+				continue
+			}
+			p.id = d
+			return
+		case artifact.Identifiable:
+			id := d.ID()
+			if id == "" {
+				continue
+			}
+			p.id = id
+			return
+		}
+	}
+
 	id, err := artifact.IDByHash(p)
 	if err != nil {
 		// TODO: what to do in this case?


### PR DESCRIPTION
Today if you use `syft convert`, the syft API (say via grype) with an SBOM, or use the SBOM cataloger, all packages raised up from the underlying SBOM get new IDs derived from the data discovered as opposed to using the ID found within the artifact. There are pros and cons with each approach, however, this PR is changing syft's opinion on this to prefer the ID of artifacts from the SBOM discovered.

This is done by adding a new `SupplementalData []any` field to `pkg.Package` which can be populated with any type. This is intended to introduce new data onto the package without encoding the field directly into the JSON format, without affecting the package ID hash, nor guaranteeing any type expectations around this field.

Here's an example of before and after of a grype run with these changes integrated; now the artifact IDs in the grype JSON are the native SBOM ID:


<img width="913" alt="Screenshot 2025-05-07 at 10 13 04 PM" src="https://github.com/user-attachments/assets/90e9b3e8-7b13-4211-ae61-ad5ca41a165f" />


Supersedes #1872 and addresses https://github.com/anchore/grype/issues/1265 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
