### PR TITLE
chore: add source completion tester

### DIFF
--- a/syft/internal/packagemetadata/completion_tester.go
+++ b/syft/internal/packagemetadata/completion_tester.go
@@ -12,6 +12,7 @@ type CompletionTester struct {
 }
 
 func NewCompletionTester(t testing.TB, ignore ...any) *CompletionTester {
+	t.Helper()
 	tester := &CompletionTester{
 		valid:  AllTypes(),
 		ignore: ignore,

--- a/syft/internal/sourcemetadata/completion_tester.go
+++ b/syft/internal/sourcemetadata/completion_tester.go
@@ -12,6 +12,7 @@ type CompletionTester struct {
 }
 
 func NewCompletionTester(t testing.TB, ignore ...any) *CompletionTester {
+	t.Helper()
 	tester := &CompletionTester{
 		valid:  AllTypes(),
 		ignore: ignore,

--- a/syft/testutil/completion_testing.go
+++ b/syft/testutil/completion_testing.go
@@ -16,12 +16,14 @@ type SourceMetadataCompletionTester struct {
 }
 
 func NewPackageMetadataCompletionTester(t testing.TB, ignore ...any) *PackageMetadataCompletionTester {
+	t.Helper()
 	return &PackageMetadataCompletionTester{
 		CompletionTester: packagemetadata.NewCompletionTester(t, ignore...),
 	}
 }
 
 func NewSourceMetadataCompletionTester(t testing.TB, ignore ...any) *SourceMetadataCompletionTester {
+	t.Helper()
 	return &SourceMetadataCompletionTester{
 		CompletionTester: sourcemetadata.NewCompletionTester(t, ignore...),
 	}


### PR DESCRIPTION
Adds a source metadata completion tester for use in grype the same way we have a package metadata completion tester (to verify that all metadata types are exercised).

Additionally tweaks the output to be more helpful when tracing issues (for both the package and source metadata helpers)...

before:
```
--- PASS: TestNewSource/nil_metadata (0.00s)
    completion_tester.go:82: metadata type SnapMetadata is not covered by a test
--- FAIL: TestNewSource (0.00s)
```

after:
```
--- PASS: TestNewSource/nil_metadata (0.00s)
    source_test.go:22: metadata type SnapMetadata is not covered by a test
--- FAIL: TestNewSource (0.00s)
```

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
