### PR TITLE
chore: delete unused cli license fixture

### DIFF
--- a/test/cli/test-fixtures/image-unknown-licenses/Dockerfile
+++ b/test/cli/test-fixtures/image-unknown-licenses/Dockerfile
@@ -1,3 +1,0 @@
-FROM alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33
-RUN rm -rf /lib/apk/db/installed
-COPY . /home/files


### PR DESCRIPTION
# Description
Remove unused cli license fixture from cli tests

- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)