### PR TITLE
fix: fix go purl with subpath to syft package name error

### DIFF
--- a/syft/format/internal/backfill.go
+++ b/syft/format/internal/backfill.go
@@ -97,10 +97,14 @@ var epochPrefix = regexp.MustCompile(`^\d+:`)
 // nameFromPurl returns the syft package name of the package from the purl. If the purl includes a namespace,
 // the name is prefixed as appropriate based on the PURL type
 func nameFromPurl(purl packageurl.PackageURL) string {
+	result := purl.Name
 	if !nameExcludesPurlNamespace(purl.Type) && purl.Namespace != "" {
-		return fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+		result = fmt.Sprintf("%s/%s", purl.Namespace, result)
 	}
-	return purl.Name
+	if purl.Subpath != "" {
+		result = fmt.Sprintf("%s/%s", result, purl.Subpath)
+	}
+	return result
 }
 
 func nameExcludesPurlNamespace(purlType string) bool {

--- a/syft/format/internal/backfill_test.go
+++ b/syft/format/internal/backfill_test.go
@@ -106,6 +106,19 @@ func Test_Backfill(t *testing.T) {
 				Metadata: pkg.JavaArchive{},
 			},
 		},
+		{
+			name: "golang with subpath",
+			in: pkg.Package{
+				PURL: "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes",
+			},
+			expected: pkg.Package{
+				PURL:     "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes",
+				Type:     pkg.GoModulePkg,
+				Language: pkg.Go,
+				Name:     "github.com/hashicorp/vault/api/auth/kubernetes",
+				Version:  "v0.9.0",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -160,6 +173,10 @@ func Test_nameFromPurl(t *testing.T) {
 		{
 			in:       "pkg:oci/library/mysql@8.1.0",
 			expected: "library/mysql",
+		},
+		{
+			in:       "pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes",
+			expected: "github.com/hashicorp/vault/api/auth/kubernetes",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description

Fix https://github.com/anchore/grype/issues/2838

https://pkg.go.dev/github.com/hashicorp/vault/api/auth/kubernetes@v0.9.0 is a package without vulnerability.

It is different from https://pkg.go.dev/github.com/hashicorp/vault@v0.9.0 which is vulnerable.

syft produce purl like `pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes`, which I believe is correct.

However when running

```bash
grype 'pkg:golang/github.com/hashicorp/vault@v0.9.0#api/auth/kubernetes'
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 7 high, 10 medium, 1 low, 0 negligible
   └── by status:   18 fixed, 0 not-fixed, 0 ignored
NAME                        INSTALLED  FIXED IN  TYPE       VULNERABILITY        SEVERITY  EPSS           RISK
github.com/hashicorp/vault  v0.9.0     1.2.5     go-module  GHSA-fp52-qw33-mfmw  High      1.0% (76th)    0.8
github.com/hashicorp/vault  v0.9.0     1.2.5     go-module  GHSA-4mp7-2m29-gqxf  High      0.9% (74th)    0.7
github.com/hashicorp/vault  v0.9.0     1.6.6     go-module  GHSA-6239-28c2-9mrm  Medium    0.6% (68th)    0.3
github.com/hashicorp/vault  v0.9.0     1.13.5    go-module  GHSA-9v3w-w2jh-4hff  Medium    0.6% (67th)    0.3
github.com/hashicorp/vault  v0.9.0     1.11.11   go-module  GHSA-gq98-53rq-qr5h  Medium    0.5% (64th)    0.2
github.com/hashicorp/vault  v0.9.0     1.13.10   go-module  GHSA-4qhc-v8r6-8vwm  High      0.3% (51st)    0.2
github.com/hashicorp/vault  v0.9.0     1.18.0    go-module  GHSA-rr8j-7w34-xp5j  High      0.2% (37th)    0.1
github.com/hashicorp/vault  v0.9.0     1.3.4     go-module  GHSA-m979-w9wj-qfj9  Medium    0.2% (44th)    0.1
github.com/hashicorp/vault  v0.9.0     1.13.0    go-module  GHSA-86c6-3g63-5w64  High      0.1% (34th)    0.1
github.com/hashicorp/vault  v0.9.0     1.10.11   go-module  GHSA-wmg5-g953-qqfw  High      0.1% (29th)    < 0.1
github.com/hashicorp/vault  v0.9.0     1.11.9    go-module  GHSA-v3hp-mcj5-pg39  Medium    < 0.1% (26th)  < 0.1
github.com/hashicorp/vault  v0.9.0     1.9.10    go-module  GHSA-9mh8-9j64-443f  Medium    < 0.1% (27th)  < 0.1
github.com/hashicorp/vault  v0.9.0     1.7.5     go-module  GHSA-qv95-g3gm-x542  Low       0.1% (36th)    < 0.1
github.com/hashicorp/vault  v0.9.0     1.11.9    go-module  GHSA-hwc3-3qh6-r4gg  Medium    < 0.1% (18th)  < 0.1
github.com/hashicorp/vault  v0.9.0     1.11.9    go-module  GHSA-vq4h-9ghm-qmrr  Medium    < 0.1% (7th)   < 0.1
github.com/hashicorp/vault  v0.9.0     1.16.0    go-module  GHSA-j2rp-gmqv-frhv  Medium    < 0.1% (5th)   < 0.1
github.com/hashicorp/vault  v0.9.0     1.14.10   go-module  GHSA-r3w7-mfpm-c2vw  High      < 0.1% (2nd)   < 0.1
github.com/hashicorp/vault  v0.9.0     1.19.3    go-module  GHSA-gcqf-f89c-68hv  Medium    < 0.1% (1st)   < 0.1`
```

It does not handle the subpath, interpreted it as name `github.com/hashicorp/vault` and version `v0.9.0`, therefore report vulnerabilities such as CVE-2020-16250.

<!-- If this completes an issue, please include: -->

- Fixes https://github.com/anchore/grype/issues/2838

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
