### PR TITLE
fix: exclude packages with SPDX described_by and related indications

### DIFF
--- a/syft/format/common/spdxhelpers/to_syft_model.go
+++ b/syft/format/common/spdxhelpers/to_syft_model.go
@@ -668,8 +668,13 @@ func packageIDsToSkip(doc *spdx.Document) *strset.Set {
 	skipIDs := strset.New()
 	for i := 0; i < len(doc.Relationships); i++ {
 		r := doc.Relationships[i]
-		if r != nil && r.Relationship == spdx.RelationshipGeneratedFrom {
-			skipIDs.Add(string(r.RefB.ElementRefID))
+		if r != nil {
+			switch r.Relationship {
+			case spdx.RelationshipGenerates, spdx.RelationshipDescribes:
+				skipIDs.Add(string(r.RefA.ElementRefID))
+			case spdx.RelationshipGeneratedFrom, spdx.RelationshipDescribedBy:
+				skipIDs.Add(string(r.RefB.ElementRefID))
+			}
 		}
 	}
 	return skipIDs

--- a/syft/format/common/spdxhelpers/to_syft_model_test.go
+++ b/syft/format/common/spdxhelpers/to_syft_model_test.go
@@ -770,8 +770,8 @@ func Test_skipsPackagesWithGeneratedFromRelationship(t *testing.T) {
 				PackageVersion:        "1.0.5",
 			},
 			{
-				PackageName:           "package-1-src",
-				PackageSPDXIdentifier: "1-src",
+				PackageName:           "package-2",
+				PackageSPDXIdentifier: "2",
 				PackageVersion:        "1.0.5-src",
 			},
 		},
@@ -781,15 +781,54 @@ func Test_skipsPackagesWithGeneratedFromRelationship(t *testing.T) {
 				RefA: common.DocElementID{ // package 1
 					ElementRefID: spdx.ElementID("1"),
 				},
-				RefB: common.DocElementID{ // generated from package 1-src
-					ElementRefID: spdx.ElementID("1-src"),
+				RefB: common.DocElementID{ // generated from package 2
+					ElementRefID: spdx.ElementID("2"),
 				},
 			},
 		},
 	}
-	s, err := ToSyftModel(doc)
 
-	assert.Nil(t, err)
-	assert.NotNil(t, s.Artifacts.Packages.Package("1"))
-	assert.Nil(t, s.Artifacts.Packages.Package("1-src"))
+	tests := []struct {
+		name             string
+		doc              *spdx.Document
+		relationshipType string
+		expected         []string
+	}{
+		{
+			relationshipType: spdx.RelationshipGeneratedFrom,
+			expected:         []string{"1"},
+		},
+		{
+			relationshipType: spdx.RelationshipDescribedBy,
+			expected:         []string{"1"},
+		},
+		{
+			relationshipType: spdx.RelationshipGenerates,
+			expected:         []string{"2"},
+		},
+		{
+			relationshipType: spdx.RelationshipDescribes,
+			expected:         []string{"2"},
+		},
+		{
+			relationshipType: spdx.RelationshipDependsOn, // no filtering
+			expected:         []string{"1", "2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			doc.Relationships[0].Relationship = test.relationshipType
+
+			s, err := ToSyftModel(doc)
+
+			assert.Nil(t, err)
+			for _, expected := range test.expected {
+				assert.NotNil(t, s.Artifacts.Packages.Package(artifact.ID(expected)))
+			}
+			for _, got := range s.Artifacts.Packages.Sorted() {
+				assert.Contains(t, test.expected, string(got.ID()))
+			}
+		})
+	}
 }


### PR DESCRIPTION
# Description

This PR adds more relationship-based package filtering, specifically for:
* DESCRIBES
* DESCRIBED_BY
* GENERATES

- Fixes #3983

NOTE: before merging this we should carefully review the SPDX relationship types and the expected behavior to adjust the set that affects import behavior, or decide that we should retain these packages and relationships in some other manner and make appropriate changes such as adding a top-level indicator that a package describes something _not installed_ in the scan target.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
