### PR TITLE
`pkg.JavaArchive.PomProperties` is being populated even though no `pom.properties` file was present for analysis

### DIFF
--- a/syft/format/internal/backfill.go
+++ b/syft/format/internal/backfill.go
@@ -71,31 +71,14 @@ func Backfill(p *pkg.Package) {
 	}
 }
 
-func setJavaMetadataFromPurl(p *pkg.Package, purl packageurl.PackageURL) {
+func setJavaMetadataFromPurl(p *pkg.Package, _ packageurl.PackageURL) {
 	if p.Type != pkg.JavaPkg {
 		return
 	}
-	if purl.Namespace != "" {
-		if p.Metadata == nil {
-			p.Metadata = pkg.JavaArchive{}
-		}
-		meta, got := p.Metadata.(pkg.JavaArchive)
-		if got && meta.PomProperties == nil {
-			meta.PomProperties = &pkg.JavaPomProperties{}
-			p.Metadata = meta
-		}
-		if meta.PomProperties != nil {
-			// capture the group id from the purl if it is not already set
-			if meta.PomProperties.ArtifactID == "" {
-				meta.PomProperties.ArtifactID = purl.Name
-			}
-			if meta.PomProperties.GroupID == "" {
-				meta.PomProperties.GroupID = purl.Namespace
-			}
-			if meta.PomProperties.Version == "" {
-				meta.PomProperties.Version = purl.Version
-			}
-		}
+	if p.Metadata == nil {
+		// since we don't know if the purl elements directly came from pom properties or the manifest,
+		// we can only go as far as to set the type to JavaArchive, but not fill in the group id and artifact id
+		p.Metadata = pkg.JavaArchive{}
 	}
 }
 

--- a/syft/format/internal/backfill_test.go
+++ b/syft/format/internal/backfill_test.go
@@ -101,13 +101,9 @@ func Test_Backfill(t *testing.T) {
 				Language: pkg.Java,
 				Name:     "some-thing",
 				Version:  "1.2.3",
-				Metadata: pkg.JavaArchive{
-					PomProperties: &pkg.JavaPomProperties{
-						GroupID:    "org.apache",
-						ArtifactID: "some-thing",
-						Version:    "1.2.3",
-					},
-				},
+				// we intentionally don't claim we found a pom properties file with a groupID from the purl.
+				// but we do claim that we found java data with an empty type.
+				Metadata: pkg.JavaArchive{},
 			},
 		},
 	}

