### PR TITLE
Fix typos and linguistic errors in documentation / hacktoberfest

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,7 +27,7 @@ Also double check that the docker context being used is the default context. If 
 
 `docker context use default`
 
-After cloning the following step can help you get setup:
+After cloning, the following steps can help you get setup:
 1. run `make bootstrap` to download go mod dependencies, create the `/.tmp` dir, and download helper utilities.
 2. run `make` to view the selection of developer commands in the Makefile
 3. run `make build` to build the release snapshot binaries and packages
@@ -120,7 +120,7 @@ sequenceDiagram
     source-->>+sbom: add source to SBOM struct
     source-->>+catalog: pass src to generate catalog
     catalog-->-sbom: add cataloging results onto SBOM
-    sbom-->>encoder: pass SBOM and format desiered to syft encoder
+    sbom-->>encoder: pass SBOM and format desired to syft encoder
     encoder-->>source: return bytes that are the SBOM of the original input 
 
     Note right of catalog: cataloger configuration is done based on src
@@ -186,7 +186,7 @@ Cataloger names should be unique and named with the following rules of thumb in 
 - Use lowercase letters, numbers, and hyphens only
 - Use hyphens to separate words
 - Catalogers for language ecosystems should start with the language name (e.g. `python-` for a cataloger that raises up python packages)
-- Distinct between when the cataloger is searching for evidence of installed packages vs declared packages. For example, there are currently two different gemspec-based catalogers, the `ruby-gemspec-cataloger` and `ruby-installed-gemspec-cataloger`, where the latter requires that the gemspec is found within a `specifications` directory (which means it was installed, not just at the root of a source repo).
+- Distinguish between when the cataloger is searching for evidence of installed packages vs declared packages. For example, there are currently two different gemspec-based catalogers, the `ruby-gemspec-cataloger` and `ruby-installed-gemspec-cataloger`, where the latter requires that the gemspec is found within a `specifications` directory (which means it was installed, not just at the root of a source repo).
 
 #### Building a new Cataloger
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,4 +29,4 @@ To report a security issue, please email
 with a description of the issue, the steps you took to create the issue,
 affected versions, and, if known, mitigations for the issue.
 
-All support will be made on the best effort base, so please indicate the "urgency level" of the vulnerability as Critical, High, Medium or Low.
+All support will be made on a best effort basis, so please indicate the "urgency level" of the vulnerability as Critical, High, Medium or Low.

--- a/internal/cache/README.md
+++ b/internal/cache/README.md
@@ -18,7 +18,7 @@ based on the _structure_ of the provided type.
 If the structure changes in any way it will end up with a new version key and all will re populate this new key,
 ignoring cached values from older, different versions.
 The resolver will store items using the `json` package to serialize/deserialize values, so to save space
-it is encouraged  to use `omitempty`. For example:
+it is encouraged to use `omitempty`. For example:
 
 ```go
 type myCacheItem struct {

--- a/schema/cyclonedx/README.md
+++ b/schema/cyclonedx/README.md
@@ -13,6 +13,6 @@ prior spec version (e.g. if updating to 1.7, compare the files in this directory
 equivalents). 
 
 One can also update the schemas and observe the errors in order to make the necessary updates. 
-At the time of writing, the cyclonedx.xsd needed modifications to link to the local spdx.xsd, 
-and also to changes the minOccurs for a license tag to 0. (The json schema does not require 
+At the time of writing, the cyclonedx.xsd needed modifications to link to the local spdx.xsd,
+and also to change the minOccurs for a license tag to 0. (The json schema does not require
 modification for the generated file to lint properly, but can simply be copy/pasted).   

--- a/syft/internal/fileresolver/test-fixtures/symlinks-loop/README.md
+++ b/syft/internal/fileresolver/test-fixtures/symlinks-loop/README.md
@@ -1,1 +1,1 @@
-this mimics a partial layout on a linux system within /sys/devices/virtual to help with ensuring globbing for files does not end up in a infinite loop
+This mimics a partial layout on a Linux system within /sys/devices/virtual to help ensure globbing for files does not end up in an infinite loop.

--- a/syft/pkg/cataloger/binary/test-fixtures/elf-test-fixtures/README.md
+++ b/syft/pkg/cataloger/binary/test-fixtures/elf-test-fixtures/README.md
@@ -55,7 +55,7 @@ Contents of section .note.package:
 ```
 
 #### Binaries related to Libraries
-The resulting SBOM shoult show the following relationships:
+The resulting SBOM should show the following relationships:
 ```
 elfbinwithnestedlib -> libhello_world.so
 elfwithparallellibbin2 -> libhello_world.so

--- a/syft/pkg/cataloger/cpp/test-fixtures/README.md
+++ b/syft/pkg/cataloger/cpp/test-fixtures/README.md
@@ -6,7 +6,7 @@ This folder contains the test data for the Conan package manager.
 
 The conan lock file is created in the following way.
 
-We explicitly use a package which has dependencies, which in turn also have dependendencies.
+We explicitly use a package which has dependencies, which in turn also have dependencies.
 This is necessary to verify that the dependency tree is properly parsed.
 
 1. Use `conan lock create --reference "mfast/1.2.2#c6f6387c9b99780f0ee05e25f99d0f39"`

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/README.md
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/README.md
@@ -1,7 +1,7 @@
 # Jar-Metadata test fixtures
 
 Each directory is the name of a jar to be created (simply a zip) based on the contents of the directory.
-This prevents us from having to create real jars by hand or keep binaries in the repo. This also means we dont need the
+This prevents us from having to create real jars by hand or keep binaries in the repo. This also means we don't need the
 entire jar, only the necessary metadata for testing.
 
 ### api-all-2.0.0-sources


### PR DESCRIPTION
# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

Fix typos and linguistic errors in documentation.  It's not much, but I'm happy to help.

- Fixes

## Type of change

- [X] Documentation (updates the documentation)

