### PR TITLE
goreleaser: add ARM64 GOARCH for Windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,7 @@ builds:
     dir: ./cmd/syft
     binary: syft
     goos: [windows]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
     mod_timestamp: *build-timestamp
     ldflags: *build-ldflags
 

--- a/test/install/1_download_snapshot_asset_test.sh
+++ b/test/install/1_download_snapshot_asset_test.sh
@@ -104,6 +104,8 @@ run_test_case test_positive_snapshot_download_asset "darwin" "arm64" "tar.gz"
 
 run_test_case test_positive_snapshot_download_asset "windows" "amd64" "sbom"
 run_test_case test_positive_snapshot_download_asset "windows" "amd64" "zip"
+run_test_case test_positive_snapshot_download_asset "windows" "arm64" "sbom"
+run_test_case test_positive_snapshot_download_asset "windows" "arm64" "zip"
 # note: the mac signing process produces a dmg which is not part of the snapshot process (thus is not exercised here)
 
 # let's make certain we covered all assets that were expected

--- a/test/install/3_install_asset_test.sh
+++ b/test/install/3_install_asset_test.sh
@@ -99,6 +99,7 @@ run_test_case test_positive_snapshot_install_asset "linux" "s390x" "tar.gz"
 run_test_case test_positive_snapshot_install_asset "darwin" "amd64" "tar.gz"
 run_test_case test_positive_snapshot_install_asset "darwin" "arm64" "tar.gz"
 run_test_case test_positive_snapshot_install_asset "windows" "amd64" "zip"
+run_test_case test_positive_snapshot_install_asset "windows" "arm64" "zip"
 
 # let's make certain we covered all assets that were expected
 run_test_case test_install_asset_exercised_all_archive_assets


### PR DESCRIPTION
Update the architectures to support Windows AMD64 and ARM64 releases.

Fixes: #4179
Signed-off-by: Saleem Abdulrasool <compnerd@compnerd.org>