### PR TITLE
fix: CPE detection for APK libavif to use aomedia vendor

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/apk_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/apk_test.go
@@ -97,6 +97,15 @@ func Test_candidateVendorsForAPK(t *testing.T) {
 			},
 			expected: []string{"rake", "ruby-lang"},
 		},
+		{
+			name: "libavif",
+			pkg: pkg.Package{
+				Metadata: pkg.ApkDBEntry{
+					Package: "libavif",
+				},
+			},
+			expected: []string{"aomedia", "libavif"},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -412,6 +412,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		},
 		{
 			pkg.ApkPkg,
+			candidateKey{PkgName: "libavif"},
+			candidateAddition{AdditionalVendors: []string{"aomedia"}},
+		},
+		{
+			pkg.ApkPkg,
 			candidateKey{PkgName: "bind"},
 			candidateAddition{AdditionalVendors: []string{"isc"}},
 		},


### PR DESCRIPTION
## Description

TLDR: This change adds libavif to the APK package CPE candidate additions with `aomedia` as an additional vendor, enabling Syft/Grype to match CVEs like CVE-2025-48174 and CVE-2025-48175 using CPEs.

NVD uses `aomedia` as the vendor for libavif CVEs, see for example https://nvd.nist.gov/vuln/detail/CVE-2025-48174:

```text
cpe:2.3:a:aomedia:libavif:*:*:*:*:*:*:*:*
```

The CPE currently computed by Syft/Grype uses the vendor `libavif`, which causes a CPE mismatch:

```text
[0003] TRACE searching for vulnerability matches package=pkg:apk/alpine/libavif@1.0.4-r0?arch=x86_64&distro=alpine-3.21.5
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=176.125µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=none duration=87.875µs pkg=package(cpe=cpe:2.3:a:libavif:libavif:1.0.4:*:*:*:*:*:*:*) records=0 vulns=any
[0003] TRACE fetched CPE record cpe=cpe:2.3:a:libavif:libavif:1.0.4:*:*:*:*:*:*:* duration=45.417µs records=0
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=263.042µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=244µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=178.292µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=none duration=106.25µs pkg=package(cpe=cpe:2.3:a:libavif:libavif:1.0.4:*:*:*:*:*:*:*) records=0 vulns=any
[0003] TRACE fetched CPE record cpe=cpe:2.3:a:libavif:libavif:1.0.4:*:*:*:*:*:*:* duration=51.458µs records=0
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=174.167µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=133.375µs pkg=package(name=libavif) records=0 vulns=any
[0003] TRACE fetched package record distro=alpine@3.21.5 duration=133.166µs pkg=package(name=libavif) records=0 vulns=any
```

With this PR merged, the generated CPE for `libavif` will match what NVD is using, which fixes false negatives in Grype.

<!-- Please include a summary of the changes along with any relevant motivation and context -->

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
