### PR TITLE
fix: detect unknown JAR version from path

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -92,6 +92,17 @@ func newJavaArchiveFilename(raw string) archiveFilename {
 		version = getSubexp(matches, "version", secondaryVersionPattern, raw)
 		if version != "" {
 			name = name[0 : len(name)-len(version)-1]
+		} else {
+			// some jars have the version only in the path, e.g.:
+			// .../jruby/3.1.0/gems/nokogiri-1.16.4-java/lib/nokogiri/nokogiri.jar
+			// or .../repository/com/nokogiri/1.16.4/nokogiri.jar
+			versionExpression, err := regexp.Compile(name + `.(\d+(?:[-.][-a-zA-Z]*\d+)+(?:-SNAPSHOT)?)`)
+			if err == nil {
+				versionMatches := versionExpression.FindStringSubmatch(raw)
+				if len(versionMatches) > 1 {
+					version = versionMatches[1]
+				}
+			}
 		}
 	}
 

--- a/syft/pkg/cataloger/java/archive_filename_test.go
+++ b/syft/pkg/cataloger/java/archive_filename_test.go
@@ -187,6 +187,34 @@ func TestExtractInfoFromJavaArchiveFilename(t *testing.T) {
 			name:      "gradle-build-cache",
 			ty:        pkg.JavaPkg,
 		},
+		{
+			filename:  "/usr/share/jruby/3.1.0/gems/nokogiri-1.2.4-java/lib/nokogiri/nokogiri.jar",
+			version:   "1.2.4",
+			extension: "jar",
+			name:      "nokogiri",
+			ty:        pkg.JavaPkg,
+		},
+		{
+			filename:  "/usr/share/jruby/3.1.0/gems/nokogiri-31.12.40-java/lib/nokogiri/nokogiri.jar",
+			version:   "31.12.40",
+			extension: "jar",
+			name:      "nokogiri",
+			ty:        pkg.JavaPkg,
+		},
+		{
+			filename:  "/usr/share/repository/ehacache/12.11.10-rc1/ehacache.jar",
+			version:   "12.11.10-rc1",
+			extension: "jar",
+			name:      "ehacache",
+			ty:        pkg.JavaPkg,
+		},
+		{
+			filename:  "/usr/share/repository/ehacache/12.11.10-SNAPSHOT/ehacache.jar",
+			version:   "12.11.10-SNAPSHOT",
+			extension: "jar",
+			name:      "ehacache",
+			ty:        pkg.JavaPkg,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Description

This PR adds a step during JAR version identification to try to find the version from the path if unable to determine this from the contents or filename. This accounts for some common scenarios such as JRuby JARs.

- Fixes #2877 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
