### PR TITLE
chore: use git ls-files instead of find to list files

### DIFF
--- a/.github/scripts/check_binary_fixture_size.sh
+++ b/.github/scripts/check_binary_fixture_size.sh
@@ -24,7 +24,7 @@ while IFS= read -r -d '' file; do
     echo "File $file is greater than ${size} bytes."
     found_large_files=1
   fi
-done < <(find "$directory" -type f -print0)
+done < <(git ls-files -z "$directory")
 
 if [ "$found_large_files" -eq 1 ]; then
   echo "Script failed: Some files are greater than ${size} bytes."


### PR DESCRIPTION
# Description

Please include a summary of the changes along with any relevant motivation and context,
or link to an issue where this is explained.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

## Before:

``` sh
task: [check-binary-fixture-size] .github/scripts/check_binary_fixture_size.sh syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets
File syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store is greater than 1000 bytes.
Script failed: Some files are greater than 1000 bytes.
task: Failed to run task "static-analysis": task: Failed to run task "check-binary-fixture-size": exit status 1
make: *** [static-analysis] Error 201

# but these are ignored! you failed my branch when I wasn't going to add a large file

❯ git check-ignore -v syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
.gitignore:64:.DS_STORE syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
```

## After

### when the large file isn't tracked

``` sh
❯ ll -h syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
-rw-r--r--@ 1 willmurphy  staff    18K Dec  1 10:44 syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store

❯ git check-ignore -v syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
.gitignore:64:.DS_STORE syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store

task: [check-binary-fixture-size] .github/scripts/check_binary_fixture_size.sh syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets
All files in syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets and its subdirectories are 1000 bytes or smaller. Check passed.
```

### when the large file is tracked it still fails

``` sh
❯ git add syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
The following paths are ignored by one of your .gitignore files:
syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"

❯ git add -f syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store

❯ git commit -m 'track this large file please!'
[chore-git-ls-files d74eabf0] track this large file please!
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store

❯ make static-analysis
...
task: [check-binary-fixture-size] .github/scripts/check_binary_fixture_size.sh syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets
File syft/pkg/cataloger/binary/test-fixtures/classifiers/snippets/.DS_Store is greater than 1000 bytes.
Script failed: Some files are greater than 1000 bytes.
task: Failed to run task "static-analysis": task: Failed to run task "check-binary-fixture-size": exit status 1
make: *** [static-analysis] Error 201
```