### PR TITLE
fix: add .bpl file extension support to PE/DLL cataloger

### DIFF
--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -32,6 +32,7 @@ func TestCataloger_Globs(t *testing.T) {
 			fixture:   "testdata/glob-paths",
 			cataloger: NewDotnetPortableExecutableCataloger(),
 			expected: []string{
+				"src/something.bpl",
 				"src/something.dll",
 				"src/something.exe",
 			},
@@ -41,6 +42,7 @@ func TestCataloger_Globs(t *testing.T) {
 			fixture:   "testdata/glob-paths",
 			cataloger: NewDotnetDepsBinaryCataloger(DefaultCatalogerConfig()),
 			expected: []string{
+				"src/something.bpl",
 				"src/something.deps.json",
 				"src/something.dll",
 				"src/something.exe",

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -23,6 +23,7 @@ const (
 	depsJSONGlob = "**/*.deps.json"
 	dllGlob      = "**/*.dll"
 	exeGlob      = "**/*.exe"
+	bplGlob      = "**/*.bpl"
 )
 
 // depsBinaryCataloger will search for both deps.json evidence and PE file evidence to create packages. All packages
@@ -464,7 +465,7 @@ func readDepsJSON(resolver file.Resolver, loc file.Location) (*depsJSON, error) 
 
 // findPEFiles locates and parses all PE files (dll/exe).
 func findPEFiles(resolver file.Resolver) ([]logicalPE, error, error) {
-	peLocs, err := resolver.FilesByGlob(dllGlob, exeGlob)
+	peLocs, err := resolver.FilesByGlob(dllGlob, exeGlob, bplGlob)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to find PE files: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds `.bpl` (Borland Package Library) file extension support to the dotnet PE/DLL cataloger.

Closes #4664

## Changes

- Added `bplGlob = "**/*.bpl"` constant alongside existing `dllGlob` and `exeGlob`
- Updated `findPEFiles()` to include the new `.bpl` glob pattern
- Added test fixture file and updated glob test expectations

## Why

`.bpl` files are standard Windows PE (Portable Executable) files used in the Delphi and C++Builder ecosystems. They are structurally identical to `.dll` files — renaming a `.bpl` to `.dll` already works with the existing cataloger. This change adds native support so users don't need workarounds.

As noted in the issue, this is a minimal change to the file matching logic since the underlying PE format is already fully supported.