### PR TITLE
fix: stop emitting redis redis CPE for PHP PECL redis

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -630,6 +630,12 @@ var defaultCandidateRemovals = buildCandidateRemovalLookup(
 			candidateKey{PkgName: "grpc"},
 			candidateRemovals{ProductsToRemove: []string{"grpc"}},
 		},
+		// PHP Packages
+		{
+			pkg.PhpPearPkg,
+			candidateKey{PkgName: "redis"},
+			candidateRemovals{ProductsToRemove: []string{"redis"}},
+		},
 	})
 
 // buildCandidateLookup is a convenience function for creating the defaultCandidateAdditions set


### PR DESCRIPTION
This prevents the `cpe:a:redis:redis...` from being emitted for the PHP Pear / PECL package called redis.

# Description

Previously, syft would generate a cpe beginning with `cpe:a:redis:redis` for the PHP PECL / pear package called "redis" which as I understand it is a PHP native extension providing a Redis client. Essentially, we want Grype to assume that vulns with `cpe:a:redis:redis` are about the server binary for the key value store.

Note that since the Grype issue was opened #2775 merged the pear and PECL package types, hence the Grype issue mentioning PECLs but this fix addressing pear.

- Fixes https://github.com/anchore/grype/issues/1804

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have tested my code in common scenarios and confirmed there are no regressions
