### PR TITLE
fix: golang PURL should include full module

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -188,7 +188,8 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 					WithFromContents(cfg.Golang.MainModuleVersion.FromContents).
 					WithFromBuildSettings(cfg.Golang.MainModuleVersion.FromBuildSettings).
 					WithFromLDFlags(cfg.Golang.MainModuleVersion.FromLDFlags),
-			),
+			).
+			WithUsePackagesLib(*multiLevelOption(true, enrichmentEnabled(cfg.Enrich, task.Go, task.Golang), cfg.Golang.UsePackagesLib)),
 		JavaScript: javascript.DefaultCatalogerConfig().
 			WithIncludeDevDependencies(*multiLevelOption(false, cfg.JavaScript.IncludeDevDependencies)).
 			WithSearchRemoteLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.JavaScript, task.Node, task.NPM), cfg.JavaScript.SearchRemoteLicenses)).

--- a/cmd/syft/internal/options/golang.go
+++ b/cmd/syft/internal/options/golang.go
@@ -16,6 +16,7 @@ type golangConfig struct {
 	Proxy                       string                        `json:"proxy" yaml:"proxy" mapstructure:"proxy"`
 	NoProxy                     string                        `json:"no-proxy" yaml:"no-proxy" mapstructure:"no-proxy"`
 	MainModuleVersion           golangMainModuleVersionConfig `json:"main-module-version" yaml:"main-module-version" mapstructure:"main-module-version"`
+	UsePackagesLib              *bool                         `json:"use-packages-lib" yaml:"use-packages-lib" mapstructure:"use-packages-lib"`
 }
 
 var _ interface {
@@ -37,6 +38,7 @@ if unset this defaults to $GONOPROXY`)
 	descriptions.Add(&o.MainModuleVersion, `the go main module version discovered from binaries built with the go compiler will
 always show (devel) as the version. Use these options to control heuristics to guess
 a more accurate version from the binary.`)
+	descriptions.Add(&o.UsePackagesLib, `use the golang.org/x/tools/go/packages library, which executes golang tooling found on the path in addition to potential network access to get the most accurate results`)
 	descriptions.Add(&o.MainModuleVersion.FromLDFlags, `look for LD flags that appear to be setting a version (e.g. -X main.version=1.0.0)`)
 	descriptions.Add(&o.MainModuleVersion.FromBuildSettings, `use the build settings (e.g. vcs.version & vcs.time) to craft a v0 pseudo version 
 (e.g. v0.0.0-20220308212642-53e6d0aaf6fb) when a more accurate version cannot be found otherwise`)
@@ -64,5 +66,6 @@ func defaultGolangConfig() golangConfig {
 			FromContents:      def.MainModuleVersion.FromContents,
 			FromBuildSettings: def.MainModuleVersion.FromBuildSettings,
 		},
+		UsePackagesLib: nil, // this defaults to true, which is the API default
 	}
 }

--- a/syft/pkg/cataloger/golang/config.go
+++ b/syft/pkg/cataloger/golang/config.go
@@ -48,6 +48,9 @@ type CatalogerConfig struct {
 	NoProxy []string `yaml:"no-proxy,omitempty" json:"no-proxy,omitempty" mapstructure:"no-proxy"`
 
 	MainModuleVersion MainModuleVersionConfig `yaml:"main-module-version" json:"main-module-version" mapstructure:"main-module-version"`
+
+	// Whether to use the golang.org/x/tools/go/packages, which executes golang tooling found on the path in addition to potential network access
+	UsePackagesLib bool `json:"use-packages-lib" yaml:"use-packages-lib" mapstructure:"use-packages-lib"`
 }
 
 type MainModuleVersionConfig struct {
@@ -70,6 +73,7 @@ type MainModuleVersionConfig struct {
 // - setting the default local module cache dir if none is provided
 func DefaultCatalogerConfig() CatalogerConfig {
 	g := CatalogerConfig{
+		UsePackagesLib:    true,
 		MainModuleVersion: DefaultMainModuleVersionConfig(),
 		LocalModCacheDir:  defaultGoModDir(),
 	}
@@ -177,6 +181,11 @@ func (g CatalogerConfig) WithNoProxy(input string) CatalogerConfig {
 
 func (g CatalogerConfig) WithMainModuleVersion(input MainModuleVersionConfig) CatalogerConfig {
 	g.MainModuleVersion = input
+	return g
+}
+
+func (g CatalogerConfig) WithUsePackagesLib(useLib bool) CatalogerConfig {
+	g.UsePackagesLib = useLib
 	return g
 }
 

--- a/syft/pkg/cataloger/golang/config_test.go
+++ b/syft/pkg/cataloger/golang/config_test.go
@@ -57,6 +57,7 @@ func Test_Config(t *testing.T) {
 				Proxies:                     []string{"https://my.proxy"},
 				NoProxy:                     []string{"my.private", "no.proxy"},
 				MainModuleVersion:           DefaultMainModuleVersionConfig(),
+				UsePackagesLib:              true,
 			},
 		},
 		{
@@ -84,6 +85,7 @@ func Test_Config(t *testing.T) {
 				Proxies:                     []string{"https://alt.proxy", "direct"},
 				NoProxy:                     []string{"alt.no.proxy"},
 				MainModuleVersion:           DefaultMainModuleVersionConfig(),
+				UsePackagesLib:              true,
 			},
 		},
 	}

--- a/syft/pkg/cataloger/golang/package.go
+++ b/syft/pkg/cataloger/golang/package.go
@@ -64,27 +64,23 @@ func newBinaryMetadata(dep *debug.Module, mainModule, goVersion, architecture st
 func packageURL(moduleName, moduleVersion string) string {
 	// source: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#golang
 	// note: "The version is often empty when a commit is not specified and should be the commit in most cases when available."
-
-	fields := strings.Split(moduleName, "/")
-	if len(fields) == 0 {
+	if moduleName == "" {
 		return ""
 	}
 
 	namespace := ""
-	name := ""
-	// The subpath is used to point to a subpath inside a package (e.g. pkg:golang/google.golang.org/genproto#googleapis/api/annotations)
-	subpath := ""
+	name := moduleName
 
-	switch len(fields) {
-	case 1:
-		name = fields[0]
-	case 2:
-		name = fields[1]
-		namespace = fields[0]
-	default:
-		name = fields[2]
-		namespace = strings.Join(fields[0:2], "/")
-		subpath = strings.Join(fields[3:], "/")
+	// golang PURLs from _modules_ are constructed as pkg:golang/<module>@version, where
+	// the full module name often includes multiple segments including `/v#`-type versions, for example:
+	//  pkg:golang/github.com/cli/cli/v2@2.63.0
+	// see: https://github.com/package-url/purl-spec/issues/63
+	// and: https://github.com/package-url/purl-spec/blob/main/types-doc/golang-definition.md#subpath-definition
+	// by setting the namespace this way, it does not escape the slashes:
+	lastSlash := strings.LastIndex(moduleName, "/")
+	if lastSlash > 0 && lastSlash < len(moduleName)-1 {
+		name = moduleName[lastSlash+1:]
+		namespace = moduleName[0:lastSlash]
 	}
 
 	return packageurl.NewPackageURL(
@@ -93,35 +89,6 @@ func packageURL(moduleName, moduleVersion string) string {
 		name,
 		moduleVersion,
 		nil,
-		subpath,
-	).ToString()
-}
-
-func packageURLForGoMod(moduleName, moduleVersion string) string {
-	fields := strings.Split(moduleName, "/")
-	if len(fields) == 0 {
-		return ""
-	}
-
-	var namespace, name string
-
-	switch len(fields) {
-	case 1:
-		name = fields[0]
-	case 2:
-		namespace = fields[0]
-		name = fields[1]
-	default:
-		namespace = strings.Join(fields[0:len(fields)-1], "/")
-		name = fields[len(fields)-1]
-	}
-
-	return packageurl.NewPackageURL(
-		packageurl.TypeGolang,
-		namespace,
-		name,
-		moduleVersion,
-		nil,
-		"",
+		"", // subpath is used to reference a specific _package_ within the module
 	).ToString()
 }

--- a/syft/pkg/cataloger/golang/package_test.go
+++ b/syft/pkg/cataloger/golang/package_test.go
@@ -38,14 +38,14 @@ func Test_packageURL(t *testing.T) {
 				Name:    "github.com/coreos/go-systemd/v22",
 				Version: "v22.1.0",
 			},
-			expected: "pkg:golang/github.com/coreos/go-systemd@v22.1.0#v22",
+			expected: "pkg:golang/github.com/coreos/go-systemd/v22@v22.1.0",
 		},
 		{
 			name: "golang with subpath deep",
 			pkg: pkg.Package{
 				Name: "google.golang.org/genproto/googleapis/api/annotations",
 			},
-			expected: "pkg:golang/google.golang.org/genproto/googleapis#api/annotations",
+			expected: "pkg:golang/google.golang.org/genproto/googleapis/api/annotations",
 		},
 	}
 

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -278,7 +278,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				{
 					Name:     "github.com/a/b/c",
 					Version:  "", // this was (devel) but we cleared it explicitly
-					PURL:     "pkg:golang/github.com/a/b#c",
+					PURL:     "pkg:golang/github.com/a/b/c",
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
 					Locations: file.NewLocationSet(

--- a/syft/pkg/cataloger/golang/parse_go_mod_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod_test.go
@@ -111,7 +111,7 @@ func TestParseGoMod(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.fixture, func(t *testing.T) {
-			c := newGoModCataloger(DefaultCatalogerConfig())
+			c := newGoModCataloger(DefaultCatalogerConfig().WithUsePackagesLib(false))
 			pkgtest.NewCatalogTester().
 				FromFile(t, test.fixture).
 				Expects(test.expected, nil).
@@ -172,7 +172,9 @@ func Test_GoSumHashes(t *testing.T) {
 			pkgtest.NewCatalogTester().
 				FromDirectory(t, test.fixture).
 				Expects(test.expected, nil).
-				TestCataloger(t, NewGoModuleFileCataloger(CatalogerConfig{}))
+				TestCataloger(t, NewGoModuleFileCataloger(CatalogerConfig{
+					UsePackagesLib: false,
+				}))
 		})
 	}
 }
@@ -189,7 +191,6 @@ func Test_parseGoSource_packageResolution(t *testing.T) {
 	tests := []struct {
 		name             string
 		fixturePath      string
-		config           CatalogerConfig
 		expectedPkgs     []string
 		expectedRels     []string
 		expectedLicenses map[string][]string
@@ -333,7 +334,7 @@ func Test_parseGoSource_packageResolution(t *testing.T) {
 						t.Errorf("mismatch in licenses (-want +got):\n%s", diff)
 					}
 				}).
-				TestCataloger(t, NewGoModuleFileCataloger(CatalogerConfig{}))
+				TestCataloger(t, NewGoModuleFileCataloger(DefaultCatalogerConfig().WithUsePackagesLib(true)))
 		})
 	}
 }


### PR DESCRIPTION
# Description

fixed wrong go module purl when module paths had version suffixes like /v5

<!-- If this completes an issue, please include: -->

- Fixes #4316 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
