### PR TITLE
fix: update applyLicenseContentRules to factor default case

### DIFF
--- a/cmd/syft/internal/options/license.go
+++ b/cmd/syft/internal/options/license.go
@@ -2,20 +2,14 @@ package options
 
 import (
 	"fmt"
-
 	"github.com/anchore/clio"
+	"github.com/anchore/syft/internal"
 	"github.com/anchore/syft/syft/cataloging"
 )
 
 type licenseConfig struct {
-	Content cataloging.LicenseContent `yaml:"content" json:"content" mapstructure:"content"`
-	// Deprecated: please use include-license-content instead
-	IncludeUnknownLicenseContent *bool `yaml:"-" json:"-" mapstructure:"include-unknown-license-content"`
-
-	Coverage float64 `yaml:"coverage" json:"coverage" mapstructure:"coverage"`
-	// Deprecated: please use coverage instead
-	LicenseCoverage *float64 `yaml:"license-coverage" json:"license-coverage" mapstructure:"license-coverage"`
-
+	Content                 cataloging.LicenseContent   `yaml:"content" json:"content" mapstructure:"content"`
+	Coverage                float64                     `yaml:"coverage" json:"coverage" mapstructure:"coverage"`
 	AvailableLicenseContent []cataloging.LicenseContent `yaml:"-" json:"-" mapstructure:"-"`
 }
 
@@ -25,43 +19,16 @@ var _ interface {
 
 func (o *licenseConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
 	descriptions.Add(&o.Content, fmt.Sprintf("include the content of licenses in the SBOM for a given syft scan; valid values are: %s", o.AvailableLicenseContent))
-	descriptions.Add(&o.IncludeUnknownLicenseContent, `deprecated: please use 'license-content' instead`)
 
 	descriptions.Add(&o.Coverage, `adjust the percent as a fraction of the total text, in normalized words, that
 matches any valid license for the given inputs, expressed as a percentage across all of the licenses matched.`)
-	descriptions.Add(&o.LicenseCoverage, `deprecated: please use 'coverage' instead`)
 }
 
 func (o *licenseConfig) PostLoad() error {
-	cfg := cataloging.DefaultLicenseConfig()
-	defaultContent := cfg.IncludeContent
-	defaultCoverage := cfg.Coverage
-
-	// if both legacy and new fields are specified, error out
-	if o.IncludeUnknownLicenseContent != nil && o.Content != defaultContent {
-		return fmt.Errorf("both 'include-unknown-license-content' and 'content' are set, please use only 'content'")
+	validContent := internal.NewSet(o.AvailableLicenseContent...)
+	if !validContent.Contains(o.Content) {
+		return fmt.Errorf("could not use %q as license content option; valid values are: %v", o.Content, validContent.ToSlice())
 	}
-
-	if o.LicenseCoverage != nil && o.Coverage != defaultCoverage {
-		return fmt.Errorf("both 'license-coverage' and 'coverage' are set, please use only 'coverage'")
-	}
-
-	// finalize the license content value
-	if o.IncludeUnknownLicenseContent != nil {
-		// convert 'include-unknown-license-content' -> 'license-content'
-		v := cataloging.LicenseContentExcludeAll
-		if *o.IncludeUnknownLicenseContent {
-			v = cataloging.LicenseContentIncludeUnknown
-		}
-		o.Content = v
-	}
-
-	// finalize the coverage value
-	if o.LicenseCoverage != nil {
-		// convert 'license-coverage' -> 'coverage'
-		o.Coverage = *o.LicenseCoverage
-	}
-
 	return nil
 }
 

--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -277,17 +277,17 @@ func applyLicenseContentRules(p *pkg.Package, cfg cataloging.LicenseConfig) {
 	for i := range licenses {
 		l := &licenses[i]
 		switch cfg.IncludeContent {
-		case cataloging.LicenseContentIncludeUnknown:
-			// we don't have an SPDX expression, which means we didn't find an SPDX license
-			// include the unknown licenses content in the final SBOM
-			if l.SPDXExpression != "" {
-				licenses[i].Contents = ""
-			}
 		case cataloging.LicenseContentExcludeAll:
 			// clear it all out
 			licenses[i].Contents = ""
 		case cataloging.LicenseContentIncludeAll:
 			// always include the content
+		default:
+			// we don't have an SPDX expression, which means we didn't find an SPDX license
+			// include the unknown licenses content in the final SBOM
+			if l.SPDXExpression != "" {
+				licenses[i].Contents = ""
+			}
 		}
 	}
 

--- a/internal/task/package_task_factory_test.go
+++ b/internal/task/package_task_factory_test.go
@@ -194,6 +194,25 @@ func TestApplyLicenseContentRules(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid license content cataloging config results in the default case",
+			inputLicenses: []pkg.License{
+				licenseWithSPDX,
+				licenseWithoutSPDX,
+			},
+			cfg: cataloging.LicenseConfig{
+				IncludeContent: cataloging.LicenseContent("invalid"),
+			},
+			expectedLicenses: []pkg.License{
+				{
+					SPDXExpression: "MIT",
+				},
+				{
+					Value:    "License-Not-A-SPDX-Expression",
+					Contents: "Non-SPDX license content", // content preserved
+				},
+			},
+		},
+		{
 			name:          "Empty licenses",
 			inputLicenses: []pkg.License{},
 			cfg: cataloging.LicenseConfig{

--- a/syft/cataloging/license.go
+++ b/syft/cataloging/license.go
@@ -14,10 +14,6 @@ const (
 )
 
 type LicenseConfig struct {
-	// IncludeUnknownLicenseContent controls whether the content of a license should be included in the SBOM when the license ID cannot be determined.
-	// Deprecated: use IncludeContent instead
-	IncludeUnknownLicenseContent bool `json:"-" yaml:"-" mapstructure:"-"`
-
 	// IncludeContent controls whether license copy discovered should be included in the SBOM.
 	IncludeContent LicenseContent `json:"include-content" yaml:"include-content" mapstructure:"include-content"`
 
@@ -27,7 +23,7 @@ type LicenseConfig struct {
 
 func DefaultLicenseConfig() LicenseConfig {
 	return LicenseConfig{
-		IncludeContent: LicenseContentExcludeAll,
+		IncludeContent: LicenseContentIncludeUnknown,
 		Coverage:       licenses.DefaultCoverageThreshold,
 	}
 }


### PR DESCRIPTION
# Description
This PR updates the license config to account for a default case where users could potentially have misused the API and gotten the undesired result of contents being included for all licenses on all packages.

This PR also removes old fields that were previously not wired up correctly in the syft config. See: https://github.com/anchore/syft/pull/3900

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
