### PR TITLE
Harden Container Runtime with Non-Root User

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -63,18 +63,18 @@ jobs:
 
 
   Build-Snapshot-Artifacts:
-    name: "Build snapshot artifacts"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-
+      - uses: actions/checkout@v4
+      - name: Enable QEMU for multi-arch
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx (needed by GoReleaser)
+        uses: docker/setup-buildx-action@v3
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap
-        with:
-          bootstrap-apt-packages: ""
-
       - name: Build snapshot artifacts
         run: make snapshot
+
 
       # why not use actions/upload-artifact? It is very slow (3 minutes to upload ~600MB of data, vs 10 seconds with this approach).
       # see https://github.com/actions/upload-artifact/issues/199 for more info

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -63,18 +63,28 @@ jobs:
 
 
   Build-Snapshot-Artifacts:
+    name: "Build snapshot artifacts"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Enable QEMU for multi-arch
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Buildx (needed by GoReleaser)
-        uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap
+        with:
+          bootstrap-apt-packages: ""
+
+      - name: Enable QEMU for multi-arch
+        uses: docker/setup-qemu-action@976512e99f06adc0ee8522552d4506bb9e4e2cbe   # v3 pinned
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@0fb43db2cebcdcac6112ee20be2c60dfe4e86193 # v3 pinned
+        with:
+          builder: multiarch
+
       - name: Build snapshot artifacts
         run: make snapshot
-
 
       # why not use actions/upload-artifact? It is very slow (3 minutes to upload ~600MB of data, vs 10 seconds with this approach).
       # see https://github.com/actions/upload-artifact/issues/199 for more info

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -74,12 +74,12 @@ jobs:
           bootstrap-apt-packages: ""
 
       - name: Enable QEMU for multi-arch
-        uses: docker/setup-qemu-action@976512e99f06adc0ee8522552d4506bb9e4e2cbe   # v3 pinned
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
-
+      
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@0fb43db2cebcdcac6112ee20be2c60dfe4e86193 # v3 pinned
+        uses: docker/setup-buildx-action@v3
         with:
           builder: multiarch
 

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Build snapshot artifacts
         run: make snapshot
 
-      - name: Smoke test images
+      - name: Smoke test snapshot build
         run: make snapshot-smoke-test
 
       # why not use actions/upload-artifact? It is very slow (3 minutes to upload ~600MB of data, vs 10 seconds with this approach).

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -73,18 +73,11 @@ jobs:
         with:
           bootstrap-apt-packages: ""
 
-      - name: Enable QEMU for multi-arch
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          builder: multiarch
-
       - name: Build snapshot artifacts
         run: make snapshot
+
+      - name: Smoke test images
+        run: make snapshot-smoke-test
 
       # why not use actions/upload-artifact? It is very slow (3 minutes to upload ~600MB of data, vs 10 seconds with this approach).
       # see https://github.com/actions/upload-artifact/issues/199 for more info

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,26 +1,21 @@
 version: 2
+project_name: syft
 
 release:
   prerelease: auto
   draft: false
 
 env:
-  # required to support multi architecture docker builds
   - DOCKER_CLI_EXPERIMENTAL=enabled
   - CGO_ENABLED=0
 
 builds:
+  # (unchanged: leave your builds, archives, nfpms, brews, sboms, and signs as-is)
   - id: linux-build
     dir: ./cmd/syft
     binary: syft
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-      - ppc64le
-      - s390x
-    # set the modified timestamp on the output binary to the git timestamp to ensure a reproducible build
+    goos: [linux]
+    goarch: [amd64, arm64, ppc64le, s390x]
     mod_timestamp: &build-timestamp '{{ .CommitTimestamp }}'
     ldflags: &build-ldflags |
       -w
@@ -30,15 +25,11 @@ builds:
       -X main.gitCommit={{.Commit}}
       -X main.buildDate={{.Date}}
       -X main.gitDescription={{.Summary}}
