### PR TITLE
fix: Ignore dpkg entries that have "deinstall" status

### DIFF
--- a/syft/pkg/cataloger/debian/parse_dpkg_db_test.go
+++ b/syft/pkg/cataloger/debian/parse_dpkg_db_test.go
@@ -237,6 +237,37 @@ func Test_parseDpkgStatus(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "deinstall status packages are ignored",
+			fixturePath: "test-fixtures/var/lib/dpkg/status.d/deinstall",
+			expected: []pkg.DpkgDBEntry{
+				{
+					Package:       "linux-image-6.14.0-1012-aws",
+					Source:        "linux-signed-aws-6.14",
+					Version:       "6.14.0-1012.12~24.04.1",
+					Architecture:  "amd64",
+					InstalledSize: 15221,
+					Maintainer:    "Canonical Kernel Team <kernel-team@lists.ubuntu.com>",
+					Description: `Signed kernel image aws
+ A kernel image for aws.  This version of it is signed with
+ Canonical's signing key.`,
+					Provides: []string{"fuse-module",
+						"linux-image",
+						"spl-dkms",
+						"spl-modules",
+						"v4l2loopback-dkms",
+						"v4l2loopback-modules",
+						"zfs-dkms",
+						"zfs-modules"},
+					Depends: []string{
+						"kmod",
+						"linux-base (>= 4.5ubuntu1~16.04.1)",
+						"linux-modules-6.14.0-1012-aws",
+					},
+					Files: []pkg.DpkgFileRecord{},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/debian/test-fixtures/var/lib/dpkg/status.d/deinstall
+++ b/syft/pkg/cataloger/debian/test-fixtures/var/lib/dpkg/status.d/deinstall
@@ -1,0 +1,38 @@
+Package: linux-image-6.14.0-1012-aws
+Status: install ok installed
+Priority: optional
+Section: kernel
+Installed-Size: 15221
+Maintainer: Canonical Kernel Team <kernel-team@lists.ubuntu.com>
+Architecture: amd64
+Source: linux-signed-aws-6.14
+Version: 6.14.0-1012.12~24.04.1
+Provides: fuse-module, linux-image, spl-dkms, spl-modules, v4l2loopback-dkms, v4l2loopback-modules, zfs-dkms, zfs-modules
+Depends: kmod, linux-base (>= 4.5ubuntu1~16.04.1), linux-modules-6.14.0-1012-aws
+Recommends: grub-pc | grub-efi-amd64 | grub-efi-ia32 | grub | lilo, initramfs-tools | linux-initramfs-tool
+Suggests: bpftool, linux-perf, linux-aws-6.14-doc-6.14.0 | linux-aws-6.14-source-6.14.0, linux-aws-6.14-tools, linux-headers-6.14.0-1012-aws
+Conflicts: linux-image-unsigned-6.14.0-1012-aws
+Description: Signed kernel image aws
+ A kernel image for aws.  This version of it is signed with
+ Canonical's signing key.
+Built-Using: linux-aws-6.14 (= 6.14.0-1012.12~24.04.1)
+
+Package: linux-image-6.8.0-1029-aws
+Status: deinstall ok config-files
+Priority: optional
+Section: kernel
+Installed-Size: 14591
+Maintainer: Canonical Kernel Team <kernel-team@lists.ubuntu.com>
+Architecture: amd64
+Source: linux-signed-aws
+Version: 6.8.0-1029.31
+Config-Version: 6.8.0-1029.31
+Provides: fuse-module, linux-image, spl-dkms, spl-modules, v4l2loopback-dkms, v4l2loopback-modules, zfs-dkms, zfs-modules
+Depends: kmod, linux-base (>= 4.5ubuntu1~16.04.1), linux-modules-6.8.0-1029-aws
+Recommends: grub-pc | grub-efi-amd64 | grub-efi-ia32 | grub | lilo, initramfs-tools | linux-initramfs-tool
+Suggests: fdutils, linux-aws-doc-6.8.0 | linux-aws-source-6.8.0, linux-aws-tools, linux-headers-6.8.0-1029-aws
+Conflicts: linux-image-unsigned-6.8.0-1029-aws
+Description: Signed kernel image aws
+ A kernel image for aws.  This version of it is signed with
+ Canonical's signing key.
+Built-Using: linux-aws (= 6.8.0-1029.31)


### PR DESCRIPTION
# Description

Ignore dpkg entries that have "deinstall" status indicating package has been removed but not purged.

When running `dpkg -l` these entries typically show as `rc` indicating the package has been removed but configuration still remains on the asset such as the following example
```
dpkg -l | grep -E "^rc"
rc  linux-image-6.14.0-1009-aws        6.14.0-1009.9~24.04.1                   amd64        Signed kernel image aws
rc  linux-image-6.14.0-1010-aws        6.14.0-1010.10~24.04.1                  amd64        Signed kernel image aws
rc  linux-image-6.8.0-1029-aws         6.8.0-1029.31                           amd64        Signed kernel image aws
rc  linux-image-6.8.0-1031-aws         6.8.0-1031.33                           amd64        Signed kernel image aws
rc  linux-modules-6.14.0-1009-aws      6.14.0-1009.9~24.04.1                   amd64        Linux kernel extra modules for version 6.14.0 on DESC
rc  linux-modules-6.14.0-1010-aws      6.14.0-1010.10~24.04.1                  amd64        Linux kernel extra modules for version 6.14.0 on DESC
rc  linux-modules-6.8.0-1029-aws       6.8.0-1029.31                           amd64        Linux kernel extra modules for version 6.8.0 on 64 bit x86 SMP
rc  linux-modules-6.8.0-1031-aws       6.8.0-1031.33                           amd64        Linux kernel extra modules for version 6.8.0 on 64 bit x86 SMP
```
Frequently this can be seen when scanning a host instance, rather than a container, where old kernel packages are automatically removed but not purged resulting in them being present in the SBOM and assigned vulnerabilities against these removed packages when performing a Grype scan.

<!-- If this completes an issue, please include: -->

- Fixes https://github.com/anchore/syft/issues/3063

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
