### PR TITLE
add MatchNone and update redis classifier

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -106,13 +106,19 @@ func DefaultClassifiers() []binutils.Classifier {
 		{
 			Class:    "redis-binary",
 			FileGlob: "**/redis-server",
-			EvidenceMatcher: binutils.MatchAny(
-				// matches most recent versions of redis (~v7), e.g. "7.0.14buildkitsandbox-1702957741000000000"
-				m.FileContentsVersionMatcher(`[^\d](?P<version>\d+.\d+\.\d+)buildkitsandbox-\d+`),
-				// matches against older versions of redis (~v3 - v6), e.g. "4.0.11841ce7054bd9-1542359302000000000"
-				m.FileContentsVersionMatcher(`[^\d](?P<version>[0-9]+\.[0-9]+\.[0-9]+)\w{12}-\d+`),
-				// matches against older versions of redis (~v2), e.g. "Server started, Redis version 2.8.23"
-				m.FileContentsVersionMatcher(`Redis version (?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			EvidenceMatcher: binutils.MatchAll(
+				// Negative Matchers to exclude valkey-server
+				binutils.MatchNone(
+					binutils.MatchPath("**/valkey-server"),
+				),
+				binutils.MatchAny(
+					// matches most recent versions of redis (~v7), e.g. "7.0.14buildkitsandbox-1702957741000000000"
+					m.FileContentsVersionMatcher(`[^\d](?P<version>\d+.\d+\.\d+)buildkitsandbox-\d+`),
+					// matches against older versions of redis (~v3 - v6), e.g. "4.0.11841ce7054bd9-1542359302000000000"
+					m.FileContentsVersionMatcher(`[^\d](?P<version>[0-9]+\.[0-9]+\.[0-9]+)\w{12}-\d+`),
+					// matches against older versions of redis (~v2), e.g. "Server started, Redis version 2.8.23"
+					m.FileContentsVersionMatcher(`Redis version (?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+				),
 			),
 			Package: "redis",
 			PURL:    mustPURL("pkg:generic/redis@version"),

--- a/syft/pkg/cataloger/binary/testdata/config.yaml
+++ b/syft/pkg/cataloger/binary/testdata/config.yaml
@@ -567,12 +567,14 @@ from-images:
     paths:
       - /usr/local/bin/redis-server
 
-  - version: 9.0.0
+  - name: valkey-server
+    version: 9.0.0
     images:
       - ref: valkey/valkey:9.0.0@sha256:42ea97850708540d4e05f6241cfbd241c1ba502e64d9a42efb2c2e277a8ca9d6
         platform: linux/amd64
     paths:
       - /usr/local/bin/valkey-server
+      - /usr/local/bin/redis-server
 
   - version: 2.9.0
     images:

--- a/syft/pkg/cataloger/internal/binutils/classifier.go
+++ b/syft/pkg/cataloger/internal/binutils/classifier.go
@@ -120,6 +120,20 @@ func MatchAll(matchers ...EvidenceMatcher) EvidenceMatcher {
 	}
 }
 
+// MatchNone succeeds only if the matcher returns no results.
+func MatchNone(matcher EvidenceMatcher) EvidenceMatcher {
+	return func(classifier Classifier, context MatcherContext) ([]pkg.Package, error) {
+		match, err := matcher(classifier, context)
+		if err != nil {
+			return nil, err
+		}
+		if match != nil {
+			return nil, nil
+		}
+		return []pkg.Package{}, nil
+	}
+}
+
 type ContextualEvidenceMatchers struct {
 	CatalogerName string
 }

--- a/syft/pkg/cataloger/internal/binutils/classifier_test.go
+++ b/syft/pkg/cataloger/internal/binutils/classifier_test.go
@@ -243,3 +243,40 @@ func Test_SupportingEvidenceMatcher(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchNone(t *testing.T) {
+	matchingMatcher := MatchPath("**")
+	notMatchingMatcher := MatchPath("will-not-match")
+
+	tests := []struct {
+		name     string
+		matcher  EvidenceMatcher
+		expected bool // true if MatchNone should succeed (inner failed)
+	}{
+		{
+			name:     "inner matches, MatchNone fails",
+			matcher:  MatchNone(matchingMatcher),
+			expected: false,
+		},
+		{
+			name:     "inner fails, MatchNone succeeds",
+			matcher:  MatchNone(notMatchingMatcher),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pkgs, err := tt.matcher(Classifier{}, MatcherContext{
+				Location: file.NewLocation("some/path"),
+			})
+			require.NoError(t, err)
+			if tt.expected {
+				assert.NotNil(t, pkgs)
+				assert.Empty(t, pkgs)
+			} else {
+				assert.Nil(t, pkgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Valkey images include both `valkey-server` and `redis-server` (symlink), and their matcher patterns are same. This causes Redis is detected in Valkey images.

This PR introduces `MatchNone` and updates redis classifier. `
MatchNone` is negative matching, which will be helpful for forked software like this.

Before update redis classifier, redis-server file is detected as redis. And updated test will fail
```
$ syft -q valkey/valkey:8.1.4 | grep -e redis -e valkey
redis                    8.1.4                        binary
valkey                   8.1.4                        binary
$ go test -v ./syft/pkg/cataloger/binary -run Test_Cataloger_PositiveCases/valkey
=== RUN   Test_Cataloger_PositiveCases
=== RUN   Test_Cataloger_PositiveCases/valkey-server/9.0.0/linux-amd64
    classifier_cataloger_test.go:1845:
                Error Trace:    /home/witchcraze/syft/syft/pkg/cataloger/binary/classifier_cataloger_test.go:1845
                Error:          "[Pkg(name="redis" version="9.0.0" type="binary" id="d89e16b4b27e12cb") Pkg(name="valkey" version="9.0.0" type="binary" id="95fc95f62eddb3e3")]" should have 1 item(s), but has 2
                Test:           Test_Cataloger_PositiveCases/valkey-server/9.0.0/linux-amd64
                Messages:       mismatched package count
--- FAIL: Test_Cataloger_PositiveCases (0.54s)
    --- FAIL: Test_Cataloger_PositiveCases/valkey-server/9.0.0/linux-amd64 (0.54s)
FAIL
FAIL    github.com/anchore/syft/syft/pkg/cataloger/binary       0.560s
FAIL
```

After update redis classifier, redis-server is not detected as redis. Only valkey-server file is detected as valkey.
```
$ go run cmd/syft/main.go -q valkey/valkey:8.1.4 | grep -e redis -e valkey
valkey                   8.1.4                        binary
$ go test -v ./syft/pkg/cataloger/binary -run Test_Cataloger_PositiveCases/valkey
=== RUN   Test_Cataloger_PositiveCases
=== RUN   Test_Cataloger_PositiveCases/valkey-server/9.0.0/linux-amd64
--- PASS: Test_Cataloger_PositiveCases (0.27s)
    --- PASS: Test_Cataloger_PositiveCases/valkey-server/9.0.0/linux-amd64 (0.27s)
PASS
ok      github.com/anchore/syft/syft/pkg/cataloger/binary       0.291s
```





## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4591