-
   - id: darwin-build
     dir: ./cmd/syft
     binary: syft
-    goos:
-      - darwin
-    goarch:
-      - amd64
-      - arm64
+    goos: [darwin]
+    goarch: [amd64, arm64]
     mod_timestamp: *build-timestamp
     ldflags: *build-ldflags
     hooks:
@@ -46,49 +37,36 @@ builds:
         - cmd: .tool/quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
-
   - id: windows-build
     dir: ./cmd/syft
     binary: syft
-    goos:
-      - windows
-    goarch:
-      - amd64
+    goos: [windows]
+    goarch: [amd64]
     mod_timestamp: *build-timestamp
     ldflags: *build-ldflags
 
 archives:
   - id: linux-archives
-    builds:
-      - linux-build
-
-  # note: the signing process is depending on tar.gz archives. If this format changes then .github/scripts/apple-signing/*.sh will need to be adjusted
+    builds: [linux-build]
   - id: darwin-archives
-    builds:
-      - darwin-build
-
+    builds: [darwin-build]
   - id: windows-archives
     format: zip
-    builds:
-      - windows-build
+    builds: [windows-build]
 
 nfpms:
   - license: "Apache 2.0"
     maintainer: "Anchore, Inc"
     homepage: &website "https://github.com/anchore/syft"
     description: &description "A tool that generates a Software Bill Of Materials (SBOM) from container images and filesystems"
-    formats:
-      - rpm
-      - deb
+    formats: [rpm, deb]
 
 brews:
   - repository:
       owner: anchore
       name: homebrew-syft
       token: "{{.Env.GITHUB_BREW_TOKEN}}"
-    ids:
-      - darwin-archives
-      - linux-archives
+    ids: [darwin-archives, linux-archives]
     homepage: *website
     description: *description
     license: "Apache License 2.0"
@@ -99,160 +77,37 @@ dockers:
       - anchore/syft:{{.Tag}}-debug
       - ghcr.io/anchore/syft:debug
       - ghcr.io/anchore/syft:{{.Tag}}-debug
-    goarch: amd64
     dockerfile: Dockerfile.debug
     use: buildx
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/syft:debug-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/syft:debug-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:debug-s390x
-      - anchore/syft:{{.Tag}}-debug-s390x
-      - ghcr.io/anchore/syft:debug-s390x
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
-    goarch: s390x
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
+    skip_push: true
+    skip_when_snapshot: false
 
   - image_templates:
       - anchore/syft:latest
       - anchore/syft:{{.Tag}}
       - ghcr.io/anchore/syft:latest
       - ghcr.io/anchore/syft:{{.Tag}}
-    goarch: amd64
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
-      - "--platform=linux/amd64"
+      - "--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
+    skip_push: true
+    skip_when_snapshot: false
 
-  - image_templates:
-      - anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-s390x
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-    goarch: s390x
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-docker_manifests:
-  - name_template: anchore/syft:latest
-    image_templates:
-      - anchore/syft:{{.Tag}}
-      - anchore/syft:{{.Tag}}-arm64v8
-      - anchore/syft:{{.Tag}}-ppc64le
-      - anchore/syft:{{.Tag}}-s390x
-
-  - name_template: anchore/syft:debug
-      - anchore/syft:{{.Tag}}-debug
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: anchore/syft:{{.Tag}}
-    image_templates:
-      - anchore/syft:{{.Tag}}
-      - anchore/syft:{{.Tag}}-arm64v8
-      - anchore/syft:{{.Tag}}-ppc64le
-      - anchore/syft:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/syft:latest
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/syft:debug
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-debug
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: ghcr.io/anchore/syft:{{.Tag}}
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
+# docker_manifests section removed: no longer needed due to buildx handling multi-arch manifests automatically
 
 sboms:
   - artifacts: archive
-    # this is relative to the snapshot/dist directory, not the root of the repo
     cmd: ../.tool/syft
     documents:
       - "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}.sbom"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -86,7 +86,7 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
     skip_push: true
