### PR TITLE
Add support for authors in package.json. Fixes #2250

### DIFF
--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -25,22 +25,38 @@ func newPackageJSONPackage(ctx context.Context, u packageJSON, indexLocation fil
 	}
 
 	license := pkg.NewLicensesFromLocationWithContext(ctx, indexLocation, licenseCandidates...)
-	// Handle both author and authors fields
-	var authorInfo string
-	if u.Author.Name != "" || u.Author.Email != "" || u.Author.URL != "" {
-		// Single author field exists, use it
-		authorInfo = u.Author.AuthorString()
-	}
+	// Handle author, authors, contributors, and maintainers fields
+	var authorParts []string
 
-	// If authors field exists, append it
-	if len(u.Authors) > 0 {
-		authorsStr := u.Authors.AuthorsString()
-		if authorInfo != "" {
-			authorInfo = authorInfo + ", " + authorsStr
-		} else {
-			authorInfo = authorsStr
+	// Add a single author field if it exists
+	if u.Author.Name != "" || u.Author.Email != "" || u.Author.URL != "" {
+		if authStr := u.Author.AuthorString(); authStr != "" {
+			authorParts = append(authorParts, authStr)
 		}
 	}
+
+	// Add authors field if it exists
+	if len(u.Authors) > 0 {
+		if authorsStr := u.Authors.String(); authorsStr != "" {
+			authorParts = append(authorParts, authorsStr)
+		}
+	}
+
+	// Add contributors field if it exists
+	if len(u.Contributors) > 0 {
+		if contributorsStr := u.Contributors.String(); contributorsStr != "" {
+			authorParts = append(authorParts, contributorsStr)
+		}
+	}
+
+	// Add maintainers field if it exists
+	if len(u.Maintainers) > 0 {
+		if maintainersStr := u.Maintainers.String(); maintainersStr != "" {
+			authorParts = append(authorParts, maintainersStr)
+		}
+	}
+
+	authorInfo := strings.Join(authorParts, ", ")
 
 	p := pkg.Package{
 		Name:      u.Name,

--- a/syft/pkg/cataloger/javascript/package.go
+++ b/syft/pkg/cataloger/javascript/package.go
@@ -25,6 +25,23 @@ func newPackageJSONPackage(ctx context.Context, u packageJSON, indexLocation fil
 	}
 
 	license := pkg.NewLicensesFromLocationWithContext(ctx, indexLocation, licenseCandidates...)
+	// Handle both author and authors fields
+	var authorInfo string
+	if u.Author.Name != "" || u.Author.Email != "" || u.Author.URL != "" {
+		// Single author field exists, use it
+		authorInfo = u.Author.AuthorString()
+	}
+
+	// If authors field exists, append it
+	if len(u.Authors) > 0 {
+		authorsStr := u.Authors.AuthorsString()
+		if authorInfo != "" {
+			authorInfo = authorInfo + ", " + authorsStr
+		} else {
+			authorInfo = authorsStr
+		}
+	}
+
 	p := pkg.Package{
 		Name:      u.Name,
 		Version:   u.Version,
@@ -37,7 +54,7 @@ func newPackageJSONPackage(ctx context.Context, u packageJSON, indexLocation fil
 			Name:        u.Name,
 			Version:     u.Version,
 			Description: u.Description,
-			Author:      u.Author.AuthorString(),
+			Author:      authorInfo,
 			Homepage:    u.Homepage,
 			URL:         u.Repository.URL,
 			Private:     u.Private,

--- a/syft/pkg/cataloger/javascript/parse_package_json.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json.go
@@ -52,7 +52,7 @@ type repository struct {
 
 // match example: "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)"
 // ---> name: "Isaac Z. Schlueter" email: "i@izs.me" url: "http://blog.izs.me"
-var authorPattern = regexp.MustCompile(`^\s*(?P<n>[^<(]*)(\s+<(?P<email>.*)>)?(\s\((?P<url>.*)\))?\s*$`)
+var authorPattern = regexp.MustCompile(`^\s*(?P<name>[^<(]*)(\s+<(?P<email>.*)>)?(\s\((?P<url>.*)\))?\s*$`)
 
 // parsePackageJSON parses a package.json and returns the discovered JavaScript packages.
 func parsePackageJSON(ctx context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
@@ -90,8 +90,6 @@ func (a *author) UnmarshalJSON(b []byte) error {
 		if err := mapstructure.Decode(fields, &auth); err != nil {
 			return fmt.Errorf("unable to decode package.json author: %w", err)
 		}
-		// Make sure name is properly set (the "n" in the regex captures the name)
-		auth.Name = strings.TrimSpace(fields["n"])
 	} else {
 		// it's a map that may contain fields of various data types (not just strings)
 		var fields map[string]interface{}
@@ -230,8 +228,7 @@ func (a *authors) UnmarshalJSON(b []byte) error {
 			if err := mapstructure.Decode(fields, &auth); err != nil {
 				return fmt.Errorf("unable to decode package.json author: %w", err)
 			}
-			// The "n" in the regex captures the name
-			auth.Name = strings.TrimSpace(fields["n"])
+			auth.Name = strings.TrimSpace(fields["name"])
 			auths[i] = auth
 		}
 		*a = auths

--- a/syft/pkg/cataloger/javascript/parse_package_json_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json_test.go
@@ -152,7 +152,7 @@ func TestParsePackageJSON(t *testing.T) {
 				Metadata: pkg.NpmPackage{
 					Name:        "function-bind",
 					Version:     "1.1.1",
-					Author:      "Raynos <raynos2@gmail.com>",
+					Author:      "Raynos <raynos2@gmail.com>, Raynos, Jordan Harband (https://github.com/ljharb)",
 					Homepage:    "https://github.com/Raynos/function-bind",
 					URL:         "git://github.com/Raynos/function-bind.git",
 					Description: "Implementation of Function.prototype.bind",
@@ -259,6 +259,69 @@ func TestParsePackageJSON(t *testing.T) {
 					Name:        "npm",
 					Version:     "6.14.6",
 					Author:      "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me), Harry Potter <hp@hogwards.com> (http://youknowwho.com/), John Smith <j.smith@something.com> (http://awebsite.com/)",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-contributors.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-contributors.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Alice Contributor <alice@example.com>, Bob Helper <bob@example.com>",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-maintainers.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-maintainers.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Charlie Maintainer <charlie@example.com>, Diana Keeper <diana@example.com>",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-all-author-fields.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-all-author-fields.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Main Author <main@example.com>, Second Author <second@example.com>, Contrib One <contrib1@example.com>, Maintainer One <maintain1@example.com>",
 					Homepage:    "https://docs.npmjs.com/",
 					URL:         "https://github.com/npm/cli",
 					Description: "a package manager for JavaScript",

--- a/syft/pkg/cataloger/javascript/parse_package_json_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json_test.go
@@ -202,6 +202,69 @@ func TestParsePackageJSON(t *testing.T) {
 				},
 			},
 		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-authors-array.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-authors-array.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Harry Potter <hp@hogwards.com> (http://youknowwho.com/), John Smith <j.smith@something.com> (http://awebsite.com/)",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-authors-objects.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-authors-objects.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Harry Potter <hp@hogwards.com> (http://youknowwho.com/), John Smith <j.smith@something.com> (http://awebsite.com/)",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
+		{
+			Fixture: "test-fixtures/pkg-json/package-both-author-and-authors.json",
+			ExpectedPkg: pkg.Package{
+				Name:    "npm",
+				Version: "6.14.6",
+				PURL:    "pkg:npm/npm@6.14.6",
+				Type:    pkg.NpmPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromLocationsWithContext(ctx, "Artistic-2.0", file.NewLocation("test-fixtures/pkg-json/package-both-author-and-authors.json")),
+				),
+				Language: pkg.JavaScript,
+				Metadata: pkg.NpmPackage{
+					Name:        "npm",
+					Version:     "6.14.6",
+					Author:      "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me), Harry Potter <hp@hogwards.com> (http://youknowwho.com/), John Smith <j.smith@something.com> (http://awebsite.com/)",
+					Homepage:    "https://docs.npmjs.com/",
+					URL:         "https://github.com/npm/cli",
+					Description: "a package manager for JavaScript",
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-all-author-fields.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-all-author-fields.json
@@ -1,0 +1,24 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": "Main Author <main@example.com>",
+  "authors": [
+    "Second Author <second@example.com>"
+  ],
+  "contributors": [
+    "Contrib One <contrib1@example.com>"
+  ],
+  "maintainers": [
+    {
+      "name": "Maintainer One",
+      "email": "maintain1@example.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-authors-array.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-authors-array.json
@@ -1,0 +1,15 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "authors": [
+    "Harry Potter <hp@hogwards.com> (http://youknowwho.com/)",
+    "John Smith <j.smith@something.com> (http://awebsite.com/)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-authors-objects.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-authors-objects.json
@@ -1,0 +1,23 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "authors": [
+    {
+      "name": "Harry Potter",
+      "email": "hp@hogwards.com",
+      "url": "http://youknowwho.com/"
+    },
+    {
+      "name": "John Smith",
+      "email": "j.smith@something.com",
+      "url": "http://awebsite.com/"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-both-author-and-authors.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-both-author-and-authors.json
@@ -1,0 +1,16 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
+  "authors": [
+    "Harry Potter <hp@hogwards.com> (http://youknowwho.com/)",
+    "John Smith <j.smith@something.com> (http://awebsite.com/)"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-contributors.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-contributors.json
@@ -1,0 +1,15 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "contributors": [
+    "Alice Contributor <alice@example.com>",
+    "Bob Helper <bob@example.com>"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}

--- a/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-maintainers.json
+++ b/syft/pkg/cataloger/javascript/test-fixtures/pkg-json/package-maintainers.json
@@ -1,0 +1,21 @@
+{
+  "version": "6.14.6",
+  "name": "npm",
+  "description": "a package manager for JavaScript",
+  "homepage": "https://docs.npmjs.com/",
+  "maintainers": [
+    {
+      "name": "Charlie Maintainer",
+      "email": "charlie@example.com"
+    },
+    {
+      "name": "Diana Keeper",
+      "email": "diana@example.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli"
+  },
+  "license": "Artistic-2.0"
+}


### PR DESCRIPTION
# Description

This PR adds support for parsing the `authors` field in `package.json` files. Previously, Syft only recognized the singular `author` field, but the npm ecosystem supports both formats. This change ensures that Syft properly parses both formats and combines them when both are present in a `package.json` file.

The implementation:
1. Adds a new `authors []author` type to handle the plural form
2. Implements `UnmarshalJSON` to handle parsing different formats (array of strings or objects)
3. Adds `AuthorsString()` to convert authors array to a properly formatted string
4. Updates `newPackageJSONPackage` to handle both fields appropriately

This change improves the accuracy of npm package metadata parsing in Syft.

<!-- If this completes an issue, please include: -->

- Fixes #2250

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
