### PR TITLE
test: add failing CPE formatting for colons

### DIFF
--- a/syft/cpe/cpe_test.go
+++ b/syft/cpe/cpe_test.go
@@ -219,6 +219,16 @@ func Test_RoundTrip(t *testing.T) {
 				Version: "3.2",
 			},
 		},
+		{
+			name: "escaped colon",
+			cpe:  "cpe:2.3:a:test_vendor:name\\:\\:module:3.2:*:*:*:*:*:*:*",
+			parsedCPE: Attributes{
+				Part:    "a",
+				Vendor:  "test_vendor",
+				Product: "name::module",
+				Version: "3.2",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Syft CPE formatting does not currently emit spec-compliant CPE string for CPEs with escaped colons

<!-- Please include a summary of the changes along with any relevant motivation and context -->

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
