### PR TITLE
fix(java): improve lz4 detection

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/java.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java.go
@@ -302,7 +302,11 @@ func GetManifestFieldGroupIDs(manifest *pkg.JavaManifest, fields []string) (grou
 }
 
 func cleanGroupID(groupID string) string {
-	return strings.TrimSpace(strings.Split(removeOSCIDirectives(groupID), "#")[0])
+	groupID = strings.TrimSpace(strings.Split(removeOSCIDirectives(groupID), "#")[0])
+	if replacement, ok := GroupIDCorrections[groupID]; ok {
+		return replacement
+	}
+	return groupID
 }
 
 func removeOSCIDirectives(groupID string) string {

--- a/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
@@ -1,5 +1,9 @@
 package cpegenerate
 
+var GroupIDCorrections = map[string]string{
+	"org.lz4.java": "org.lz4",
+}
+
 var DefaultArtifactIDToGroupID = map[string]string{
 	"ant":                                         "org.apache.ant",
 	"ant-antlr":                                   "org.apache.ant",
@@ -1910,5 +1914,4 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"kafka_2.8.2":                                              "org.apache.kafka",
 	"kafka_2.9.1":                                              "org.apache.kafka",
 	"kafka_2.9.2":                                              "org.apache.kafka",
-	"lz4-java":                                                 "org.lz4",
 }

--- a/syft/pkg/cataloger/internal/cpegenerate/java_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_test.go
@@ -184,6 +184,22 @@ func Test_groupIDsFromJavaPackage(t *testing.T) {
 			expects: []string{"io.jenkins-ci.plugin.thing"},
 		},
 		{
+			name: "groupId correction properly applied",
+			pkg: pkg.Package{
+				Metadata: pkg.JavaArchive{
+					Manifest: &pkg.JavaManifest{
+						Main: pkg.KeyValues{
+							{
+								Key:   "Automatic-Module-Name",
+								Value: "org.lz4.java",
+							},
+						},
+					},
+				},
+			},
+			expects: []string{"org.lz4"},
+		},
+		{
 			name: "from main Extension-Name field",
 			pkg: pkg.Package{
 				Metadata: pkg.JavaArchive{


### PR DESCRIPTION
Improve lz4 detection.

Before:
```
$ syft --output purls /tmp/test-syft/ 2>/dev/null
pkg:maven/org.lz4.java/lz4-java@1.8.0
```

After:
```
$ ./syft-cli --output purls /tmp/test-syft/ 2>/dev/null
pkg:maven/org.lz4/lz4-java@1.8.0
```

And it now has intented effect with grype:

```
$ syft --output purls /tmp/test-syft/ 2>/dev/null | grype
No vulnerabilities found

$ ./syft-cli --output purls /tmp/test-syft/ 2>/dev/null | grype
NAME      INSTALLED  FIXED IN  TYPE          VULNERABILITY        SEVERITY  EPSS           RISK
lz4-java  1.8.0                java-archive  GHSA-cmp6-m4wj-q63q  High      < 0.1% (21st)  < 0.1
lz4-java  1.8.0      1.8.1     java-archive  GHSA-vqf4-7m7x-wgfc  High      < 0.1% (20th)  < 0.1
```

Fixes: https://github.com/anchore/syft/issues/4611
Fixes: https://github.com/anchore/grype/issues/3205
