### PR TITLE
ci: further pr target code checkout assurances

### DIFF
--- a/.github/workflows/detect-schema-changes.yaml
+++ b/.github/workflows/detect-schema-changes.yaml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           persist-credentials: false
+          repository: anchore/syft # IMPORTANT! An additional protection that this is checking out code from the expected repository 
           ref: main # IMPORTANT!  It is CRITICAL that this only ever considers the code from main and NEVER EVER from a fork.
 
       - run: python .github/scripts/labeler.py


### PR DESCRIPTION
## Description

This also explicitly specifies repository on the checkout in the pull_request_target workflow as an additional assurance it is only checking out the intended code