### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,24 +31,9 @@ updates:
           - "patch"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "friday"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    directory: "/.github/actions/bootstrap"
+    directories:
+      - "/"
+      - "/.github/actions/bootstrap"
     schedule:
       interval: "weekly"
       day: "friday"


### PR DESCRIPTION
This tweaks the dependabot config so that:
- we group all minor or patch updates into a single PR (unless they address a CVE)
- security updates still get their own PR
- major updates still get their own PR
- we post these PRs on fridays (where releases tend to be monday)