### PR TITLE
chore: redhat cataloger error when sqlite not regsitered

### DIFF
--- a/examples/create_custom_sbom/main.go
+++ b/examples/create_custom_sbom/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
+	_ "modernc.org/sqlite"
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"

--- a/examples/create_custom_sbom/main.go
+++ b/examples/create_custom_sbom/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"gopkg.in/yaml.v3"
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // required for rpmdb and other features
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"

--- a/examples/create_simple_sbom/main.go
+++ b/examples/create_simple_sbom/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/format/syftjson"

--- a/examples/create_simple_sbom/main.go
+++ b/examples/create_simple_sbom/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // required for rpmdb and other features
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format"

--- a/examples/select_catalogers/main.go
+++ b/examples/select_catalogers/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"os"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // required for rpmdb and other features
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"

--- a/examples/select_catalogers/main.go
+++ b/examples/select_catalogers/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"

--- a/examples/source_from_registry/main.go
+++ b/examples/source_from_registry/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format/syftjson"
 )

--- a/examples/source_from_registry/main.go
+++ b/examples/source_from_registry/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	_ "modernc.org/sqlite"
+	_ "modernc.org/sqlite" // required for rpmdb and other features
 
 	"github.com/anchore/syft/syft"
 	"github.com/anchore/syft/syft/format/syftjson"

--- a/syft/pkg/cataloger/redhat/sqlitetest/no_sqlite_driver_test.go
+++ b/syft/pkg/cataloger/redhat/sqlitetest/no_sqlite_driver_test.go
@@ -1,0 +1,22 @@
+package sqlitetest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/internal/fileresolver"
+	"github.com/anchore/syft/syft/pkg/cataloger/redhat"
+)
+
+func Test_noSQLiteDriverError(t *testing.T) {
+	// this test package does must not import the sqlite library
+	file := "../test-fixtures/Packages"
+	resolver, err := fileresolver.NewFromFile(file, file)
+	require.NoError(t, err)
+
+	cataloger := redhat.NewDBCataloger()
+	_, _, err = cataloger.Catalog(context.TODO(), resolver)
+	require.ErrorContains(t, err, "sqlite")
+}


### PR DESCRIPTION
# Description

This PR causes a syft scan to return an error when there is no SQLite driver registered. This may occur when using Syft as a library and not including the import `_ "modernc.org/sqlite"`.

- Fixes #3234

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
