### PR TITLE
chore: migrate `.goreleaser` config to use docker_v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,8 +63,13 @@ jobs:
     #   spot disabled: reliability for build workflows (used for releases too)
     #   goreleaser uses parallelism of 12, so we need more CPUs
     #   s3-cache: faster actions cache
-    #   tmpfs: faster io-intensive workflows
-    runs-on: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false/extras=s3-cache+tmpfs
+    #   volume: enlarge dist/ disk -- the default 40GB EBS root fills up during the multi-arch
+    #   image + binary build and OOMs (runs out of disk); size it well above peak usage.
+    #   provisioned throughput/iops above the gp3 free baseline (125mbs/3000iops) approximate
+    #   the tmpfs IO speed on disk, for ~1c/run.
+    #   note: tmpfs intentionally omitted -- a RAM-backed dist/ never touches the enlarged
+    #   volume and competes with the build's memory peak, so keep dist/ on disk.
+    runs-on: runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false/extras=s3-cache/volume=120gb:gp3:500mbs:4000iops
     permissions:
       contents: write # required for creating the GitHub release and pushing the version tag
       packages: write # required for publishing release artifacts to GitHub packages

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -92,10 +92,12 @@ jobs:
     # runs-on.com: compute instances for parallel builds
     #   spot disabled: reliability for build workflows (used for releases too)
     #   goreleaser uses parallelism of 12, so we need more CPUs
-    #   tmpfs: faster io-intensive workflows
+    #   tmpfs intentionally omitted -- a RAM-backed dist/ competes with the goreleaser
+    #   build's memory peak (parallel binaries + multi-arch image assembly) and OOMs the
+    #   instance; keep dist/ on disk.
     #   note: s3-cache intentionally omitted -- PR runs are untrusted and must not write to the
     #   shared cache backend that the trusted release workflow reads from (cache poisoning).
-    runs-on: "runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false/extras=tmpfs"
+    runs-on: "runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false"
     permissions:
       contents: read
     steps:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -97,7 +97,11 @@ jobs:
     #   instance; keep dist/ on disk.
     #   note: s3-cache intentionally omitted -- PR runs are untrusted and must not write to the
     #   shared cache backend that the trusted release workflow reads from (cache poisoning).
-    runs-on: "runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false"
+    #   volume: enlarge dist/ disk -- the default 40GB EBS root fills up during the multi-arch
+    #   image + binary build and OOMs (runs out of disk); size it well above peak usage.
+    #   provisioned throughput/iops above the gp3 free baseline (125mbs/3000iops) approximate
+    #   the tmpfs IO speed on disk, for ~1c/run.
+    runs-on: "runs-on=${{ github.run_id }}/cpu=16+32/ram=32+128/family=c5+c6+c7+c8/spot=false/volume=120gb:gp3:500mbs:4000iops"
     permissions:
       contents: read
     steps:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,306 +73,88 @@ brews:
     description: *description
     license: "Apache License 2.0"
 
-dockers:
-  # production images...
-  - image_templates:
-      - anchore/syft:{{.Tag}}-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-amd64
-    goarch: amd64
+dockers_v2:
+  # production images (scratch base, root)
+  - id: production
     dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
+    ids: &docker-ids
+      - linux-build
+    images: &docker-images
+      - anchore/syft
+      - ghcr.io/anchore/syft
+    platforms: &docker-platforms
+      - linux/amd64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/riscv64
+      - linux/s390x
+    labels: &docker-labels
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.title": "syft"
+      "org.opencontainers.image.description": "CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
+      "org.opencontainers.image.source": "{{.GitURL}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.vendor": "Anchore, Inc."
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.licenses": "Apache-2.0"
+      "io.artifacthub.package.readme-url": "https://raw.githubusercontent.com/anchore/syft/main/README.md"
+      "io.artifacthub.package.logo-url": "https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png"
+      "io.artifacthub.package.license": "Apache-2.0"
+    tags:
+      - latest
+      - "{{.Tag}}"
+    # DEBIAN_VERSION 13 (trixie) is the first distroless release with a riscv64 base image
+    # and is a superset of debian 12 for the other targeted arches; docker_v2 builds all
+    # platforms in a single buildx invocation, so build_args cannot vary per platform.
+    build_args: &docker-build-args
+      DEBIAN_VERSION: "13"
+    # disable provenance attestations to keep the manifest free of unknown/unknown entries
+    flags: &docker-flags
+      - "--provenance=false"
+    # SBOMs are produced separately for the archives (see the sboms section)
+    sbom: &docker-sbom "false"
 
