### PR TITLE
ci: use apple creds before pushing tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Bootstrap environment
+        uses: ./.github/actions/bootstrap
+
+      - name: Validate Apple notarization credentials
+        run: .tool/quill submission list
+        env:
+          QUILL_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+          QUILL_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          QUILL_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+
       - name: Check if running on main
         if: github.ref != 'refs/heads/main'
         # we are using the following flag when running `cosign blob-verify` for checksum signature verification:


### PR DESCRIPTION
We have had a few releases fail because the Apple credentials needed some sort of fix. These release were operationally more interesting because they failed after pushing a git tag (which effectively releases the golagn package). Therefore, try to use these creds early, before there's a tag pushed.

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
