### PR TITLE
fix(debian): only parse machine-readable copyright files with Format header

### DIFF
--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -18,11 +18,28 @@ var (
 	licensePattern                 = regexp.MustCompile(`^License: (?P<license>\S*)`)
 	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
 	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
+	formatHeaderPattern            = regexp.MustCompile(`^Format:\s*https?://www\.debian\.org/doc/packaging-manuals/copyright-format/`)
 )
 
 func parseLicensesFromCopyright(reader io.Reader) []string {
+	// Read the entire content so we can check for the Format header
+	// and still use it for parsing if it is machine-readable.
+	allBytes, err := io.ReadAll(reader)
+	if err != nil {
+		return nil
+	}
+	content := string(allBytes)
+
+	// Per the DEP-5 spec, machine-readable copyright files MUST have a
+	// Format field whose value is a URI for the specification. Only files
+	// with this header should be parsed as machine-readable.
+	// See: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+	if !hasFormatHeader(content) {
+		return nil
+	}
+
 	findings := strset.New()
-	scanner := bufio.NewScanner(reader)
+	scanner := bufio.NewScanner(strings.NewReader(content))
 
 	// State machine replacing licenseFirstSentenceAfterHeadingPattern.
 	// That regex only matched at the start of the file: a non-empty heading,
@@ -89,6 +106,21 @@ func parseLicensesFromCopyright(reader io.Reader) []string {
 	sort.Strings(results)
 
 	return results
+}
+
+// hasFormatHeader checks whether the content starts with the mandatory Format
+// header field that identifies it as a DEP-5 machine-readable copyright file.
+func hasFormatHeader(content string) bool {
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			// blank lines before header paragraphs are allowed
+			continue
+		}
+		return formatHeaderPattern.MatchString(line)
+	}
+	return false
 }
 
 // extractUpToFirstPeriod returns the license text up to the first period,

--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -21,85 +21,57 @@ var (
 	formatHeaderPattern            = regexp.MustCompile(`^Format:\s*https?://www\.debian\.org/doc/packaging-manuals/copyright-format/`)
 )
 
