### PR TITLE
chore: update fixtures based on CI builds

### DIFF
--- a/syft/format/cyclonedxxml/encoder_test.go
+++ b/syft/format/cyclonedxxml/encoder_test.go
@@ -98,6 +98,14 @@ func redactor(values ...string) testutil.Redactor {
 				Replace: "redacted",
 			},
 		).
+		WithPatternRedactorSpec(
+			testutil.PatternReplacement{
+				// only the source component bom-ref (not package or other component bom-refs)
+				Search:  regexp.MustCompile(`<component bom-ref="(?P<redact>[^"]*)" type="container">`),
+				Groups:  []string{"redact"}, // use the regex to anchore the search, but only replace bytes within the capture group
+				Replace: "redacted",
+			},
+		).
 		WithPatternRedactors(
 			map[string]string{
 				// dates

--- a/syft/format/cyclonedxxml/encoder_test.go
+++ b/syft/format/cyclonedxxml/encoder_test.go
@@ -94,7 +94,7 @@ func redactor(values ...string) testutil.Redactor {
 			testutil.PatternReplacement{
 				// only the source component bom-ref (not package or other component bom-refs)
 				Search:  regexp.MustCompile(`<component bom-ref="(?P<redact>[^"]*)" type="file">`),
-				Groups:  []string{"redact"}, // use the regex to anchore the search, but only replace bytes within the capture group
+				Groups:  []string{"redact"}, // use the regex to anchor the search, but only replace bytes within the capture group
 				Replace: "redacted",
 			},
 		).
@@ -102,7 +102,7 @@ func redactor(values ...string) testutil.Redactor {
 			testutil.PatternReplacement{
 				// only the source component bom-ref (not package or other component bom-refs)
 				Search:  regexp.MustCompile(`<component bom-ref="(?P<redact>[^"]*)" type="container">`),
-				Groups:  []string{"redact"}, // use the regex to anchore the search, but only replace bytes within the capture group
+				Groups:  []string{"redact"}, // use the regex to anchor the search, but only replace bytes within the capture group
 				Replace: "redacted",
 			},
 		).

--- a/syft/pkg/cataloger/python/cataloger_test.go
+++ b/syft/pkg/cataloger/python/cataloger_test.go
@@ -758,7 +758,7 @@ func Test_PackageCataloger_SitePackageRelationships(t *testing.T) {
 				// Note: we'll only see new relationships, so any relationship where there is at least one new player (in FROM or TO)
 				"blessed @ 1.20.0 (/usr/local/lib/python3.9/dist-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",      // note: depends on global site package!
 				"python-editor @ 1.0.4 (/usr/local/lib/python3.9/dist-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)", // note: depends on global site package!
-				"readchar @ 4.2.0 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",
+				"readchar @ 4.2.1 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] inquirer @ 3.0.0 (/app/project1/venv/lib/python3.9/site-packages)",
 				"soupsieve @ 2.3 (/app/project1/venv/lib/python3.9/site-packages) [dependency-of] beautifulsoup4 @ 4.10.0 (/app/project1/venv/lib/python3.9/site-packages)",
 
 				// project 2 virtual env

--- a/syft/pkg/cataloger/python/test-fixtures/image-multi-site-package/Dockerfile
+++ b/syft/pkg/cataloger/python/test-fixtures/image-multi-site-package/Dockerfile
@@ -13,10 +13,10 @@ RUN python3.9 -m pip install click==8.0.3 beautifulsoup4==4.9.3 soupsieve==2.2.1
 RUN python3.9 -m pip install six==1.16.0 wcwidth==0.2.13 blessed==1.20.0 python-editor==1.0.4  # total dependencies for inquirer in project1 (which is linked)
 RUN python3.9 -m pip install requests==2.25.0 certifi==2020.12.5 chardet==3.0.4 idna==2.10 urllib3==1.26.18 # total dependencies for requests
 
+RUN python3.8 -m pip install readchar==4.2.1
 RUN python3.8 -m pip install click==8.0.2 beautifulsoup4==4.9.2 soupsieve==2.2.0 requests==2.25.0
 RUN python3.8 -m pip install runs==1.2.2 xmod==1.8.1 # partial dependencies for inquirer in project2 (which is a red herring)
 RUN python3.8 -m pip install requests==2.25.0 certifi==2020.12.5 chardet==3.0.4 idna==2.10 urllib3==1.26.18 # total dependencies for requests
-RUN python3.8 -m pip install readchar==4.2.0
 
 # create directories for the two projects
 RUN mkdir -p /app/project1 /app/project2


### PR DESCRIPTION
This stabilizes fixtures so that we can [fix the existing fixture publish job](https://github.com/anchore/syft/actions/workflows/test-fixture-cache-publish.yaml) to keep CI running as fast as possible.

