### PR TITLE
fix(javascript): remove debug print statement in dependency parser

### DIFF
--- a/syft/pkg/cataloger/javascript/dependency.go
+++ b/syft/pkg/cataloger/javascript/dependency.go
@@ -27,8 +27,6 @@ func packageLockDependencySpecifier(p pkg.Package) dependency.Specification {
 			// if the package url is valid, include the name from the package url since this is likely an alias
 			var fullName = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
 			requires = append(requires, fullName)
-		} else {
-			fmt.Println("error", err)
 		}
 
 		requires = append(requires, name)


### PR DESCRIPTION
## Summary

Removes an accidental `fmt.Println("error", err)` that was left in the javascript dependency parser from PR #4304. 

This causes noisy output to stdout when parsing npm `package-lock.json` files that contain dependency specifiers that aren't valid PURLs (e.g., empty strings or version ranges).

## Example of the noise

When scanning a repository with npm dependencies:
```
error purl scheme is not "pkg": ""
error purl scheme is not "pkg": ""
error purl scheme is not "pkg": ""
... (repeated hundreds of times)
```

## Fix

Simply remove the debug print statement - the error case is already handled correctly (the dependency is still added via `requires = append(requires, name)` on line 34).

## Testing

- Verified that repositories with npm dependencies no longer produce noisy output
- The actual dependency parsing logic is unchanged