### PR TITLE
fix: add facebook as additional CPE vendor for react npm package

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -198,6 +198,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		// NPM packages
 		{
 			pkg.NpmPkg,
+			candidateKey{PkgName: "react"},
+			candidateAddition{AdditionalVendors: []string{"facebook"}},
+		},
+		{
+			pkg.NpmPkg,
 			candidateKey{PkgName: "next"},
 			candidateAddition{AdditionalProducts: []string{"next.js"}, AdditionalVendors: []string{"vercel"}},
 		},

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -855,6 +855,20 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			// regression: react npm package should include facebook as vendor (NVD CPE uses facebook:react)
+			// see https://github.com/anchore/syft/issues/4653
+			name: "react npm package includes facebook vendor",
+			p: pkg.Package{
+				Name:    "react",
+				Version: "18.3.1",
+				Type:    pkg.NpmPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:react:react:18.3.1:*:*:*:*:*:*:*",
+				"cpe:2.3:a:facebook:react:18.3.1:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1033,6 +1047,17 @@ func TestCandidateVendor(t *testing.T) {
 				Type: pkg.PythonPkg,
 			},
 			expected: []string{"djangoproject", "python-Django", "python_Django" /* <-- known good names | default guess --> */, "python", "Django"},
+		},
+		{
+			// regression: react npm package vendor should include "facebook"
+			// NVD uses cpe:2.3:a:facebook:react not cpe:2.3:a:react:react
+			// see https://github.com/anchore/syft/issues/4653
+			name: "react npm vendor includes facebook",
+			p: pkg.Package{
+				Name: "react",
+				Type: pkg.NpmPkg,
+			},
+			expected: []string{"facebook" /* <-- known good names | default guess --> */, "react"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #4653

The NVD uses `facebook` as the vendor for React in CPE identifiers:
```
cpe:2.3:a:facebook:react:<version>:*:*:*:*:*:*:*
```

Syft was generating `react` as the vendor:
```
cpe:2.3:a:react:react:<version>:*:*:*:*:*:*:*
```

This caused failures in vulnerability matching tools like DependencyTrack because the generated CPE did not match the NVD canonical form, preventing CVE matching for React packages.

## Changes

- Added `react` to `defaultCandidateAdditions` in `candidate_by_package_type.go` with `AdditionalVendors: ["facebook"]`
- Added regression tests in `TestGeneratePackageCPEs` and `TestCandidateVendor` that verify the `facebook` vendor is included

## Testing

```
go test ./syft/pkg/cataloger/internal/cpegenerate/... -run "TestGeneratePackageCPEs/react|TestCandidateVendor/react"
```

All existing tests pass.

## References

- NVD CPE for React: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=facebook%3Areact
- Maintainer guidance: https://github.com/anchore/syft/issues/4653#issuecomment-2732327043