### PR TITLE
Fix crash when scanning PHP extensions with special characters in paths

### DIFF
--- a/syft/pkg/cataloger/php/interpreter_cataloger.go
+++ b/syft/pkg/cataloger/php/interpreter_cataloger.go
@@ -3,7 +3,8 @@ package php
 import (
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/anchore/packageurl-go"
@@ -202,7 +203,7 @@ func (p interpreterCataloger) getClassifier(realPath string) (string, *binutils.
 		return "", nil
 	}
 
-	base := path.Base(realPath)
+	base := filepath.Base(realPath)
 	name := strings.TrimSuffix(base, ".so")
 
 	var match string
@@ -214,7 +215,7 @@ func (p interpreterCataloger) getClassifier(realPath string) (string, *binutils.
 	case "zip":
 		match = `\x00+(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00+Zip`
 	default:
-		match = fmt.Sprintf(`(?m)(\x00+%s)?\x00+(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00+API`, name)
+		match = fmt.Sprintf(`(?m)(\x00+%s)?\x00+(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00+API`, regexp.QuoteMeta(name))
 	}
 
 	return name, &binutils.Classifier{


### PR DESCRIPTION
## Summary

Fix regex compilation error that caused Syft to crash when scanning directories containing PHP extension files with special characters (such as backslashes) in their paths.

## Motivation

When scanning directories on Windows or with paths containing special regex characters, the PHP cataloger would panic with a regex compilation error.
## Changes

- Use `filepath.Base()` instead of `path.Base()` for better cross-platform path handling
- Escape extension names using `regexp.QuoteMeta()` before inserting them into regex patterns

## Type of change

- [x] Bug fix (non-breaking change)
<img width="1874" height="644" alt="image" src="https://github.com/user-attachments/assets/820fd436-46f3-4e78-8c1e-6c97b5e35080" />
