### PR TITLE
chore: remove go-rpmdb replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/anchore/go-homedir v0.0.0-20250319154043-c29668562e4d
 	github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb
+	github.com/anchore/go-rpmdb v0.0.0-20250516171929-f77691e1faec
 	github.com/anchore/go-sync v0.0.0-20250326131806-4eda43a485b6
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
@@ -57,7 +58,6 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/jinzhu/copier v0.4.0
 	github.com/kastenhq/goversion v0.0.0-20230811215019-93b2f8823953
-	github.com/knqyf263/go-rpmdb v0.1.1
 	github.com/magiconair/properties v1.8.10
 	github.com/mholt/archives v0.1.2
 	github.com/moby/sys/mountinfo v0.7.2
@@ -260,9 +260,7 @@ require (
 )
 
 retract (
+	v1.25.0 // published with a replace directive (confusing for API users)
 	v0.53.2
-	v0.53.1 // Published accidentally with incorrect license in depdencies
+	v0.53.1 // published accidentally with incorrect license in depdencies
 )
-
-// adds RSA Headers from RPMDB via https://github.com/knqyf263/go-rpmdb/pull/58 (in review)
-replace github.com/knqyf263/go-rpmdb => github.com/anchore/go-rpmdb v0.0.0-20250515153519-38be2efee8ed

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722 h1:2SqmFgE7h+Ql4
 github.com/anchore/go-logger v0.0.0-20250318195838-07ae343dd722/go.mod h1:oFuE8YuTCM+spgMXhePGzk3asS94yO9biUfDzVTFqNw=
 github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb h1:iDMnx6LIjtjZ46C0akqveX83WFzhpTD3eqOthawb5vU=
 github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb/go.mod h1:DmTY2Mfcv38hsHbG78xMiTDdxFtkHpgYNVDPsF2TgHk=
-github.com/anchore/go-rpmdb v0.0.0-20250515153519-38be2efee8ed h1:ixtJ1s+L3+AvxlGn4Tm5VcV7RiMVLcUGmNOGXQ6U9Gg=
-github.com/anchore/go-rpmdb v0.0.0-20250515153519-38be2efee8ed/go.mod h1:0A7fN6+ED0l7YrO4GNEz6kgDmkKUwzK2bDl2v0E2Hog=
+github.com/anchore/go-rpmdb v0.0.0-20250516171929-f77691e1faec h1:SjjPMOXTzpuU1ZME4XeoHyek+dry3/C7I8gzaCo02eg=
+github.com/anchore/go-rpmdb v0.0.0-20250516171929-f77691e1faec/go.mod h1:eQVa6QFGzKy0qMcnW2pez0XBczvgwSjw9vA23qifEyU=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 h1:aM1rlcoLz8y5B2r4tTLMiVTrMtpfY0O8EScKJxaSaEc=
 github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/anchore/go-sync v0.0.0-20250326131806-4eda43a485b6 h1:Ha+LSCVuXYSYGi7wIkJK6G8g6jI3LH7y6LbyEVyp4Io=

--- a/syft/pkg/cataloger/redhat/parse_rpm_archive.go
+++ b/syft/pkg/cataloger/redhat/parse_rpm_archive.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	rpmdb "github.com/anchore/go-rpmdb/pkg"
 	"github.com/sassoftware/go-rpmutils"
 
 	"github.com/anchore/syft/internal/log"

--- a/syft/pkg/cataloger/redhat/parse_rpm_db.go
+++ b/syft/pkg/cataloger/redhat/parse_rpm_db.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	rpmdb "github.com/knqyf263/go-rpmdb/pkg"
+	rpmdb "github.com/anchore/go-rpmdb/pkg"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"


### PR DESCRIPTION
This removes the replace directive added to support #3179 -- though it is functional from the perspective of a syft release, anyone using syft via go module will also need to add the replace directive, which was not intended.

The go-rpmdb fork has been updated to use anchore path references and incorporated the upstream match into the default branch of the fork.

This additionally retracts the release for v1.25.0 as this could cause confusion for folks trying to use the release.
