### PR TITLE
fix: panic during java archive maven resolution

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -263,7 +263,7 @@ func (j *archiveParser) discoverMainPackage(ctx context.Context) (*pkg.Package, 
 	}
 	var pkgPomProject *pkg.JavaPomProject
 	if parsedPom != nil {
-		pkgPomProject = newPomProject(ctx, nil, parsedPom.path, parsedPom.project)
+		pkgPomProject = newPomProject(ctx, j.maven, parsedPom.path, parsedPom.project)
 	}
 
 	return &pkg.Package{

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1632,3 +1632,26 @@ func Test_corruptJarArchive(t *testing.T) {
 		WithError().
 		TestParser(t, ap.parseJavaArchive)
 }
+
+func Test_jarPomPropertyResolutionDoesNotPanic(t *testing.T) {
+	jarName := generateJavaMetadataJarFixture(t, "commons-lang3-3.12.0", "jar")
+	fixture, err := os.Open(jarName)
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+	// setup parser
+	ap, cleanupFn, err := newJavaArchiveParser(
+		ctx,
+		file.LocationReadCloser{
+			Location:   file.NewLocation(fixture.Name()),
+			ReadCloser: fixture,
+		}, false, ArchiveCatalogerConfig{
+			UseMavenLocalRepository: true,
+			MavenLocalRepositoryDir: "internal/maven/test-fixtures/maven-repo",
+		})
+	defer cleanupFn()
+	require.NoError(t, err)
+
+	_, _, err = ap.parse(ctx, nil)
+	require.NoError(t, err)
+}

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/Makefile
@@ -14,7 +14,7 @@ SPRING_INSTRUMENTATION = spring-instrumentation-4.3.0-1.0
 MULTIPLE_MATCHING = multiple-matching-2.11.5
 ORG_MULTIPLE_THENAME = org.multiple-thename
 MICRONAUT_AOP = micronaut-aop-4.9.11
-
+COMMONS_LANG3 = commons-lang3-3.12.0
 
 .DEFAULT_GOAL := fixtures
 
@@ -24,7 +24,7 @@ fixtures: $(CACHE_DIR)
 # requirement 2: 'fingerprint' goal to determine if the fixture input that indicates any existing cache should be busted
 fingerprint: $(FINGERPRINT_FILE)
 
-$(CACHE_DIR): $(CACHE_DIR)/$(JACKSON_CORE).jar $(CACHE_DIR)/$(SBT_JACKSON_CORE).jar $(CACHE_DIR)/$(OPENSAML_CORE).jar  $(CACHE_DIR)/$(API_ALL_SOURCES).jar $(CACHE_DIR)/$(SPRING_INSTRUMENTATION).jar $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar $(CACHE_DIR)/$(MICRONAUT_AOP).jar
+$(CACHE_DIR): $(CACHE_DIR)/$(JACKSON_CORE).jar $(CACHE_DIR)/$(SBT_JACKSON_CORE).jar $(CACHE_DIR)/$(OPENSAML_CORE).jar  $(CACHE_DIR)/$(API_ALL_SOURCES).jar $(CACHE_DIR)/$(SPRING_INSTRUMENTATION).jar $(CACHE_DIR)/$(MULTIPLE_MATCHING).jar $(CACHE_DIR)/$(MICRONAUT_AOP).jar $(CACHE_DIR)/$(COMMONS_LANG3).jar
 
 $(CACHE_DIR)/$(JACKSON_CORE).jar:
 	mkdir -p $(CACHE_DIR)
@@ -57,6 +57,10 @@ $(CACHE_DIR)/$(ORG_MULTIPLE_THENAME).jar:
 $(CACHE_DIR)/$(MICRONAUT_AOP).jar:
 	mkdir -p $(CACHE_DIR)
 	cd $(MICRONAUT_AOP) && zip -r $(CACHE_PATH)/$(MICRONAUT_AOP).jar .
+
+$(CACHE_DIR)/$(COMMONS_LANG3).jar:
+	mkdir -p $(CACHE_DIR)
+	cd $(COMMONS_LANG3) && zip -r $(CACHE_PATH)/$(COMMONS_LANG3).jar .
 
 # Jenkins plugins typically do not have the version included in the archive name,
 # so it is important to not include it in the generated test fixture

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/commons-lang3-3.12.0/META-INF/MANIFEST.MF
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/commons-lang3-3.12.0/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Manifest-Version: 1.0

--- a/syft/pkg/cataloger/java/test-fixtures/jar-metadata/commons-lang3-3.12.0/META-INF/maven/org.apache.commons-lang3/pom.xml
+++ b/syft/pkg/cataloger/java/test-fixtures/jar-metadata/commons-lang3-3.12.0/META-INF/maven/org.apache.commons-lang3/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-parent</artifactId>
+        <version>54</version>
+    </parent>
+  <groupId>org.apache.commons</groupId>
+  <artifactId>commons-lang3</artifactId>
+  <version>${commons.release.version}</version>
+  <packaging>pom</packaging>
+  <name>JUnit 5 (Bill of Materials)</name>
+  <licenses>
+    <license>
+      <name>Eclipse Public License v2.0</name>
+      <url>https://www.eclipse.org/legal/epl-v20.html</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:git://github.com/junit-team/junit5.git</connection>
+    <developerConnection>scm:git:git://github.com/junit-team/junit5.git</developerConnection>
+    <url>https://github.com/junit-team/junit5</url>
+  </scm>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${commons.release.version}</version>
+      </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
# Description

Fixes a panic that occurs during certain cases of java archive maven property resolution.

- Fixes #4288
- Fixes https://github.com/anchore/grype/issues/3002

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
