### PR TITLE
Pkg Metadata type unmarshal bug

### DIFF
--- a/syft/format/syftjson/model/package.go
+++ b/syft/format/syftjson/model/package.go
@@ -204,5 +204,6 @@ func unpackPkgMetadata(p *Package, unpacker packageMetadataUnpacker) error {
 		}
 	}
 	p.Metadata = reflect.ValueOf(val).Elem().Interface()
+	p.MetadataType = ty
 	return nil
 }


### PR DESCRIPTION
A minor issue with (de)serializing the model.Document object from JSON output:

Use case:
When running Syft with JSON output, the model.Document marshaling function silently omits the MetadataType field.