### PR TITLE
chore: options to run release-install-script without release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,11 +9,20 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      phase:
+        description: the specific workflow phase to run or all
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - "all"
+          - "install-script-only"
 
 jobs:
   quality-gate:
     environment: release
     runs-on: ubuntu-24.04
+    if: ${{ github.event.inputs.phase == 'all' }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
@@ -120,6 +129,7 @@ jobs:
   release:
     needs: [quality-gate]
     runs-on: ubuntu-24.04
+    if: ${{ github.event.inputs.phase == 'all' }}
     permissions:
       contents: write
       packages: write
@@ -189,7 +199,7 @@ jobs:
 
   release-install-script:
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
+    if: ${{ always() && (needs.release.result == 'success' || github.event.inputs.phase == 'install-script-only') }}
     uses: "anchore/workflows/.github/workflows/release-install-script.yaml@main"
     with:
       tag: ${{ github.event.inputs.version }}


### PR DESCRIPTION
# Description

This PR makes a change to be able to manually run selected portions of the release workflow.

<!-- If this completes an issue, please include: -->

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

