### PR TITLE
chore: ignore .DS_Store in test fixtures

### DIFF
--- a/syft/pkg/cataloger/binary/test-fixtures/manager/internal/list_entries.go
+++ b/syft/pkg/cataloger/binary/test-fixtures/manager/internal/list_entries.go
@@ -174,7 +174,7 @@ func getLogicalKey(managedBinaryPath string) (*LogicalEntryKey, error) {
 func allFilePaths(root string) ([]string, error) {
 	var paths []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
-		if info != nil && !info.IsDir() && !strings.HasSuffix(path, digestFileSuffix) {
+		if info != nil && !info.IsDir() && !strings.HasSuffix(path, digestFileSuffix) && !strings.HasSuffix(path, ".DS_Store") {
 			paths = append(paths, path)
 		}
 		return nil


### PR DESCRIPTION
Otherwise, we get test failures on macOS if macOS has decided to put .DS_Store entries in the test fixtures.

# Description

Otherwise, I sometimes get errors like `unable to get logical key for snippet "classifiers/snippets/arangodb/.DS_Store": invalid managed binary path: "arangodb/.DS_Store"` when trying to run `make unit` locally on a macbook.w

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

# Checklist:

Checklist is not really applicable as only test fixture handling code is changed, not production code.

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
