### PR TITLE
fix: normalize python package names from dependency lists

### DIFF
--- a/syft/pkg/cataloger/python/cataloger_test.go
+++ b/syft/pkg/cataloger/python/cataloger_test.go
@@ -567,6 +567,7 @@ func Test_PackageCataloger_Relationships(t *testing.T) {
 				"colorama @ 0.4.6 (.) [dependency-of] pygments @ 2.18.0 (.)",
 				"colorama @ 0.4.6 (.) [dependency-of] uvicorn @ 0.29.0 (.)", // proof of uvicorn[standard]
 				"dnspython @ 2.6.1 (.) [dependency-of] email-validator @ 2.1.1 (.)",
+				"email-validator @ 2.1.1 (.) [dependency-of] fastapi @ 0.111.0 (.)",
 				"email-validator @ 2.1.1 (.) [dependency-of] pydantic @ 2.7.1 (.)",
 				"fastapi @ 0.111.0 (.) [dependency-of] fastapi-cli @ 0.0.4 (.)",
 				"fastapi-cli @ 0.0.4 (.) [dependency-of] fastapi @ 0.111.0 (.)",

--- a/syft/pkg/cataloger/python/dependency.go
+++ b/syft/pkg/cataloger/python/dependency.go
@@ -181,7 +181,9 @@ func extractPackageName(s string) string {
 	// requests (>= 2.8.1)			--> requests
 	// requests ; python_version < "2.7"	--> requests
 
-	return strings.TrimSpace(internal.SplitAny(s, "[(<!=>~;")[0])
+	name := strings.TrimSpace(internal.SplitAny(s, "[(<!=>~;")[0])
+	// normalize the name to match how packages are stored (lowercase, with hyphens instead of underscores)
+	return normalize(name)
 }
 
 // extractPackageNames applies extractPackageName to each string in the slice.


### PR DESCRIPTION
Because package names in METADATA files may have upper case like Werkzeug or Jinja2, but Syft artifacts have normalized names and are lower case, like werkzeug or jinja2, Syft would miss emitting dependency relationships. Therefore, normalize dependency names before comparing with existing artifacts.

# Description

Syft's cataloging of venv/site-packages uses a dependency resolving post processor to compare the `requires` statements from the METADATA file to other python artifacts emitted and create relationships between them. However, the name comparison between the requires statements from the METADATA files was normalized via a different codepath than the artifact names, so there were missed relationships because, for example `"Werkzeug" != "werkzeug"`.

Therefore, normalize the dependency names via the same normalization used for artifact names before building the relationships.

Fixes #4401 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
