### PR TITLE
fix(cyclonedx): exclude distro group from package name

### DIFF
--- a/syft/format/internal/backfill.go
+++ b/syft/format/internal/backfill.go
@@ -151,13 +151,13 @@ var epochPrefix = regexp.MustCompile(`^\d+:`)
 // nameFromPurl returns the syft package name of the package from the purl. If the purl includes a namespace,
 // the name is prefixed as appropriate based on the PURL type
 func nameFromPurl(purl packageurl.PackageURL) string {
-	if !nameExcludesPurlNamespace(purl.Type) && purl.Namespace != "" {
+	if !NameExcludesPurlNamespace(purl.Type) && purl.Namespace != "" {
 		return fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
 	}
 	return purl.Name
 }
 
-func nameExcludesPurlNamespace(purlType string) bool {
+func NameExcludesPurlNamespace(purlType string) bool {
 	switch purlType {
 	case packageurl.TypeAlpine,
 		packageurl.TypeAlpm,

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -165,6 +165,7 @@ func getPURL(c *cyclonedx.Component, ty pkg.Type) string {
 	return purl.ToString()
 }
 
+//nolint:gocognit
 func setPackageName(p *pkg.Package, c *cyclonedx.Component) {
 	name := c.Name
 	if c.Group != "" {
@@ -195,7 +196,7 @@ func setPackageName(p *pkg.Package, c *cyclonedx.Component) {
 				}
 			}
 		default:
-			if !internal.NameExcludesPurlNamespace(string(p.Type.PackageURLType())) {
+			if !internal.NameExcludesPurlNamespace(p.Type.PackageURLType()) {
 				name = fmt.Sprintf("%s/%s", c.Group, name)
 			}
 		}

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -195,7 +195,9 @@ func setPackageName(p *pkg.Package, c *cyclonedx.Component) {
 				}
 			}
 		default:
-			name = fmt.Sprintf("%s/%s", c.Group, name)
+			if !internal.NameExcludesPurlNamespace(string(p.Type.PackageURLType())) {
+				name = fmt.Sprintf("%s/%s", c.Group, name)
+			}
 		}
 	}
 	p.Name = name

--- a/syft/format/internal/cyclonedxutil/helpers/component_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component_test.go
@@ -384,6 +384,65 @@ func Test_decodeComponent(t *testing.T) {
 	}
 }
 
+func Test_setPackageName(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      pkg.Package
+		comp     cyclonedx.Component
+		wantName string
+	}{
+		{
+			name:     "debian group excluded from name",
+			pkg:      pkg.Package{Type: pkg.DebPkg},
+			comp:     cyclonedx.Component{Name: "wget", Group: "debian"},
+			wantName: "wget",
+		},
+		{
+			name:     "rpm group excluded from name",
+			pkg:      pkg.Package{Type: pkg.RpmPkg},
+			comp:     cyclonedx.Component{Name: "acl", Group: "centos"},
+			wantName: "acl",
+		},
+		{
+			name:     "apk group excluded from name",
+			pkg:      pkg.Package{Type: pkg.ApkPkg},
+			comp:     cyclonedx.Component{Name: "musl", Group: "alpine"},
+			wantName: "musl",
+		},
+		{
+			name:     "npm group included in name",
+			pkg:      pkg.Package{Type: pkg.NpmPkg},
+			comp:     cyclonedx.Component{Name: "node", Group: "@types"},
+			wantName: "@types/node",
+		},
+		{
+			name:     "go module group included in name",
+			pkg:      pkg.Package{Type: pkg.GoModulePkg},
+			comp:     cyclonedx.Component{Name: "net", Group: "golang.org/x"},
+			wantName: "golang.org/x/net",
+		},
+		{
+			name:     "no group leaves name unchanged",
+			pkg:      pkg.Package{Type: pkg.DebPkg},
+			comp:     cyclonedx.Component{Name: "wget"},
+			wantName: "wget",
+		},
+		{
+			name: "java group stored in metadata not name",
+			pkg:  pkg.Package{Type: pkg.JavaPkg},
+			comp: cyclonedx.Component{Name: "log4j", Group: "org.apache.logging.log4j"},
+			wantName: "log4j",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := tt.pkg
+			setPackageName(&p, &tt.comp)
+			assert.Equal(t, tt.wantName, p.Name)
+		})
+	}
+}
+
 func TestGetPURL(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/syft/format/internal/cyclonedxutil/helpers/component_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component_test.go
@@ -428,9 +428,9 @@ func Test_setPackageName(t *testing.T) {
 			wantName: "wget",
 		},
 		{
-			name: "java group stored in metadata not name",
-			pkg:  pkg.Package{Type: pkg.JavaPkg},
-			comp: cyclonedx.Component{Name: "log4j", Group: "org.apache.logging.log4j"},
+			name:     "java group stored in metadata not name",
+			pkg:      pkg.Package{Type: pkg.JavaPkg},
+			comp:     cyclonedx.Component{Name: "log4j", Group: "org.apache.logging.log4j"},
 			wantName: "log4j",
 		},
 	}


### PR DESCRIPTION
## Summary

- CycloneDX decoder's `setPackageName` unconditionally prepends `component.group` to the package name for all non-Java types, producing names like `debian/wget` instead of `wget` for distro packages
- Downstream tools (Grype) then fail to match these mangled names against vulnerability databases — **silently returning zero results**
- Reuses the existing `NameExcludesPurlNamespace` helper (exported from `backfill.go`) to gate the group prefix, aligning the CycloneDX decode path with the PURL decode path as a single source of truth

Fixes anchore/grype#2967. Also fixes the same latent bug for RPM and Alpine packages.

## Details

`setPackageName` in `cyclonedxutil/helpers/component.go` only special-cased Java — everything else hit a `default` branch that blindly did `fmt.Sprintf("%s/%s", group, name)`. Meanwhile, `backfill.go` already had `nameExcludesPurlNamespace` which correctly identifies package types (Debian, RPM, Alpine, Maven, etc.) where the namespace/group is structural metadata, not part of the display name. The PURL decode path used it; the CycloneDX decode path didn't.

This PR:
1. Exports `NameExcludesPurlNamespace` so it's callable from the `helpers` package
2. Adds a guard in `setPackageName`'s default branch: only prefix `group/name` when `NameExcludesPurlNamespace` returns false
3. Adds 7 test cases covering regression (Debian, RPM, Alpine), preservation (npm, Go, Java), and baseline (no group)

### Verified end-to-end

Built Grype against this patched Syft and scanned a CycloneDX SBOM containing Debian packages with `"group": "debian"`:

| | Stock Syft | Patched Syft |
|---|---|---|
| Package name | `debian/wget` | `wget` |
| Grype vuln matches | **0** (silent miss) | **29 CVEs found** |

## Test plan

- [x] `Test_setPackageName` — 7 cases: debian excluded, rpm excluded, apk excluded, npm preserved, go preserved, no-group baseline, java preserved
- [x] All existing `cyclonedxutil/helpers` tests pass (no regressions)
- [x] All existing `backfill` tests pass (`nameFromPurl` calls the renamed export)
- [x] End-to-end: Grype + patched Syft correctly matches Debian vulns from CycloneDX SBOM with group field