### PR TITLE
fix: exclude packages with SPDX generated_from source package indication

### DIFF
--- a/syft/format/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/format/common/spdxhelpers/to_syft_model_test.go
@@ -759,3 +759,37 @@ func Test_useSPDXIdentifierOverDerivedSyftArtifactID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, s.Artifacts.Packages.Package("1"))
 }
+
+func Test_skipsPackagesWithGeneratedFromRelationship(t *testing.T) {
+	doc := &spdx.Document{
+		SPDXVersion: "SPDX-2.3",
+		Packages: []*spdx.Package{
+			{
+				PackageName:           "package-1",
+				PackageSPDXIdentifier: "1",
+				PackageVersion:        "1.0.5",
+			},
+			{
+				PackageName:           "package-1-src",
+				PackageSPDXIdentifier: "1-src",
+				PackageVersion:        "1.0.5-src",
+			},
+		},
+		Relationships: []*spdx.Relationship{
+			{
+				Relationship: spdx.RelationshipGeneratedFrom,
+				RefA: common.DocElementID{ // package 1
+					ElementRefID: spdx.ElementID("1"),
+				},
+				RefB: common.DocElementID{ // generated from package 1-src
+					ElementRefID: spdx.ElementID("1-src"),
+				},
+			},
+		},
+	}
+	s, err := ToSyftModel(doc)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, s.Artifacts.Packages.Package("1"))
+	assert.Nil(t, s.Artifacts.Packages.Package("1-src"))
+}


### PR DESCRIPTION
# Description

This PR excludes packages with GENERATED_FROM relationships during SPDX imports.

Note: there is another PR: #3849, which I think we may want to move towards in the longer term. But in the shorter term, it will likely cause more problems with downstream tooling that we can avoid by simply filtering the packages in question.

- Fixes #3662 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
