### PR TITLE
fix: Allow the override of release on generic cataloger

### DIFF
--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -26,7 +26,7 @@ func newPackageTaskFactory(catalogerFactory func(CatalogingFactoryConfig) pkg.Ca
 	}
 }
 
-func newSimplePackageTaskFactory(catalogerFactory func() pkg.Cataloger, tags ...string) factory {
+func newSimplePackageTaskFactory[T pkg.Cataloger](catalogerFactory func() T, tags ...string) factory {
 	return func(cfg CatalogingFactoryConfig) Task {
 		return NewPackageTask(cfg, catalogerFactory(), tags...)
 	}

--- a/syft/pkg/cataloger.go
+++ b/syft/pkg/cataloger.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/linux"
 )
 
 // Cataloger describes behavior for an object to participate in parsing container image or file system
@@ -15,4 +16,11 @@ type Cataloger interface {
 	Name() string
 	// Catalog is given an object to resolve file references and content, this function returns any discovered Packages after analyzing the catalog source.
 	Catalog(context.Context, file.Resolver) ([]Package, []artifact.Relationship, error)
+}
+
+// CatalogerWithRelease is a Cataloger that can be configured with a Linux release. Every implementation built around the GenericCataloger should return
+// this interface, where the caller can set the release, but every input should accept only the Cataloger interface, to maintain backwards compatibility.
+type CatalogerWithRelease interface {
+	Cataloger
+	WithRelease(release *linux.Release) CatalogerWithRelease
 }

--- a/syft/pkg/cataloger/alpine/cataloger.go
+++ b/syft/pkg/cataloger/alpine/cataloger.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewDBCataloger returns a new cataloger object initialized for Alpine package DB flat-file stores.
-func NewDBCataloger() pkg.Cataloger {
+func NewDBCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("apk-db-cataloger").
 		WithParserByGlobs(parseApkDB, pkg.ApkDBGlob).
 		WithProcessors(dependency.Processor(dbEntryDependencySpecifier))

--- a/syft/pkg/cataloger/arch/cataloger.go
+++ b/syft/pkg/cataloger/arch/cataloger.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewDBCataloger returns a new cataloger object initialized for arch linux pacman database flat-file stores.
-func NewDBCataloger() pkg.Cataloger {
+func NewDBCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("alpm-db-cataloger").
 		WithParserByGlobs(parseAlpmDB, pkg.AlpmDBGlob).
 		WithProcessors(dependency.Processor(dbEntryDependencySpecifier))

--- a/syft/pkg/cataloger/bitnami/cataloger.go
+++ b/syft/pkg/cataloger/bitnami/cataloger.go
@@ -19,7 +19,7 @@ import (
 const catalogerName = "bitnami-cataloger"
 
 // NewCataloger returns a new SBOM cataloger object loaded from saved SBOM JSON.
-func NewCataloger() pkg.Cataloger {
+func NewCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger(catalogerName).
 		WithParserByGlobs(parseSBOM,
 			"/opt/bitnami/**/.spdx-*.spdx",

--- a/syft/pkg/cataloger/cpp/cataloger.go
+++ b/syft/pkg/cataloger/cpp/cataloger.go
@@ -9,14 +9,14 @@ import (
 )
 
 // NewConanCataloger returns a new C/C++ conanfile.txt and conan.lock cataloger object.
-func NewConanCataloger() pkg.Cataloger {
+func NewConanCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("conan-cataloger").
 		WithParserByGlobs(parseConanfile, "**/conanfile.txt").
 		WithParserByGlobs(parseConanLock, "**/conan.lock")
 }
 
 // NewConanInfoCataloger returns a new C/C++ conaninfo.txt cataloger object.
-func NewConanInfoCataloger() pkg.Cataloger {
+func NewConanInfoCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("conan-info-cataloger").
 		WithParserByGlobs(parseConaninfo, "**/conaninfo.txt")
 }

--- a/syft/pkg/cataloger/dart/cataloger.go
+++ b/syft/pkg/cataloger/dart/cataloger.go
@@ -9,13 +9,13 @@ import (
 )
 
 // NewPubspecLockCataloger returns a new Dartlang cataloger object base on pubspec lock files.
-func NewPubspecLockCataloger() pkg.Cataloger {
+func NewPubspecLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("dart-pubspec-lock-cataloger").
 		WithParserByGlobs(parsePubspecLock, "**/pubspec.lock")
 }
 
 // NewPubspecCataloger returns a new Dartlang cataloger object base on pubspec files.
-func NewPubspecCataloger() pkg.Cataloger {
+func NewPubspecCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("dart-pubspec-cataloger").
 		WithParserByGlobs(parsePubspec, "**/pubspec.yml", "**/pubspec.yaml")
 }

--- a/syft/pkg/cataloger/debian/cataloger.go
+++ b/syft/pkg/cataloger/debian/cataloger.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewDBCataloger returns a new Deb package cataloger capable of parsing DPKG status DB flat-file stores.
-func NewDBCataloger() pkg.Cataloger {
+func NewDBCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("dpkg-db-cataloger").
 		// note: these globs have been intentionally split up in order to improve search performance,
 		// please do NOT combine into: "**/var/lib/dpkg/{status,status.d/*}"
@@ -19,7 +19,7 @@ func NewDBCataloger() pkg.Cataloger {
 }
 
 // NewArchiveCataloger returns a new Debian package cataloger object capable of parsing .deb archive files
-func NewArchiveCataloger() pkg.Cataloger {
+func NewArchiveCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("deb-archive-cataloger").
 		WithParserByGlobs(parseDebArchive, "**/*.deb")
 }

--- a/syft/pkg/cataloger/dotnet/cataloger.go
+++ b/syft/pkg/cataloger/dotnet/cataloger.go
@@ -25,7 +25,7 @@ func NewDotnetPortableExecutableCataloger() pkg.Cataloger {
 }
 
 // NewDotnetPackagesLockCataloger returns a cataloger based on packages.lock.json files.
-func NewDotnetPackagesLockCataloger() pkg.Cataloger {
+func NewDotnetPackagesLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("dotnet-packages-lock-cataloger").
 		WithParserByGlobs(parseDotnetPackagesLock, "**/packages.lock.json")
 }

--- a/syft/pkg/cataloger/elixir/cataloger.go
+++ b/syft/pkg/cataloger/elixir/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewMixLockCataloger returns a cataloger object for Elixir mix.lock files.
-func NewMixLockCataloger() pkg.Cataloger {
+func NewMixLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("elixir-mix-lock-cataloger").
 		WithParserByGlobs(parseMixLock, "**/mix.lock")
 }

--- a/syft/pkg/cataloger/erlang/cataloger.go
+++ b/syft/pkg/cataloger/erlang/cataloger.go
@@ -9,12 +9,12 @@ import (
 )
 
 // NewRebarLockCataloger returns a new cataloger instance for Erlang rebar.lock files.
-func NewRebarLockCataloger() pkg.Cataloger {
+func NewRebarLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("erlang-rebar-lock-cataloger").
 		WithParserByGlobs(parseRebarLock, "**/rebar.lock")
 }
 
-func NewOTPCataloger() pkg.Cataloger {
+func NewOTPCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("erlang-otp-application-cataloger").
 		WithParserByGlobs(parseOTPApp, "**/*.app")
 }

--- a/syft/pkg/cataloger/gentoo/cataloger.go
+++ b/syft/pkg/cataloger/gentoo/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewPortageCataloger returns a new cataloger object initialized for Gentoo Portage package manager files (a flat-file store).
-func NewPortageCataloger() pkg.Cataloger {
+func NewPortageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("portage-cataloger").
 		WithParserByGlobs(parsePortageContents, "**/var/db/pkg/*/*/CONTENTS")
 }

--- a/syft/pkg/cataloger/githubactions/cataloger.go
+++ b/syft/pkg/cataloger/githubactions/cataloger.go
@@ -9,14 +9,14 @@ import (
 )
 
 // NewActionUsageCataloger returns GitHub Actions used within workflows and composite actions.
-func NewActionUsageCataloger() pkg.Cataloger {
+func NewActionUsageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("github-actions-usage-cataloger").
 		WithParserByGlobs(parseWorkflowForActionUsage, "**/.github/workflows/*.yaml", "**/.github/workflows/*.yml").
 		WithParserByGlobs(parseCompositeActionForActionUsage, "**/.github/actions/*/action.yml", "**/.github/actions/*/action.yaml")
 }
 
 // NewWorkflowUsageCataloger returns shared workflows used within workflows.
-func NewWorkflowUsageCataloger() pkg.Cataloger {
+func NewWorkflowUsageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("github-action-workflow-usage-cataloger").
 		WithParserByGlobs(parseWorkflowForWorkflowUsage, "**/.github/workflows/*.yaml", "**/.github/workflows/*.yml")
 }

--- a/syft/pkg/cataloger/golang/cataloger.go
+++ b/syft/pkg/cataloger/golang/cataloger.go
@@ -19,13 +19,13 @@ const (
 )
 
 // NewGoModuleFileCataloger returns a new cataloger object that searches within go.mod files.
-func NewGoModuleFileCataloger(opts CatalogerConfig) pkg.Cataloger {
+func NewGoModuleFileCataloger(opts CatalogerConfig) pkg.CatalogerWithRelease {
 	return generic.NewCataloger(modFileCatalogerName).
 		WithParserByGlobs(newGoModCataloger(opts).parseGoModFile, "**/go.mod")
 }
 
 // NewGoModuleBinaryCataloger returns a new cataloger object that searches within binaries built by the go compiler.
-func NewGoModuleBinaryCataloger(opts CatalogerConfig) pkg.Cataloger {
+func NewGoModuleBinaryCataloger(opts CatalogerConfig) pkg.CatalogerWithRelease {
 	return generic.NewCataloger(binaryCatalogerName).
 		WithParserByMimeTypes(
 			newGoBinaryCataloger(opts).parseGoBinary,

--- a/syft/pkg/cataloger/haskell/cataloger.go
+++ b/syft/pkg/cataloger/haskell/cataloger.go
@@ -13,7 +13,7 @@ import (
 // This hints at splitting these into multiple catalogers, but for now we'll keep them together.
 
 // NewHackageCataloger returns a new Haskell cataloger object.
-func NewHackageCataloger() pkg.Cataloger {
+func NewHackageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("haskell-cataloger").
 		WithParserByGlobs(parseStackYaml, "**/stack.yaml").
 		WithParserByGlobs(parseStackLock, "**/stack.yaml.lock").

--- a/syft/pkg/cataloger/homebrew/cataloger.go
+++ b/syft/pkg/cataloger/homebrew/cataloger.go
@@ -5,7 +5,7 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/generic"
 )
 
-func NewCataloger() pkg.Cataloger {
+func NewCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("homebrew-cataloger").
 		WithParserByGlobs(
 			parseHomebrewFormula,

--- a/syft/pkg/cataloger/java/cataloger.go
+++ b/syft/pkg/cataloger/java/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewArchiveCataloger returns a new Java archive cataloger object for detecting packages with archives (jar, war, ear, par, sar, jpi, hpi, and native-image formats)
-func NewArchiveCataloger(cfg ArchiveCatalogerConfig) pkg.Cataloger {
+func NewArchiveCataloger(cfg ArchiveCatalogerConfig) pkg.CatalogerWithRelease {
 	gap := newGenericArchiveParserAdapter(cfg)
 
 	c := generic.NewCataloger("java-archive-cataloger").
@@ -39,13 +39,13 @@ func NewPomCataloger(cfg ArchiveCatalogerConfig) pkg.Cataloger {
 
 // NewGradleLockfileCataloger returns a cataloger capable of parsing dependencies from a gradle.lockfile file.
 // Note: Older versions of lockfiles aren't supported yet
-func NewGradleLockfileCataloger() pkg.Cataloger {
+func NewGradleLockfileCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("java-gradle-lockfile-cataloger").
 		WithParserByGlobs(parseGradleLockfile, gradleLockfileGlob)
 }
 
 // NewJvmDistributionCataloger returns packages representing JDK/JRE installations (of multiple distribution types).
-func NewJvmDistributionCataloger() pkg.Cataloger {
+func NewJvmDistributionCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("java-jvm-cataloger").
 		WithParserByGlobs(parseJVMRelease, jvmReleaseGlob)
 }

--- a/syft/pkg/cataloger/javascript/cataloger.go
+++ b/syft/pkg/cataloger/javascript/cataloger.go
@@ -9,13 +9,13 @@ import (
 )
 
 // NewPackageCataloger returns a new cataloger object for NPM.
-func NewPackageCataloger() pkg.Cataloger {
+func NewPackageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("javascript-package-cataloger").
 		WithParserByGlobs(parsePackageJSON, "**/package.json")
 }
 
 // NewLockCataloger returns a new cataloger object for NPM (and NPM-adjacent, such as yarn) lock files.
-func NewLockCataloger(cfg CatalogerConfig) pkg.Cataloger {
+func NewLockCataloger(cfg CatalogerConfig) pkg.CatalogerWithRelease {
 	yarnLockAdapter := newGenericYarnLockAdapter(cfg)
 	packageLockAdapter := newGenericPackageLockAdapter(cfg)
 	return generic.NewCataloger("javascript-lock-cataloger").

--- a/syft/pkg/cataloger/lua/cataloger.go
+++ b/syft/pkg/cataloger/lua/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewPackageCataloger returns a new cataloger object for Lua ROck.
-func NewPackageCataloger() pkg.Cataloger {
+func NewPackageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("lua-rock-cataloger").
 		WithParserByGlobs(parseRockspec, "**/*.rockspec")
 }

--- a/syft/pkg/cataloger/ocaml/cataloger.go
+++ b/syft/pkg/cataloger/ocaml/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewOpamPackageManagerCataloger returns a new cataloger object for OCaml opam.
-func NewOpamPackageManagerCataloger() pkg.Cataloger {
+func NewOpamPackageManagerCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("opam-cataloger").
 		WithParserByGlobs(parseOpamPackage, "*opam")
 }

--- a/syft/pkg/cataloger/php/cataloger.go
+++ b/syft/pkg/cataloger/php/cataloger.go
@@ -12,19 +12,19 @@ import (
 // semantic meanings. The lock file represents what should be installed, whereas the installed file represents what is installed.
 
 // NewComposerInstalledCataloger returns a new cataloger for PHP installed.json files.
-func NewComposerInstalledCataloger() pkg.Cataloger {
+func NewComposerInstalledCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("php-composer-installed-cataloger").
 		WithParserByGlobs(parseInstalledJSON, "**/installed.json")
 }
 
 // NewComposerLockCataloger returns a new cataloger for PHP composer.lock files.
-func NewComposerLockCataloger() pkg.Cataloger {
+func NewComposerLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("php-composer-lock-cataloger").
 		WithParserByGlobs(parseComposerLock, "**/composer.lock")
 }
 
 // NewPearCataloger returns a new cataloger for PHP Pear metadata (including Pecl metadata).
-func NewPearCataloger() pkg.Cataloger {
+func NewPearCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("php-pear-serialized-cataloger").
 		WithParserByGlobs(parsePear, "**/php/.registry/**/*.reg")
 }
@@ -32,7 +32,7 @@ func NewPearCataloger() pkg.Cataloger {
 // NewPeclCataloger returns a new cataloger for PHP Pecl metadata. Note: this will also catalog Pear metadata so should
 // not be used in conjunction with the Pear Cataloger.
 // Deprecated: please use NewPearCataloger instead.
-func NewPeclCataloger() pkg.Cataloger {
+func NewPeclCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("php-pecl-serialized-cataloger").
 		WithParserByGlobs(parsePecl, "**/php/.registry/.channel.*/*.reg")
 }

--- a/syft/pkg/cataloger/python/cataloger.go
+++ b/syft/pkg/cataloger/python/cataloger.go
@@ -21,7 +21,7 @@ func DefaultCatalogerConfig() CatalogerConfig {
 }
 
 // NewPackageCataloger returns a new cataloger for python packages referenced from poetry lock files, requirements.txt files, and setup.py files.
-func NewPackageCataloger(cfg CatalogerConfig) pkg.Cataloger {
+func NewPackageCataloger(cfg CatalogerConfig) pkg.CatalogerWithRelease {
 	rqp := newRequirementsParser(cfg)
 	return generic.NewCataloger("python-package-cataloger").
 		WithParserByGlobs(rqp.parseRequirementsTxt, "**/*requirements*.txt").
@@ -31,7 +31,7 @@ func NewPackageCataloger(cfg CatalogerConfig) pkg.Cataloger {
 }
 
 // NewInstalledPackageCataloger returns a new cataloger for python packages within egg or wheel installation directories.
-func NewInstalledPackageCataloger() pkg.Cataloger {
+func NewInstalledPackageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("python-installed-package-cataloger").
 		WithParserByGlobs(
 			parseWheelOrEgg,

--- a/syft/pkg/cataloger/r/cataloger.go
+++ b/syft/pkg/cataloger/r/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewPackageCataloger returns a new R cataloger object based on detection of R package DESCRIPTION files.
-func NewPackageCataloger() pkg.Cataloger {
+func NewPackageCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("r-package-cataloger").
 		WithParserByGlobs(parseDescriptionFile, "**/DESCRIPTION")
 }

--- a/syft/pkg/cataloger/redhat/cataloger.go
+++ b/syft/pkg/cataloger/redhat/cataloger.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewDBCataloger returns a new RPM DB cataloger object.
-func NewDBCataloger() pkg.Cataloger {
+func NewDBCataloger() pkg.CatalogerWithRelease {
 	// check if a sqlite driver is available
 	if !isSqliteDriverAvailable() {
 		log.Debugf("sqlite driver is not available, newer RPM databases might not be cataloged")
@@ -42,7 +42,7 @@ func denySelfReferences(pkgs []pkg.Package, rels []artifact.Relationship, err er
 }
 
 // NewArchiveCataloger returns a new RPM file cataloger object.
-func NewArchiveCataloger() pkg.Cataloger {
+func NewArchiveCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("rpm-archive-cataloger").
 		WithParserByGlobs(parseRpmArchive, "**/*.rpm")
 }

--- a/syft/pkg/cataloger/ruby/cataloger.go
+++ b/syft/pkg/cataloger/ruby/cataloger.go
@@ -9,19 +9,19 @@ import (
 )
 
 // NewGemFileLockCataloger returns a new Bundler cataloger object tailored for parsing index-oriented files (e.g. Gemfile.lock).
-func NewGemFileLockCataloger() pkg.Cataloger {
+func NewGemFileLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("ruby-gemfile-cataloger").
 		WithParserByGlobs(parseGemFileLockEntries, "**/Gemfile.lock")
 }
 
 // NewInstalledGemSpecCataloger returns a new Bundler cataloger object tailored for detecting installations of gems (e.g. Gemspec).
-func NewInstalledGemSpecCataloger() pkg.Cataloger {
+func NewInstalledGemSpecCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("ruby-installed-gemspec-cataloger").
 		WithParserByGlobs(parseGemSpecEntries, "**/specifications/**/*.gemspec")
 }
 
 // NewGemSpecCataloger looks for gems without the additional requirement of the gem being installed.
-func NewGemSpecCataloger() pkg.Cataloger {
+func NewGemSpecCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("ruby-gemspec-cataloger").
 		WithParserByGlobs(parseGemSpecEntries, "**/*.gemspec")
 }

--- a/syft/pkg/cataloger/rust/cataloger.go
+++ b/syft/pkg/cataloger/rust/cataloger.go
@@ -12,14 +12,14 @@ import (
 const cargoAuditBinaryCatalogerName = "cargo-auditable-binary-cataloger"
 
 // NewCargoLockCataloger returns a new Rust Cargo lock file cataloger object.
-func NewCargoLockCataloger() pkg.Cataloger {
+func NewCargoLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("rust-cargo-lock-cataloger").
 		WithParserByGlobs(parseCargoLock, "**/Cargo.lock")
 }
 
 // NewAuditBinaryCataloger returns a new Rust auditable binary cataloger object that can detect dependencies
 // in binaries produced with https://github.com/Shnatsel/rust-audit
-func NewAuditBinaryCataloger() pkg.Cataloger {
+func NewAuditBinaryCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger(cargoAuditBinaryCatalogerName).
 		WithParserByMimeTypes(parseAuditBinary, mimetype.ExecutableMIMETypeSet.List()...)
 }

--- a/syft/pkg/cataloger/sbom/cataloger.go
+++ b/syft/pkg/cataloger/sbom/cataloger.go
@@ -20,7 +20,7 @@ import (
 const catalogerName = "sbom-cataloger"
 
 // NewCataloger returns a new SBOM cataloger object loaded from saved SBOM JSON.
-func NewCataloger() pkg.Cataloger {
+func NewCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger(catalogerName).
 		WithParserByGlobs(parseSBOM,
 			"**/*.syft.json",

--- a/syft/pkg/cataloger/swift/cataloger.go
+++ b/syft/pkg/cataloger/swift/cataloger.go
@@ -9,13 +9,13 @@ import (
 )
 
 // NewSwiftPackageManagerCataloger returns a new Swift package manager cataloger object.
-func NewSwiftPackageManagerCataloger() pkg.Cataloger {
+func NewSwiftPackageManagerCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("swift-package-manager-cataloger").
 		WithParserByGlobs(parsePackageResolved, "**/Package.resolved", "**/.package.resolved")
 }
 
 // NewCocoapodsCataloger returns a new Swift Cocoapods lock file cataloger object.
-func NewCocoapodsCataloger() pkg.Cataloger {
+func NewCocoapodsCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("cocoapods-cataloger").
 		WithParserByGlobs(parsePodfileLock, "**/Podfile.lock")
 }

--- a/syft/pkg/cataloger/swipl/cataloger.go
+++ b/syft/pkg/cataloger/swipl/cataloger.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewSwiplPackCataloger returns a new SWI Prolog Pack package manager cataloger object.
-func NewSwiplPackCataloger() pkg.Cataloger {
+func NewSwiplPackCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("swipl-pack-cataloger").
 		WithParserByGlobs(parsePackPackage, "**/pack.pl")
 }

--- a/syft/pkg/cataloger/terraform/cataloger.go
+++ b/syft/pkg/cataloger/terraform/cataloger.go
@@ -5,7 +5,7 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/generic"
 )
 
-func NewLockCataloger() pkg.Cataloger {
+func NewLockCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger("terraform-lock-cataloger").
 		WithParserByGlobs(parseTerraformLock, "**/.terraform.lock.hcl")
 }

--- a/syft/pkg/cataloger/wordpress/cataloger.go
+++ b/syft/pkg/cataloger/wordpress/cataloger.go
@@ -10,7 +10,7 @@ const (
 	wordpressPluginsGlob = "**/wp-content/plugins/*/*.php"
 )
 
-func NewWordpressPluginCataloger() pkg.Cataloger {
+func NewWordpressPluginCataloger() pkg.CatalogerWithRelease {
 	return generic.NewCataloger(catalogerName).
 		WithParserByGlobs(parseWordpressPluginFiles, wordpressPluginsGlob)
 }


### PR DESCRIPTION
Still WIP. 

Basically virtually all catalogers are wrappers around generic/cataloger, I've extended this to provide a WithRelease function, that allows the setting of a linux.Release, then the Catalog method checks if that's not nil before doing distro detection. 

In order to support this, I've had to an a new interface that is an extension of pkg.Cataloger (creatively called pkg.CatalogerWithRelease). 

Now everywhere that builds things returns pkg.CatalogerWIthRelease, while we still accept pkg.Cataloger (as pkg.CatalogerWithRelease by nature implements pkg.Cataloger) 
