### PR TITLE
chore:cancel in-progress workflows for new commits on same PR

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -1,5 +1,9 @@
 name: "Validations"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
# Description
Ensures CI only runs for the most recent commit, improving speed and reducing resource usage.[changelog-ignored]

## Type of change

<!-- Delete any that are not relevant -->
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)


# Checklist:

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
