### PR TITLE
cpe: map conan expat to libexpat product+vendor

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -221,6 +221,23 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "mustache"},
 			candidateAddition{AdditionalProducts: []string{"mustache.js"}},
 		},
+		{
+			// NVD records react under the facebook vendor, e.g.
+			// cpe:2.3:a:facebook:react:*, but the npm package.json
+			// names neither the vendor nor the author. Without
+			// this hint syft emits cpe:2.3:a:react:react:* and
+			// grype/DependencyTrack miss every React CVE. See #4653.
+			pkg.NpmPkg,
+			candidateKey{PkgName: "react"},
+			candidateAddition{AdditionalVendors: []string{"facebook"}},
+		},
+		{
+			// Same story for react-dom, which NVD also records under
+			// facebook (and ties to react CVEs).
+			pkg.NpmPkg,
+			candidateKey{PkgName: "react-dom"},
+			candidateAddition{AdditionalVendors: []string{"facebook"}},
+		},
 
 		// Gem packages
 		{
@@ -329,6 +346,17 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			pkg.ApkPkg,
 			candidateKey{PkgName: "curl"},
 			candidateAddition{AdditionalVendors: []string{"haxx"}},
+		},
+		{
+			// libpcap is maintained by the tcpdump project and NVD
+			// records the CVEs under vendor "tcpdump", e.g.
+			// cpe:2.3:a:tcpdump:libpcap:*. Without this hint syft
+			// generates cpe:2.3:a:libpcap:libpcap:* from the Alpine
+			// package name, which NVD does not match, so grype
+			// reports zero vulnerabilities for libpcap (see #4712).
+			pkg.ApkPkg,
+			candidateKey{PkgName: "libpcap"},
+			candidateAddition{AdditionalVendors: []string{"tcpdump"}},
 		},
 		{
 			pkg.ApkPkg,
@@ -507,6 +535,19 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			pkg.ConanPkg,
 			candidateKey{PkgName: "poco"},
 			candidateAddition{AdditionalVendors: []string{"pocoproject"}},
+		},
+		{
+			// NVD records expat CVEs (e.g. CVE-2024-45492) under the
+			// libexpat product name, cpe:2.3:a:libexpat:libexpat:*.
+			// Without this hint the conan-derived CPE
+			// cpe:2.3:a:expat:expat:* misses every expat CVE, see
+			// anchore/syft#4771.
+			pkg.ConanPkg,
+			candidateKey{PkgName: "expat"},
+			candidateAddition{
+				AdditionalVendors:  []string{"libexpat"},
+				AdditionalProducts: []string{"libexpat"},
+			},
 		},
 	})
 

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -221,23 +221,6 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "mustache"},
 			candidateAddition{AdditionalProducts: []string{"mustache.js"}},
 		},
