### PR TITLE
feat: add support for encoding hashes in CycloneDX format

### DIFF
--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -349,12 +349,18 @@ func toBomDescriptorComponent(srcMetadata source.Description) *cyclonedx.Compone
 		if err != nil {
 			log.Debugf("unable to get fingerprint of source file metadata path=%s: %+v", metadata.Path, err)
 		}
+		var hashes []cyclonedx.Hash
+		if len(metadata.Digests) > 0 {
+			hashes = digestsToHashes(metadata.Digests)
+		}
+
 		return &cyclonedx.Component{
 			BOMRef: string(bomRef),
 			// TODO: this is lossy... we can't know if this is a file or a directory
 			Type:    cyclonedx.ComponentTypeFile,
 			Name:    name,
 			Version: version,
+			Hashes:  &hashes,
 		}
 	}
 

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -57,6 +57,7 @@ func EncodeComponent(p pkg.Package, locationSorter func(a, b file.Location) int)
 		ExternalReferences: encodeExternalReferences(p),
 		Properties:         properties,
 		BOMRef:             DeriveBomRef(p),
+		Hashes:             encodeHashes(p),
 	}
 }
 

--- a/syft/format/internal/cyclonedxutil/helpers/external_references.go
+++ b/syft/format/internal/cyclonedxutil/helpers/external_references.go
@@ -54,18 +54,7 @@ func encodeExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 				})
 			}
 		case pkg.JavaArchive:
-			if len(metadata.ArchiveDigests) > 0 {
-				for _, digest := range metadata.ArchiveDigests {
-					refs = append(refs, cyclonedx.ExternalReference{
-						URL:  "",
-						Type: cyclonedx.ERTypeBuildMeta,
-						Hashes: &[]cyclonedx.Hash{{
-							Algorithm: toCycloneDXAlgorithm(digest.Algorithm),
-							Value:     digest.Value,
-						}},
-					})
-				}
-			}
+			//TODO: add support for java archive external references
 		case pkg.PythonPackage:
 			if metadata.DirectURLOrigin != nil && metadata.DirectURLOrigin.URL != "" {
 				ref := cyclonedx.ExternalReference{
@@ -83,21 +72,6 @@ func encodeExternalReferences(p pkg.Package) *[]cyclonedx.ExternalReference {
 		return &refs
 	}
 	return nil
-}
-
-// supported algorithm in cycloneDX as of 1.4
-// "MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512",
-// "SHA3-256", "SHA3-384", "SHA3-512", "BLAKE2b-256", "BLAKE2b-384", "BLAKE2b-512", "BLAKE3"
-// syft supported digests: cmd/syft/cli/eventloop/tasks.go
-// MD5, SHA1, SHA256
-func toCycloneDXAlgorithm(algorithm string) cyclonedx.HashAlgorithm {
-	validMap := map[string]cyclonedx.HashAlgorithm{
-		"sha1":   cyclonedx.HashAlgorithm("SHA-1"),
-		"md5":    cyclonedx.HashAlgorithm("MD5"),
-		"sha256": cyclonedx.HashAlgorithm("SHA-256"),
-	}
-
-	return validMap[strings.ToLower(algorithm)]
 }
 
 func decodeExternalReferences(c *cyclonedx.Component, metadata interface{}) {

--- a/syft/format/internal/cyclonedxutil/helpers/external_references_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/external_references_test.go
@@ -172,27 +172,3 @@ func Test_isValidExternalRef(t *testing.T) {
 		})
 	}
 }
-
-func Test_toCycloneDXAlgorithm(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected cyclonedx.HashAlgorithm
-	}{
-		{
-			name:     "valid algorithm name in upper case",
-			input:    "SHA1",
-			expected: cyclonedx.HashAlgorithm("SHA-1"),
-		},
-		{
-			name:     "valid algorithm name in lower case",
-			input:    "sha1",
-			expected: cyclonedx.HashAlgorithm("SHA-1"),
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, toCycloneDXAlgorithm(test.input))
-		})
-	}
-}

