### PR TITLE
chore: update release workflow to persist credentials for tag step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap


### PR DESCRIPTION
# Description

With https://github.com/anchore/syft/pull/4062 we updated our security around github actions using the zizmor linter to call out common pitfalls and misaligned files.

This PR reverts a small change in #4062 by setting `persist-credentials: true` for the release step of syft.

Here we are still following the outlined practice in the linter documentation:
https://docs.zizmor.sh/audits/#artipacked
> Unless needed for git operations, [actions/checkout](https://github.com/actions/checkout) should be used with persist-credentials: false. If the persisted credential is needed, it should be made explicit with persist-credentials: true.

We are being explicit with this change that we need `persist-crendentials: true` in this case