### PR TITLE
fix: Remove three Rust crate false positive CPE matches

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -632,12 +632,32 @@ var defaultCandidateRemovals = buildCandidateRemovalLookup(
 		// Rust packages
 		{
 			pkg.RustPkg,
+			candidateKey{PkgName: "hyper"},
+			// Avoid matching CVE-2024-23741
+			candidateRemovals{VendorsToRemove: []string{"vercel"}},
+		},
+		{
+			pkg.RustPkg,
 			candidateKey{PkgName: "opentelemetry"},
+			// Avoid matching CVE-2023-45142
 			candidateRemovals{ProductsToRemove: []string{"opentelemetry"}},
 		},
 		{
 			pkg.RustPkg,
+			candidateKey{PkgName: "prometheus"},
+			// Avoid matching CVE-2019-3826
+			candidateRemovals{VendorsToRemove: []string{"prometheus"}},
+		},
+		{
+			pkg.RustPkg,
+			candidateKey{PkgName: "phf"},
+			// Avoid matching CVE-2000-1186
+			candidateRemovals{VendorsToRemove: []string{"phf"}},
+		},
+		{
+			pkg.RustPkg,
 			candidateKey{PkgName: "redis"},
+			// Avoid matching CVE-2022-24735
 			candidateRemovals{VendorsToRemove: []string{"redis"}},
 		},
 		// PHP packages


### PR DESCRIPTION
# Description

An extension of https://github.com/anchore/syft/pull/3962 , avoiding CPE matches of Rust crates with non-Rust CPEs in order to avoid matching of CVEs in the non-Rust software.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
