### PR TITLE
fix: cyclonedx.ComponentTypeOS skipped in package collection

### DIFF
--- a/syft/format/cyclonedxjson/decoder_test.go
+++ b/syft/format/cyclonedxjson/decoder_test.go
@@ -26,13 +26,13 @@ func TestDecoder_Decode(t *testing.T) {
 			name:     "dir-scan",
 			file:     "snapshot/TestCycloneDxDirectoryEncoder.golden",
 			distro:   "debian:1.2.3",
-			packages: []string{"package-1:1.0.1", "package-2:2.0.1"},
+			packages: []string{"package-1:1.0.1", "package-2:2.0.1", "debian:1.2.3"},
 		},
 		{
 			name:     "image-scan",
 			file:     "snapshot/TestCycloneDxImageEncoder.golden",
 			distro:   "debian:1.2.3",
-			packages: []string{"package-1:1.0.1", "package-2:2.0.1"},
+			packages: []string{"package-1:1.0.1", "package-2:2.0.1", "debian:1.2.3"},
 		},
 		{
 			name: "not-an-sbom",

--- a/syft/format/cyclonedxjson/encoder_test.go
+++ b/syft/format/cyclonedxjson/encoder_test.go
@@ -171,8 +171,16 @@ func TestSupportedVersions(t *testing.T) {
 
 			assert.Equal(t, len(subject.Relationships), len(s.Relationships), "mismatched relationship count")
 
-			if !assert.Equal(t, subject.Artifacts.Packages.PackageCount(), s.Artifacts.Packages.PackageCount(), "mismatched package count") {
-				t.Logf("expected: %d", subject.Artifacts.Packages.PackageCount())
+			// When encoding to CycloneDX, LinuxDistribution becomes an OS component.
+			// When decoding back, this OS component is also decoded as an OperatingSystemPkg,
+			// so the decoded SBOM will have one additional package.
+			expectedPkgCount := subject.Artifacts.Packages.PackageCount()
+			if subject.Artifacts.LinuxDistribution != nil {
+				expectedPkgCount++
+			}
+
+			if !assert.Equal(t, expectedPkgCount, s.Artifacts.Packages.PackageCount(), "mismatched package count") {
+				t.Logf("expected: %d", expectedPkgCount)
 				for _, p := range subject.Artifacts.Packages.Sorted() {
 					t.Logf("  - %s", p.String())
 				}

--- a/syft/format/cyclonedxxml/decoder_test.go
+++ b/syft/format/cyclonedxxml/decoder_test.go
@@ -26,13 +26,13 @@ func TestDecoder_Decode(t *testing.T) {
 			name:     "dir-scan",
 			file:     "snapshot/TestCycloneDxDirectoryEncoder.golden",
 			distro:   "debian:1.2.3",
-			packages: []string{"package-1:1.0.1", "package-2:2.0.1"},
+			packages: []string{"package-1:1.0.1", "package-2:2.0.1", "debian:1.2.3"},
 		},
 		{
 			name:     "image-scan",
 			file:     "snapshot/TestCycloneDxImageEncoder.golden",
 			distro:   "debian:1.2.3",
-			packages: []string{"package-1:1.0.1", "package-2:2.0.1"},
+			packages: []string{"package-1:1.0.1", "package-2:2.0.1", "debian:1.2.3"},
 		},
 		{
 			name: "not-an-sbom",

--- a/syft/format/cyclonedxxml/encoder_test.go
+++ b/syft/format/cyclonedxxml/encoder_test.go
@@ -152,8 +152,16 @@ func TestSupportedVersions(t *testing.T) {
 
 			assert.Equal(t, len(subject.Relationships), len(s.Relationships), "mismatched relationship count")
 
-			if !assert.Equal(t, subject.Artifacts.Packages.PackageCount(), s.Artifacts.Packages.PackageCount(), "mismatched package count") {
-				t.Logf("expected: %d", subject.Artifacts.Packages.PackageCount())
+			// When encoding to CycloneDX, LinuxDistribution becomes an OS component.
+			// When decoding back, this OS component is also decoded as an OperatingSystemPkg,
+			// so the decoded SBOM will have one additional package.
+			expectedPkgCount := subject.Artifacts.Packages.PackageCount()
+			if subject.Artifacts.LinuxDistribution != nil {
+				expectedPkgCount++
+			}
+
+			if !assert.Equal(t, expectedPkgCount, s.Artifacts.Packages.PackageCount(), "mismatched package count") {
+				t.Logf("expected: %d", expectedPkgCount)
 				for _, p := range subject.Artifacts.Packages.Sorted() {
 					t.Logf("  - %s", p.String())
 				}

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -45,6 +45,8 @@ func EncodeComponent(p pkg.Package, supplier string, locationSorter func(a, b fi
 		componentType = cyclonedx.ComponentTypeApplication
 	case pkg.ModelPkg:
 		componentType = cyclonedx.ComponentTypeMachineLearningModel
+	case pkg.OperatingSystemPkg:
+		componentType = cyclonedx.ComponentTypeOS
 	}
 
 	return cyclonedx.Component{

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -55,6 +55,7 @@ const (
 	WordpressPluginPkg      Type = "wordpress-plugin"
 	HomebrewPkg             Type = "homebrew"
 	ModelPkg                Type = "model"
+	OperatingSystemPkg      Type = "operating-system"
 )
 
 // AllPkgs represents all supported package types
@@ -100,6 +101,7 @@ var AllPkgs = []Type{
 	WordpressPluginPkg,
 	HomebrewPkg,
 	ModelPkg,
+	OperatingSystemPkg,
 }
 
 // PackageURLType returns the PURL package type for the current package.
@@ -176,6 +178,8 @@ func (t Type) PackageURLType() string {
 		return "wordpress-plugin"
 	case HomebrewPkg:
 		return "homebrew"
+	case OperatingSystemPkg:
+		return packageurl.TypeGeneric
 	default:
 		// TODO: should this be a "generic" purl type instead?
 		return ""
@@ -264,6 +268,8 @@ func TypeByName(name string) Type {
 		return WordpressPluginPkg
 	case "homebrew":
 		return HomebrewPkg
+	case "operating-system":
+		return OperatingSystemPkg
 	default:
 		return UnknownPkg
 	}

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -135,6 +135,11 @@ func TestTypeFromPURL(t *testing.T) {
 			purl:     "pkg:generic/conda@1.2.3",
 			expected: CondaPkg,
 		},
+		{
+			name:     "operating-system",
+			purl:     "pkg:generic/operating-system@11",
+			expected: OperatingSystemPkg,
+		},
 	}
 
 	var pkgTypes = strset.New()


### PR DESCRIPTION
Fixes #4414

## Changes
- Add `OperatingSystemPkg` type to represent OS components as packages
- Decode `cyclonedx.ComponentTypeOS` as `OperatingSystemPkg` in package collection (not just for Linux distro info)
- Encode `OperatingSystemPkg` as `cyclonedx.ComponentTypeOS` in CycloneDX output
- Add tests for OS component decoding as package