### PR TITLE
fix:after compliance applied,the relationship concerning the original one should be omitted 

### DIFF
--- a/internal/relationship/index.go
+++ b/internal/relationship/index.go
@@ -79,6 +79,10 @@ func (i *Index) Remove(id artifact.ID) {
 
 func (i *Index) Replace(ogID artifact.ID, replacement artifact.Identifiable) {
 	for _, mapped := range fromMappedByID(i.fromID, ogID) {
+		// the stale relationship(i.e. if there's an elder ID in either side) should be discarded
+		if len(fromMappedByID(i.toID, mapped.relationship.To.ID())) == 0 {
+			continue
+		}
 		i.Add(artifact.Relationship{
 			From: replacement,
 			To:   mapped.relationship.To,
@@ -87,6 +91,10 @@ func (i *Index) Replace(ogID artifact.ID, replacement artifact.Identifiable) {
 	}
 
 	for _, mapped := range fromMappedByID(i.toID, ogID) {
+		// same as the above
+		if len(fromMappedByID(i.fromID, mapped.relationship.To.ID())) == 0 {
+			continue
+		}
 		i.Add(artifact.Relationship{
 			From: mapped.relationship.From,
 			To:   replacement,

--- a/syft/pkg/cataloger/golang/package.go
+++ b/syft/pkg/cataloger/golang/package.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/anchore/packageurl-go"
-	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 )
@@ -23,22 +22,16 @@ func (c *goBinaryCataloger) newGoBinaryPackage(dep *debug.Module, m pkg.GolangBi
 	}
 
 	version := dep.Version
-	finalVersion := dep.Version
 	if version == devel {
 		// this is a special case for the "devel" version, which is used when the module is built from source
 		// and there is no vcs tag info available. In this case, we remove the placeholder to indicate
 		// we don't know the version.
 		version = ""
 	}
-	// empty version is non-compliant and thus will probably result in 1 more ghost module to appear in some relationship
-	// see:https://github.com/anchore/syft/issues/4415
-	if version == "" {
-		finalVersion = cataloging.UnknownStubValue
-	}
 
 	p := pkg.Package{
 		Name:      finalPath,
-		Version:   finalVersion,
+		Version:   version,
 		Licenses:  pkg.NewLicenseSet(licenses...),
 		PURL:      packageURL(finalPath, version),
 		Language:  pkg.Go,

--- a/syft/pkg/cataloger/golang/parse_go_binary_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_binary_test.go
@@ -880,7 +880,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 			expected: []pkg.Package{
 				{
 					Name:     "example.com/mylib",
-					Version:  "UNKNOWN",
+					Version:  "",
 					PURL:     "pkg:golang/example.com/mylib",
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,
@@ -901,7 +901,7 @@ func TestBuildGoPkgInfo(t *testing.T) {
 				},
 				{
 					Name:     "command-line-arguments",
-					Version:  "UNKNOWN",
+					Version:  "",
 					PURL:     "pkg:golang/command-line-arguments",
 					Language: pkg.Go,
 					Type:     pkg.GoModulePkg,


### PR DESCRIPTION
# Description

When the replace directive only involving module path is applied, the version is empty ,which means it's non-compliant. Therefore, [the compliance needs to be applied](https://github.com/VictorHuu/syft/blob/5b96d1d69d76098778be0f8556d1a63d1050239f/internal/task/package_task_factory.go#L125-L139) ,however,after which the previous non-compliant module entry still exists.

And the problem is that the [replace](https://github.com/VictorHuu/syft/blob/5b96d1d69d76098778be0f8556d1a63d1050239f/internal/relationship/index.go#L80-L98) and remove in index.go ignore that IDs of both sides in a relationship need to be compliant.

<!-- If this completes an issue, please include: -->

- Fixes #4415 

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
