### PR TITLE
feat(spdx): enable deterministic output

### DIFF
--- a/cmd/syft/internal/options/format.go
+++ b/cmd/syft/internal/options/format.go
@@ -54,6 +54,7 @@ Note: long term support for this option is not guaranteed (it may change or brea
 note: inherits default value from 'format.pretty' or 'false' if parent is unset`
 	descriptions.Add(&o.SyftJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.SPDXJSON.Pretty, prettyDescription)
+	descriptions.Add(&o.SPDXJSON.DeterministicUUID, `if true, uses UUIDv5 for deterministic document namespace generation`)
 	descriptions.Add(&o.CyclonedxJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.CyclonedxXML.Pretty, prettyDescription)
 }

--- a/cmd/syft/internal/options/format.go
+++ b/cmd/syft/internal/options/format.go
@@ -28,7 +28,7 @@ func (o *Format) PostLoad() error {
 	o.CyclonedxJSON.Pretty = multiLevelOption[bool](false, o.Pretty, o.CyclonedxJSON.Pretty)
 	o.CyclonedxXML.Pretty = multiLevelOption[bool](false, o.Pretty, o.CyclonedxXML.Pretty)
 
-	return nil
+	return o.SPDXJSON.Validate()
 }
 
 func (o *Format) DescribeFields(descriptions clio.FieldDescriptionSet) {
@@ -55,7 +55,7 @@ note: inherits default value from 'format.pretty' or 'false' if parent is unset`
 	descriptions.Add(&o.SyftJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.SPDXJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.SPDXJSON.DeterministicUUID, `if true, uses UUIDv5 for deterministic document namespace generation`)
-	descriptions.Add(&o.SPDXJSON.CreatedTime, `if set, uses the given timestamp as the SPDX document creation time instead of the current time.`)
+	descriptions.Add(&o.SPDXJSON.CreatedTime, `if set, uses the given Unix timestamp as the SPDX document creation time instead of the current time. Must be a non-negative integer.`)
 	descriptions.Add(&o.CyclonedxJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.CyclonedxXML.Pretty, prettyDescription)
 }

