### PR TITLE
Use redhat as namespace for hummingbird rpms

### DIFF
--- a/syft/pkg/cataloger/redhat/package.go
+++ b/syft/pkg/cataloger/redhat/package.go
@@ -84,13 +84,13 @@ func newMetadataFromManifestLine(entry string) (*pkg.RpmDBEntry, error) {
 	}, nil
 }
 
-// packageURL returns the PURL for the specific RHEL package (see https://github.com/package-url/purl-spec)
+// packageURL returns the PURL for the specific RHEL or Hummingbird package (see https://github.com/package-url/purl-spec)
 func packageURL(name, arch string, epoch *int, srpm string, version, release string, distro *linux.Release) string {
 	var namespace string
 	if distro != nil {
 		namespace = distro.ID
 	}
-	if namespace == "rhel" {
+	if namespace == "rhel" || namespace == "hummingbird" {
 		namespace = "redhat"
 	}
 	if strings.HasPrefix(namespace, "opensuse") {

--- a/syft/pkg/cataloger/redhat/package_test.go
+++ b/syft/pkg/cataloger/redhat/package_test.go
@@ -56,6 +56,20 @@ func Test_packageURL(t *testing.T) {
 			expected: "pkg:rpm/p@v-r",
 		},
 		{
+			name: "hummingbird distro maps to redhat namespace",
+			distro: &linux.Release{
+				ID:        "hummingbird",
+				VersionID: "1.0",
+			},
+			metadata: pkg.RpmDBEntry{
+				Name:    "p",
+				Version: "v",
+				Release: "r",
+				Epoch:   nil,
+			},
+			expected: "pkg:rpm/redhat/p@v-r?distro=hummingbird-1.0",
+		},
+		{
 			name: "with upstream source rpm info",
 			distro: &linux.Release{
 				ID:        "rhel",


### PR DESCRIPTION
## Description
* The namespace value of `redhat` signifies this as an RPM package produced and distributed by Red Hat.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added unit tests that cover changed behavior
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections
