### PR TITLE
chore: update cosign args to not use new config functionality

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -337,6 +337,7 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - "sign-blob"
+      - "--use-signing-config=false"
       - "--oidc-issuer=https://token.actions.githubusercontent.com"
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"


### PR DESCRIPTION
# Description

fixes: .tool/cosign failed: exit status 1: Error: cannot specify service URLs and use signing config

I can't get this to simulate on my local detecting the github config that provides the service URL automatically, but see that v3 now fetches service URLs from the Sigstore signing-config by default. This change should unblock us 🤞 

## Type of change

- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
