### PR TITLE
fix format string in search results struct

### DIFF
--- a/syft/file/search_result.go
+++ b/syft/file/search_result.go
@@ -26,5 +26,5 @@ type SearchResult struct {
 }
 
 func (s SearchResult) String() string {
-	return fmt.Sprintf("SearchResult(classification=%q seek=%q length=%q)", s.Classification, s.SeekPosition, s.Length)
+	return fmt.Sprintf("SearchResult(classification=%q seek=%d length=%d)", s.Classification, s.SeekPosition, s.Length)
 }


### PR DESCRIPTION
Passing '%q' to format strings for integer types is a go vet error in recent go versions, and likely a bug.

## Description

This fixes an incorrect fmt string arg that will be a go vet error in later versions of go.

It _does_ change the result of calling `String()` on this struct, but I don't think anyone does that, and if they do, I don't think they want the ints interpreted as char bytes or whatever is going on at https://go.dev/play/p/P3Cvx9GYBgV

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

🤷 changes visible behavior in seemingly dead code, that was always wrong...

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
