### PR TITLE
chore: remove benchmark utils

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -87,19 +87,6 @@ tools:
     with:
       repo: wagoodman/go-bouncer
 
-  # used for showing benchmark testing
-  - name: benchstat
-    version:
-      want: latest
-      method: go-proxy
-      with:
-        module: golang.org/x/perf
-        allow-unresolved-version: true
-    method: go-install
-    with:
-      entrypoint: cmd/benchstat
-      module: golang.org/x/perf
-
   # used for running all local and CI tasks
   - name: task
     version:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -249,27 +249,6 @@ tasks:
       - cmd: .github/scripts/labeler_test.py
 
 
-  ## Benchmark test targets #################################
-
-  benchmark:
-    deps: [tmpdir]
-    generates:
-      - "{{ .TMP_DIR }}/benchmark-main.txt"
-    cmds:
-      - "go test -p 1 -run=^Benchmark -bench=. -count=7 -benchmem ./... | tee {{ .TMP_DIR }}/benchmark-{{ .VERSION }}.txt"
-      - |
-        bash -c "(test -s {{ .TMP_DIR }}/benchmark-main.txt && \
-        {{ .TOOL_DIR }}/benchstat {{ .TMP_DIR }}/benchmark-main.txt {{ .TMP_DIR }}/benchmark-{{ .VERSION }}.txt || \
-        {{ .TOOL_DIR }}/benchstat {{ .TMP_DIR }}/benchmark-{{ .VERSION }}.txt) \
-        | tee {{ .TMP_DIR }}/benchstat.txt"
-
-  show-benchstat:
-    deps: [benchmark, tmpdir]
-    cmds:
-      - cmd: "cat {{ .TMP_DIR }}/benchstat.txt"
-        silent: true
-
-
   ## Test-fixture-related targets #################################
 
   fingerprints:


### PR DESCRIPTION
Expanding on #3906, the benchstat tool is having some difficulty being installed with binny. We don't really need this tooling to be installed for all operations if benchmarking is a one-off development task now.