### PR TITLE
Clear `(devel)` version from go main modules

### DIFF
--- a/syft/pkg/cataloger/golang/cataloger_test.go
+++ b/syft/pkg/cataloger/golang/cataloger_test.go
@@ -53,7 +53,7 @@ func Test_PackageCataloger_Binary(t *testing.T) {
 			// see the dockerfile for details
 			fixture: "image-not-a-module",
 			expectedPkgs: []string{
-				"command-line-arguments @ (devel) (/run-me)", // this is the difference!
+				"command-line-arguments @  (/run-me)", // this is the difference!
 				"github.com/andybalholm/brotli @ v1.1.1 (/run-me)",
 				"github.com/dsnet/compress @ v0.0.2-0.20210315054119-f66993602bf5 (/run-me)",
 				"github.com/golang/snappy @ v0.0.4 (/run-me)",
@@ -67,17 +67,17 @@ func Test_PackageCataloger_Binary(t *testing.T) {
 				"stdlib @ go1.23.2 (/run-me)",
 			},
 			expectedRels: []string{
-				"github.com/anchore/archiver/v3 @ v3.5.3-0.20241210171143-5b1d8d1c7c51 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/andybalholm/brotli @ v1.1.1 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/dsnet/compress @ v0.0.2-0.20210315054119-f66993602bf5 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/golang/snappy @ v0.0.4 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/klauspost/compress @ v1.17.11 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/klauspost/pgzip @ v1.2.6 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/nwaples/rardecode @ v1.1.3 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/pierrec/lz4/v4 @ v4.1.21 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/ulikunitz/xz @ v0.5.12 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"github.com/xi2/xz @ v0.0.0-20171230120015-48954b6210f8 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
-				"stdlib @ go1.23.2 (/run-me) [dependency-of] command-line-arguments @ (devel) (/run-me)",
+				"github.com/anchore/archiver/v3 @ v3.5.3-0.20241210171143-5b1d8d1c7c51 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/andybalholm/brotli @ v1.1.1 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/dsnet/compress @ v0.0.2-0.20210315054119-f66993602bf5 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/golang/snappy @ v0.0.4 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/klauspost/compress @ v1.17.11 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/klauspost/pgzip @ v1.2.6 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/nwaples/rardecode @ v1.1.3 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/pierrec/lz4/v4 @ v4.1.21 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/ulikunitz/xz @ v0.5.12 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"github.com/xi2/xz @ v0.0.0-20171230120015-48954b6210f8 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
+				"stdlib @ go1.23.2 (/run-me) [dependency-of] command-line-arguments @  (/run-me)",
 			},
 		},
 	}

