### PR TITLE
Use go.yaml.in/yaml

### DIFF
--- a/cmd/syft/internal/commands/scan.go
+++ b/cmd/syft/internal/commands/scan.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/clio"
 	"github.com/anchore/fangs"

--- a/examples/create_custom_sbom/main.go
+++ b/examples/create_custom_sbom/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	_ "modernc.org/sqlite" // required for rpmdb and other features
 
 	"github.com/anchore/syft/syft"

--- a/go.mod
+++ b/go.mod
@@ -88,10 +88,10 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	github.com/zyedidia/generic v1.2.2-0.20230320175451-4410d2372cb1
 	go.uber.org/goleak v1.3.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
 	golang.org/x/mod v0.27.0
 	golang.org/x/net v0.43.0
-	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.38.2
 )
 
@@ -283,6 +283,7 @@ require (
 	google.golang.org/grpc v1.67.3 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1621,6 +1621,8 @@ go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9i
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go4.org v0.0.0-20230225012048-214862532bf5 h1:nifaUDeh+rPaBCMPMQHZmvJf+QdpLFnuQPwx+LxVmtc=
 go4.org v0.0.0-20230225012048-214862532bf5/go.mod h1:F57wTi5Lrj6WLyswp5EYV1ncrEbFGHD4hhz6S1ZYeaU=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/syft/pkg/cataloger/binary/test-fixtures/manager/internal/cli/commands/write_snippet.go
+++ b/syft/pkg/cataloger/binary/test-fixtures/manager/internal/cli/commands/write_snippet.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/syft/pkg/cataloger/binary/test-fixtures/manager/internal"
 	"github.com/anchore/syft/syft/pkg/cataloger/binary/test-fixtures/manager/internal/config"

--- a/syft/pkg/cataloger/binary/test-fixtures/manager/internal/config/application.go
+++ b/syft/pkg/cataloger/binary/test-fixtures/manager/internal/config/application.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/scylladb/go-set/strset"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const Path = "config.yaml"

--- a/syft/pkg/cataloger/binary/test-fixtures/manager/internal/config/binary_from_image.go
+++ b/syft/pkg/cataloger/binary/test-fixtures/manager/internal/config/binary_from_image.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/OneOfOne/xxhash"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type BinaryFromImage struct {

--- a/syft/pkg/cataloger/binary/test-fixtures/manager/internal/snippet_metadata.go
+++ b/syft/pkg/cataloger/binary/test-fixtures/manager/internal/snippet_metadata.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 type SnippetMetadata struct {

--- a/syft/pkg/cataloger/dart/parse_pubspec.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"

--- a/syft/pkg/cataloger/dart/parse_pubspec_lock.go
+++ b/syft/pkg/cataloger/dart/parse_pubspec_lock.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"sort"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"

--- a/syft/pkg/cataloger/githubactions/parse_composite_action.go
+++ b/syft/pkg/cataloger/githubactions/parse_composite_action.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"

--- a/syft/pkg/cataloger/githubactions/parse_workflow.go
+++ b/syft/pkg/cataloger/githubactions/parse_workflow.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"regexp"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"

--- a/syft/pkg/cataloger/haskell/parse_stack_lock.go
+++ b/syft/pkg/cataloger/haskell/parse_stack_lock.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"

--- a/syft/pkg/cataloger/haskell/parse_stack_yaml.go
+++ b/syft/pkg/cataloger/haskell/parse_stack_yaml.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"

--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/unknown"

--- a/syft/pkg/cataloger/swift/parse_podfile_lock.go
+++ b/syft/pkg/cataloger/swift/parse_podfile_lock.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"

--- a/test/cli/config_test.go
+++ b/test/cli/config_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func Test_configLoading(t *testing.T) {


### PR DESCRIPTION
# Description

gopkg.in/yaml.v3 is no longer supported, updated to fork https://github.com/yaml/go-yaml

Also fixes:
* https://github.com/go-yaml/yaml/issues/1050
* https://github.com/kubernetes-sigs/yaml/issues/117

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