--- a/syft/format/internal/cyclonedxutil/helpers/component_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component_test.go
@@ -275,6 +275,7 @@ func Test_decodeComponent(t *testing.T) {
 		component    cyclonedx.Component
 		wantLanguage pkg.Language
 		wantMetadata any
+		wantPURL     string
 	}{
 		{
 			name: "derive language from pURL if missing",
@@ -286,6 +287,18 @@ func Test_decodeComponent(t *testing.T) {
 				BOMRef:     "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
 			},
 			wantLanguage: pkg.Java,
+			wantPURL:     "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+		},
+		{
+			name: "derive language from bomref if missing",
+			component: cyclonedx.Component{
+				Name:    "ch.qos.logback/logback-classic",
+				Version: "1.2.3",
+				Type:    "library",
+				BOMRef:  "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
+			},
+			wantLanguage: pkg.Java,
+			wantPURL:     "pkg:maven/ch.qos.logback/logback-classic@1.2.3",
 		},
 		{
 			name: "handle RpmdbMetadata type without properties",
@@ -303,6 +316,7 @@ func Test_decodeComponent(t *testing.T) {
 				},
 			},
 			wantMetadata: pkg.RpmDBEntry{},
+			wantPURL:     "pkg:rpm/centos/acl@2.2.53-1.el8?arch=x86_64&upstream=acl-2.2.53-1.el8.src.rpm&distro=centos-8",
 		},
 		{
 			name: "handle RpmdbMetadata type with properties",
@@ -326,6 +340,24 @@ func Test_decodeComponent(t *testing.T) {
 			wantMetadata: pkg.RpmDBEntry{
 				Release: "some-release",
 			},
+			wantPURL: "pkg:rpm/centos/acl@2.2.53-1.el8?arch=x86_64&upstream=acl-2.2.53-1.el8.src.rpm&distro=centos-8",
+		},
+		{
+			name: "generate a purl from package type",
+			component: cyclonedx.Component{
+				Name:    "log4j",
+				Group:   "org.apache.logging.log4j",
+				Version: "2.0.4",
+				Type:    "library",
+				BOMRef:  "log4j",
+				Properties: &[]cyclonedx.Property{
+					{
+						Name:  "syft:package:type",
+						Value: "java-archive",
+					},
+				},
+			},
+			wantPURL: "pkg:maven/org.apache.logging.log4j/log4j@2.0.4",
 		},
 	}
 
@@ -338,9 +370,122 @@ func Test_decodeComponent(t *testing.T) {
 			if tt.wantMetadata != nil {
 				assert.Truef(t, reflect.DeepEqual(tt.wantMetadata, p.Metadata), "metadata should match: %+v != %+v", tt.wantMetadata, p.Metadata)
 			}
-			if tt.wantMetadata == nil && tt.wantLanguage == "" {
+
+			if tt.wantPURL != "" {
+				assert.Equal(t, tt.wantPURL, p.PURL, "purl should match")
+			}
+
+			if tt.wantMetadata == nil && tt.wantLanguage == "" && tt.wantPURL == "" {
 				t.Fatal("this is a useless test, please remove it")
 			}
+		})
+	}
+}
+
+func TestGetPURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		component *cyclonedx.Component
+		pkgType   pkg.Type
+		expected  string
+	}{
+		{
+			name: "component with PackageURL",
+			component: &cyclonedx.Component{
+				PackageURL: "pkg:npm/lodash@4.17.21",
+				Name:       "lodash",
+				Version:    "4.17.20", // different version to verify PackageURL is used
+				Group:      "npm",
+			},
+			pkgType:  pkg.NpmPkg,
+			expected: "pkg:npm/lodash@4.17.21",
+		},
+		{
+			name: "component with BOMRef as valid PURL",
+			component: &cyclonedx.Component{
+				BOMRef:  "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+				Name:    "commons-lang3",
+				Version: "3.11.0", // different version to verify BOMRef is used
+				Group:   "org.apache.commons",
+			},
+			pkgType:  pkg.JavaPkg,
+			expected: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+		},
+		{
+			name: "component with BOMRef not a valid PURL",
+			component: &cyclonedx.Component{
+				BOMRef:  "not-a-purl-ref",
+				Name:    "commons-lang3",
+				Version: "3.12.0",
+				Group:   "org.apache.commons",
+			},
+			pkgType:  pkg.JavaPkg,
+			expected: "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+		},
+		{
+			name: "component with unknown package type",
+			component: &cyclonedx.Component{
+				Name:    "some-component",
+				Version: "1.0.0",
+				Group:   "org.example",
+			},
+			pkgType:  pkg.UnknownPkg,
+			expected: "",
+		},
+		{
+			name: "component with empty package type",
+			component: &cyclonedx.Component{
+				Name:    "some-component",
+				Version: "1.0.0",
+				Group:   "org.example",
+			},
+			pkgType:  "",
+			expected: "",
+		},
+		{
+			name: "component with generic package type",
+			component: &cyclonedx.Component{
+				Name:    "some-component",
+				Version: "1.0.0",
+				Group:   "org.example",
+			},
+			pkgType:  pkg.LinuxKernelModulePkg,
+			expected: "",
+		},
+		{
+			name: "component with valid package type",
+			component: &cyclonedx.Component{
+				Name:    "react",
+				Version: "18.2.0",
+				Group:   "facebook",
+			},
+			pkgType:  pkg.NpmPkg,
+			expected: "pkg:npm/facebook/react@18.2.0",
+		},
+		{
+			name: "component with no group",
+			component: &cyclonedx.Component{
+				Name:    "express",
+				Version: "4.18.2",
+			},
+			pkgType:  pkg.NpmPkg,
+			expected: "pkg:npm/express@4.18.2",
+		},
+		{
+			name: "component with no version",
+			component: &cyclonedx.Component{
+				Name:  "express",
+				Group: "npm",
+			},
+			pkgType:  pkg.NpmPkg,
+			expected: "pkg:npm/npm/express",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPURL(tt.component, tt.pkgType)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/syft/format/purls/decoder_test.go
+++ b/syft/format/purls/decoder_test.go
@@ -165,13 +165,9 @@ func TestDecoder_Decode(t *testing.T) {
 					Type:     pkg.JavaPkg,
 					PURL:     "pkg:maven/org.apache/some-pkg@4.11.3",
 					Language: pkg.Java,
-					Metadata: pkg.JavaArchive{
-						PomProperties: &pkg.JavaPomProperties{
-							GroupID:    "org.apache",
-							ArtifactID: "some-pkg",
-							Version:    "4.11.3",
-						},
-					},
+					// we intentionally do not claim we found a pom properties file (don't derive this from the purl).
+					// but we need a metadata allocated since all Java packages have a this metadata type (a consistency point)
+					Metadata: pkg.JavaArchive{},
 				},
 			},
 		},

--- a/syft/pkg/cataloger/redhat/parse_rpm_archive.go
+++ b/syft/pkg/cataloger/redhat/parse_rpm_archive.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"time"
 
-	rpmdb "github.com/anchore/go-rpmdb/pkg"
 	"github.com/sassoftware/go-rpmutils"
 
+	rpmdb "github.com/anchore/go-rpmdb/pkg"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"

--- a/syft/pkg/cataloger/redhat/parse_rpm_db.go
+++ b/syft/pkg/cataloger/redhat/parse_rpm_db.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	rpmdb "github.com/anchore/go-rpmdb/pkg"
-
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"


### PR DESCRIPTION
With #3853 we began creating `pkg.JavaArchive.PomProperties` metadata fields populated from the purl fields (groupid = namespace, artifactid = name). This is generally OK, however, can cause confusion when looking at only the syft json output for a package when the SBOM was decoded from any format into syft json: it makes it seem that we conclusively found a `pom.properties` file on disk during the analysis even though that's not necessarily true.

Even more confusing, if you take syft json output that does not have `pkg.JavaArchive.PomProperties` populated and you run `syft convert -o json` (the same format) the field is populated.

For this reason this PR makes a small alteration: we don't generate any `pkg.JavaArchive.PomProperties` from purl info.

However, we don't want to drop CycloneDX group information when it is present. It makes sense when encoding and decoding to use this pom properties field (as this is symmetric) when a cyclonedx property hints that the syft metadataType is `JavaArchive`. It doesn't make sense to make that same assumption when there are no syft specific properties (when the user is bringing their own CDX document). In this case the group information should already be encoded into the purl for the case of java, or if there is no PURL, syft now generates a PURL with the group encoded as the namespace (unless the purl type is empty or `generic`).

Downstream in grype a change will be needed to still derive the group ID and artifact ID from the PURL when it can't be found anywhere else.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
