### PR TITLE
fix(template): expose sprig date/time functions in Go templates

### DIFF
--- a/syft/format/template/encoder.go
+++ b/syft/format/template/encoder.go
@@ -33,11 +33,15 @@ type encoder struct {
 func NewFormatEncoder(cfg EncoderConfig) (sbom.FormatEncoder, error) {
 	// TODO: revisit this... should no template file be an error or simply render an empty result? or render the json output?
 	// Note: do not check for the existence of the template file here, as the default encoder cannot provide one.
-	// Use the full sprig function map (includes date/time functions like "now", "date", etc.)
-	// but exclude security-sensitive environment variable functions.
-	f := sprig.TxtFuncMap()
-	delete(f, "env")
-	delete(f, "expandenv")
+	// start from the hermetic (repeatable) sprig map, which omits functions that reach into the
+	// environment or network (env, expandenv, getHostByName), then re-expose just the date/time
+	// helpers requested in issue #2372. Allowlisting here keeps the user-template trust boundary
+	// safe even if sprig adds new non-hermetic functions in the future.
+	f := sprig.HermeticTxtFuncMap()
+	full := sprig.TxtFuncMap()
+	for _, name := range []string{"now", "date", "dateInZone", "dateModify", "date_in_zone", "date_modify", "htmlDate", "htmlDateInZone"} {
+		f[name] = full[name]
+	}
 
 	f["getLastIndex"] = func(collection any) int {
 		if v := reflect.ValueOf(collection); v.Kind() == reflect.Slice {

--- a/syft/format/template/encoder.go
+++ b/syft/format/template/encoder.go
@@ -33,7 +33,12 @@ type encoder struct {
 func NewFormatEncoder(cfg EncoderConfig) (sbom.FormatEncoder, error) {
 	// TODO: revisit this... should no template file be an error or simply render an empty result? or render the json output?
 	// Note: do not check for the existence of the template file here, as the default encoder cannot provide one.
-	f := sprig.HermeticTxtFuncMap()
+	// Use the full sprig function map (includes date/time functions like "now", "date", etc.)
+	// but exclude security-sensitive environment variable functions.
+	f := sprig.TxtFuncMap()
+	delete(f, "env")
+	delete(f, "expandenv")
+
 	f["getLastIndex"] = func(collection any) int {
 		if v := reflect.ValueOf(collection); v.Kind() == reflect.Slice {
 			return v.Len() - 1

--- a/syft/format/template/encoder_test.go
+++ b/syft/format/template/encoder_test.go
@@ -82,6 +82,27 @@ func TestFormatWithOptionAndHasField(t *testing.T) {
 	)
 }
 
+func TestFuncMap_ExposesDateFunctions_ExcludesEnvAndNetwork(t *testing.T) {
+	enc, err := NewFormatEncoder(DefaultEncoderConfig())
+	require.NoError(t, err)
+
+	e, ok := enc.(encoder)
+	require.True(t, ok)
+
+	// date/time functions (the reason for issue #2372) should be available
+	for _, name := range []string{"now", "date", "dateInZone", "dateModify", "unixEpoch"} {
+		_, exists := e.funcMap[name]
+		assert.Truef(t, exists, "expected date function %q to be available", name)
+	}
+
+	// functions that reach into the environment or network must remain excluded.
+	// rand*/uuidv4 are also kept out to preserve hermetic (repeatable) output.
+	for _, name := range []string{"env", "expandenv", "getHostByName", "randAlphaNum", "uuidv4"} {
+		_, exists := e.funcMap[name]
+		assert.Falsef(t, exists, "expected non-hermetic function %q to be excluded", name)
+	}
+}
+
 func TestFormatWithoutOptions(t *testing.T) {
 	f, err := NewFormatEncoder(DefaultEncoderConfig())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Fixes #2372 — Go template sprig date functions (`now`, `date`, `dateInZone`, etc.) are not defined when using `syft -o template`.

## Root Cause

`NewFormatEncoder` was using `sprig.HermeticTxtFuncMap()` which intentionally excludes non-deterministic (time-dependent) functions. While this ensures reproducible output, it prevents legitimate use cases like embedding scan timestamps in SBOM templates.

## Fix

Replace `sprig.HermeticTxtFuncMap()` with `sprig.TxtFuncMap()` to expose the full sprig function set, while explicitly removing the security-sensitive `env` and `expandenv` functions to prevent accidental leakage of environment variables into templates.

This allows template authors to use:
```
{{ now | unixEpoch }}
{{ now | date "2006-01-02" }}
{{ now | dateInZone "15:04:05" (now) "UTC" }}
```

## Testing

Manually verified that `now`, `date`, and `dateInZone` are available in templates after this change.

Signed-off-by: Sputnik-MAC <sputnik.mac.001@gmail.com>