--- a/syft/format/internal/cyclonedxutil/helpers/hashes.go
+++ b/syft/format/internal/cyclonedxutil/helpers/hashes.go
@@ -1,0 +1,70 @@
+package helpers
+
+import (
+	"strings"
+
+	"github.com/CycloneDX/cyclonedx-go"
+
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func encodeHashes(p pkg.Package) *[]cyclonedx.Hash {
+	var hashes []cyclonedx.Hash
+
+	if hasMetadata(p) {
+		switch metadata := p.Metadata.(type) {
+		case pkg.ApkDBEntry:
+			if metadata.Checksum != "" {
+				hashes = append(hashes, cyclonedx.Hash{
+					Algorithm: toCycloneDXAlgorithm("sha256"),
+					Value:     metadata.Checksum,
+				})
+			}
+		case pkg.RustCargoLockEntry:
+			if metadata.Checksum != "" {
+				hashes = append(hashes, cyclonedx.Hash{
+					Algorithm: toCycloneDXAlgorithm("sha256"),
+					Value:     metadata.Checksum,
+				})
+			}
+		case pkg.JavaArchive:
+			if len(metadata.ArchiveDigests) > 0 {
+				for _, digest := range metadata.ArchiveDigests {
+					hashes = append(hashes, cyclonedx.Hash{
+						Algorithm: toCycloneDXAlgorithm(digest.Algorithm),
+						Value:     digest.Value,
+					})
+				}
+			}
+		}
+	}
+	if len(hashes) > 0 {
+		return &hashes
+	}
+	return nil
+}
+
+// supported algorithm in cycloneDX as of 1.4
+// "MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512",
+// "SHA3-256", "SHA3-384", "SHA3-512", "BLAKE2b-256", "BLAKE2b-384", "BLAKE2b-512", "BLAKE3"
+// syft supported digests: cmd/syft/cli/eventloop/tasks.go
+// MD5, SHA1, SHA256
+func toCycloneDXAlgorithm(algorithm string) cyclonedx.HashAlgorithm {
+	validMap := map[string]cyclonedx.HashAlgorithm{
+		"md5":         cyclonedx.HashAlgorithm("MD5"),
+		"sha1":        cyclonedx.HashAlgorithm("SHA-1"),
+		"sha224":      cyclonedx.HashAlgorithm("SHA-224"),
+		"sha256":      cyclonedx.HashAlgorithm("SHA-256"),
+		"sha384":      cyclonedx.HashAlgorithm("SHA-384"),
+		"sha512":      cyclonedx.HashAlgorithm("SHA-512"),
+		"sha3_224":    cyclonedx.HashAlgorithm("SHA3-224"),
+		"sha3_256":    cyclonedx.HashAlgorithm("SHA3-256"),
+		"sha3_384":    cyclonedx.HashAlgorithm("SHA3-384"),
+		"sha3_512":    cyclonedx.HashAlgorithm("SHA3-512"),
+		"BLAKE2b_256": cyclonedx.HashAlgorithm("BLAKE2b-256"),
+		"BLAKE2b_384": cyclonedx.HashAlgorithm("BLAKE2b-384"),
+		"BLAKE2b_512": cyclonedx.HashAlgorithm("BLAKE2b-512"),
+	}
+
+	return validMap[strings.ToLower(algorithm)]
+}

--- a/syft/format/internal/cyclonedxutil/helpers/hashes_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/hashes_test.go
@@ -1,0 +1,123 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func Test_encodeHashes(t *testing.T) {
+	type args struct {
+		p pkg.Package
+	}
+	tests := []struct {
+		name string
+		args args
+		want *[]cyclonedx.Hash
+	}{
+		{
+			name: "APK package with checksum",
+			args: args{
+				p: pkg.Package{
+					Metadata: pkg.ApkDBEntry{
+						Checksum: "abc123",
+					},
+				},
+			},
+			want: &[]cyclonedx.Hash{
+				{
+					Algorithm: cyclonedx.HashAlgorithm("SHA-256"),
+					Value:     "abc123",
+				},
+			},
+		},
+		{
+			name: "Rust package with checksum",
+			args: args{
+				p: pkg.Package{
+					Metadata: pkg.RustCargoLockEntry{
+						Checksum: "def456",
+					},
+				},
+			},
+			want: &[]cyclonedx.Hash{
+				{
+					Algorithm: cyclonedx.HashAlgorithm("SHA-256"),
+					Value:     "def456",
+				},
+			},
+		},
+		{
+			name: "Java package with multiple digests",
+			args: args{
+				p: pkg.Package{
+					Metadata: pkg.JavaArchive{
+						ArchiveDigests: []file.Digest{
+							{Algorithm: "sha1", Value: "123abc"},
+							{Algorithm: "sha256", Value: "456def"},
+						},
+					},
+				},
+			},
+			want: &[]cyclonedx.Hash{
+				{
+					Algorithm: cyclonedx.HashAlgorithm("SHA-1"),
+					Value:     "123abc",
+				},
+				{
+					Algorithm: cyclonedx.HashAlgorithm("SHA-256"),
+					Value:     "456def",
+				},
+			},
+		},
+		{
+			name: "Package with no metadata",
+			args: args{
+				p: pkg.Package{},
+			},
+			want: nil,
+		},
+		{
+			name: "Package with unsupported metadata type",
+			args: args{
+				p: pkg.Package{
+					Metadata: struct{}{}, // Unsupported metadata type
+				},
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, encodeHashes(tt.args.p), "encodeHashes(%v)", tt.args.p)
+		})
+	}
+}
+
+func Test_toCycloneDXAlgorithm(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected cyclonedx.HashAlgorithm
+	}{
+		{
+			name:     "valid algorithm name in upper case",
+			input:    "SHA1",
+			expected: cyclonedx.HashAlgorithm("SHA-1"),
+		},
+		{
+			name:     "valid algorithm name in lower case",
+			input:    "sha1",
+			expected: cyclonedx.HashAlgorithm("SHA-1"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, toCycloneDXAlgorithm(test.input))
+		})
+	}
+}


