### PR TITLE
Do not search for main module versions within binary contents by default

### DIFF
--- a/syft/pkg/cataloger/golang/config.go
+++ b/syft/pkg/cataloger/golang/config.go
@@ -91,7 +91,7 @@ func defaultGoModDir() string {
 func DefaultMainModuleVersionConfig() MainModuleVersionConfig {
 	return MainModuleVersionConfig{
 		FromLDFlags:       true,
-		FromContents:      true,
+		FromContents:      false,
 		FromBuildSettings: true,
 	}
 }

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -855,6 +855,14 @@ func TestBuildGoPkgInfo(t *testing.T) {
 		},
 		{
 			name: "parse main mod and replace devel with pattern from binary contents",
+			cfg: func() *CatalogerConfig {
+				c := DefaultCatalogerConfig()
+				// off by default
+				assert.False(t, c.MainModuleVersion.FromContents)
+				// override to true for this test
+				c.MainModuleVersion.FromContents = true
+				return &c
+			}(),
 			mod: &extendedBuildInfo{
 				BuildInfo: &debug.BuildInfo{
 					GoVersion: goCompiledVersion,


### PR DESCRIPTION
Today if no version can be found for a go module within a binary (searching buildinfo or ldflags) then a semver regex is applied to the full contents of the binary. This is costly resource-wise and often raises incorrect versions. For this reason this PR makes this behavior opt-in only.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## PR Stack
- #3873 
