### PR TITLE
cyclonedx: decode operating-system components into Packages

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -60,9 +60,18 @@ func collectBomPackages(bom *cyclonedx.BOM, s *sbom.SBOM, idMap map[string]any) 
 
 func collectPackages(component *cyclonedx.Component, s *sbom.SBOM, idMap map[string]any) {
 	switch component.Type {
-	case cyclonedx.ComponentTypeOS:
+	// ComponentTypeContainer describes the image itself, not a package
+	// inside it, so we still skip it here. For everything that is a
+	// real piece of software (including an operating-system component,
+	// which carries a CPE that vulnerability matchers key off of, see
+	// anchore/syft#4414 and anchore/grype#3062) we decode it into a
+	// Package so downstream matchers can find it.
 	case cyclonedx.ComponentTypeContainer:
-	case cyclonedx.ComponentTypeApplication, cyclonedx.ComponentTypeFramework, cyclonedx.ComponentTypeLibrary, cyclonedx.ComponentTypeMachineLearningModel:
+	case cyclonedx.ComponentTypeOS,
+		cyclonedx.ComponentTypeApplication,
+		cyclonedx.ComponentTypeFramework,
+		cyclonedx.ComponentTypeLibrary,
+		cyclonedx.ComponentTypeMachineLearningModel:
 		p := decodeComponent(component)
 		idMap[component.BOMRef] = p
 		if component.BOMRef != "" {


### PR DESCRIPTION
Fixes #4414 (and, through that, downstream grype issue anchore/grype#3062).

## Problem

When syft decodes a CycloneDX BOM, `collectPackages` in `syft/format/internal/cyclonedxutil/helpers/decoder.go` has:

```go
switch component.Type {
case cyclonedx.ComponentTypeOS:
case cyclonedx.ComponentTypeContainer:
case cyclonedx.ComponentTypeApplication, ComponentTypeFramework, ComponentTypeLibrary, ComponentTypeMachineLearningModel:
    p := decodeComponent(component)
    ...
    s.Artifacts.Packages.Add(*p)
}
```

Empty case bodies for `ComponentTypeOS` and `ComponentTypeContainer` silently drop those components (Go does not fall through). That meant an `operating-system` component with a valid CPE, for example:

```json
{
    "type": "operating-system",
    "name": "NEXO-OS",
    "version": "V1500-SP2",
    "cpe": "cpe:2.3:o:bosch:nexo-os:v1500-SP2:*"
}
```

never made it into `s.Artifacts.Packages`, and grype subsequently reported `found 0 vulnerability matches across 0 packages` despite the CPE pointing directly at NVD entries.

## Fix

Move `ComponentTypeOS` into the decoded set. Container components are still intentionally skipped because a container component describes the image scope rather than a package inside it.

```go
case cyclonedx.ComponentTypeContainer:
    // container describes the scope, not a package
case cyclonedx.ComponentTypeOS,
    cyclonedx.ComponentTypeApplication,
    cyclonedx.ComponentTypeFramework,
    cyclonedx.ComponentTypeLibrary,
    cyclonedx.ComponentTypeMachineLearningModel:
    // decode into Package and add to s.Artifacts.Packages
```

The separate `linuxReleaseFromOSComponent` / `linuxRelease` extraction further down in the same file walks the components independently, so exposing OS to `Packages` does not disturb the OS release metadata path. It just makes the OS component additionally visible to vulnerability matchers, which is what the issue requires.

Signed off per DCO.
