### PR TITLE
minor: rename test func

### DIFF
--- a/syft/format/cpes/decoder_test.go
+++ b/syft/format/cpes/decoder_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/anchore/syft/syft/sbom"
 )
 
-func Test_CPEProvider(t *testing.T) {
+func TestDecoder_Decode(t *testing.T) {
 	tests := []struct {
 		name      string
 		userInput string


### PR DESCRIPTION
# Description

A very small change, but the test case should be named differently.

<!-- If this completes an issue, please include: -->

- Fixes

## Type of change

<!-- Delete any that are not relevant -->

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)