### PR TITLE
ci: output oras path

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -25,11 +25,6 @@ inputs:
     description: "Space delimited list of tools to install via apt"
     default: "libxml2-utils"
 
-outputs:
-  oras:
-    description: "Path to the oras binary"
-    value: ${{ github.workspace }}/.tool/oras
-
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/update-cpe-dictionary-index.yml
+++ b/.github/workflows/update-cpe-dictionary-index.yml
@@ -28,8 +28,9 @@ jobs:
         id: bootstrap
 
       - name: Login to GitHub Container Registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | ${{ steps.bootstrap.outputs.oras }} login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | .tool/oras login ghcr.io -u "$ACTOR" --password-stdin
+        env:
+          ACTOR: ${{ github.actor }}
 
       - name: Pull CPE cache from registry
         run: make generate:cpe-index:cache:pull


### PR DESCRIPTION
Some workflows expect bootstrap to output the oras path. This seems like a reasonable thing for it to do.

Here's a link to a test run of the job from this branch: https://github.com/anchore/syft/actions/runs/19433894759

# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
