### PR TITLE
Preserve --from argument order

### DIFF
--- a/cmd/syft/internal/commands/cataloger_list.go
+++ b/cmd/syft/internal/commands/cataloger_list.go
@@ -87,8 +87,8 @@ func runCatalogerList(opts *catalogerListOptions) error {
 }
 
 func catalogerListReport(opts *catalogerListOptions, allTaskGroups [][]task.Task) (string, error) {
-	defaultCatalogers := options.Flatten(opts.DefaultCatalogers)
-	selectCatalogers := options.Flatten(opts.SelectCatalogers)
+	defaultCatalogers := options.FlattenAndSort(opts.DefaultCatalogers)
+	selectCatalogers := options.FlattenAndSort(opts.SelectCatalogers)
 	selectedTaskGroups, selectionEvidence, err := task.SelectInGroups(
 		allTaskGroups,
 		cataloging.NewSelectionRequest().

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -283,10 +283,10 @@ func (cfg *Catalog) PostLoad() error {
 
 	cfg.From = Flatten(cfg.From)
 
-	cfg.Catalogers = Flatten(cfg.Catalogers)
-	cfg.DefaultCatalogers = Flatten(cfg.DefaultCatalogers)
-	cfg.SelectCatalogers = Flatten(cfg.SelectCatalogers)
-	cfg.Enrich = Flatten(cfg.Enrich)
+	cfg.Catalogers = FlattenAndSort(cfg.Catalogers)
+	cfg.DefaultCatalogers = FlattenAndSort(cfg.DefaultCatalogers)
+	cfg.SelectCatalogers = FlattenAndSort(cfg.SelectCatalogers)
+	cfg.Enrich = FlattenAndSort(cfg.Enrich)
 
 	// for backwards compatibility
 	cfg.DefaultCatalogers = append(cfg.DefaultCatalogers, cfg.Catalogers...)
@@ -311,6 +311,11 @@ func Flatten(commaSeparatedEntries []string) []string {
 			out = append(out, strings.TrimSpace(s))
 		}
 	}
+	return out
+}
+
+func FlattenAndSort(commaSeparatedEntries []string) []string {
+	out := Flatten(commaSeparatedEntries)
 	sort.Strings(out)
 	return out
 }


### PR DESCRIPTION
The `--from` flag should preserve the order in which to try various sources the user has passed. Today this list is being sorted, which appears to be a mistake. This PR fixes this, preserving the original order as passed by the user. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
