### PR TITLE
fix(terraform): terraform provider lock entries should not require constraints

### DIFF
--- a/syft/pkg/cataloger/terraform/cataloger_test.go
+++ b/syft/pkg/cataloger/terraform/cataloger_test.go
@@ -59,7 +59,7 @@ func TestTerraformCataloger(t *testing.T) {
 		Metadata: pkg.TerraformLockProviderEntry{
 			URL:         "registry.terraform.io/hashicorp/google",
 			Version:     "6.8.0",
-			Constraints: "6.8.0",
+			Constraints: "",
 			Hashes: []string{
 				"h1:GlCaVPk6eKMg2ZbRY7C5tUeHGNIABT+qFtMl8+XWZHM=",
 				"zh:1b78f4451f1617092eb6891c9c13eda79671060601c40947feea6794c732157a",

--- a/syft/pkg/cataloger/terraform/test-fixtures/two-providers/.terraform.lock.hcl
+++ b/syft/pkg/cataloger/terraform/test-fixtures/two-providers/.terraform.lock.hcl
@@ -26,7 +26,6 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "6.8.0"
-  constraints = "6.8.0"
   hashes = [
     "h1:GlCaVPk6eKMg2ZbRY7C5tUeHGNIABT+qFtMl8+XWZHM=",
     "zh:1b78f4451f1617092eb6891c9c13eda79671060601c40947feea6794c732157a",

--- a/syft/pkg/terraform.go
+++ b/syft/pkg/terraform.go
@@ -3,7 +3,7 @@ package pkg
 // TerraformLockProviderEntry represents a single provider entry in a Terraform dependency lock file (.terraform.lock.hcl).
 type TerraformLockProviderEntry struct {
 	URL         string   `hcl:",label" json:"url"`
-	Constraints string   `hcl:"constraints" json:"constraints"`
+	Constraints string   `hcl:"constraints,optional" json:"constraints"`
 	Version     string   `hcl:"version" json:"version"`
 	Hashes      []string `hcl:"hashes" json:"hashes"`
 }


### PR DESCRIPTION
# Description
In a `.terraform.lock.hcl` within a provider block the `constraints` attribute is not required (=optional). A lock file like this is valid for Terraform:
```hcl
provider "registry.terraform.io/hashicorp/archive" {
  version = "2.7.0"
  hashes = [
    "h1:YkXq4JfcoAW0L4B9ghskZUxYbYAXIPlfSqqVFrAS06U=",
    # redacted
  ]
}

provider "registry.terraform.io/hashicorp/aws" {
  version     = "5.82.2"
  constraints = ">= 2.0.0, >= 3.0.0, >= 3.74.0, >= 4.9.0, >= 4.29.0, >= 4.38.0, >= 4.40.0, >= 4.52.0, >= 5.21.0, >= 5.27.0, >= 5.30.0, >= 5.32.0, >= 5.49.0, 5.82.2"
  hashes = [
    "h1:RuPaHbllUB8a2TGTyc149wJfoh6zhIEjUvFYKR6iP2E=",
    # redacted
  ]
}
```

However, the current implementation of syft will not discover any providers and silently fail with an error given the above lock file:
```
[0001] TRACE cataloger returned errors cataloger=terraform-lock-cataloger error=failed to decode terraform lock file: /.terraform.lock.hcl:1,52-52: Missing required argument; The argument "constraints" is required, but no definition was found. location=/.terraform.lock.hcl
```

- This PR fixes the described issue (See also [here](https://github.com/anchore/syft/pull/3378#issuecomment-2903984453))

Output of syft after applying these changes:
```
✔ Indexed file system                                                                                                                                                         /tmp/.terraform.lock.hcl 
 ✔ Cataloged contents                                                                                                                  72cadbfde3e4b67b91d07cd984f4e8df26ed6d9b45ced100c7bf0ef9e9654a95 
   ├── ✔ Packages                        [2 packages]  
   ├── ✔ Executables                     [0 executables]  
   ├── ✔ File digests                    [1 files]  
   └── ✔ File metadata                   [1 locations]  
NAME                                     VERSION  TYPE        
registry.terraform.io/hashicorp/archive  2.7.0    terraform    
registry.terraform.io/hashicorp/aws      5.82.2   terraform  
```

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

/cc @sukh-234 and thanks for reporting 🙏🏻 