### PR TITLE
add binary classifier for hashicorp vault

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1010,7 +1010,7 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 		{
 			logicalFixture: "vault/1.20.2/linux-amd64",
 			expected: pkg.Package{
-				Name:      "vault",
+				Name:      "github.com/hashicorp/vault",
 				Version:   "1.20.2",
 				Type:      "golang",
 				PURL:      "pkg:golang/github.com/hashicorp/vault@1.20.2",
@@ -1021,7 +1021,7 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 		{
 			logicalFixture: "vault/1.19.4/linux-arm64",
 			expected: pkg.Package{
-				Name:      "vault",
+				Name:      "github.com/hashicorp/vault",
 				Version:   "1.19.4",
 				Type:      "golang",
 				PURL:      "pkg:golang/github.com/hashicorp/vault@1.19.4",

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1008,6 +1008,28 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "vault/1.20.2/linux-amd64",
+			expected: pkg.Package{
+				Name:      "vault",
+				Version:   "1.20.2",
+				Type:      "golang",
+				PURL:      "pkg:golang/github.com/hashicorp/vault@1.20.2",
+				Locations: locations("vault"),
+				Metadata:  metadata("hashicorp-vault-binary"),
+			},
+		},
+		{
+			logicalFixture: "vault/1.19.4/linux-arm64",
+			expected: pkg.Package{
+				Name:      "vault",
+				Version:   "1.19.4",
+				Type:      "golang",
+				PURL:      "pkg:golang/github.com/hashicorp/vault@1.19.4",
+				Locations: locations("vault"),
+				Metadata:  metadata("hashicorp-vault-binary"),
+			},
+		},
+		{
 			logicalFixture: "erlang/25.3.2.6/linux-amd64",
 			expected: pkg.Package{
 				Name:      "erlang",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -617,6 +617,16 @@ func DefaultClassifiers() []binutils.Classifier {
 			PURL:    mustPURL("pkg:generic/chrome@version"),
 			CPEs:    singleCPE("cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"),
 		},
+		{
+			Class:    "hashicorp-vault-binary",
+			FileGlob: "**/vault",
+			EvidenceMatcher: m.FileContentsVersionMatcher(
+				// revoke1.18.0
+				`(?m)revoke(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			Package: "hashicorp-vault",
+			PURL:    mustPURL("pkg:generic/hashicorp-vault@version"),
+			CPEs:    singleCPE("cpe:2.3:a:hashicorp:vault:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
 	}
 
 	return append(classifiers, defaultJavaClassifiers()...)

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -449,6 +449,16 @@ func DefaultClassifiers() []binutils.Classifier {
 			CPEs:    singleCPE("cpe:2.3:a:hashicorp:consul:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
 		{
+			Class:    "hashicorp-vault-binary",
+			FileGlob: "**/vault",
+			EvidenceMatcher: m.FileContentsVersionMatcher(
+				// revoke1.18.0
+				`(?m)revoke(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			Package: "github.com/hashicorp/vault",
+			PURL:    mustPURL("pkg:golang/github.com/hashicorp/vault@version"),
+			CPEs:    singleCPE("cpe:2.3:a:hashicorp:vault:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
+		{
 			Class:    "nginx-binary",
 			FileGlob: "**/nginx",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
@@ -616,16 +626,6 @@ func DefaultClassifiers() []binutils.Classifier {
 			Package: "chrome",
 			PURL:    mustPURL("pkg:generic/chrome@version"),
 			CPEs:    singleCPE("cpe:2.3:a:google:chrome:*:*:*:*:*:*:*:*"),
-		},
-		{
-			Class:    "hashicorp-vault-binary",
-			FileGlob: "**/vault",
-			EvidenceMatcher: m.FileContentsVersionMatcher(
-				// revoke1.18.0
-				`(?m)revoke(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
-			Package: "vault",
-			PURL:    mustPURL("pkg:golang/github.com/hashicorp/vault@version"),
-			CPEs:    singleCPE("cpe:2.3:a:hashicorp:vault:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
 	}
 

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -623,8 +623,8 @@ func DefaultClassifiers() []binutils.Classifier {
 			EvidenceMatcher: m.FileContentsVersionMatcher(
 				// revoke1.18.0
 				`(?m)revoke(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
-			Package: "hashicorp-vault",
-			PURL:    mustPURL("pkg:generic/hashicorp-vault@version"),
+			Package: "vault",
+			PURL:    mustPURL("pkg:golang/github.com/hashicorp/vault@version"),
 			CPEs:    singleCPE("cpe:2.3:a:hashicorp:vault:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
 	}

--- a/syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/vault/1.19.4/linux-arm64/vault
+++ b/syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/vault/1.19.4/linux-arm64/vault
@@ -1,0 +1,11 @@
+name: vault
+offset: 191891817
+length: 420
+snippetSha256: fd8eb7979e1e7bbc254f2f7a26f6a70ecb479cc4f50c804f3b0789bc0e229097
+fileSha256: a4754a343e619adef87a1d7e1368a0709ba29802fefbe8d70105c11085becd43
+
+### byte snippet to follow ###
+ctstreamPragma</a>.
+:httpssocks Locked%s.logCT_LOGLOCAL0@level[INFO][WARN]env:///v1/%sDELETEcreateErrorserrorsclient/data/lookupactualAcceptregionawskmsocikmspkcs11%s%s%scloud:%s.%s:revoke1.19.4)(nil))(%#v) {...}frenchCommonArabicBrahmiCarianChakmaCopticGothicHangulHatranHebrewKaithiKhojkiLepchaLycianLydianRejangSyriacTai_LeTangsaTangutTeluguThaanaWanchoYezidiHyphen\u%04x\U%08xgetentpasswd390625%s
+%s
+%q: %wnumber\uff

--- a/syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/vault/1.20.2/linux-amd64/vault
+++ b/syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/vault/1.20.2/linux-amd64/vault
@@ -1,0 +1,9 @@
+name: vault
+offset: 213670425
+length: 220
+snippetSha256: d9b23916d00e8085a4066974641ef77962f2e0aae6f4244688d2c4fe4286c92b
+fileSha256: fb484f1b458e5d2fd28270b406a8b26b28d040dddcaa1d099aa9ee4ac927b730
+
+### byte snippet to follow ###
+ctstreamPragma</a>.
+:httpssocks Locked%s.logCT_LOGLOCAL0@level[INFO][WARN]env:///v1/%sDELETEcreateErrorserrorsclient/data/lookupactualAcceptregionawskmsocikmspkcs11%s%s%scloud:%s.%s:revoke1.20.2)(nil))(%#v) {...}frenchCo

--- a/syft/pkg/cataloger/binary/test-fixtures/config.yaml
+++ b/syft/pkg/cataloger/binary/test-fixtures/config.yaml
@@ -724,6 +724,20 @@ from-images:
     paths:
       - /bin/consul
 
+  - version: 1.20.2
+    images:
+      - ref: hashicorp/vault@sha256:5cd2003247e0a574a66c66aee1916b1e9e7f99640298f2e61271a8842d2d2a19
+        platform: linux/amd64
+    paths:
+      - /bin/vault
+
+  - version: 1.19.4
+    images:
+      - ref: hashicorp/vault@sha256:b5f675b0bf681568cd7354c697fe4ce953024312d6d23ee7216deda60c192bad
+        platform: linux/arm64
+    paths:
+      - /bin/vault
+
   - version: 3.0.2
     images:
       - ref: fluent/fluent-bit:3.0.2-amd64@sha256:7e6fe8efd51dda0739e355f58bf5e3b1623cbf2d4a23c06c7a365d9553e2d242


### PR DESCRIPTION
The Go Binary Cataloger isn't able to parse the version out of the binary shipped in the DockerHub images of hashicorp/vault because the version of the main module isn't set in the binary. Therefore, add a binary classifier cataloger for this binary.


