### PR TITLE
fix: remove race when writing errors in generic cataloger

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -221,7 +221,8 @@ tasks:
     cmds:
       - "go test -v ./cmd/syft/internal/test/integration"
       # exercise most of the CLI with the data race detector
-      - "go run -race cmd/syft/main.go alpine:latest"
+      # we use a larger image to ensure we're using multiple catalogers at a time
+      - "go run -race cmd/syft/main.go anchore/test_images:grype-quality-dotnet-69f15d2"
 
   validate-cyclonedx-schema:
     desc: Validate that Syft produces valid CycloneDX documents

--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -171,13 +171,12 @@ func (c *Cataloger) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.
 
 		log.WithFields("path", location.RealPath).Trace("parsing file contents")
 
-		var errs error
 		discoveredPackages, discoveredRelationships, err := invokeParser(ctx, resolver, location, lgr, parser, &env)
 		if err != nil {
 			// parsers may return errors and valid packages / relationships
-			errs = unknown.Append(errs, location, err)
+			err = unknown.New(location, err)
 		}
-		return result{discoveredPackages, discoveredRelationships}, errs
+		return result{discoveredPackages, discoveredRelationships}, err
 	}, func(_ request, res result) {
 		for _, p := range res.pkgs {
 			p.FoundBy = c.upstreamCataloger

--- a/syft/pkg/cataloger/generic/cataloger.go
+++ b/syft/pkg/cataloger/generic/cataloger.go
@@ -154,7 +154,6 @@ func (c *Cataloger) Name() string {
 func (c *Cataloger) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
 	var packages []pkg.Package
 	var relationships []artifact.Relationship
-	var errs error
 
 	lgr := log.Nested("cataloger", c.upstreamCataloger)
 
@@ -167,11 +166,12 @@ func (c *Cataloger) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.
 		pkgs []pkg.Package
 		rels []artifact.Relationship
 	}
-	errs = sync.Collect(&ctx, cataloging.ExecutorFile, sync.ToSeq(c.selectFiles(resolver)), func(req request) (result, error) {
+	errs := sync.Collect(&ctx, cataloging.ExecutorFile, sync.ToSeq(c.selectFiles(resolver)), func(req request) (result, error) {
 		location, parser := req.Location, req.Parser
 
 		log.WithFields("path", location.RealPath).Trace("parsing file contents")
 
+		var errs error
 		discoveredPackages, discoveredRelationships, err := invokeParser(ctx, resolver, location, lgr, parser, &env)
 		if err != nil {
 			// parsers may return errors and valid packages / relationships


### PR DESCRIPTION
I'm seeing partial values referenced in the issue traceback and a nil dereference:

```
unexpected fault address 0x0
fatal error: fault
[0001] DEBUG discovered 0 packages cataloger=go-module-binary-cataloger
[signal SIGSEGV: segmentation violation code=0x80 addr=0x0 pc=0x123a0da]

goroutine 85 gp=0xc000cb36c0 m=21 mp=0xc000278008 [running]:
runtime.throw({0x1c6f462?, 0xb0efc6?})
        /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:1101 +0x48 fp=0xc002f29938 sp=0xc002f29908 pc=0x479ac8
runtime.sigpanic()
        /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/signal_unix.go:939 +0x26c fp=0xc002f29998 sp=0xc002f29938 pc=0x47bbec
github.com/anchore/syft/internal/unknown.visitErrors({0x6168732f7273752f, 0x656e746f642f6572}, 0xc002f29d70)
        /home/runner/work/syft/syft/internal/unknown/coordinate_error.go:170 +0x3a fp=0xc002f29ad0 sp=0xc002f29998 pc=0x123a0da
github.com/anchore/syft/internal/unknown.visitErrors({0x22afe20, 0xc005a4f3e0}, 0xc002f29d70)
        /home/runner/work/syft/syft/internal/unknown/coordinate_error.go:173 +0xf8 fp=0xc002f29c08 sp=0xc002f29ad0 pc=0x123a198
github.com/anchore/syft/internal/unknown.visitErrors({0x22afe20, 0xc002d807b0}, 0xc002f29d70)
        /home/runner/work/syft/syft/internal/unknown/coordinate_error.go:173 +0xf8 fp=0xc002f29d40 sp=0xc002f29c08 pc=0x123a198
github.com/anchore/syft/internal/unknown.ExtractCoordinateErrors({0x22afe20?, 0xc002d807b0?})
        /home/runner/work/syft/syft/internal/unknown/coordinate_error.go:106 +0x47 fp=0xc002f29d90 sp=0xc002f29d40 pc=0x1239767
...
```

Which:
- `github.com/anchore/syft/internal/unknown.visitErrors({0x6168732f7273752f, 0x656e746f642f6572}, 0xc002f29d70)` when decoded appears to be `entod/erahs/rsu/`, when flipped  `/usr/share/dotne`, I don't think I should be seeing partial values here
- based off of a code analysis of `visitErrors`, it seems that the address of the error after type assertion is assigned out of band to 0 (which would not be possible without multiple concurrent writers)

I think a reproduction without concurrent writers of this would be something akin to (but not exactly the same as what the traceback is):
```golang
func TestCorruptErrorSegfault(t *testing.T) {
	path := "/usr/share/dotnet"

	var err error
	strPtr := unsafe.Pointer(&path)
	errPtr := (*error)(unsafe.Pointer(&strPtr))
	err = *errPtr

	defer func() {
		if r := recover(); r != nil {
			t.Logf("Test recovered from panic: %v", r)
		}
	}()

	_, _ = ExtractCoordinateErrors(err)
}

```

The fix is to ensure that the errors being processed are only written within the `Collect()` closure, and not to a variable on the stack of the caller.

- Fixes #3872

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
