### PR TITLE
refactor(squashfs): adapt code to go-diskfs 1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dave/jennifer v1.7.1
 	github.com/deitch/magic v0.0.0-20230404182410-1ff89d7342da
-	github.com/diskfs/go-diskfs v1.7.0
+	github.com/diskfs/go-diskfs v1.9.3
 	github.com/distribution/reference v0.6.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elliotchance/phpserialize v1.4.0
@@ -255,11 +255,11 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pborman/indent v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
-	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
-	github.com/pkg/xattr v0.4.9 // indirect
+	github.com/pkg/xattr v0.4.12 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -335,8 +335,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/deitch/magic v0.0.0-20230404182410-1ff89d7342da h1:ZOjWpVsFZ06eIhnh4mkaceTiVoktdU67+M7KDHJ268M=
 github.com/deitch/magic v0.0.0-20230404182410-1ff89d7342da/go.mod h1:B3tI9iGHi4imdLi4Asdha1Sc6feLMTfPLXh9IUYmysk=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
-github.com/diskfs/go-diskfs v1.7.0 h1:vonWmt5CMowXwUc79jWyGrf2DIMeoOjkLlMnQYGVOs8=
-github.com/diskfs/go-diskfs v1.7.0/go.mod h1:LhQyXqOugWFRahYUSw47NyZJPezFzB9UELwhpszLP/k=
+github.com/diskfs/go-diskfs v1.9.3 h1:cLciNCeZ4QAXVxyPJDr1ZJ9N9CCG3rQlQ/z/Cs/cNDM=
+github.com/diskfs/go-diskfs v1.9.3/go.mod h1:TePJORO83Adh5pb2SqsxAwaP0fofFxKLkxctiS/9OQc=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
@@ -358,8 +358,8 @@ github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/elliotchance/phpserialize v1.4.0 h1:cAp/9+KSnEbUC8oYCE32n2n84BeW8HOY3HMDI8hG2OY=
 github.com/elliotchance/phpserialize v1.4.0/go.mod h1:gt7XX9+ETUcLXbtTKEuyrqW3lcLUAeS/AnGZ2e49TZs=
-github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab h1:h1UgjJdAAhj+uPL68n7XASS6bU+07ZX1WJvVS2eyoeY=
-github.com/elliotwutingfeng/asciiset v0.0.0-20230602022725-51bbb787efab/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
+github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57 h1:x5yxNrq8XffV/OoNUeFPM6hxHVi5OTspSTBxr/9pemg=
+github.com/elliotwutingfeng/asciiset v0.0.0-20260129054604-cfde2086bc57/go.mod h1:GLo/8fDswSAniFG+BFIaiSPcK610jyzgEhWYPQwuQdw=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -788,8 +788,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
-github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
-github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
+github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
 github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
@@ -800,8 +800,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=
 github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
