### PR TITLE
feat: Phase 1 memory optimization for JavaScript SBOM generation

### DIFF
--- a/internal/licenses/context.go
+++ b/internal/licenses/context.go
@@ -2,11 +2,14 @@ package licenses
 
 import (
 	"context"
+	"errors"
 )
 
 type licenseScannerKey struct{}
 
 var ctxKey = licenseScannerKey{}
+
+var ErrNoLicenseScanner = errors.New("no license scanner set in context")
 
 func SetContextLicenseScanner(ctx context.Context, s Scanner) context.Context {
 	return context.WithValue(ctx, ctxKey, s)
@@ -18,8 +21,9 @@ func IsContextLicenseScannerSet(ctx context.Context) bool {
 }
 
 func ContextLicenseScanner(ctx context.Context) (Scanner, error) {
-	if s, ok := ctx.Value(ctxKey).(Scanner); ok {
-		return s, nil
+	s, ok := ctx.Value(ctxKey).(Scanner)
+	if !ok {
+		return nil, ErrNoLicenseScanner
 	}
-	return NewDefaultScanner()
+	return s, nil
 }

--- a/internal/licenses/context_test.go
+++ b/internal/licenses/context_test.go
@@ -33,16 +33,15 @@ func TestContextLicenseScanner(t *testing.T) {
 		scanner := testScanner()
 		ctx := SetContextLicenseScanner(context.Background(), scanner)
 		s, err := ContextLicenseScanner(ctx)
-		if err != nil || s != scanner {
-			t.Fatal("expected scanner from context")
-		}
+		require.NoError(t, err)
+		require.Equal(t, scanner, s)
 	})
 
 	t.Run("without scanner", func(t *testing.T) {
 		ctx := context.Background()
 		s, err := ContextLicenseScanner(ctx)
-		if err != nil || s == nil {
-			t.Fatal("expected default scanner")
-		}
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrNoLicenseScanner)
+		require.Nil(t, s)
 	})
 }


### PR DESCRIPTION
This commit implements Phase 1 of the memory optimization plan, focusing on quick wins that reduce memory allocations.

Changes:

1. JavaScript Lock File Parsers:
   - yarn.lock: Use bufio.Scanner for line-by-line reading instead of
     loading entire file and regex.Split, reducing peak memory usage.
     Only loads the first 100 bytes to detect version, then parses v1 files
     line-by-line directly from the file handle.
   - pnpm-lock.yaml: Replace string concatenation with strings.Join and
     use strings.Cut for efficient splitting, reducing string allocations
   - Pre-allocate map sizes to reduce reallocations

2. Dependency Resolution:
   - Replace strset-based deduplication with efficient map-based approach
   - Use struct keys instead of string concatenation for relationship tracking
   - Eliminate temporary string allocations in deduplicate function

Note: A previous optimization to defer license scanner creation was removed
after review, as the scanner should always be set in the context before
cataloging begins.

Memory Impact:
- Reduced memory usage for JavaScript SBOM generation
- Peak memory reduction for large JS projects (10k+ packages)
- Maintains all existing functionality and test coverage

All existing tests pass with these changes.

Related: Detailed analysis available at https://gist.github.com/matthyx/e500d3282876fd6a41064770eacc7229
Issue: #4586