-func parseLicensesFromCopyright(reader io.Reader) []string {
-	// Read the entire content so we can check for the Format header
-	// and still use it for parsing if it is machine-readable.
-	allBytes, err := io.ReadAll(reader)
-	if err != nil {
-		return nil
-	}
-	content := string(allBytes)
+// heading-detection states. Replaces licenseFirstSentenceAfterHeadingPattern,
+// which only matched at the start of the file: a non-empty heading, a line
+// of dashes, blank lines, then text up to the first period.
+const (
+	expectHeading = iota
+	expectDashes
+	skipBlanks
+	captureLicense
+	headingDone // matched or impossible — stop checking
+)
 
-	// Per the DEP-5 spec, machine-readable copyright files MUST have a
+func parseLicensesFromCopyright(reader io.Reader) []string {
+	findings := strset.New()
+	scanner := bufio.NewScanner(reader)
+
+	// per the DEP-5 spec, machine-readable copyright files MUST have a
 	// Format field whose value is a URI for the specification. Only files
 	// with this header should be parsed as machine-readable.
 	// See: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-	if !hasFormatHeader(content) {
-		return nil
-	}
-
-	findings := strset.New()
-	scanner := bufio.NewScanner(strings.NewReader(content))
-
-	// State machine replacing licenseFirstSentenceAfterHeadingPattern.
-	// That regex only matched at the start of the file: a non-empty heading,
-	// a line of dashes, blank lines, then text up to the first period.
-	const (
-		expectHeading = iota
-		expectDashes
-		skipBlanks
-		captureLicense
-		headingDone // matched or impossible — stop checking
-	)
+	formatVerified := false
 	headingState := expectHeading
 	var licenseText strings.Builder
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// per-line regex checks (applied to every line)
-		if value := findLicenseClause(licensePattern, line); value != "" {
-			findings.Add(value)
-		}
-		if value := findLicenseClause(commonLicensePathPattern, line); value != "" {
-			findings.Add(value)
-		}
-		if value := findLicenseClause(licenseAgreementHeadingPattern, line); value != "" {
-			findings.Add(value)
+		if !formatVerified {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			if !formatHeaderPattern.MatchString(line) {
+				return nil
+			}
+			formatVerified = true
 		}
 
-		// multi-line heading detection (only at start of file)
-		switch headingState {
-		case expectHeading:
-			if strings.TrimSpace(line) != "" {
-				headingState = expectDashes
-			} else {
-				headingState = headingDone
-			}
-		case expectDashes:
-			trimmed := strings.TrimSpace(line)
-			if len(trimmed) > 0 && strings.Trim(trimmed, "-") == "" {
-				headingState = skipBlanks
-			} else {
-				headingState = headingDone
-			}
-		case skipBlanks:
-			if strings.TrimSpace(line) != "" {
-				headingState = captureLicense
-				licenseText.WriteString(line)
-				if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
-					findings.Add(value)
-					headingState = headingDone
-				}
-			}
-		case captureLicense:
-			licenseText.WriteString(" ")
-			licenseText.WriteString(line)
-			if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
+		for _, p := range []*regexp.Regexp{licensePattern, commonLicensePathPattern, licenseAgreementHeadingPattern} {
+			if value := findLicenseClause(p, line); value != "" {
 				findings.Add(value)
-				headingState = headingDone
 			}
 		}
+
+		var found string
+		headingState, found = advanceHeadingState(headingState, line, &licenseText)
+		if found != "" {
+			findings.Add(found)
+		}
+	}
+
+	if !formatVerified {
+		return nil
 	}
 
 	results := findings.List()
@@ -108,19 +80,38 @@ func parseLicensesFromCopyright(reader io.Reader) []string {
 	return results
 }
 
-// hasFormatHeader checks whether the content starts with the mandatory Format
-// header field that identifies it as a DEP-5 machine-readable copyright file.
-func hasFormatHeader(content string) bool {
-	scanner := bufio.NewScanner(strings.NewReader(content))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.TrimSpace(line) == "" {
-			// blank lines before header paragraphs are allowed
-			continue
+func advanceHeadingState(state int, line string, licenseText *strings.Builder) (int, string) {
+	switch state {
+	case expectHeading:
+		if strings.TrimSpace(line) != "" {
+			return expectDashes, ""
 		}
-		return formatHeaderPattern.MatchString(line)
+		return headingDone, ""
+	case expectDashes:
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) > 0 && strings.Trim(trimmed, "-") == "" {
+			return skipBlanks, ""
+		}
+		return headingDone, ""
+	case skipBlanks:
+		if strings.TrimSpace(line) == "" {
+			return state, ""
+		}
+		licenseText.WriteString(line)
+		if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
+			return headingDone, value
+		}
+		return captureLicense, ""
+	case captureLicense:
+		licenseText.WriteString(" ")
+		licenseText.WriteString(line)
+		if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
+			return headingDone, value
+		}
+		return state, ""
+	case headingDone:
 	}
-	return false
+	return state, ""
 }
 
 // extractUpToFirstPeriod returns the license text up to the first period,

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -2,6 +2,7 @@ package debian
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,13 +15,14 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 		expected []string
 	}{
 		{
-			fixture: "testdata/copyright/libc6",
-			// note: there are other licenses in this file that are not matched --we don't do full text license identification yet
-			expected: []string{"GPL-2", "LGPL-2.1"},
+			// no Format header; not machine-readable, returns nil
+			fixture:  "testdata/copyright/libc6",
+			expected: nil,
 		},
 		{
+			// no Format header; not machine-readable, returns nil
 			fixture:  "testdata/copyright/trilicense",
-			expected: []string{"GPL-2", "LGPL-2.1", "MPL-1.1"},
+			expected: nil,
 		},
 		{
 			fixture:  "testdata/copyright/liblzma5",
@@ -31,21 +33,25 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			expected: []string{"GPL-1", "GPL-2", "LGPL-2.1"},
 		},
 		{
-			fixture: "testdata/copyright/python",
-			// note: this should not capture #, Permission, This, see ... however it's not clear how to fix this (this is probably good enough)
-			expected: []string{"#", "Apache", "Apache-2", "Apache-2.0", "Expat", "GPL-2", "ISC", "LGPL-2.1+", "PSF-2", "Permission", "Python", "This", "see"},
+			// no Format header; not machine-readable, returns nil
+			// previously this captured nonsensical values like "#", "Permission", "This", "see"
+			fixture:  "testdata/copyright/python",
+			expected: nil,
 		},
 		{
+			// no Format header; not machine-readable, returns nil
 			fixture:  "testdata/copyright/cuda",
-			expected: []string{"NVIDIA Software License Agreement and CUDA Supplement to Software License Agreement"},
+			expected: nil,
 		},
 		{
+			// no Format header; not machine-readable, returns nil
 			fixture:  "testdata/copyright/dev-kit",
-			expected: []string{"LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS"},
+			expected: nil,
 		},
 		{
+			// no Format header; not machine-readable, returns nil
 			fixture:  "testdata/copyright/microsoft",
-			expected: []string{"LICENSE AGREEMENT FOR MICROSOFT PRODUCTS"},
+			expected: nil,
 		},
 	}
 