-    skip_when_snapshot: false
+    skip_when_snapshot: true
 
   - image_templates:
       - anchore/syft:latest
@@ -102,8 +102,8 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
     skip_push: true
-    skip_when_snapshot: false
-
+    skip_when_snapshot: true
+    
 # docker_manifests section removed: no longer needed due to buildx handling multi-arch manifests automatically
 
 sboms:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,6 @@ env:
   - CGO_ENABLED=0
 
 builds:
-  # (unchanged: leave your builds, archives, nfpms, brews, sboms, and signs as-is)
   - id: linux-build
     dir: ./cmd/syft
     binary: syft
@@ -25,6 +24,7 @@ builds:
       -X main.gitCommit={{.Commit}}
       -X main.buildDate={{.Date}}
       -X main.gitDescription={{.Summary}}
+
   - id: darwin-build
     dir: ./cmd/syft
     binary: syft
@@ -37,6 +37,7 @@ builds:
         - cmd: .tool/quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
           env:
             - QUILL_LOG_FILE=/tmp/quill-{{ .Target }}.log
+
   - id: windows-build
     dir: ./cmd/syft
     binary: syft
@@ -72,39 +73,169 @@ brews:
     license: "Apache License 2.0"
 
 dockers:
+  # production images
   - image_templates:
-      - anchore/syft:debug
-      - anchore/syft:{{.Tag}}-debug
-      - ghcr.io/anchore/syft:debug
-      - ghcr.io/anchore/syft:{{.Tag}}-debug
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-    skip_push: true
-    skip_when_snapshot: true
-
-  - image_templates:
-      - anchore/syft:latest
-      - anchore/syft:{{.Tag}}
-      - ghcr.io/anchore/syft:latest
-      - ghcr.io/anchore/syft:{{.Tag}}
+      - anchore/syft:{{.Tag}}-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-amd64
+    goarch: amd64
     dockerfile: Dockerfile
     use: buildx
     build_flag_templates:
-      - "--platform=linux/amd64,linux/arm64,linux/ppc64le,linux/s390x"
+      - "--platform=linux/amd64"
       - "--build-arg=BUILD_DATE={{.Date}}"
       - "--build-arg=BUILD_VERSION={{.Version}}"
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
-    skip_push: true
-    skip_when_snapshot: true
-    
-# docker_manifests section removed: no longer needed due to buildx handling multi-arch manifests automatically
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
+    goarch: ppc64le
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-s390x
+      - ghcr.io/anchore/syft:{{.Tag}}-s390x
+    goarch: s390x
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/s390x"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  # debug images
+  - image_templates:
+      - anchore/syft:{{.Tag}}-debug-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
+    goarch: amd64
+    dockerfile: Dockerfile.debug
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-debug-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
+    goarch: arm64
+    dockerfile: Dockerfile.debug
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-debug-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
+    goarch: ppc64le
+    dockerfile: Dockerfile.debug
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-debug-s390x
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
+    goarch: s390x
+    dockerfile: Dockerfile.debug
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/s390x"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+docker_manifests:
+  - name_template: anchore/syft:latest
+    image_templates:
+      - anchore/syft:{{.Tag}}-amd64
+      - anchore/syft:{{.Tag}}-arm64v8
+      - anchore/syft:{{.Tag}}-ppc64le
+      - anchore/syft:{{.Tag}}-s390x
+
+  - name_template: anchore/syft:{{.Tag}}
+    image_templates:
+      - anchore/syft:{{.Tag}}-amd64
+      - anchore/syft:{{.Tag}}-arm64v8
+      - anchore/syft:{{.Tag}}-ppc64le
+      - anchore/syft:{{.Tag}}-s390x
+
+  - name_template: anchore/syft:debug
+    image_templates:
+      - anchore/syft:{{.Tag}}-debug-amd64
+      - anchore/syft:{{.Tag}}-debug-arm64v8
+      - anchore/syft:{{.Tag}}-debug-ppc64le
+      - anchore/syft:{{.Tag}}-debug-s390x
+
+  - name_template: anchore/syft:{{.Tag}}-debug
+    image_templates:
+      - anchore/syft:{{.Tag}}-debug-amd64
+      - anchore/syft:{{.Tag}}-debug-arm64v8
+      - anchore/syft:{{.Tag}}-debug-ppc64le
+      - anchore/syft:{{.Tag}}-debug-s390x
+
+  - name_template: ghcr.io/anchore/syft:latest
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-s390x
+
+  - name_template: ghcr.io/anchore/syft:{{.Tag}}
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-s390x
+
+  - name_template: ghcr.io/anchore/syft:debug
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
+
+  - name_template: ghcr.io/anchore/syft:{{.Tag}}-debug
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
+
 
 sboms:
   - artifacts: archive

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,7 +73,7 @@ brews:
     license: "Apache License 2.0"
 
 dockers:
