### PR TITLE
fix: use vercel for vendor in nextjs CPE

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -198,6 +198,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		// NPM packages
 		{
 			pkg.NpmPkg,
+			candidateKey{PkgName: "next"},
+			candidateAddition{AdditionalProducts: []string{"next.js"}, AdditionalVendors: []string{"vercel"}},
+		},
+		{
+			pkg.NpmPkg,
 			candidateKey{PkgName: "hapi"},
 			candidateAddition{AdditionalProducts: []string{"hapi_server_framework"}},
 		},


### PR DESCRIPTION
The recent react / next CVE uses "vercel" as the vendor, see https://nvd.nist.gov/vuln/detail/CVE-2025-55182

- Fixes #4443 4443

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

# Questions

1. Do we think it's worth also preventing `cpe:a:next:next.js:...` from being emitted?
