### PR TITLE
fix: include default license config for sbom builder

### DIFF
--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -255,6 +255,7 @@ func (c *CreateSBOMConfig) selectTasks(src source.Description) ([]task.Task, []t
 		RelationshipsConfig:  c.Relationships,
 		DataGenerationConfig: c.DataGeneration,
 		PackagesConfig:       c.Packages,
+		LicenseConfig:        c.Licenses,
 		ComplianceConfig:     c.Compliance,
 		FilesConfig:          c.Files,
 	}

--- a/test/cli/license_test.go
+++ b/test/cli/license_test.go
@@ -3,7 +3,7 @@ package cli
 import "testing"
 
 func Test_Licenses(t *testing.T) {
-	testImage := getFixtureImage(t, "image-unknown-licenses")
+	testImage := getFixtureImage(t, "image-pkg-coverage")
 	tests := []struct {
 		name       string
 		args       []string

--- a/test/cli/trait_assertions_test.go
+++ b/test/cli/trait_assertions_test.go
@@ -169,7 +169,7 @@ func assertUnknownLicenseContent(required bool) traitAssertion {
 
 		for _, pkg := range data.Artifacts {
 			for _, lic := range pkg.Licenses {
-				if strings.Contains(lic.SPDXExpression, "UNKNOWN") && required {
+				if strings.Contains(lic.Value, "sha256") && required {
 					assert.NotZero(tb, len(lic.Contents))
 				} else {
 					assert.Empty(tb, lic.Contents)


### PR DESCRIPTION
# Description

With the latest syft release of v1.24.0 some users were seeing contents of licenses in their default outputs. This change fixes the link between the lost config values so that contents can be dropped in a post processing step. It also updates the CLI test fixture to use an image that covers this case correctly

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

### Demo showing new change
On branch
```json
      "licenses": [
        {
          "value": "LicenseRef-sha256:9e3a4384b6d8d2358d44103f62bcd948328b3f8a63a1a6baa66abeb43302d581",
          "spdxExpression": "",
          "type": "concluded",
          "urls": [],
          "locations": [
            {
              "path": "/usr/share/doc/libcom-err2/copyright",
              "layerID": "sha256:a8c68591d421fc2d4bdda704f67a796edf5ff880c59358d75107eb5261821650",
              "accessPath": "/usr/share/doc/libcom-err2/copyright",
              "annotations": {
                "evidence": "supporting"
              }
            }
          ]
        }
      ],

```

Syft v1.24.0
```json
      "licenses": [
        {
          "value": "LicenseRef-sha256:9e3a4384b6d8d2358d44103f62bcd948328b3f8a63a1a6baa66abeb43302d581",
          "spdxExpression": "",
          "type": "concluded",
          "urls": [],
          "locations": [
            {
              "path": "/usr/share/doc/libcom-err2/copyright",
              "layerID": "sha256:a8c68591d421fc2d4bdda704f67a796edf5ff880c59358d75107eb5261821650",
              "accessPath": "/usr/share/doc/libcom-err2/copyright",
              "annotations": {
                "evidence": "supporting"
              }
            }
          ],
          "contents": "This is the Debian GNU/Linux prepackaged version of the Common Error\nDescription library. It is currently distributed together with the EXT2 file\nsystem utilities, which are otherwise packaged as \"e2fsprogs\".\n\nThis package was put together by Yann Dirson <dirson@debian.org>,\nfrom sources obtained from a mirror of:\n tsx-11.mit.edu:/pub/linux/packages/ext2fs/\n\nFrom the original distribution:\n\nCopyright 1987, 1988 by the Student Information Processing Board\n\tof the Massachusetts Institute of Technology\n\nPermission to use, copy, modify, and distribute this software\nand its documentation for any purpose and without fee is\nhereby granted, provided that the above copyright notice\nappear in all copies and that both that copyright notice and\nthis permission notice appear in supporting documentation,\nand that the names of M.I.T. and the M.I.T. S.I.P.B. not be\nused in advertising or publicity pertaining to distribution\nof the software without specific, written prior permission.\nM.I.T. and the M.I.T. S.I.P.B. make no representations about\nthe suitability of this software for any purpose.  It is\nprovided \"as is\" without express or implied warranty.\n"
        }
      ],
```

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