-  - image_templates:
-      - anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-riscv64
-    goarch: riscv64
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/riscv64"
-      - "--build-arg=DEBIAN_VERSION=13"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-s390x
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-    goarch: s390x
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  # nonroot images...
-  - image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
-    goarch: amd64
+  # nonroot images
+  - id: nonroot
     dockerfile: Dockerfile.nonroot
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
+    ids: *docker-ids
+    images: *docker-images
+    platforms: *docker-platforms
+    labels: *docker-labels
+    tags:
+      - nonroot
+      - "{{.Tag}}-nonroot"
+    build_args: *docker-build-args
+    flags: *docker-flags
+    sbom: *docker-sbom
 
-  - image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile.nonroot
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile.nonroot
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-riscv64
-    goarch: riscv64
-    dockerfile: Dockerfile.nonroot
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/riscv64"
-      - "--build-arg=DEBIAN_VERSION=13"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-s390x
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
-    goarch: s390x
-    dockerfile: Dockerfile.nonroot
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  # debug images...
-  - image_templates:
-      - anchore/syft:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
-    goarch: amd64
+  # debug images (root)
+  - id: debug
     dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
+    ids: *docker-ids
+    images: *docker-images
+    platforms: *docker-platforms
+    labels: *docker-labels
+    tags:
+      - debug
+      - "{{.Tag}}-debug"
+    build_args: *docker-build-args
+    flags: *docker-flags
+    sbom: *docker-sbom
 
-  - image_templates:
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
-    goarch: arm64
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
-    goarch: ppc64le
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-debug-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-riscv64
-    goarch: riscv64
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/riscv64"
-      - "--build-arg=DEBIAN_VERSION=13"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-  - image_templates:
-      - anchore/syft:{{.Tag}}-debug-s390x
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
-    goarch: s390x
-    dockerfile: Dockerfile.debug
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - "--build-arg=BUILD_DATE={{.Date}}"
-      - "--build-arg=BUILD_VERSION={{.Version}}"
-      - "--build-arg=VCS_REF={{.FullCommit}}"
-      - "--build-arg=VCS_URL={{.GitURL}}"
-
-docker_manifests:
-  - name_template: anchore/syft:latest
-    image_templates:
-      - anchore/syft:{{.Tag}}-amd64
-      - anchore/syft:{{.Tag}}-arm64v8
-      - anchore/syft:{{.Tag}}-ppc64le
-      - anchore/syft:{{.Tag}}-riscv64
-      - anchore/syft:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/syft:latest
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-
-  - name_template: anchore/syft:{{.Tag}}
-    image_templates:
-      - anchore/syft:{{.Tag}}-amd64
-      - anchore/syft:{{.Tag}}-arm64v8
-      - anchore/syft:{{.Tag}}-ppc64le
-      - anchore/syft:{{.Tag}}-riscv64
-      - anchore/syft:{{.Tag}}-s390x
-
-  - name_template: ghcr.io/anchore/syft:{{.Tag}}
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-s390x
-
-  # nonroot images...
-  - name_template: anchore/syft:nonroot
-    image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-amd64
-      - anchore/syft:{{.Tag}}-nonroot-arm64v8
-      - anchore/syft:{{.Tag}}-nonroot-ppc64le
-      - anchore/syft:{{.Tag}}-nonroot-riscv64
-      - anchore/syft:{{.Tag}}-nonroot-s390x
-
-  - name_template: ghcr.io/anchore/syft:nonroot
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
-
-  - name_template: anchore/syft:{{.Tag}}-nonroot
-    image_templates:
-      - anchore/syft:{{.Tag}}-nonroot-amd64
-      - anchore/syft:{{.Tag}}-nonroot-arm64v8
-      - anchore/syft:{{.Tag}}-nonroot-ppc64le
-      - anchore/syft:{{.Tag}}-nonroot-riscv64
-      - anchore/syft:{{.Tag}}-nonroot-s390x
-
-  - name_template: ghcr.io/anchore/syft:{{.Tag}}-nonroot
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-nonroot-s390x
-
-  # debug images...
-  - name_template: anchore/syft:debug
-    image_templates:
-      - anchore/syft:{{.Tag}}-debug-amd64
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-riscv64
-      - anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: ghcr.io/anchore/syft:debug
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: anchore/syft:{{.Tag}}-debug
-    image_templates:
-      - anchore/syft:{{.Tag}}-debug-amd64
-      - anchore/syft:{{.Tag}}-debug-arm64v8
-      - anchore/syft:{{.Tag}}-debug-ppc64le
-      - anchore/syft:{{.Tag}}-debug-riscv64
-      - anchore/syft:{{.Tag}}-debug-s390x
-
-  - name_template: ghcr.io/anchore/syft:{{.Tag}}-debug
-    image_templates:
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-amd64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-arm64v8
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-ppc64le
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-riscv64
-      - ghcr.io/anchore/syft:{{.Tag}}-debug-s390x
+  # debug-nonroot images
+  - id: debug-nonroot
+    dockerfile: Dockerfile.debug-nonroot
+    ids: *docker-ids
+    images: *docker-images
+    platforms: *docker-platforms
+    labels: *docker-labels
+    tags:
+      - debug-nonroot
+      - "{{.Tag}}-debug-nonroot"
+    build_args: *docker-build-args
+    flags: *docker-flags
+    sbom: *docker-sbom
 
 sboms:
   - artifacts: archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEBIAN_VERSION=12
