### PR TITLE
fix(dotnet-deps-cataloger): avoid repeated dependency resolution

### DIFF
--- a/syft/pkg/cataloger/dotnet/deps_json_test.go
+++ b/syft/pkg/cataloger/dotnet/deps_json_test.go
@@ -149,6 +149,11 @@ func TestGetLogicalDepsJSON_MergeTargets(t *testing.T) {
 						"lib/netcoreapp3.1/Microsoft.CodeAnalysis.CSharp.dll": {},
 					},
 				},
+				"Microsoft.CodeAnalysis.Common/4.0.0": {
+					Dependencies: map[string]string{
+						"Microsoft.CodeAnalysis.CSharp": "4.0.0",
+					},
+				},
 			},
 		},
 		Libraries: map[string]depsLibrary{


### PR DESCRIPTION
# Description

This PR fixes an issue where the Dotnet deps cataloger can get into a loop resolving dependencies.

- Fixes: #3919

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