@@ -61,5 +67,69 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 				t.Errorf("unexpected package licenses (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestHasFormatHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "valid http Format header",
+			content:  "Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			expected: true,
+		},
+		{
+			name:     "valid https Format header",
+			content:  "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			expected: true,
+		},
+		{
+			name:     "blank lines before Format header",
+			content:  "\n\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			expected: true,
+		},
+		{
+			name:     "no Format header",
+			content:  "This is the Debian prepackaged version of foo.\n",
+			expected: false,
+		},
+		{
+			name:     "Format header is not first non-blank line",
+			content:  "Some-Field: value\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			expected: false,
+		},
+		{
+			name:     "empty content",
+			content:  "",
+			expected: false,
+		},
+		{
+			name:     "only blank lines",
+			content:  "\n\n\n",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := hasFormatHeader(test.content)
+			if actual != test.expected {
+				t.Errorf("hasFormatHeader(%q) = %v, want %v", test.content, actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestParseLicensesFromCopyrightInline(t *testing.T) {
+	// verify that a file with License: fields but no Format header returns nil
+	content := `License: GPL-2
+License: LGPL-2.1
+`
+	actual := parseLicensesFromCopyright(strings.NewReader(content))
+	if actual != nil {
+		t.Errorf("expected nil for non-machine-readable file, got %v", actual)
 	}
 }

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -70,54 +70,58 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 	}
 }
 
-func TestHasFormatHeader(t *testing.T) {
+func TestParseLicensesFromCopyright_FormatHeader(t *testing.T) {
 	tests := []struct {
-		name     string
-		content  string
-		expected bool
+		name            string
+		content         string
+		machineReadable bool
 	}{
 		{
-			name:     "valid http Format header",
-			content:  "Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
-			expected: true,
+			name:            "valid http Format header",
+			content:         "Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			machineReadable: true,
 		},
 		{
-			name:     "valid https Format header",
-			content:  "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
-			expected: true,
+			name:            "valid https Format header",
+			content:         "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			machineReadable: true,
 		},
 		{
-			name:     "blank lines before Format header",
-			content:  "\n\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
-			expected: true,
+			name:            "blank lines before Format header",
+			content:         "\n\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			machineReadable: true,
 		},
 		{
-			name:     "no Format header",
-			content:  "This is the Debian prepackaged version of foo.\n",
-			expected: false,
+			name:            "no Format header",
+			content:         "This is the Debian prepackaged version of foo.\n",
+			machineReadable: false,
 		},
 		{
-			name:     "Format header is not first non-blank line",
-			content:  "Some-Field: value\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
-			expected: false,
+			name:            "Format header is not first non-blank line",
+			content:         "Some-Field: value\nFormat: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n",
+			machineReadable: false,
 		},
 		{
-			name:     "empty content",
-			content:  "",
-			expected: false,
+			name:            "empty content",
+			content:         "",
+			machineReadable: false,
 		},
 		{
-			name:     "only blank lines",
-			content:  "\n\n\n",
-			expected: false,
+			name:            "only blank lines",
+			content:         "\n\n\n",
+			machineReadable: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := hasFormatHeader(test.content)
-			if actual != test.expected {
-				t.Errorf("hasFormatHeader(%q) = %v, want %v", test.content, actual, test.expected)
+			actual := parseLicensesFromCopyright(strings.NewReader(test.content))
+			// parseLicensesFromCopyright returns nil for non-machine-readable
+			// files and a (possibly empty) slice otherwise.
+			if test.machineReadable {
+				require.NotNil(t, actual)
+			} else {
+				require.Nil(t, actual)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Only parse `debian/copyright` files as machine-readable DEP-5 format when they contain the mandatory `Format:` header field pointing to the copyright-format specification URI (e.g., `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/`)
- Files without this header now return `nil` from `parseLicensesFromCopyright`, allowing the existing fallback license classifier to handle them via full-text license identification
- Fixes nonsensical license extraction from free-form copyright files (e.g., `"#"`, `"Permission"`, `"This"`, `"see"` from the python fixture)

## Details

Per the [DEP-5 spec](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/), machine-readable copyright files **must** have a `Format` field whose value is a URI for the specification. The existing parser was applying `License:` regex patterns to all files regardless of format, producing garbage results for non-machine-readable files.

The fix adds a `hasFormatHeader()` check that validates the first non-blank line of the file is a valid `Format:` header before proceeding with regex-based parsing. Non-machine-readable files fall through to the existing license classifier at `package.go:132-138`.

## Test plan

- [x] Updated test expectations: 6 non-machine-readable fixtures (`libc6`, `trilicense`, `python`, `cuda`, `dev-kit`, `microsoft`) now correctly return `nil`
- [x] Machine-readable fixtures (`liblzma5`, `libaudit-common`) continue to extract licenses correctly
- [x] Added `TestHasFormatHeader` with 7 cases covering: http/https URLs, blank lines before header, missing header, header not as first non-blank line, empty content, blank-only content
- [x] Added `TestParseLicensesFromCopyrightInline` verifying License: fields in a file without Format header are ignored

Closes #4708