+ARG DEBIAN_VERSION=13
 FROM gcr.io/distroless/static-debian${DEBIAN_VERSION}:latest AS build
 
 FROM scratch
@@ -8,23 +8,7 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifica
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
-COPY syft /
-
-ARG BUILD_DATE
-ARG BUILD_VERSION
-ARG VCS_REF
-ARG VCS_URL
-
-LABEL org.opencontainers.image.created=$BUILD_DATE
-LABEL org.opencontainers.image.title="syft"
-LABEL org.opencontainers.image.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
-LABEL org.opencontainers.image.source=$VCS_URL
-LABEL org.opencontainers.image.revision=$VCS_REF
-LABEL org.opencontainers.image.vendor="Anchore, Inc."
-LABEL org.opencontainers.image.version=$BUILD_VERSION
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/anchore/syft/main/README.md"
-LABEL io.artifacthub.package.logo-url="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png"
-LABEL io.artifacthub.package.license="Apache-2.0"
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/syft /
 
 ENTRYPOINT ["/syft"]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,28 +1,10 @@
-ARG DEBIAN_VERSION=12
-FROM gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug-nonroot
+ARG DEBIAN_VERSION=13
+FROM gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp
 
-COPY syft /
-
-USER nonroot
-
-ARG BUILD_DATE
-ARG BUILD_VERSION
-ARG VCS_REF
-ARG VCS_URL
-
-LABEL org.opencontainers.image.created=$BUILD_DATE
-LABEL org.opencontainers.image.title="syft"
-LABEL org.opencontainers.image.description="CLI tool and library for generating a Software Bill of Materials from container images and filesystems"
-LABEL org.opencontainers.image.source=$VCS_URL
-LABEL org.opencontainers.image.revision=$VCS_REF
-LABEL org.opencontainers.image.vendor="Anchore, Inc."
-LABEL org.opencontainers.image.version=$BUILD_VERSION
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/anchore/syft/main/README.md"
-LABEL io.artifacthub.package.logo-url="https://user-images.githubusercontent.com/5199289/136844524-1527b09f-c5cb-4aa9-be54-5aa92a6086c1.png"
-LABEL io.artifacthub.package.license="Apache-2.0"
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/syft /
 
 ENTRYPOINT ["/syft"]

