### PR TITLE
cpe: add facebook as a candidate vendor for react and react-dom

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -221,6 +221,23 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "mustache"},
 			candidateAddition{AdditionalProducts: []string{"mustache.js"}},
 		},
+		{
+			// NVD records react under the facebook vendor, e.g.
+			// cpe:2.3:a:facebook:react:*, but the npm package.json
+			// names neither the vendor nor the author. Without
+			// this hint syft emits cpe:2.3:a:react:react:* and
+			// grype/DependencyTrack miss every React CVE. See #4653.
+			pkg.NpmPkg,
+			candidateKey{PkgName: "react"},
+			candidateAddition{AdditionalVendors: []string{"facebook"}},
+		},
+		{
+			// Same story for react-dom, which NVD also records under
+			// facebook (and ties to react CVEs).
+			pkg.NpmPkg,
+			candidateKey{PkgName: "react-dom"},
+			candidateAddition{AdditionalVendors: []string{"facebook"}},
+		},
 
 		// Gem packages
 		{

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
@@ -232,3 +232,25 @@ func Test_findProductsToRemove(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/anchore/syft/issues/4653:
+// NVD records React under the facebook vendor, so the default npm-derived
+// CPE (cpe:2.3:a:react:react:*) misses every React CVE. The candidate
+// table must add "facebook" to the list of candidate vendors for react
+// (and react-dom, which is tied to the same CVE stream).
+func Test_npmCandidateAdditions_react(t *testing.T) {
+	tests := []struct {
+		pkgName         string
+		expectedVendors []string
+	}{
+		{pkgName: "react", expectedVendors: []string{"facebook"}},
+		{pkgName: "react-dom", expectedVendors: []string{"facebook"}},
+	}
+	for _, test := range tests {
+		t.Run(test.pkgName, func(t *testing.T) {
+			got := findAdditionalVendors(defaultCandidateAdditions, pkg.NpmPkg, test.pkgName, "")
+			assert.ElementsMatch(t, test.expectedVendors, got,
+				"npm package %q should map to vendors %v", test.pkgName, test.expectedVendors)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4653.

## Problem

NVD records React and `react-dom` under the `facebook` vendor, so the CPE syft emits from an npm `package-lock.json` today:

```
cpe:2.3:a:react:react:18.3.1:*:*:*:*:*:*:*
```

fails to match any NVD record. Users uploading the resulting SBOM to Dependency Track (or scanning with grype) miss every React CVE, because NVD expects:

```
cpe:2.3:a:facebook:react:18.3.1:*:*:*:*:*:*:*
```

## Fix

`syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go` already has an "aliases" table for exactly this kind of mismatch (see the existing entries for `next` / `vercel`, `hapi`, `handlebars.js`, `mustache`). Added two more:

```go
{
    pkg.NpmPkg,
    candidateKey{PkgName: "react"},
    candidateAddition{AdditionalVendors: []string{"facebook"}},
},
{
    pkg.NpmPkg,
    candidateKey{PkgName: "react-dom"},
    candidateAddition{AdditionalVendors: []string{"facebook"}},
},
```

`react-dom` shares the same CVE stream so it gets the same alias.

## Test

Added `Test_npmCandidateAdditions_react` in `candidate_by_package_type_test.go`, which runs the real `findAdditionalVendors` lookup against `defaultCandidateAdditions` for both package names and asserts `facebook` is in the returned slice. Means the mapping cannot silently regress if someone later edits the table.

## Back-compat

Existing consumers that relied on matching `cpe:2.3:a:react:react:*` directly (there should not be any, since it does not match NVD) still see that CPE candidate emitted, because we only _add_ to the candidate-vendor set. This is purely additive.

Signed off per DCO.
