### PR TITLE
feat: update cyclonedx encoder to use url as Name field for empty case

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/licenses.go
+++ b/syft/format/internal/cyclonedxutil/helpers/licenses.go
@@ -163,10 +163,16 @@ func processCustomLicense(l pkg.License) cyclonedx.Licenses {
 func processLicenseURLs(l pkg.License, spdxID string, populate *cyclonedx.Licenses) {
 	for _, url := range l.URLs {
 		if spdxID == "" {
+			// CycloneDX requires either an id or name to be present for a license
+			// If l.Value is empty, use the URL as the name to ensure schema compliance
+			name := l.Value
+			if name == "" {
+				name = url
+			}
 			*populate = append(*populate, cyclonedx.LicenseChoice{
 				License: &cyclonedx.License{
 					URL:  url,
-					Name: l.Value,
+					Name: name,
 				},
 			})
 		} else {

--- a/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
@@ -122,6 +122,22 @@ func Test_encodeLicense(t *testing.T) {
 			},
 		},
 		{
+			name: "with URL only and no name or SPDX ID",
+			input: pkg.Package{
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromURLsWithContext(ctx, "", "http://jaxen.codehaus.org/license.html"),
+				),
+			},
+			expected: &cyclonedx.Licenses{
+				{
+					License: &cyclonedx.License{
+						Name: "http://jaxen.codehaus.org/license.html",
+						URL:  "http://jaxen.codehaus.org/license.html",
+					},
+				},
+			},
+		},
+		{
 			name: "with multiple values licenses are deduplicated",
 			input: pkg.Package{
 				Licenses: pkg.NewLicenseSet(


### PR DESCRIPTION
# Description
This updates the cyclonedx encoder so that if we encode a license that ONLY has a URL we also include it as the name to maintain a valid cyclonedx format.

- Fixes #1964

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
