### PR TITLE
chore: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,12 +48,13 @@ builds:
 
 archives:
   - id: linux-archives
-    builds: [linux-build]
+    ids: [linux-build]
   - id: darwin-archives
-    builds: [darwin-build]
+    ids: [darwin-build]
   - id: windows-archives
-    format: zip
-    builds: [windows-build]
+    formats:
+      - zip
+    ids: [windows-build]
 
 nfpms:
   - license: "Apache 2.0"


### PR DESCRIPTION
# Description
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/anchore/syft/actions/runs/16837593361/job/47700795304#step:7:184): 
```
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