--- a/cmd/syft/internal/options/format.go
+++ b/cmd/syft/internal/options/format.go
@@ -55,6 +55,7 @@ note: inherits default value from 'format.pretty' or 'false' if parent is unset`
 	descriptions.Add(&o.SyftJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.SPDXJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.SPDXJSON.DeterministicUUID, `if true, uses UUIDv5 for deterministic document namespace generation`)
+	descriptions.Add(&o.SPDXJSON.CreatedTime, `if set, uses the given timestamp as the SPDX document creation time instead of the current time.`)
 	descriptions.Add(&o.CyclonedxJSON.Pretty, prettyDescription)
 	descriptions.Add(&o.CyclonedxXML.Pretty, prettyDescription)
 }

--- a/cmd/syft/internal/options/format_cyclonedx_json_test.go
+++ b/cmd/syft/internal/options/format_cyclonedx_json_test.go
@@ -41,6 +41,9 @@ func getNonZeroExampleValue(t testing.TB, v any, name string) any {
 		return &val
 	case string:
 		return name
+	case *int64:
+		val := int64(1)
+		return &val
 	}
 	t.Fatalf("unsupported type: %T", v)
 	return nil

--- a/cmd/syft/internal/options/format_spdx_json.go
+++ b/cmd/syft/internal/options/format_spdx_json.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/anchore/syft/syft/format/spdxjson"
@@ -14,6 +15,15 @@ type FormatSPDXJSON struct {
 
 func DefaultFormatSPDXJSON() FormatSPDXJSON {
 	return FormatSPDXJSON{}
+}
+
+func (o FormatSPDXJSON) Validate() error {
+	if o.CreatedTime != nil {
+		if *o.CreatedTime < 0 {
+			return fmt.Errorf("created-time must be a non-negative Unix timestamp")
+		}
+	}
+	return nil
 }
 
 func (o FormatSPDXJSON) config(v string) spdxjson.EncoderConfig {

--- a/cmd/syft/internal/options/format_spdx_json.go
+++ b/cmd/syft/internal/options/format_spdx_json.go
@@ -1,12 +1,15 @@
 package options
 
 import (
+	"time"
+
 	"github.com/anchore/syft/syft/format/spdxjson"
 )
 
 type FormatSPDXJSON struct {
-	Pretty            *bool `yaml:"pretty" json:"pretty" mapstructure:"pretty"`
-	DeterministicUUID *bool `yaml:"deterministic-uuid" json:"deterministic-uuid" mapstructure:"deterministic-uuid"`
+	Pretty            *bool  `yaml:"pretty" json:"pretty" mapstructure:"pretty"`
+	DeterministicUUID *bool  `yaml:"deterministic-uuid" json:"deterministic-uuid" mapstructure:"deterministic-uuid"`
+	CreatedTime       *int64 `yaml:"created-time" json:"created-time" mapstructure:"created-time"`
 }
 
 func DefaultFormatSPDXJSON() FormatSPDXJSON {
@@ -21,6 +24,10 @@ func (o FormatSPDXJSON) config(v string) spdxjson.EncoderConfig {
 	}
 	if o.DeterministicUUID != nil {
 		c.DeterministicUUID = *o.DeterministicUUID
+	}
+	if o.CreatedTime != nil {
+		ts := time.Unix(*o.CreatedTime, 0)
+		c.CreatedTime = &ts
 	}
 	return c
 }

--- a/cmd/syft/internal/options/format_spdx_json.go
+++ b/cmd/syft/internal/options/format_spdx_json.go
@@ -5,7 +5,8 @@ import (
 )
 
 type FormatSPDXJSON struct {
-	Pretty *bool `yaml:"pretty" json:"pretty" mapstructure:"pretty"`
+	Pretty            *bool `yaml:"pretty" json:"pretty" mapstructure:"pretty"`
+	DeterministicUUID *bool `yaml:"deterministic-uuid" json:"deterministic-uuid" mapstructure:"deterministic-uuid"`
 }
 
 func DefaultFormatSPDXJSON() FormatSPDXJSON {
@@ -17,6 +18,9 @@ func (o FormatSPDXJSON) config(v string) spdxjson.EncoderConfig {
 	c.Version = v
 	if o.Pretty != nil {
 		c.Pretty = *o.Pretty
+	}
+	if o.DeterministicUUID != nil {
+		c.DeterministicUUID = *o.DeterministicUUID
 	}
 	return c
 }

--- a/cmd/syft/internal/options/format_spdx_json_test.go
+++ b/cmd/syft/internal/options/format_spdx_json_test.go
@@ -17,3 +17,45 @@ func TestFormatSPDXJSON_buildConfig(t *testing.T) {
 	require.Equal(t, "2.3", subject.DefaultVersion)
 	require.True(t, subject.Pretty)
 }
+
+func TestFormatSPDXJSON_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		createdTime *int64
+		wantErr   bool
+	}{
+		{
+			name:      "nil timestamp is valid",
+			createdTime: nil,
+			wantErr:   false,
+		},
+		{
+			name:      "positive timestamp is valid",
+			createdTime: ptr(int64(1234567890)),
+			wantErr:   false,
+		},
+		{
+			name:      "zero timestamp is valid",
+			createdTime: ptr(int64(0)),
+			wantErr:   false,
+		},
+		{
+			name:      "negative timestamp is invalid",
+			createdTime: ptr(int64(-1)),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := FormatSPDXJSON{
+				CreatedTime: tt.createdTime,
+			}
+			err := o.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+

--- a/cmd/syft/internal/options/format_spdx_json_test.go
+++ b/cmd/syft/internal/options/format_spdx_json_test.go
@@ -20,29 +20,29 @@ func TestFormatSPDXJSON_buildConfig(t *testing.T) {
 
 func TestFormatSPDXJSON_Validate(t *testing.T) {
 	tests := []struct {
-		name      string
+		name        string
 		createdTime *int64
-		wantErr   bool
+		wantErr     bool
 	}{
 		{
-			name:      "nil timestamp is valid",
+			name:        "nil timestamp is valid",
 			createdTime: nil,
-			wantErr:   false,
+			wantErr:     false,
 		},
 		{
-			name:      "positive timestamp is valid",
+			name:        "positive timestamp is valid",
 			createdTime: ptr(int64(1234567890)),
-			wantErr:   false,
+			wantErr:     false,
 		},
 		{
-			name:      "zero timestamp is valid",
+			name:        "zero timestamp is valid",
 			createdTime: ptr(int64(0)),
-			wantErr:   false,
+			wantErr:     false,
 		},
 		{
-			name:      "negative timestamp is invalid",
+			name:        "negative timestamp is invalid",
 			createdTime: ptr(int64(-1)),
-			wantErr:   true,
+			wantErr:     true,
 		},
 	}
 
@@ -58,4 +58,3 @@ func TestFormatSPDXJSON_Validate(t *testing.T) {
 		})
 	}
 }
-

--- a/syft/format/common/spdxhelpers/to_format_model.go
+++ b/syft/format/common/spdxhelpers/to_format_model.go
@@ -47,7 +47,7 @@ const (
 // spec from the given SBOM model.
 //
 //nolint:funlen
-func ToFormatModel(s sbom.SBOM, deterministicUUID bool) *spdx.Document {
+func ToFormatModel(s sbom.SBOM, deterministicUUID bool, createdTime *time.Time) *spdx.Document {
 	rels := relationship.NewIndex(s.Relationships...)
 	packages, otherLicenses := toPackages(rels, s.Artifacts.Packages, s)
 
@@ -112,6 +112,11 @@ func ToFormatModel(s sbom.SBOM, deterministicUUID bool) *spdx.Document {
 
 	name := helpers.DocumentName(s.Source)
 	namespace := helpers.DocumentNamespace(name, s.Source, s.Descriptor, uniqueID)
+
+	currentTime := time.Now()
+	if createdTime == nil {
+		createdTime = &currentTime
+	}
 
 	return &spdx.Document{
 		// 6.1: SPDX Version; should be in the format "SPDX-x.x"
@@ -178,7 +183,7 @@ func ToFormatModel(s sbom.SBOM, deterministicUUID bool) *spdx.Document {
 
 			// 6.9: Created: data format YYYY-MM-DDThh:mm:ssZ
 			// Cardinality: mandatory, one
-			Created: time.Now().UTC().Format(time.RFC3339),
+			Created: createdTime.UTC().Format(time.RFC3339),
 
 			// 6.10: Creator Comment
 			// Cardinality: optional, one

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -105,6 +106,21 @@ func Test_toFormatModel(t *testing.T) {
 						Relationship: spdx.RelationshipDescribes,
 					},
 				},
+				CreationInfo: &spdx.CreationInfo{
+					LicenseListVersion: "3.25",
+					Creators: []spdx.Creator{
+						{
+							Creator:     "Anchore, Inc",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "-",
+							CreatorType: "Tool",
+						},
+					},
+					Created:        "2025-05-26T14:50:19Z",
+					CreatorComment: "",
+				},
 			},
 		},
 		{
@@ -167,6 +183,21 @@ func Test_toFormatModel(t *testing.T) {
 						},
 						Relationship: spdx.RelationshipDescribes,
 					},
+				},
+				CreationInfo: &spdx.CreationInfo{
+					LicenseListVersion: "3.25",
+					Creators: []spdx.Creator{
+						{
+							Creator:     "Anchore, Inc",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "-",
+							CreatorType: "Tool",
+						},
+					},
+					Created:        "2025-05-26T14:50:19Z",
+					CreatorComment: "",
 				},
 			},
 		},
@@ -237,6 +268,21 @@ func Test_toFormatModel(t *testing.T) {
 						},
 						Relationship: spdx.RelationshipDescribes,
 					},
+				},
+				CreationInfo: &spdx.CreationInfo{
+					LicenseListVersion: "3.25",
+					Creators: []spdx.Creator{
+						{
+							Creator:     "Anchore, Inc",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "-",
+							CreatorType: "Tool",
+						},
+					},
+					Created:        "2025-05-26T14:50:19Z",
+					CreatorComment: "",
 				},
 			},
 		},
@@ -406,12 +452,12 @@ func Test_toFormatModel(t *testing.T) {
 			test.in.Artifacts.Packages = pkg.NewCollection(pkgs...)
 
 			// convert
-			got := ToFormatModel(test.in, false)
+			ts := time.Unix(1748271019, 0)
+			got := ToFormatModel(test.in, true, &ts)
 
 			// check differences
 			if diff := cmp.Diff(test.expected, got,
 				cmpopts.IgnoreUnexported(spdx.Document{}, spdx.Package{}),
-				cmpopts.IgnoreFields(spdx.Document{}, "CreationInfo", "DocumentNamespace"),
 				cmpopts.IgnoreFields(spdx.Package{}, "PackageDownloadLocation", "IsFilesAnalyzedTagPresent", "PackageSourceInfo", "PackageLicenseConcluded", "PackageLicenseDeclared", "PackageCopyrightText"),
 			); diff != "" {
 				t.Error(diff)
@@ -1126,7 +1172,7 @@ func Test_otherLicenses(t *testing.T) {
 					Packages: pkg.NewCollection(test.packages...),
 				},
 			}
-			got := ToFormatModel(s, false)
+			got := ToFormatModel(s, false, nil)
 			require.Equal(t, test.expected, got.OtherLicenses)
 		})
 	}

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -406,7 +406,7 @@ func Test_toFormatModel(t *testing.T) {
 			test.in.Artifacts.Packages = pkg.NewCollection(pkgs...)
 
 			// convert
-			got := ToFormatModel(test.in)
+			got := ToFormatModel(test.in, false)
 
 			// check differences
 			if diff := cmp.Diff(test.expected, got,
@@ -1126,7 +1126,7 @@ func Test_otherLicenses(t *testing.T) {
 					Packages: pkg.NewCollection(test.packages...),
 				},
 			}
-			got := ToFormatModel(s)
+			got := ToFormatModel(s, false)
 			require.Equal(t, test.expected, got.OtherLicenses)
 		})
 	}

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/anchore/syft/internal/relationship"
 	"github.com/anchore/syft/internal/sourcemetadata"
+	"github.com/anchore/syft/internal/spdxlicense"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/format/internal/spdxutil/helpers"
@@ -108,7 +109,7 @@ func Test_toFormatModel(t *testing.T) {
 					},
 				},
 				CreationInfo: &spdx.CreationInfo{
-					LicenseListVersion: "3.25",
+					LicenseListVersion: trimPatchVersion(spdxlicense.Version),
 					Creators: []spdx.Creator{
 						{
 							Creator:     "Anchore, Inc",
@@ -186,7 +187,7 @@ func Test_toFormatModel(t *testing.T) {
 					},
 				},
 				CreationInfo: &spdx.CreationInfo{
-					LicenseListVersion: "3.25",
+					LicenseListVersion: trimPatchVersion(spdxlicense.Version),
 					Creators: []spdx.Creator{
 						{
 							Creator:     "Anchore, Inc",
@@ -272,7 +273,7 @@ func Test_toFormatModel(t *testing.T) {
 					},
 				},
 				CreationInfo: &spdx.CreationInfo{
-					LicenseListVersion: "3.25",
+					LicenseListVersion: trimPatchVersion(spdxlicense.Version),
 					Creators: []spdx.Creator{
 						{
 							Creator:     "Anchore, Inc",
@@ -364,7 +365,7 @@ func Test_toFormatModel(t *testing.T) {
 					},
 				},
 				CreationInfo: &spdx.CreationInfo{
-					LicenseListVersion: "3.25",
+					LicenseListVersion: trimPatchVersion(spdxlicense.Version),
 					Creators: []spdx.Creator{
 						{
 							Creator:     "Anchore, Inc",

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -53,10 +53,11 @@ func Test_toFormatModel(t *testing.T) {
 				},
 			},
 			expected: &spdx.Document{
-				SPDXIdentifier: "DOCUMENT",
-				SPDXVersion:    spdx.Version,
-				DataLicense:    spdx.DataLicense,
-				DocumentName:   "alpine",
+				SPDXIdentifier:    "DOCUMENT",
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				DocumentName:      "alpine",
+				DocumentNamespace: "https://anchore.com/image/alpine-d573751a-5604-5439-9da4-72b7145e5199",
 				Packages: []*spdx.Package{
 					{
 						PackageSPDXIdentifier: "Package-pkg-1-pkg-1",
@@ -140,11 +141,11 @@ func Test_toFormatModel(t *testing.T) {
 				},
 			},
 			expected: &spdx.Document{
-				SPDXIdentifier: "DOCUMENT",
-				SPDXVersion:    spdx.Version,
-				DataLicense:    spdx.DataLicense,
-				DocumentName:   "some/directory",
-
+				SPDXIdentifier:    "DOCUMENT",
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				DocumentName:      "some/directory",
+				DocumentNamespace: "https://anchore.com/dir/some/directory-ce13b821-ee09-557a-8148-d4092410457f",
 				Packages: []*spdx.Package{
 					{
 						PackageSPDXIdentifier: "Package-pkg-1-pkg-1",
@@ -225,10 +226,11 @@ func Test_toFormatModel(t *testing.T) {
 				},
 			},
 			expected: &spdx.Document{
-				SPDXIdentifier: "DOCUMENT",
-				SPDXVersion:    spdx.Version,
-				DataLicense:    spdx.DataLicense,
-				DocumentName:   "path/to/some.file",
+				SPDXIdentifier:    "DOCUMENT",
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				DocumentName:      "path/to/some.file",
+				DocumentNamespace: "https://anchore.com/file/path/to/some.file-a7f2ecb8-114d-542c-aeb5-341d9a3153eb",
 				Packages: []*spdx.Package{
 					{
 						PackageSPDXIdentifier: "Package-pkg-1-pkg-1",
@@ -316,10 +318,11 @@ func Test_toFormatModel(t *testing.T) {
 				},
 			},
 			expected: &spdx.Document{
-				SPDXIdentifier: "DOCUMENT",
-				SPDXVersion:    spdx.Version,
-				DataLicense:    spdx.DataLicense,
-				DocumentName:   "etcd",
+				SPDXIdentifier:    "DOCUMENT",
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				DocumentName:      "etcd",
+				DocumentNamespace: "https://anchore.com/snap/etcd-71356805-84b2-57a3-ab30-bd155fc15956",
 				Packages: []*spdx.Package{
 					{
 						PackageSPDXIdentifier: "Package-pkg-1-pkg-1",
@@ -359,6 +362,21 @@ func Test_toFormatModel(t *testing.T) {
 						},
 						Relationship: spdx.RelationshipDescribes,
 					},
+				},
+				CreationInfo: &spdx.CreationInfo{
+					LicenseListVersion: "3.25",
+					Creators: []spdx.Creator{
+						{
+							Creator:     "Anchore, Inc",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "-",
+							CreatorType: "Tool",
+						},
+					},
+					Created:        "2025-05-26T14:50:19Z",
+					CreatorComment: "",
 				},
 			},
 		},

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -401,10 +401,11 @@ func Test_toFormatModel(t *testing.T) {
 				},
 			},
 			expected: &spdx.Document{
-				SPDXIdentifier: "DOCUMENT",
-				SPDXVersion:    spdx.Version,
-				DataLicense:    spdx.DataLicense,
-				DocumentName:   "llama",
+				SPDXIdentifier:    "DOCUMENT",
+				SPDXVersion:       spdx.Version,
+				DataLicense:       spdx.DataLicense,
+				DocumentName:      "llama",
+				DocumentNamespace: "https://anchore.com/oci-model/llama-85932321-c7ad-5379-98f5-40e9884ab57a",
 				Packages: []*spdx.Package{
 					{
 						PackageSPDXIdentifier: "Package-pkg-1-pkg-1",
@@ -453,6 +454,21 @@ func Test_toFormatModel(t *testing.T) {
 						},
 						Relationship: spdx.RelationshipDescribes,
 					},
+				},
+				CreationInfo: &spdx.CreationInfo{
+					LicenseListVersion: trimPatchVersion(spdxlicense.Version),
+					Creators: []spdx.Creator{
+						{
+							Creator:     "Anchore, Inc",
+							CreatorType: "Organization",
+						},
+						{
+							Creator:     "-",
+							CreatorType: "Tool",
+						},
+					},
+					Created:        "2025-05-26T14:50:19Z",
+					CreatorComment: "",
 				},
 			},
 		},

--- a/syft/format/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/format/common/spdxhelpers/to_syft_model_test.go
@@ -587,7 +587,7 @@ func Test_convertToAndFromFormat(t *testing.T) {
 				},
 				Relationships: test.relationships,
 			}
-			doc := ToFormatModel(s)
+			doc := ToFormatModel(s, false)
 			got, err := ToSyftModel(doc)
 			require.NoError(t, err)
 

--- a/syft/format/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/format/common/spdxhelpers/to_syft_model_test.go
@@ -587,7 +587,7 @@ func Test_convertToAndFromFormat(t *testing.T) {
 				},
 				Relationships: test.relationships,
 			}
-			doc := ToFormatModel(s, false)
+			doc := ToFormatModel(s, false, nil)
 			got, err := ToSyftModel(doc)
 			require.NoError(t, err)
 

--- a/syft/format/internal/spdxutil/helpers/document_namespace.go
+++ b/syft/format/internal/spdxutil/helpers/document_namespace.go
@@ -20,12 +20,7 @@ const (
 	InputSnap      = "snap"
 )
 
-func DocumentNameAndNamespace(src source.Description, desc sbom.Descriptor) (string, string) {
-	name := DocumentName(src)
-	return name, DocumentNamespace(name, src, desc)
-}
-
-func DocumentNamespace(name string, src source.Description, desc sbom.Descriptor) string {
+func DocumentNamespace(name string, src source.Description, desc sbom.Descriptor, uniqueID uuid.UUID) string {
 	name = cleanName(name)
 	input := "unknown-source-type"
 	switch src.Metadata.(type) {
@@ -41,7 +36,6 @@ func DocumentNamespace(name string, src source.Description, desc sbom.Descriptor
 		input = InputSnap
 	}
 
-	uniqueID := uuid.Must(uuid.NewRandom())
 	identifier := path.Join(input, uniqueID.String())
 	if name != "." {
 		identifier = path.Join(input, fmt.Sprintf("%s-%s", name, uniqueID.String()))

--- a/syft/format/internal/spdxutil/helpers/document_namespace_test.go
+++ b/syft/format/internal/spdxutil/helpers/document_namespace_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/anchore/syft/internal/sourcemetadata"
@@ -78,7 +79,7 @@ func Test_DocumentNamespace(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			actual := DocumentNamespace(test.inputName, test.src, sbom.Descriptor{
 				Name: "syft",
-			})
+			}, uuid.Must(uuid.NewRandom()))
 
 			// note: since the namespace ends with a UUID we check the prefix
 			assert.True(t, strings.HasPrefix(actual, test.expected), fmt.Sprintf("expected prefix: '%s' got: '%s'", test.expected, actual))

--- a/syft/format/spdxjson/encoder.go
+++ b/syft/format/spdxjson/encoder.go
@@ -25,7 +25,7 @@ func SupportedVersions() []string {
 
 type EncoderConfig struct {
 	Version           string
-	Pretty            bool       // don't include spaces and newlines; same as jq -c
+	Pretty            bool // don't include spaces and newlines; same as jq -c
 	DefaultVersion    string
 	DeterministicUUID bool       // use UUIDv5 for deterministic document namespace generation
 	CreatedTime       *time.Time // if nil, the current time is used

--- a/syft/format/spdxjson/encoder.go
+++ b/syft/format/spdxjson/encoder.go
@@ -23,9 +23,10 @@ func SupportedVersions() []string {
 }
 
 type EncoderConfig struct {
-	Version        string
-	Pretty         bool // don't include spaces and newlines; same as jq -c
-	DefaultVersion string
+	Version           string
+	Pretty            bool // don't include spaces and newlines; same as jq -c
+	DefaultVersion    string
+	DeterministicUUID bool // use UUIDv5 for deterministic document namespace generation
 }
 
 type encoder struct {
@@ -40,9 +41,10 @@ func NewFormatEncoderWithConfig(cfg EncoderConfig) (sbom.FormatEncoder, error) {
 
 func DefaultEncoderConfig() EncoderConfig {
 	return EncoderConfig{
-		DefaultVersion: spdxutil.DefaultVersion,
-		Version:        spdxutil.DefaultVersion,
-		Pretty:         false,
+		DefaultVersion:    spdxutil.DefaultVersion,
+		Version:           spdxutil.DefaultVersion,
+		Pretty:            false,
+		DeterministicUUID: false,
 	}
 }
 
@@ -59,7 +61,7 @@ func (e encoder) Version() string {
 }
 
 func (e encoder) Encode(writer io.Writer, s sbom.SBOM) error {
-	latestDoc := spdxhelpers.ToFormatModel(s)
+	latestDoc := spdxhelpers.ToFormatModel(s, e.cfg.DeterministicUUID)
 	if latestDoc == nil {
 		return fmt.Errorf("unable to convert SBOM to SPDX document")
 	}

--- a/syft/format/spdxjson/encoder.go
+++ b/syft/format/spdxjson/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/spdx/tools-golang/convert"
 	"github.com/spdx/tools-golang/spdx/v2/v2_1"
@@ -24,9 +25,10 @@ func SupportedVersions() []string {
 
 type EncoderConfig struct {
 	Version           string
-	Pretty            bool // don't include spaces and newlines; same as jq -c
+	Pretty            bool       // don't include spaces and newlines; same as jq -c
 	DefaultVersion    string
-	DeterministicUUID bool // use UUIDv5 for deterministic document namespace generation
+	DeterministicUUID bool       // use UUIDv5 for deterministic document namespace generation
+	CreatedTime       *time.Time // if nil, the current time is used
 }
 
 type encoder struct {
@@ -45,6 +47,7 @@ func DefaultEncoderConfig() EncoderConfig {
 		Version:           spdxutil.DefaultVersion,
 		Pretty:            false,
 		DeterministicUUID: false,
+		CreatedTime:       nil,
 	}
 }
 
@@ -61,7 +64,7 @@ func (e encoder) Version() string {
 }
 
 func (e encoder) Encode(writer io.Writer, s sbom.SBOM) error {
-	latestDoc := spdxhelpers.ToFormatModel(s, e.cfg.DeterministicUUID)
+	latestDoc := spdxhelpers.ToFormatModel(s, e.cfg.DeterministicUUID, e.cfg.CreatedTime)
 	if latestDoc == nil {
 		return fmt.Errorf("unable to convert SBOM to SPDX document")
 	}

--- a/syft/format/spdxtagvalue/encoder.go
+++ b/syft/format/spdxtagvalue/encoder.go
@@ -57,7 +57,7 @@ func (e encoder) Version() string {
 }
 
 func (e encoder) Encode(writer io.Writer, s sbom.SBOM) error {
-	latestDoc := spdxhelpers.ToFormatModel(s)
+	latestDoc := spdxhelpers.ToFormatModel(s, false)
 	if latestDoc == nil {
 		return fmt.Errorf("unable to convert SBOM to SPDX document")
 	}

--- a/syft/format/spdxtagvalue/encoder.go
+++ b/syft/format/spdxtagvalue/encoder.go
@@ -57,7 +57,7 @@ func (e encoder) Version() string {
 }
 
 func (e encoder) Encode(writer io.Writer, s sbom.SBOM) error {
-	latestDoc := spdxhelpers.ToFormatModel(s, false)
+	latestDoc := spdxhelpers.ToFormatModel(s, false, nil)
 	if latestDoc == nil {
 		return fmt.Errorf("unable to convert SBOM to SPDX document")
 	}

--- a/test/cli/spdx_deterministic_test.go
+++ b/test/cli/spdx_deterministic_test.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPDXDeterministicUUID(t *testing.T) {
+	fixturePath := "dir:test-fixtures/image-pkg-coverage"
+
+	tests := []struct {
+		name           string
+		env            map[string]string
+		expectSameUUID bool
+		runs           int
+	}{
+		{
+			name: "deterministic UUID with deterministic-uuid flag",
+			env: map[string]string{
+				"SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID": "true",
+			},
+			expectSameUUID: true,
+			runs:           3,
+		},
+		{
+			name: "deterministic UUID with created-time and deterministic-uuid",
+			env: map[string]string{
+				"SYFT_FORMAT_SPDX_JSON_CREATED_TIME":       "1234567890",
+				"SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID": "true",
+			},
+			expectSameUUID: true,
+			runs:           3,
+		},
+		{
+			name: "non-deterministic UUID without flags",
+			env: map[string]string{
+				"SYFT_FORMAT_SPDX_JSON_DETERMINISTIC_UUID": "false",
+			},
+			expectSameUUID: false,
+			runs:           3,
+		},
+		{
+			name: "created-time alone does not make UUID deterministic",
+			env: map[string]string{
+				"SYFT_FORMAT_SPDX_JSON_CREATED_TIME": "1234567890",
+			},
+			expectSameUUID: false,
+			runs:           3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespaces := make([]string, 0, tt.runs)
+
+			for i := 0; i < tt.runs; i++ {
+				args := []string{"scan", fixturePath, "-o", "spdx-json", "-q"}
+				_, stdout, _ := runSyft(t, tt.env, args...)
+
+				var doc spdxDocument
+				err := json.Unmarshal([]byte(stdout), &doc)
+				require.NoError(t, err, "failed to unmarshal SPDX JSON")
+
+				namespaces = append(namespaces, doc.DocumentNamespace)
+
+				// Also verify creation time if set
+				if createdTime, ok := tt.env["SYFT_FORMAT_SPDX_JSON_CREATED_TIME"]; ok && createdTime == "1234567890" {
+					assert.Equal(t, "2009-02-13T23:31:30Z", doc.CreationInfo.Created, "creation time should match the provided timestamp")
+				}
+			}
+
+			// Check if all namespaces are the same or different based on expectation
+			firstNamespace := namespaces[0]
+			for i := 1; i < len(namespaces); i++ {
+				if tt.expectSameUUID {
+					assert.Equal(t, firstNamespace, namespaces[i],
+						"namespaces should be identical when using deterministic UUID (run %d)", i+1)
+				} else {
+					assert.NotEqual(t, firstNamespace, namespaces[i],
+						"namespaces should be different when not using deterministic UUID (run %d)", i+1)
+				}
+			}
+		})
+	}
+}
+
+func TestSPDXInvalidCreatedTime(t *testing.T) {
+	fixturePath := "dir:test-fixtures/image-pkg-coverage"
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		expectError bool
+	}{
+		{
+			name: "valid timestamp should succeed",
+			env: map[string]string{
+				"SYFT_FORMAT_SPDX_JSON_CREATED_TIME": "0",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := []string{"scan", fixturePath, "-o", "spdx-json", "-q"}
+			cmd, stdout, _ := runSyftSafe(t, tt.env, args...)
+			assert.Equal(t, 0, cmd.ProcessState.ExitCode(), "command should succeed")
+			var doc spdxDocument
+			err := json.Unmarshal([]byte(stdout), &doc)
+			require.NoError(t, err, "failed to unmarshal SPDX JSON")
+		})
+	}
+}
+
+// Helper struct to parse SPDX JSON output
+type spdxDocument struct {
+	DocumentNamespace string       `json:"documentNamespace"`
+	CreationInfo      creationInfo `json:"creationInfo"`
+}
+
+type creationInfo struct {
+	Created string `json:"created"`
+}


### PR DESCRIPTION
- **feat(spdx): accept SOURCE_DATE_EPOCH**
- **feat(spdx): add an option to use UUIDv5**
- **test(spdx/to_format_model): validate deterministic UUID**

# Description

Honor SOURCE_DATE_EPOCH, add an option to use UUIDv5

<!-- If this completes an issue, please include: -->

- Fixes #3931

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
