### PR TITLE
Respect "rpmmod" PURL qualifier

### DIFF
--- a/syft/format/internal/backfill_test.go
+++ b/syft/format/internal/backfill_test.go
@@ -54,6 +54,21 @@ func Test_Backfill(t *testing.T) {
 			},
 		},
 		{
+			name: "rpm with rpmmod",
+			in: pkg.Package{
+				PURL: "pkg:rpm/redhat/httpd@2.4.37-51?arch=x86_64&distro=rhel-8.7&rpmmod=httpd:2.4",
+			},
+			expected: pkg.Package{
+				PURL:    "pkg:rpm/redhat/httpd@2.4.37-51?arch=x86_64&distro=rhel-8.7&rpmmod=httpd:2.4",
+				Type:    pkg.RpmPkg,
+				Name:    "httpd",
+				Version: "2.4.37-51",
+				Metadata: pkg.RpmDBEntry{
+					ModularityLabel: strRef("httpd:2.4"),
+				},
+			},
+		},
+		{
 			name: "bad cpe",
 			in: pkg.Package{
 				PURL: "pkg:npm/testp@3.0.0?cpes=cpe:2.3a:testv:testp:3.0.0:*:*:*:*:*:*:*",
@@ -170,4 +185,8 @@ func Test_nameFromPurl(t *testing.T) {
 			require.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+func strRef(s string) *string {
+	return &s
 }

--- a/syft/internal/fileresolver/metadata_test.go
+++ b/syft/internal/fileresolver/metadata_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/anchore/stereoscope/pkg/file"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/file"
 )
 
 func TestFileMetadataFromPath(t *testing.T) {

--- a/syft/pkg/url.go
+++ b/syft/pkg/url.go
@@ -18,6 +18,9 @@ const (
 	// PURLQualifierUpstream this qualifier is not in the pURL spec, but is used by grype to perform indirect matching based on source information
 	PURLQualifierUpstream = "upstream"
 
+	// PURLQualifierRpmModularity this qualifier is not in the pURL spec, but is used to specify RPM modularity information
+	PURLQualifierRpmModularity = "rpmmod"
+
 	purlCargoPkgType  = "cargo"
 	purlGradlePkgType = "gradle"
 )


### PR DESCRIPTION
Red Hat purls the RPM modularity info in a query param in the PURLs in their vulnerability data. It would be nice if Syft respected this qualifier so that Grype can use it when a Red Hat purl is passed.

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