-github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
-github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
+github.com/pkg/xattr v0.4.12 h1:rRTkSyFNTRElv6pkA3zpjHpQ90p/OdHQC1GmGh1aTjM=
+github.com/pkg/xattr v0.4.12/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/file/squashfs.go
+++ b/internal/file/squashfs.go
@@ -14,17 +14,21 @@ type WalkDiskDirFunc func(fsys filesystem.FileSystem, path string, d os.FileInfo
 // WalkDiskDir walks the file tree within the go-diskfs filesystem at root, calling fn for each file or directory in the tree, including root.
 // This is meant to mimic the behavior of fs.WalkDir in the standard library.
 func WalkDiskDir(fsys filesystem.FileSystem, root string, fn WalkDiskDirFunc) error {
-	infos, err := fsys.ReadDir(root)
+	entries, err := fsys.ReadDir(root)
 
 	if err != nil {
 		return err
 	}
 
-	if len(infos) == 0 {
+	if len(entries) == 0 {
 		return nil
 	}
 
-	for _, info := range infos {
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
 		p := filepath.Join(root, info.Name())
 		err = walkDiskDir(fsys, p, info, fn)
 		if err != nil {
@@ -75,7 +79,11 @@ func walkDiskDir(fsys filesystem.FileSystem, name string, d os.FileInfo, walkDir
 
 	for _, d1 := range dirs {
 		name1 := filepath.Join(name, d1.Name())
-		if err := walkDiskDir(fsys, name1, d1, walkDirFn); err != nil {
+		info1, err := d1.Info()
+		if err != nil {
+			return err
+		}
+		if err := walkDiskDir(fsys, name1, info1, walkDirFn); err != nil {
 			if errors.Is(err, fs.SkipDir) {
 				break
 			}

--- a/internal/file/squashfs_test.go
+++ b/internal/file/squashfs_test.go
@@ -29,16 +29,16 @@ func createTestFS(t *testing.T) filesystem.FileSystem {
 		content string
 		isDir   bool
 	}{
-		{"/file1.txt", "content of file1", false},
-		{"/file2.txt", "content of file2", false},
-		{"/dir1", "", true},
-		{"/dir1/subfile1.txt", "content of subfile1", false},
-		{"/dir1/subfile2.txt", "content of subfile2", false},
-		{"/dir1/subdir1", "", true},
-		{"/dir1/subdir1/deepfile.txt", "deep content", false},
-		{"/dir2", "", true},
-		{"/dir2/anotherfile.txt", "another content", false},
-		{"/emptydir", "", true},
+		{"file1.txt", "content of file1", false},
+		{"file2.txt", "content of file2", false},
+		{"dir1", "", true},
+		{"dir1/subfile1.txt", "content of subfile1", false},
+		{"dir1/subfile2.txt", "content of subfile2", false},
+		{"dir1/subdir1", "", true},
+		{"dir1/subdir1/deepfile.txt", "deep content", false},
+		{"dir2", "", true},
+		{"dir2/anotherfile.txt", "another content", false},
+		{"emptydir", "", true},
 	}
 
 	for _, tf := range testFiles {
@@ -61,7 +61,7 @@ func TestWalkDiskDir_CompleteTraversal(t *testing.T) {
 	fsys := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fsys, "/", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fsys, ".", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
 		return nil
@@ -70,16 +70,16 @@ func TestWalkDiskDir_CompleteTraversal(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedPaths := []string{
-		"/file1.txt",
-		"/file2.txt",
-		"/dir1",
-		"/dir1/subfile1.txt",
-		"/dir1/subfile2.txt",
-		"/dir1/subdir1",
-		"/dir1/subdir1/deepfile.txt",
-		"/dir2",
-		"/dir2/anotherfile.txt",
-		"/emptydir",
+		"file1.txt",
+		"file2.txt",
+		"dir1",
+		"dir1/subfile1.txt",
+		"dir1/subfile2.txt",
+		"dir1/subdir1",
+		"dir1/subdir1/deepfile.txt",
+		"dir2",
+		"dir2/anotherfile.txt",
+		"emptydir",
 	}
 
 	assert.ElementsMatch(t, expectedPaths, visitedPaths)
@@ -94,7 +94,7 @@ func TestWalkDiskDir_FileInfoCorrect(t *testing.T) {
 		name  string
 	}
 
-	err := WalkDiskDir(fsys, "/", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fsys, ".", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		require.NotNil(t, d)
 		fileInfos = append(fileInfos, struct {
@@ -115,7 +115,7 @@ func TestWalkDiskDir_FileInfoCorrect(t *testing.T) {
 		expectedName := filepath.Base(fi.path)
 		assert.Equal(t, expectedName, fi.name)
 
-		if fi.path == "/dir1" || fi.path == "/dir2" || fi.path == "/emptydir" || fi.path == "/dir1/subdir1" {
+		if fi.path == "dir1" || fi.path == "dir2" || fi.path == "emptydir" || fi.path == "dir1/subdir1" {
 			assert.True(t, fi.isDir, "Expected %s to be directory", fi.path)
 		} else {
 			assert.False(t, fi.isDir, "Expected %s to be file", fi.path)
@@ -127,10 +127,10 @@ func TestWalkDiskDir_SkipDir(t *testing.T) {
 	fsys := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fsys, "/", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fsys, ".", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
-		if path == "/dir1" {
+		if path == "dir1" {
 			return fs.SkipDir
 		}
 		return nil
@@ -138,24 +138,24 @@ func TestWalkDiskDir_SkipDir(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Contains(t, visitedPaths, "/dir1")
-	assert.NotContains(t, visitedPaths, "/dir1/subfile1.txt")
-	assert.NotContains(t, visitedPaths, "/dir1/subfile2.txt")
-	assert.NotContains(t, visitedPaths, "/dir1/subdir1")
-	assert.NotContains(t, visitedPaths, "/dir1/subdir1/deepfile.txt")
+	assert.Contains(t, visitedPaths, "dir1")
+	assert.NotContains(t, visitedPaths, "dir1/subfile1.txt")
+	assert.NotContains(t, visitedPaths, "dir1/subfile2.txt")
+	assert.NotContains(t, visitedPaths, "dir1/subdir1")
+	assert.NotContains(t, visitedPaths, "dir1/subdir1/deepfile.txt")
 
-	assert.Contains(t, visitedPaths, "/dir2")
-	assert.Contains(t, visitedPaths, "/dir2/anotherfile.txt")
+	assert.Contains(t, visitedPaths, "dir2")
+	assert.Contains(t, visitedPaths, "dir2/anotherfile.txt")
 }
 
 func TestWalkDiskDir_SkipAll(t *testing.T) {
 	fsys := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fsys, "/", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fsys, ".", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
-		if path == "/dir1" {
+		if path == "dir1" {
 			return fs.SkipAll
 		}
 		return nil
@@ -163,21 +163,21 @@ func TestWalkDiskDir_SkipAll(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Contains(t, visitedPaths, "/dir1")
+	assert.Contains(t, visitedPaths, "dir1")
 
-	assert.NotContains(t, visitedPaths, "/file1.txt")
-	assert.NotContains(t, visitedPaths, "/file2.txt")
-	assert.NotContains(t, visitedPaths, "/dir1/subfile1.txt")
-	assert.NotContains(t, visitedPaths, "/dir2")
-	assert.NotContains(t, visitedPaths, "/dir2/anotherfile.txt")
-	assert.NotContains(t, visitedPaths, "/emptydir")
+	assert.NotContains(t, visitedPaths, "file1.txt")
+	assert.NotContains(t, visitedPaths, "file2.txt")
+	assert.NotContains(t, visitedPaths, "dir1/subfile1.txt")
+	assert.NotContains(t, visitedPaths, "dir2")
+	assert.NotContains(t, visitedPaths, "dir2/anotherfile.txt")
+	assert.NotContains(t, visitedPaths, "emptydir")
 }
 
 func TestWalkDiskDir_EmptyDirectory(t *testing.T) {
 	fs := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fs, "/emptydir", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fs, "emptydir", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
 		return nil
@@ -190,7 +190,7 @@ func TestWalkDiskDir_EmptyDirectory(t *testing.T) {
 func TestWalkDiskDir_NonexistentPath(t *testing.T) {
 	fs := createTestFS(t)
 
-	err := WalkDiskDir(fs, "/nonexistent", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fs, "nonexistent", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		return nil
 	})
 
@@ -201,8 +201,8 @@ func TestWalkDiskDir_WalkFunctionError(t *testing.T) {
 	fs := createTestFS(t)
 
 	customErr := assert.AnError
-	err := WalkDiskDir(fs, "/", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
-		if path == "/file1.txt" {
+	err := WalkDiskDir(fs, ".", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+		if path == "file1.txt" {
 			return customErr
 		}
 		return nil
@@ -216,7 +216,7 @@ func TestWalkDiskDir_SubdirectoryTraversal(t *testing.T) {
 	fs := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fs, "/dir1", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fs, "dir1", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
 		return nil
@@ -225,10 +225,10 @@ func TestWalkDiskDir_SubdirectoryTraversal(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedPaths := []string{
-		"/dir1/subfile1.txt",
-		"/dir1/subfile2.txt",
-		"/dir1/subdir1",
-		"/dir1/subdir1/deepfile.txt",
+		"dir1/subfile1.txt",
+		"dir1/subfile2.txt",
+		"dir1/subdir1",
+		"dir1/subdir1/deepfile.txt",
 	}
 
 	assert.ElementsMatch(t, expectedPaths, visitedPaths)
@@ -238,7 +238,7 @@ func TestWalkDiskDir_SingleFile(t *testing.T) {
 	fs := createTestFS(t)
 
 	var visitedPaths []string
-	err := WalkDiskDir(fs, "/file1.txt", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
+	err := WalkDiskDir(fs, "file1.txt", func(fsys filesystem.FileSystem, path string, d os.FileInfo, err error) error {
 		require.NoError(t, err)
 		visitedPaths = append(visitedPaths, path)
 		return nil


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes along with any relevant motivation and context -->
The go-diskfs 1.8.0 release came with API/internal changes that are breaking WalkDiskDir for squashfs.

Changes:

- Paths starting with / are forbidden
- The entries from ReadDir do not implement the interface from os.FileInfo.

This PR updates the code as as well the tests.

This should also fix #4709

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [X] I have added unit tests that cover changed behavior
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
Fixes #4718