### PR TITLE
javascript: skip package.json under composer-managed vendor trees

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_package_json.go
+++ b/syft/pkg/cataloger/javascript/parse_package_json.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"regexp"
 	"slices"
 	"strings"
@@ -60,6 +61,15 @@ var authorPattern = regexp.MustCompile(`^\s*(?P<name>[^<(]*)(\s+<(?P<email>.*)>)
 
 // parsePackageJSON parses a package.json and returns the discovered JavaScript packages.
 func parsePackageJSON(ctx context.Context, resolver file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+	// Composer vendor/<vendor>/<pkg>/package.json files belong to PHP
+	// packages that happen to ship a bundled JS manifest. Treating them
+	// as independent npm packages leads to false-positive npm CVEs, see
+	// anchore/grype#3279. Skip these when a sibling composer.json makes
+	// it unambiguous that the vendor tree is composer-managed.
+	if isComposerVendoredPackageJSON(resolver, reader.Location.RealPath) {
+		return nil, nil, nil
+	}
+
 	var pkgs []pkg.Package
 	dec := json.NewDecoder(reader)
 
@@ -244,4 +254,38 @@ func (p people) String() string {
 		authorStrings[i] = auth.AuthorString()
 	}
 	return strings.Join(authorStrings, ", ")
+}
+
+// isComposerVendoredPackageJSON returns true when the given package.json
+// path looks like it was installed by Composer (PHP's package manager)
+// rather than by npm. Composers install layout is:
+//
+//	<project>/vendor/<vendor>/<pkg>/...
+//
+// and a composer.json sits at the project root. When we see a
+// package.json under .../vendor/<vendor>/<pkg>/ AND the project root
+// carries a composer.json, we treat that package.json as a PHP-owned
+// artefact and skip it so its contents do not leak into the npm CVE
+// matcher (see anchore/grype#3279).
+func isComposerVendoredPackageJSON(resolver file.Resolver, p string) bool {
+	if resolver == nil || p == "" {
+		return false
+	}
+	cleaned := path.Clean(p)
+	if path.Base(cleaned) != "package.json" {
+		return false
+	}
+	pkgDir := path.Dir(cleaned)               // .../vendor/<vendor>/<pkg>
+	vendorNameDir := path.Dir(pkgDir)         // .../vendor/<vendor>
+	vendorDir := path.Dir(vendorNameDir)      // .../vendor
+	projectRoot := path.Dir(vendorDir)        // ...
+	if path.Base(vendorDir) != "vendor" || projectRoot == "" {
+		return false
+	}
+	composerPath := path.Join(projectRoot, "composer.json")
+	locs, err := resolver.FilesByPath(composerPath)
+	if err != nil || len(locs) == 0 {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Fixes downstream anchore/grype#3279.

## Problem

When syft scans an image that was built with `composer install`, every PHP package under `vendor/<vendor>/<pkg>/` that happens to ship a `package.json` (to describe a bundled JS asset or simply because upstream included one) is reported as an independent npm package. Grype then matches it against the npm advisory stream and surfaces npm-only CVEs like `GHSA-hj79-42mx-m4gr` ("Malware in @umpirsky/country-list") against the PHP package:

```
@umpirsky/country-list  1.0.0  npm  GHSA-hj79-42mx-m4gr  Critical
```

The actual component is the composer package `umpirsky/country-list`, not the npm namespace. The npm CVE has no bearing on it.

## Fix

Skip those `package.json` files at the cataloger level. The signal is the composer install layout itself:

```
<project>/vendor/<vendor>/<pkg>/package.json
          ^
          composer.json sits at <project>
```

In `parse_package_json.go` the new `isComposerVendoredPackageJSON` helper checks:

1. the file is `package.json`
2. the path is under a `.../vendor/<vendor>/<pkg>/` two-level layout
3. a `composer.json` exists at the project root (the `..` above `vendor/`)

When all three hold we return `(nil, nil, nil)` and the npm cataloger never sees the file. Anything else (top-level `package.json`, `package.json` under `node_modules`, projects that don't carry `composer.json`) is unaffected.

Signed off per DCO.