### PR DESCRIPTION
# Description

add support for encoding hashes in CycloneDX format

https://cyclonedx.org/docs/1.6/json/#components_items_hashes

change 

```json
    {
      "bom-ref": "pkg:maven/net.sf.saxon.Transform/Saxon-HE@12.5?package-id=defe654c765bea5e",
      "type": "library",
      "name": "Saxon-HE",
      "version": "12.5",
      "cpe": "cpe:2.3:a:net.sf.saxon.Transform:Transform:12.5:*:*:*:*:*:*:*",
      "purl": "pkg:maven/net.sf.saxon.Transform/Saxon-HE@12.5",
      "externalReferences": [
        {
          "url": "",
          "hashes": [
            {
              "alg": "SHA-1",
              "content": "57c007520e2879387b8d13d0a512e9566eeffa73"
            }
          ],
          "type": "build-meta"
        }
      ],
      "properties": [...]
    },
```

to

```json
    {
      "bom-ref": "pkg:maven/net.sf.saxon.Transform/Saxon-HE@12.5?package-id=defe654c765bea5e",
      "type": "library",
      "name": "Saxon-HE",
      "version": "12.5",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "57c007520e2879387b8d13d0a512e9566eeffa73"
        }
      ],
      "cpe": "cpe:2.3:a:net.sf.saxon.Transform:Transform:12.5:*:*:*:*:*:*:*",
      "purl": "pkg:maven/net.sf.saxon.Transform/Saxon-HE@12.5",
      "properties": [...]
    },

```

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