-  # production images
+  # production images...
   - image_templates:
       - anchore/syft:{{.Tag}}-amd64
       - ghcr.io/anchore/syft:{{.Tag}}-amd64
@@ -126,7 +126,7 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
 
-  # debug images
+  # debug images...
   - image_templates:
       - anchore/syft:{{.Tag}}-debug-amd64
       - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
@@ -180,6 +180,7 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
 docker_manifests:
+  # anchore/syft manifests...
   - name_template: anchore/syft:latest
     image_templates:
       - anchore/syft:{{.Tag}}-amd64
@@ -208,6 +209,7 @@ docker_manifests:
       - anchore/syft:{{.Tag}}-debug-ppc64le
       - anchore/syft:{{.Tag}}-debug-s390x
 
+  # ghcr.io/anchore/syft manifests...
   - name_template: ghcr.io/anchore/syft:latest
     image_templates:
       - ghcr.io/anchore/syft:{{.Tag}}-amd64
@@ -235,7 +237,6 @@ docker_manifests:
       - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
       - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
       - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
-
 
 sboms:
   - artifacts: archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM gcr.io/distroless/static-debian12:latest AS build
 
-FROM alpine:latest AS security_provider
+ARG TARGETPLATFORM
+FROM --platform=$TARGETPLATFORM alpine:3.18 AS security_provider
 RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
 
 FROM gcr.io/distroless/base-debian12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM gcr.io/distroless/static-debian12:latest AS build
+FROM gcr.io/distroless/static-debian12:nonroot
 
-ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM alpine:3.18 AS security_provider
-RUN addgroup -S nonroot && adduser -S nonroot -G nonroot
-
-FROM gcr.io/distroless/base-debian12
-
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-
-COPY --from=security_provider /etc/passwd /etc/passwd
-
+# create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
 COPY syft /

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,9 +1,11 @@
-FROM gcr.io/distroless/static-debian12:debug
+FROM gcr.io/distroless/static-debian12:debug-nonroot
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
 COPY syft /
+
+USER nonroot
 
 ARG BUILD_DATE
 ARG BUILD_VERSION

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,11 +27,11 @@ vars:
     sh: uname -s | tr '[:upper:]' '[:lower:]'
   ARCH:
     sh: |