--- a/syft/pkg/cataloger/golang/parse_go_binary.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary.go
@@ -124,7 +124,8 @@ func (c *goBinaryCataloger) buildGoPkgInfo(ctx context.Context, licenseScanner l
 
 		lics := c.licenseResolver.getLicenses(ctx, licenseScanner, resolver, dep.Path, dep.Version)
 		gover, experiments := getExperimentsFromVersion(mod.GoVersion)
-		p := c.newGoBinaryPackage(
+
+		m := newBinaryMetadata(
 			dep,
 			mod.Main.Path,
 			gover,
@@ -132,6 +133,11 @@ func (c *goBinaryCataloger) buildGoPkgInfo(ctx context.Context, licenseScanner l
 			nil,
 			mod.cryptoSettings,
 			experiments,
+		)
+
+		p := c.newGoBinaryPackage(
+			dep,
+			m,
 			lics,
 			location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 		)
@@ -163,7 +169,8 @@ func (c *goBinaryCataloger) makeGoMainPackage(ctx context.Context, licenseScanne
 	gbs := getBuildSettings(mod.Settings)
 	lics := c.licenseResolver.getLicenses(ctx, licenseScanner, resolver, mod.Main.Path, mod.Main.Version)
 	gover, experiments := getExperimentsFromVersion(mod.GoVersion)
-	main := c.newGoBinaryPackage(
+
+	m := newBinaryMetadata(
 		&mod.Main,
 		mod.Main.Path,
 		gover,
@@ -171,32 +178,26 @@ func (c *goBinaryCataloger) makeGoMainPackage(ctx context.Context, licenseScanne
 		gbs,
 		mod.cryptoSettings,
 		experiments,
+	)
+
+	if mod.Main.Version == devel {
+		version := c.findMainModuleVersion(&m, gbs, reader)
+
+		if version != "" {
+			// make sure version is prefixed with v as some build systems parsed
+			// during `findMainModuleVersion` can include incomplete semver
+			// vx.x.x is correct
+			version = ensurePrefix(version, "v")
+		}
+		mod.Main.Version = version
+	}
+
+	main := c.newGoBinaryPackage(
+		&mod.Main,
+		m,
 		lics,
 		location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 	)
-
-	if main.Version != devel {
-		// found a full package with a non-development version... return it as is...
-		return main
-	}
-
-	// we have a package, but the version is "devel"... let's try and find a better answer
-	var metadata *pkg.GolangBinaryBuildinfoEntry
-	if v, ok := main.Metadata.(pkg.GolangBinaryBuildinfoEntry); ok {
-		metadata = &v
-	}
-	version := c.findMainModuleVersion(metadata, gbs, reader)
-
-	if version != "" {
-		// make sure version is prefixed with v as some build systems parsed
-		// during `findMainModuleVersion` can include incomplete semver
-		// vx.x.x is correct
-		version = ensurePrefix(version, "v")
-		main.Version = version
-		main.PURL = packageURL(main.Name, main.Version)
-
-		main.SetID()
-	}
 
 	return main
 }

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -152,8 +152,8 @@ func TestBuildGoPkgInfo(t *testing.T) {
 		Name:     "github.com/anchore/syft",
 		Language: pkg.Go,
 		Type:     pkg.GoModulePkg,
-		Version:  "(devel)",
-		PURL:     "pkg:golang/github.com/anchore/syft@%28devel%29",
+		Version:  "", // this was (devel) but we cleared it explicitly
+		PURL:     "pkg:golang/github.com/anchore/syft",
 		Locations: file.NewLocationSet(
 			file.NewLocationFromCoordinates(
 				file.Coordinates{
@@ -178,6 +178,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 		name          string
 		mod           *extendedBuildInfo
 		expected      []pkg.Package
+		cfg           *CatalogerConfig
 		binaryContent string
 	}{
 		{
@@ -282,8 +283,8 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			expected: []pkg.Package{
 				{
 					Name:     "github.com/a/b/c",
-					Version:  "(devel)",
-					PURL:     "pkg:golang/github.com/a/b@%28devel%29#c",
+					Version:  "", // this was (devel) but we cleared it explicitly
+					PURL:     "pkg:golang/github.com/a/b#c",
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: file.NewLocationSet(
@@ -934,8 +935,8 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				Name:     "github.com/anchore/syft",
 				Language: pkg.Go,
 				Type:     pkg.GoModulePkg,
-				Version:  "(devel)",
-				PURL:     "pkg:golang/github.com/anchore/syft@%28devel%29",
+				Version:  "", // this was (devel) but we cleared it explicitly
+				PURL:     "pkg:golang/github.com/anchore/syft",
 				Locations: file.NewLocationSet(
 					file.NewLocationFromCoordinates(
 						file.Coordinates{
@@ -1057,7 +1058,12 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				},
 			)
 
-			c := newGoBinaryCataloger(DefaultCatalogerConfig())
+			if test.cfg == nil {
+				c := DefaultCatalogerConfig()
+				test.cfg = &c
+			}
+
+			c := newGoBinaryCataloger(*test.cfg)
 			reader, err := unionreader.GetUnionReader(io.NopCloser(strings.NewReader(test.binaryContent)))
 			require.NoError(t, err)
 			mainPkg, pkgs := c.buildGoPkgInfo(context.Background(), licenseScanner, fileresolver.Empty{}, location, test.mod, test.mod.arch, reader)


### PR DESCRIPTION
This changes the behavior of the go binary cataloger to rause up a blank version over `(devel)` as a value, allowing the package compliance policy to enforce values (by default set it to `UNKNOWN`).

- Fixes #3324

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