--- a/Dockerfile.debug-nonroot
+++ b/Dockerfile.debug-nonroot
@@ -1,5 +1,5 @@
 ARG DEBIAN_VERSION=13
-FROM gcr.io/distroless/static-debian${DEBIAN_VERSION}:nonroot
+FROM gcr.io/distroless/static-debian${DEBIAN_VERSION}:debug-nonroot
 
 # create the /tmp dir, which is needed for image content cache
 WORKDIR /tmp

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -39,6 +39,12 @@ vars:
   PROJECT_ROOT:
     sh: echo $PWD
 
+  # docker platform suffix goreleaser appends to snapshot image tags (e.g. latest-amd64).
+  # snapshot builds load per-arch images rather than a multi-arch manifest, so the smoke
+  # test must run the host-native tag to avoid emulation (and red-local/green-CI splits).
+  DOCKER_ARCH:
+    sh: go env GOARCH
+
   # note: the snapshot dir must be a relative path starting with ./
   # e.g. when installing snapshot debs from a local path, ./ forces the deb to be installed in the current working directory instead of referencing a package name
   SNAPSHOT_DIR: ./snapshot
@@ -129,8 +135,8 @@ tasks:
         silent: true
       - "{{ .SNAPSHOT_BIN }} version"
       - "{{ .SNAPSHOT_BIN }} scan alpine:latest"
-      - docker run --rm anchore/syft:latest version
-      - docker run --rm anchore/syft:latest scan alpine:latest
+      - docker run --pull=never --rm anchore/syft:latest-{{ .DOCKER_ARCH }} version
+      - docker run --pull=never --rm anchore/syft:latest-{{ .DOCKER_ARCH }} scan alpine:latest
 
   ## Test-fixture-related targets ###########################################
 


### PR DESCRIPTION
## Description

Migrate the docker image builds from the legacy `dockers:` + `docker_manifests:` sections to GoReleaser's [`dockers_v2`](https://goreleaser.com/customization/dockers_v2/)

This builds a multi-arch manifest per image in a single `docker buildx` invocation. This collapses ~300 lines of per-arch/per-tag boilerplate into four declarative entries and moves image labels out of the Dockerfiles and into the release config.

Feedback discussion for the feature: https://github.com/orgs/goreleaser/discussions/6005

The same `dockers_v2` pattern has been smoke-tested in [`grant`](https://github.com/anchore/grant) on it's latest release.

Each entry builds for 5 platforms: `linux/amd64`, `linux/arm64`, `linux/ppc64le`, `linux/ri
4 entries × 2 registries × 2 tags = 16 manifest tags, each backed by 5 platform-specific images (80 platform images total).

### `debug` restored to root (fixes #4113)

Before v1.27.0, the `debug` image ran as **root**. #3941 (v1.27.0) unintentionally made it non-root; #3998 (v1.27.1) reverted the *production* images to root and added a `nonroot` tag but left `debug` non-root — the inconsistency reported in #4113.

This PR restores `debug` to **root** and adds a new **`debug-nonroot`** tag for the non-root variant. This makes both image families consistent: the bare tag is root (`latest`, `debug`) and `-nonroot` opts into a non-root user (`nonroot`, `debug-nonroot`).

- It reverts the v1.27.0 regression back to the long-standing expected behavior.
- Anyone who adopted non-root `debug` after v1.27.0 can switch `:debug` → `:debug-nonroot`; no capability is lost.

### Base image: `debian13`

All images now build from `gcr.io/distroless/static-debian13` (`DEBIAN_VERSION=13`).

`main` recently added `linux/riscv64` image support (#4757), which requires `debian13`

### Other v2 details

- **Labels** moved from `LABEL` instructions in each Dockerfile into the `dockers_v2` `labels:` config (deduped via YAML anchors), so the Dockerfiles are now minimal.
- **`--provenance=false`** there is no dedicated provenance key in the v2 schema;
- `unknown/unknown` attestation entries, matching the legacy no-attestation behavior
- **`sbom: "false"`** SBOMs are produced separately for the archives (see the `sboms:` section).

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the

## Issue references

Fixes: https://github.com/anchore/syft/issues/4113