### PR TITLE
fix: provide separate nonroot image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,6 +126,59 @@ dockers:
       - "--build-arg=VCS_REF={{.FullCommit}}"
       - "--build-arg=VCS_URL={{.GitURL}}"
 
+  # nonroot images...
+  - image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
+    goarch: amd64
+    dockerfile: Dockerfile.nonroot
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
+    goarch: arm64
+    dockerfile: Dockerfile.nonroot
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
+    goarch: ppc64le
+    dockerfile: Dockerfile.nonroot
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/ppc64le"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
+  - image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-s390x
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
+    goarch: s390x
+    dockerfile: Dockerfile.nonroot
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/s390x"
+      - "--build-arg=BUILD_DATE={{.Date}}"
+      - "--build-arg=BUILD_VERSION={{.Version}}"
+      - "--build-arg=VCS_REF={{.FullCommit}}"
+      - "--build-arg=VCS_URL={{.GitURL}}"
+
   # debug images...
   - image_templates:
       - anchore/syft:{{.Tag}}-debug-amd64
@@ -180,13 +233,19 @@ dockers:
       - "--build-arg=VCS_URL={{.GitURL}}"
 
 docker_manifests:
-  # anchore/syft manifests...
   - name_template: anchore/syft:latest
     image_templates:
       - anchore/syft:{{.Tag}}-amd64
       - anchore/syft:{{.Tag}}-arm64v8
       - anchore/syft:{{.Tag}}-ppc64le
       - anchore/syft:{{.Tag}}-s390x
+
+  - name_template: ghcr.io/anchore/syft:latest
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-s390x
 
   - name_template: anchore/syft:{{.Tag}}
     image_templates:
@@ -195,28 +254,6 @@ docker_manifests:
       - anchore/syft:{{.Tag}}-ppc64le
       - anchore/syft:{{.Tag}}-s390x
 
-  - name_template: anchore/syft:debug
-    image_templates:
-      - anchore/syft:{{.Tag}}-debug-amd64
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: anchore/syft:{{.Tag}}-debug
-    image_templates:
-      - anchore/syft:{{.Tag}}-debug-amd64
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-s390x
-
-  # ghcr.io/anchore/syft manifests...
-  - name_template: ghcr.io/anchore/syft:latest
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-
   - name_template: ghcr.io/anchore/syft:{{.Tag}}
     image_templates:
       - ghcr.io/anchore/syft:{{.Tag}}-amd64
@@ -224,12 +261,56 @@ docker_manifests:
       - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
       - ghcr.io/anchore/syft:{{.Tag}}-s390x
 
+  # nonroot images...
+  - name_template: anchore/syft:nonroot
+    image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-amd64
+      - anchore/syft:{{.Tag}}-nonroot-arm64v8
+      - anchore/syft:{{.Tag}}-nonroot-ppc64le
+      - anchore/syft:{{.Tag}}-nonroot-s390x
+
+  - name_template: ghcr.io/anchore/syft:nonroot
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
+
+  - name_template: anchore/syft:{{.Tag}}-nonroot
+    image_templates:
+      - anchore/syft:{{.Tag}}-nonroot-amd64
+      - anchore/syft:{{.Tag}}-nonroot-arm64v8
+      - anchore/syft:{{.Tag}}-nonroot-ppc64le
+      - anchore/syft:{{.Tag}}-nonroot-s390x
+
+  - name_template: ghcr.io/anchore/syft:{{.Tag}}-nonroot
+    image_templates:
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
+      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
+
+  # debug images...
+  - name_template: anchore/syft:debug
+    image_templates:
+      - anchore/syft:{{.Tag}}-debug-amd64
+      - anchore/syft:{{.Tag}}-debug-arm64v8
+      - anchore/syft:{{.Tag}}-debug-ppc64le
+      - anchore/syft:{{.Tag}}-debug-s390x
+
   - name_template: ghcr.io/anchore/syft:debug
     image_templates:
       - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
       - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
       - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
       - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
+
+  - name_template: anchore/syft:{{.Tag}}-debug
+    image_templates:
+      - anchore/syft:{{.Tag}}-debug-amd64
+      - anchore/syft:{{.Tag}}-debug-arm64v8
+      - anchore/syft:{{.Tag}}-debug-ppc64le
+      - anchore/syft:{{.Tag}}-debug-s390x
 
   - name_template: ghcr.io/anchore/syft:{{.Tag}}-debug
     image_templates:

--- a/Dockerfile.nonroot
+++ b/Dockerfile.nonroot
@@ -1,13 +1,11 @@
-FROM gcr.io/distroless/static-debian12:latest AS build
-
-FROM scratch
-# needed for version check HTTPS request
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static-debian12:nonroot
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
 COPY syft /
+
+USER nonroot
 
 ARG BUILD_DATE
 ARG BUILD_VERSION


### PR DESCRIPTION
# Description

This PR reverts a change to use `nonroot` images by default, and provides an alternate `nonroot` set of tagged images. Using `nonroot` causes a number of issues causing users friction such as accessing and modifying the `docker.sock` and mount volumes.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
