### PR TITLE
fix: nondeterministic Java archive cataloging and improve groupID

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1382,6 +1382,10 @@ func Test_deterministicMatchingPomProperties(t *testing.T) {
 			fixture:  "multiple-matching-2.11.5",
 			expected: maven.NewID("org.multiple", "multiple-matching-1", "2.11.5"),
 		},
+		{
+			fixture:  "org.multiple-thename",
+			expected: maven.NewID("org.multiple", "thename", "10.11.12"),
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1086,7 +1086,7 @@ func Test_artifactIDMatchesFilename(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, artifactIDMatchesFilename(tt.artifactID, tt.fileName, nil))
+			assert.Equal(t, tt.want, artifactIDMatchesFilename(tt.artifactID, tt.fileName, strset.New()))
 		})
 	}
 }

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
@@ -12,6 +12,7 @@ OPENSAML_CORE = opensaml-core-3.4.6
 API_ALL_SOURCES = api-all-2.0.0-sources
 SPRING_INSTRUMENTATION = spring-instrumentation-4.3.0-1.0
 MULTIPLE_MATCHING = multiple-matching-2.11.5
+ORG_MULTIPLE_THENAME = org.multiple-thename
 
 
 .DEFAULT_GOAL := fixtures
@@ -48,7 +49,11 @@ $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar:
 	mkdir -p $(CACHE_DIR)
 	cd $(MULTIPLE_MATCHING) && zip -r $(CACHE_PATH)/$(MULTIPLE_MATCHING).jar .
 
-# Jenkins plugins typically do not have the version included in the archive name, 
+$(CACHE_DIR)/$(ORG_MULTIPLE_THENAME).jar:
+	mkdir -p $(CACHE_DIR)
+	cd $(ORG_MULTIPLE_THENAME) && zip -r $(CACHE_PATH)/$(ORG_MULTIPLE_THENAME).jar .
+
+# Jenkins plugins typically do not have the version included in the archive name,
 # so it is important to not include it in the generated test fixture
 $(CACHE_DIR)/gradle.hpi:
 	mkdir -p $(CACHE_DIR)

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/MANIFEST.MF
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Created-By: Multi

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/com.multiple/thename/pom.properties
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/com.multiple/thename/pom.properties
@@ -1,0 +1,3 @@
+version=10.11.12
+groupId=com.multiple
+artifactId=thename

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/com.multiple/thename/pom.xml
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/com.multiple/thename/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.multiple</groupId>
+    <artifactId>thename</artifactId>
+    <version>10.11.12</version>
+</project>

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/org.multiple/thename/pom.properties
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/org.multiple/thename/pom.properties
@@ -1,0 +1,3 @@
+version=10.11.12
+groupId=org.multiple
+artifactId=thename

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/org.multiple/thename/pom.xml
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/org.multiple-thename/META-INF/maven/org.multiple/thename/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.multiple</groupId>
+    <artifactId>thename</artifactId>
+    <version>10.11.12</version>
+</project>


### PR DESCRIPTION
# Description

This PR fixes an issue where the Java archive cataloger could select the groupID in a nondeterministic fashion, resulting in different SBOMs on the same source material. Additionally, the logic to select the groupID and artifactID combination for Maven artifacts did not take into account the potential inclusion of groupID in the filename. As noted in the comment, this PR adjusts the behavior to be what I think is more correct when determining which pom the artifact represents: it will now favor POMs where both groupID and artifactID match, followed by exact match of the filename, and so on.

- Fixes #3521

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
