### PR TITLE
feat: add syft schema version to version command

### DIFF
--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -48,7 +48,7 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 		commands.Cataloger(app),
 		commands.Attest(app),
 		commands.Convert(app),
-		clio.VersionCommand(id, syftSchemaVersion),
+		clio.VersionCommand(id, schemaVersion),
 		clio.ConfigCommand(app, nil),
 		cranecmd.NewCmdAuthLogin(id.Name), // syft login uses the same command as crane
 	)
@@ -61,6 +61,6 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 	return app, rootCmd
 }
 
-func syftSchemaVersion() (string, any) {
+func schemaVersion() (string, any) {
 	return "SchemaVersion", constants.JSONSchemaVersion
 }

--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -62,5 +62,5 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 }
 
 func syftSchemaVersion() (string, any) {
-	return "SyftSchemaVersion", constants.JSONSchemaVersion
+	return "SchemaVersion", constants.JSONSchemaVersion
 }

--- a/cmd/syft/cli/cli.go
+++ b/cmd/syft/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/internal"
 	"github.com/anchore/syft/cmd/syft/internal/commands"
+	constants "github.com/anchore/syft/internal"
 )
 
 // Application constructs the `syft packages` command and aliases the root command to `syft packages`.
@@ -47,7 +48,7 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 		commands.Cataloger(app),
 		commands.Attest(app),
 		commands.Convert(app),
-		clio.VersionCommand(id),
+		clio.VersionCommand(id, syftSchemaVersion),
 		clio.ConfigCommand(app, nil),
 		cranecmd.NewCmdAuthLogin(id.Name), // syft login uses the same command as crane
 	)
@@ -58,4 +59,8 @@ func create(id clio.Identification, out io.Writer) (clio.Application, *cobra.Com
 	// In the future this functionality should be restored.
 
 	return app, rootCmd
+}
+
+func syftSchemaVersion() (string, any) {
+	return "SyftSchemaVersion", constants.JSONSchemaVersion
 }


### PR DESCRIPTION
# Description

This small change updates the syft version command to show the value of `internal.JSONSchemaVersion`. 

Syft users have asked for a simple way to access this value without having to generate a scan document.

` go run cmd/syft/main.go -o json version`
```json
{
 "application": "syft",
 "buildDate": "[not provided]",
 "compiler": "gc",
 "gitCommit": "[not provided]",
 "gitDescription": "[not provided]",
 "goVersion": "go1.24.3",
 "platform": "darwin/arm64",
 "syftSchemaVersion": "16.0.34",
 "version": "[not provided]"
}
```
`go run cmd/syft/main.go version`
```
Application:       syft
Version:           [not provided]
BuildDate:         [not provided]
GitCommit:         [not provided]
GitDescription:    [not provided]
Platform:          darwin/arm64
GoVersion:         go1.24.3
Compiler:          gc
SyftSchemaVersion: 16.0.34
```

## Type of change

<!-- Delete any that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)

# Checklist:
- [ ] I have tested my code in common scenarios and confirmed there are no regressions