-      [ "$(uname -m)" = "x86_64" ] && echo "amd64_v1" || { [ "$(uname -m)" = "aarch64" ] && echo "arm64_v8.0" || echo $(uname -m); }
+      [ "$(uname -m)" = "x86_64" ] && echo "amd64_v1" || { [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; } && echo "arm64_v8.0" || echo $(uname -m)
   PROJECT_ROOT:
     sh: echo $PWD
-  # note: the snapshot dir must be a relative path starting with ./
-  SNAPSHOT_DIR: ./snapshot
+
+  SNAPSHOT_DIR: snapshot
   SNAPSHOT_BIN: "{{ .PROJECT_ROOT }}/{{ .SNAPSHOT_DIR }}/{{ .OS }}-build_{{ .OS }}_{{ .ARCH }}/{{ .PROJECT }}"
   SNAPSHOT_CMD: "{{ .TOOL_DIR }}/goreleaser release --config {{ .TMP_DIR }}/goreleaser.yaml --clean --snapshot --skip=publish --skip=sign"
   BUILD_CMD:    "{{ .TOOL_DIR }}/goreleaser build   --config {{ .TMP_DIR }}/goreleaser.yaml --clean --snapshot --single-target"
@@ -230,10 +230,7 @@ tasks:
 
   cli:
     desc: Run CLI tests
-    # note: we don't want to regenerate the snapshot unless we have to. In CI it's probable
-    # that the cache being restored with the correct binary will be rebuilt since the timestamps
-    # and local checksums will not line up.
-    deps: [tools, snapshot]
+    deps: [tools]
     cmds:
       - cmd: "echo 'testing binary: {{ .SNAPSHOT_BIN }}'"
         silent: true
@@ -572,6 +569,18 @@ tasks:
           cat .goreleaser.yaml >> {{ .TMP_DIR }}/goreleaser.yaml
 
       - "{{ .SNAPSHOT_CMD }}"
+
+  snapshot-smoke-test:
+    desc: Run a smoke test on the snapshot builds + docker images
+    cmds:
+      - cmd: "echo 'testing snapshot binary: {{ .SNAPSHOT_BIN }}'"
+        silent: true
+      - cmd: "test -f {{ .SNAPSHOT_BIN }} || (find {{ .SNAPSHOT_DIR }} && echo '\nno snapshot found for {{ .SNAPSHOT_BIN }}' && false)"
+        silent: true
+      - "{{ .SNAPSHOT_BIN }} version"
+      - "{{ .SNAPSHOT_BIN }} scan alpine:latest"
+      - docker run --rm anchore/syft:latest version
+      - docker run --rm anchore/syft:latest scan alpine:latest
 
   changelog:
     desc: Generate a changelog

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -31,7 +31,9 @@ vars:
   PROJECT_ROOT:
     sh: echo $PWD
 
-  SNAPSHOT_DIR: snapshot
+  # note: the snapshot dir must be a relative path starting with ./
+  # e.g. when installing snapshot debs from a local path, ./ forces the deb to be installed in the current working directory instead of referencing a package name
+  SNAPSHOT_DIR: ./snapshot
   SNAPSHOT_BIN: "{{ .PROJECT_ROOT }}/{{ .SNAPSHOT_DIR }}/{{ .OS }}-build_{{ .OS }}_{{ .ARCH }}/{{ .PROJECT }}"
   SNAPSHOT_CMD: "{{ .TOOL_DIR }}/goreleaser release --config {{ .TMP_DIR }}/goreleaser.yaml --clean --snapshot --skip=publish --skip=sign"
   BUILD_CMD:    "{{ .TOOL_DIR }}/goreleaser build   --config {{ .TMP_DIR }}/goreleaser.yaml --clean --snapshot --single-target"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,7 +27,7 @@ vars:
     sh: uname -s | tr '[:upper:]' '[:lower:]'
   ARCH:
     sh: |
-      [ "$(uname -m)" = "x86_64" ] && echo "amd64_v1" || { [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; } && echo "arm64_v8.0" || echo $(uname -m)
+      [ "$(uname -m)" = "x86_64" ] && echo "amd64_v1" || { [ "$(uname -m)" = "aarch64" ] && echo "arm64_v8.0" || [ "$(uname -m)" = "arm64" ] && echo "arm64_v8.0" || echo $(uname -m); }
   PROJECT_ROOT:
     sh: echo $PWD
 


### PR DESCRIPTION
This PR makes the following changes:
- uses `gcr.io/distroless/static-debian12` as the base image
- ensures the built containers are non-root users

In the process of working on this additional docker manifest updates were made:
- `image_templates` section was missing from the `debug` variant
- the top-level images should be the manifests and the tagged images should always be architecture specific (according to best practices)

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
