### PR TITLE
chore: update dockerfile base images to latest rolling tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@sha256:b2141e58dd62baf0ff941e48ee8fdc58ffe4296bbe05b400eff1122484586160 AS build
+FROM gcr.io/distroless/static-debian12:debug@latest AS build
 
 FROM scratch
 # needed for version check HTTPS request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@latest AS build
+FROM gcr.io/distroless/static-debian12:latest AS build
 
 FROM scratch
 # needed for version check HTTPS request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@sha256:5c474275684bbf271ec40502ab50158b2f9826de5877d8feec27e22e8d6ee3d2 AS build
+FROM gcr.io/distroless/static-debian12:debug@sha256:b2141e58dd62baf0ff941e48ee8fdc58ffe4296bbe05b400eff1122484586160 AS build
 
 FROM scratch
 # needed for version check HTTPS request

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@sha256:5c474275684bbf271ec40502ab50158b2f9826de5877d8feec27e22e8d6ee3d2
+FROM gcr.io/distroless/static-debian12:debug@sha256:b2141e58dd62baf0ff941e48ee8fdc58ffe4296bbe05b400eff1122484586160
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@sha256:b2141e58dd62baf0ff941e48ee8fdc58ffe4296bbe05b400eff1122484586160
+FROM gcr.io/distroless/static-debian12:debug@latest
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:debug@latest
+FROM gcr.io/distroless/static-debian12:debug
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp


### PR DESCRIPTION
# Description

An upstream issue with busy box was causing issues where users would see:
```
wget: TLS error from peer (alert code 40): handshake failure
wget: error getting response: Connection reset by peer
```

This could cause issues in ci pipelines where users needed the debug image of syft for running pre CI commands before the sbom functionality was invoked.

This PR moves us forward to use the rolling tags for `latest` and `debug` images from distroless debian12

Here is a local demonstration of the fix. PR reviewers can pull down the branch and run `make snapshot` to build the docker images and test on their local:
```
[I] (base-image-updates)> docker run -it --rm --entrypoint /busybox/wget be0d5f30581e --no-check-certificate --spider https://www.google.com
Connecting to www.google.com (142.250.65.196:443)
remote file exists
[I]  (base-image-updates)> docker image ls | grep be0d
anchore/syft                                                 debug-arm64v8                                                      be0d5f30581e   2 minutes ago   50.2MB
anchore/syft                                                 v1.25.0-debug-arm64v8                                              be0d5f30581e   2 minutes ago   50.2MB
ghcr.io/anchore/syft                                         debug-arm64v8                                                      be0d5f30581e   2 minutes ago   50.2MB
ghcr.io/anchore/syft                                         v1.25.0-debug-arm64v8                                              be0d5f30581e   2 minutes ago   50.2MB
```

<!-- If this completes an issue, please include: -->

- Fixes #3891 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:
- [x] I have tested my code in common scenarios and confirmed there are no regressions
