### PR TITLE
feat(cataloger): add .bpl file support to PE/DLL cataloger

### DIFF
--- a/syft/pkg/cataloger/binary/capabilities.yaml
+++ b/syft/pkg/cataloger/binary/capabilities.yaml
@@ -851,6 +851,7 @@ catalogers:
           criteria: # AUTO-GENERATED
             - '**/*.dll'
             - '**/*.exe'
+            - '**/*.bpl'
         metadata_types: # AUTO-GENERATED
           - pkg.PEBinary
         package_types: # AUTO-GENERATED

--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -12,10 +12,10 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pe"
 )
 
-// NewPEPackageCataloger returns a cataloger that interprets packages from DLL and EXE files.
+// NewPEPackageCataloger returns a cataloger that interprets packages from DLL, EXE, and BPL files.
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe")
+		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {


### PR DESCRIPTION
## Summary
This PR adds support for `.bpl` files (Borland Package Library) to the PE/DLL cataloger.

## Changes
- Added `.bpl` file extension to the PE/DLL cataloger capabilities
- Updated the cataloger to recognize .bpl files as PE binaries

## Background
BPL files are Borland Package Library files used by Delphi and C++Builder. They have the same PE format as DLL files and should be cataloged similarly.

## Testing
- Tested with sample .bpl files
- Verified correct package identification