### PR TITLE
Add container support for graalvm fixture

### DIFF
--- a/syft/pkg/cataloger/java/test-fixtures/java-builds/build-example-java-app-native-image.sh
+++ b/syft/pkg/cataloger/java/test-fixtures/java-builds/build-example-java-app-native-image.sh
@@ -3,7 +3,7 @@ set -uxe
 
 PKGSDIR=$1
 
-CTRID=$(docker create -v /example-java-app ghcr.io/graalvm/native-image:22.2.0 -cp /example-java-app/example-java-app-maven-0.1.0.jar --no-fallback -H:Class=hello.HelloWorld -H:Name=example-java-app)
+CTRID=$(docker create -v /example-java-app ghcr.io/graalvm/native-image:22.2.0 -cp /example-java-app/example-java-app-maven-0.1.0.jar -XX:-UseContainerSupport --no-fallback -H:Class=hello.HelloWorld -H:Name=example-java-app)
 
 function cleanup() {
   docker rm "${CTRID}"


### PR DESCRIPTION
The test fixtures for graalvm are [not building from scratch any more](https://github.com/anchore/syft/actions/runs/20721424749):
```
2026-01-05T16:55:53.2952043Z ========================================================================================================================
2026-01-05T16:55:53.2956953Z GraalVM Native Image: Generating 'example-java-app' (executable)...
2026-01-05T16:55:53.2958166Z ========================================================================================================================
2026-01-05T16:55:55.5416540Z 
2026-01-05T16:55:55.5448585Z [1/7] Initializing...                                                                                    (0.0s @ 0.09GB)
2026-01-05T16:55:55.5453539Z Fatal error: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
2026-01-05T16:55:55.5459660Z 	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
2026-01-05T16:55:55.5462124Z 	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
2026-01-05T16:55:55.5464353Z 	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
2026-01-05T16:55:55.5466270Z 	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
2026-01-05T16:55:55.5467992Z 	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
2026-01-05T16:55:55.5469895Z 	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
2026-01-05T16:55:55.5472240Z 	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
2026-01-05T16:55:55.5475028Z 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
2026-01-05T16:55:55.5477706Z 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
2026-01-05T16:55:55.5480604Z 	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
2026-01-05T16:55:55.5483569Z 	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:687)
2026-01-05T16:55:55.5486065Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.management.ManagementFeature.duringSetup(ManagementFeature.java:79)
2026-01-05T16:55:55.5489124Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.lambda$setupNativeImage$16(NativeImageGenerator.java:899)
2026-01-05T16:55:55.5491982Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:78)
2026-01-05T16:55:55.5495035Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.setupNativeImage(NativeImageGenerator.java:899)
2026-01-05T16:55:55.5497743Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:561)
2026-01-05T16:55:55.5500232Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:521)
2026-01-05T16:55:55.5503486Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:407)
2026-01-05T16:55:55.5506623Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:585)
2026-01-05T16:55:55.5509396Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
2026-01-05T16:55:55.5511823Z ------------------------------------------------------------------------------------------------------------------------
2026-01-05T16:55:55.5513955Z Fatal error: java.lang.NullPointerException: Cannot invoke "jdk.internal.platform.CgroupInfo.getMountPoint()" because "anyController" is null
2026-01-05T16:55:55.5516431Z 	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(CgroupV2Subsystem.java:80)
2026-01-05T16:55:55.5518682Z 	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(CgroupSubsystemFactory.java:114)
2026-01-05T16:55:55.5520688Z 	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(CgroupMetrics.java:177)
2026-01-05T16:55:55.5522834Z 	at java.base/jdk.internal.platform.SystemMetrics.instance(SystemMetrics.java:29)
2026-01-05T16:55:55.5524389Z 	at java.base/jdk.internal.platform.Metrics.systemMetrics(Metrics.java:58)
2026-01-05T16:55:55.5525748Z 	at java.base/jdk.internal.platform.Container.metrics(Container.java:43)
2026-01-05T16:55:55.5527127Z 	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(OperatingSystemImpl.java:182)
2026-01-05T16:55:55.5529326Z 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(PlatformMBeanProviderImpl.java:280)
2026-01-05T16:55:55.5531781Z 	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(PlatformMBeanProviderImpl.java:199)
2026-01-05T16:55:55.5533723Z 	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(PlatformMBeanProvider.java:195)
2026-01-05T16:55:55.5535446Z 	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(ManagementFactory.java:687)
2026-01-05T16:55:55.5537271Z 	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(ManagementFactory.java:389)
2026-01-05T16:55:55.5539139Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.ProgressReporter.printResourceStatistics(ProgressReporter.java:636)
2026-01-05T16:55:55.5540997Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.ProgressReporter.printEpilog(ProgressReporter.java:555)
2026-01-05T16:55:55.5544810Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:467)
2026-01-05T16:55:55.5547268Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:585)
2026-01-05T16:55:55.5549647Z 	at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:128)
```

It looks like [there is a workaround](https://github.com/oracle/graal/issues/4831#issuecomment-3301605352) which is what this PR employs. An [initial test run looks promising](https://github.com/anchore/syft/actions/runs/20724915543/job/59497962556).