### PR TITLE
feat: enhance setup.py parser to handle unquoted dependencies

### DIFF
--- a/syft/pkg/cataloger/python/parse_setup.go
+++ b/syft/pkg/cataloger/python/parse_setup.go
@@ -33,66 +33,87 @@ func parseSetup(_ context.Context, _ file.Resolver, _ *generic.Environment, read
 		line := scanner.Text()
 		line = strings.TrimRight(line, "\n")
 
-		for _, match := range pinnedDependency.FindAllString(line, -1) {
-			parts := strings.Split(match, "==")
-			if len(parts) != 2 {
-				continue
-			}
-			name := strings.Trim(parts[0], "'\"")
-			name = strings.TrimSpace(name)
-			name = strings.Trim(name, "'\"")
-
-			version := strings.TrimSpace(parts[len(parts)-1])
-			version = strings.Trim(version, "'\"")
-
-			if hasTemplateDirective(name) || hasTemplateDirective(version) {
-				// this can happen in more dynamic setup.py where there is templating
-				continue
-			}
-
-			if name == "" || version == "" {
-				log.WithFields("path", reader.RealPath).Debugf("unable to parse package in setup.py line: %q", line)
-				continue
-			}
-
-			packages = append(
-				packages,
-				newPackageForIndex(
-					name,
-					version,
-					reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
-				),
-			)
-		}
-		if matches := unquotedPinnedDependency.FindStringSubmatch(line); len(matches) == 3 {
-			name := strings.TrimSpace(matches[1])
-			version := strings.TrimSpace(matches[2])
-
-			if hasTemplateDirective(name) || hasTemplateDirective(version) {
-				continue
-			}
-
-			if name != "" && version != "" {
-				// Avoid duplicates
-				isDuplicate := false
-				for _, p := range packages {
-					if p.Name == name && p.Version == version {
-						isDuplicate = true
-						break
-					}
-				}
-
-				if !isDuplicate {
-					packages = append(
-						packages,
-						newPackageForIndex(name, version, reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-					)
-				}
-			}
-		}
+		packages = processQuotedDependencies(line, reader, packages)
+		packages = processUnquotedDependency(line, reader, packages)
 	}
 
 	return packages, nil, nil
+}
+
+func processQuotedDependencies(line string, reader file.LocationReadCloser, packages []pkg.Package) []pkg.Package {
+	for _, match := range pinnedDependency.FindAllString(line, -1) {
+		if p, ok := parseQuotedDependency(match, line, reader); ok {
+			packages = append(packages, p)
+		}
+	}
+	return packages
+}
+
+func parseQuotedDependency(match, line string, reader file.LocationReadCloser) (pkg.Package, bool) {
+	parts := strings.Split(match, "==")
+	if len(parts) != 2 {
+		return pkg.Package{}, false
+	}
+
+	name := cleanDependencyString(parts[0])
+	version := cleanDependencyString(parts[len(parts)-1])
+
+	return validateAndCreatePackage(name, version, line, reader)
+}
+
+// processUnquotedDependency extracts and processes an unquoted dependency from a line
+func processUnquotedDependency(line string, reader file.LocationReadCloser, packages []pkg.Package) []pkg.Package {
+	matches := unquotedPinnedDependency.FindStringSubmatch(line)
+	if len(matches) != 3 {
+		return packages
+	}
+
+	name := strings.TrimSpace(matches[1])
+	version := strings.TrimSpace(matches[2])
+
+	if p, ok := validateAndCreatePackage(name, version, line, reader); ok {
+		if !isDuplicatePackage(p, packages) {
+			packages = append(packages, p)
+		}
+	}
+
+	return packages
+}
+
+func cleanDependencyString(s string) string {
+	s = strings.Trim(s, "'\"")
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "'\"")
+	return s
+}
+
+func validateAndCreatePackage(name, version, line string, reader file.LocationReadCloser) (pkg.Package, bool) {
+	if hasTemplateDirective(name) || hasTemplateDirective(version) {
+		// this can happen in more dynamic setup.py where there is templating
+		return pkg.Package{}, false
+	}
+
+	if name == "" || version == "" {
+		log.WithFields("path", reader.RealPath).Debugf("unable to parse package in setup.py line: %q", line)
+		return pkg.Package{}, false
+	}
+
+	p := newPackageForIndex(
+		name,
+		version,
+		reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+	)
+
+	return p, true
+}
+
+func isDuplicatePackage(p pkg.Package, packages []pkg.Package) bool {
+	for _, existing := range packages {
+		if existing.Name == p.Name && existing.Version == p.Version {
+			return true
+		}
+	}
+	return false
 }
 
 func hasTemplateDirective(s string) bool {

--- a/syft/pkg/cataloger/python/parse_setup_test.go
+++ b/syft/pkg/cataloger/python/parse_setup_test.go
@@ -61,6 +61,94 @@ func TestParseSetup(t *testing.T) {
 			fixture:  "test-fixtures/setup/dynamic-setup.py",
 			expected: nil,
 		},
+		{
+			fixture: "test-fixtures/setup/multiline-split-setup.py",
+			expected: []pkg.Package{
+				{
+					Name:     "black",
+					Version:  "23.12.1",
+					PURL:     "pkg:pypi/black@23.12.1",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "cairosvg",
+					Version:  "2.7.1",
+					PURL:     "pkg:pypi/cairosvg@2.7.1",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "celery",
+					Version:  "5.3.4",
+					PURL:     "pkg:pypi/celery@5.3.4",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "django",
+					Version:  "4.2.23",
+					PURL:     "pkg:pypi/django@4.2.23",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "mypy",
+					Version:  "1.7.1",
+					PURL:     "pkg:pypi/mypy@1.7.1",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "pillow",
+					Version:  "11.0.0",
+					PURL:     "pkg:pypi/pillow@11.0.0",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "pytest",
+					Version:  "7.4.3",
+					PURL:     "pkg:pypi/pytest@7.4.3",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURL:     "pkg:pypi/requests@2.31.0",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+			},
+		},
+		{
+			// Test mixed quoted and unquoted dependencies - ensure no duplicates
+			fixture: "test-fixtures/setup/mixed-format-setup.py",
+			expected: []pkg.Package{
+				{
+					Name:     "requests",
+					Version:  "2.31.0",
+					PURL:     "pkg:pypi/requests@2.31.0",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "django",
+					Version:  "4.2.23",
+					PURL:     "pkg:pypi/django@4.2.23",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+				{
+					Name:     "flask",
+					Version:  "3.0.0",
+					PURL:     "pkg:pypi/flask@3.0.0",
+					Language: pkg.Python,
+					Type:     pkg.PythonPkg,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/syft/pkg/cataloger/python/test-fixtures/setup/mixed-format-setup.py
+++ b/syft/pkg/cataloger/python/test-fixtures/setup/mixed-format-setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup
+
+# Test case to ensure duplicate detection works correctly
+# when same dependencies appear in both quoted and unquoted forms
+
+setup(
+    name='mixed-format-project',
+    version='1.0.0',
+    install_requires=[
+        # Quoted dependencies (should be caught by pinnedDependency regex)
+        "requests==2.31.0",
+        "django==4.2.23",
+    ] + """
+requests==2.31.0
+flask==3.0.0
+""".split(),
+)

--- a/syft/pkg/cataloger/python/test-fixtures/setup/multiline-split-setup.py
+++ b/syft/pkg/cataloger/python/test-fixtures/setup/multiline-split-setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+
+# Example setup.py using multiline string with .split() pattern
+# This pattern is commonly seen in projects like mayan-edms
+
+setup(
+    name='example-project',
+    version='1.0.0',
+    install_requires="""
+django==4.2.23
+CairoSVG==2.7.1
+Pillow==11.0.0
+requests==2.31.0
+celery==5.3.4
+""".split(),
+    extras_require={
+        'dev': """
+pytest==7.4.3
+black==23.12.1
+mypy==1.7.1
+""".split(),
+    },
+)


### PR DESCRIPTION
# Description
Enhance `syft/pkg/cataloger/python/parse_setup.go` to correctly parse unquoted Python dependencies defined in `setup.py` files, addressing a common pattern where dependencies are listed in multiline strings followed by .split().

## Why is this needed?
Many Python projects use the following pattern in their `setup.py` files:
```install_requires = 
"""
django==4.2.23
CairoSVG==2.7.1
Pillow==11.0.0
""".split()
```
Currently, Syft’s parser only recognizes dependencies wrapped in quotes (e.g., "django==4.2.23").
As a result, all dependencies written in this unquoted .split() form are missed, leading to incomplete SBOMs.

## Fix
- Added a secondary regex pattern `^\s*(\w+)\s*==\s*([\w\.\-]+)` to detect unquoted dependencies.
- Ensured backward compatibility with existing quoted parsing.
- Prevented duplicate detection.
- Preserved all existing functionality.

## Testing
 To verify:
1. Download mayan-edms (which uses this pattern): `pip download --no-deps --no-binary :all: mayan-edms==4.9.2`
2. Extract the source and inspect setup.py — it defines dependencies via """.split().
3. Run Syft before and after applying the fix: `syft dir:"/path/to/project" --select-catalogers python --output cyclonedx-json=output.json`

- Before: SBOM is empty.
- After: SBOM includes all pinned dependencies from install_requires.

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