-		{
-			// NVD records react under the facebook vendor, e.g.
-			// cpe:2.3:a:facebook:react:*, but the npm package.json
-			// names neither the vendor nor the author. Without
-			// this hint syft emits cpe:2.3:a:react:react:* and
-			// grype/DependencyTrack miss every React CVE. See #4653.
-			pkg.NpmPkg,
-			candidateKey{PkgName: "react"},
-			candidateAddition{AdditionalVendors: []string{"facebook"}},
-		},
-		{
-			// Same story for react-dom, which NVD also records under
-			// facebook (and ties to react CVEs).
-			pkg.NpmPkg,
-			candidateKey{PkgName: "react-dom"},
-			candidateAddition{AdditionalVendors: []string{"facebook"}},
-		},
 
 		// Gem packages
 		{
@@ -346,17 +329,6 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			pkg.ApkPkg,
 			candidateKey{PkgName: "curl"},
 			candidateAddition{AdditionalVendors: []string{"haxx"}},
-		},
-		{
-			// libpcap is maintained by the tcpdump project and NVD
-			// records the CVEs under vendor "tcpdump", e.g.
-			// cpe:2.3:a:tcpdump:libpcap:*. Without this hint syft
-			// generates cpe:2.3:a:libpcap:libpcap:* from the Alpine
-			// package name, which NVD does not match, so grype
-			// reports zero vulnerabilities for libpcap (see #4712).
-			pkg.ApkPkg,
-			candidateKey{PkgName: "libpcap"},
-			candidateAddition{AdditionalVendors: []string{"tcpdump"}},
 		},
 		{
 			pkg.ApkPkg,

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
@@ -232,3 +232,49 @@ func Test_findProductsToRemove(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/anchore/syft/issues/4653:
+// NVD records React under the facebook vendor, so the default npm-derived
+// CPE (cpe:2.3:a:react:react:*) misses every React CVE. The candidate
+// table must add "facebook" to the list of candidate vendors for react
+// (and react-dom, which is tied to the same CVE stream).
+func Test_npmCandidateAdditions_react(t *testing.T) {
+	tests := []struct {
+		pkgName         string
+		expectedVendors []string
+	}{
+		{pkgName: "react", expectedVendors: []string{"facebook"}},
+		{pkgName: "react-dom", expectedVendors: []string{"facebook"}},
+	}
+	for _, test := range tests {
+		t.Run(test.pkgName, func(t *testing.T) {
+			got := findAdditionalVendors(defaultCandidateAdditions, pkg.NpmPkg, test.pkgName, "")
+			assert.ElementsMatch(t, test.expectedVendors, got,
+				"npm package %q should map to vendors %v", test.pkgName, test.expectedVendors)
+		})
+	}
+}
+
+// Regression test for https://github.com/anchore/syft/issues/4712:
+// libpcap is maintained by the tcpdump project and NVD records the CVEs
+// under vendor "tcpdump". Without this hint the APK-derived CPE
+// (cpe:2.3:a:libpcap:libpcap:*) fails to match any NVD entry and grype
+// reports zero vulnerabilities for a known-vulnerable libpcap version.
+func Test_apkCandidateAdditions_libpcap(t *testing.T) {
+	got := findAdditionalVendors(defaultCandidateAdditions, pkg.ApkPkg, "libpcap", "")
+	assert.Contains(t, got, "tcpdump",
+		"apk package libpcap should map to the tcpdump vendor for NVD matching")
+}
+
+// Regression test for https://github.com/anchore/syft/issues/4771:
+// NVD records expat CVEs under product "libexpat" (vendor "libexpat"),
+// so without a hint the conan-derived cpe:2.3:a:expat:expat:* fails
+// to match every recent expat CVE like CVE-2024-45492.
+func Test_conanCandidateAdditions_expat(t *testing.T) {
+	vendors := findAdditionalVendors(defaultCandidateAdditions, pkg.ConanPkg, "expat", "")
+	assert.Contains(t, vendors, "libexpat",
+		"conan package expat should map to the libexpat vendor for NVD matching")
+	products := findAdditionalProducts(defaultCandidateAdditions, pkg.ConanPkg, "expat")
+	assert.Contains(t, products, "libexpat",
+		"conan package expat should also emit libexpat as a candidate product")
+}

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
@@ -233,39 +233,6 @@ func Test_findProductsToRemove(t *testing.T) {
 	}
 }
 
-// Regression test for https://github.com/anchore/syft/issues/4653:
-// NVD records React under the facebook vendor, so the default npm-derived
-// CPE (cpe:2.3:a:react:react:*) misses every React CVE. The candidate
-// table must add "facebook" to the list of candidate vendors for react
-// (and react-dom, which is tied to the same CVE stream).
-func Test_npmCandidateAdditions_react(t *testing.T) {
-	tests := []struct {
-		pkgName         string
-		expectedVendors []string
-	}{
-		{pkgName: "react", expectedVendors: []string{"facebook"}},
-		{pkgName: "react-dom", expectedVendors: []string{"facebook"}},
-	}
-	for _, test := range tests {
-		t.Run(test.pkgName, func(t *testing.T) {
-			got := findAdditionalVendors(defaultCandidateAdditions, pkg.NpmPkg, test.pkgName, "")
-			assert.ElementsMatch(t, test.expectedVendors, got,
-				"npm package %q should map to vendors %v", test.pkgName, test.expectedVendors)
-		})
-	}
-}
-
-// Regression test for https://github.com/anchore/syft/issues/4712:
-// libpcap is maintained by the tcpdump project and NVD records the CVEs
-// under vendor "tcpdump". Without this hint the APK-derived CPE
-// (cpe:2.3:a:libpcap:libpcap:*) fails to match any NVD entry and grype
-// reports zero vulnerabilities for a known-vulnerable libpcap version.
-func Test_apkCandidateAdditions_libpcap(t *testing.T) {
-	got := findAdditionalVendors(defaultCandidateAdditions, pkg.ApkPkg, "libpcap", "")
-	assert.Contains(t, got, "tcpdump",
-		"apk package libpcap should map to the tcpdump vendor for NVD matching")
-}
-
 // Regression test for https://github.com/anchore/syft/issues/4771:
 // NVD records expat CVEs under product "libexpat" (vendor "libexpat"),
 // so without a hint the conan-derived cpe:2.3:a:expat:expat:* fails


### PR DESCRIPTION
Fixes #4771.

## Problem

NVD records every expat CVE under the `libexpat` product (and vendor), e.g. `cpe:2.3:a:libexpat:libexpat:*`. The reporter cites [CVE-2024-45492](https://nvd.nist.gov/vuln/detail/cve-2024-45492) as a concrete recent example.

Without a hint, syft derives `cpe:2.3:a:expat:expat:*` from the Conan recipe name (Conan packages expat as `expat/2.5.0`). NVD cannot match that CPE, and grype silently reports zero expat CVEs on any Conan-built project.

## Fix

Add a `ConanPkg` alias next to the existing Poco one in `candidate_by_package_type.go`:

```go
{
    pkg.ConanPkg,
    candidateKey{PkgName: "expat"},
    candidateAddition{
        AdditionalVendors:  []string{"libexpat"},
        AdditionalProducts: []string{"libexpat"},
    },
},
```

NVD uses `libexpat` for *both* vendor and product, so this entry adds both to the candidate sets. The original `expat` vendor/product is still generated, so any future NVD reclassification under the simpler vendor/product pair keeps working.

## Test

`Test_conanCandidateAdditions_expat` in `candidate_by_package_type_test.go` exercises `findAdditionalVendors` and `findAdditionalProducts` against `defaultCandidateAdditions`.

Signed off per DCO.
