### PR TITLE
Modify RpmDBEntry to include modularityLabel for cyclonedx

### DIFF
--- a/syft/pkg/rpm.go
+++ b/syft/pkg/rpm.go
@@ -36,7 +36,7 @@ type RpmDBEntry struct {
 	Signatures      []RpmSignature  `json:"signatures,omitempty" cyclonedx:"signatures"`
 	Size            int             `json:"size" cyclonedx:"size"`
 	Vendor          string          `json:"vendor"`
-	ModularityLabel *string         `json:"modularityLabel,omitempty"`
+	ModularityLabel *string         `json:"modularityLabel,omitempty" cyclonedx:"modularityLabel"`
 	Provides        []string        `json:"provides,omitempty"`
 	Requires        []string        `json:"requires,omitempty"`
 	Files           []RpmFileRecord `json:"files"`


### PR DESCRIPTION
# Description

Adding `cyclonedx:"modularityLabel"` for `RpmDBEntry`. 

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
