### PR TITLE
feat: exclude indirect deps

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -191,7 +191,8 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 					WithFromBuildSettings(cfg.Golang.MainModuleVersion.FromBuildSettings).
 					WithFromLDFlags(cfg.Golang.MainModuleVersion.FromLDFlags),
 			).
-			WithUsePackagesLib(*multiLevelOption(true, enrichmentEnabled(cfg.Enrich, task.Go, task.Golang), cfg.Golang.UsePackagesLib)),
+			WithUsePackagesLib(*multiLevelOption(true, enrichmentEnabled(cfg.Enrich, task.Go, task.Golang), cfg.Golang.UsePackagesLib)).
+			WithExcludeIndirect(cfg.Golang.ExcludeIndirect),
 		JavaScript: javascript.DefaultCatalogerConfig().
 			WithIncludeDevDependencies(*multiLevelOption(false, cfg.JavaScript.IncludeDevDependencies)).
 			WithSearchRemoteLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.JavaScript, task.Node, task.NPM), cfg.JavaScript.SearchRemoteLicenses)).
@@ -249,6 +250,8 @@ func (cfg *Catalog) AddFlags(flags clio.FlagSet) {
 
 	flags.StringVarP(&cfg.Source.Supplier, "source-supplier", "",
 		"the organization that supplied the component, which often may be the manufacturer, distributor, or repackager")
+
+	flags.BoolVarP(&cfg.Golang.ExcludeIndirect, "exclude-indirect", "", "exclude indirect dependencies from sbom file (only golang support now)")
 }
 
 func (cfg *Catalog) DescribeFields(descriptions fangs.FieldDescriptionSet) {

--- a/cmd/syft/internal/options/catalog_test.go
+++ b/cmd/syft/internal/options/catalog_test.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,7 @@ func TestCatalog_PostLoad(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = assert.NoError
 			}
-			tt.wantErr(t, tt.options.PostLoad(), fmt.Sprintf("PostLoad()"))
+			tt.wantErr(t, tt.options.PostLoad(), "PostLoad()")
 			if tt.assert != nil {
 				tt.assert(t, tt.options)
 			}

--- a/cmd/syft/internal/options/cataloger_selection_test.go
+++ b/cmd/syft/internal/options/cataloger_selection_test.go
@@ -1,7 +1,6 @@
 package options
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,7 +58,7 @@ func TestCatalogerSelection_PostLoad(t *testing.T) {
 			if tt.wantErr == nil {
 				tt.wantErr = assert.NoError
 			}
-			tt.wantErr(t, tt.options.PostLoad(), fmt.Sprintf("PostLoad()"))
+			tt.wantErr(t, tt.options.PostLoad(), "PostLoad()")
 			if tt.assert != nil {
 				tt.assert(t, tt.options)
 			}

--- a/cmd/syft/internal/options/golang.go
+++ b/cmd/syft/internal/options/golang.go
@@ -17,6 +17,7 @@ type golangConfig struct {
 	NoProxy                     string                        `json:"no-proxy" yaml:"no-proxy" mapstructure:"no-proxy"`
 	MainModuleVersion           golangMainModuleVersionConfig `json:"main-module-version" yaml:"main-module-version" mapstructure:"main-module-version"`
 	UsePackagesLib              *bool                         `json:"use-packages-lib" yaml:"use-packages-lib" mapstructure:"use-packages-lib"`
+	ExcludeIndirect             bool                         `json:"exclude-indirect" yaml:"exclude-indirect" mapstructure:"exclude-indirect"`
 }
 
 var _ interface {
@@ -43,6 +44,7 @@ a more accurate version from the binary.`)
 	descriptions.Add(&o.MainModuleVersion.FromBuildSettings, `use the build settings (e.g. vcs.version & vcs.time) to craft a v0 pseudo version 
 (e.g. v0.0.0-20220308212642-53e6d0aaf6fb) when a more accurate version cannot be found otherwise`)
 	descriptions.Add(&o.MainModuleVersion.FromContents, `search for semver-like strings in the binary contents`)
+	descriptions.Add(&o.ExcludeIndirect, `exclude indirect dependencies`)
 }
 
 type golangMainModuleVersionConfig struct {
@@ -67,5 +69,6 @@ func defaultGolangConfig() golangConfig {
 			FromBuildSettings: def.MainModuleVersion.FromBuildSettings,
 		},
 		UsePackagesLib: nil, // this defaults to true, which is the API default
+		ExcludeIndirect: def.ExcludeIndirect,
 	}
 }

--- a/syft/pkg/cataloger/golang/config.go
+++ b/syft/pkg/cataloger/golang/config.go
@@ -51,6 +51,8 @@ type CatalogerConfig struct {
 
 	// Whether to use the golang.org/x/tools/go/packages, which executes golang tooling found on the path in addition to potential network access
 	UsePackagesLib bool `json:"use-packages-lib" yaml:"use-packages-lib" mapstructure:"use-packages-lib"`
+
+	ExcludeIndirect bool `json:"exclude-indirect" yaml:"exclude-indirect" mapstructure:"exclude-indirect"`
 }
 
 type MainModuleVersionConfig struct {
@@ -201,5 +203,10 @@ func (g MainModuleVersionConfig) WithFromContents(input bool) MainModuleVersionC
 
 func (g MainModuleVersionConfig) WithFromBuildSettings(input bool) MainModuleVersionConfig {
 	g.FromBuildSettings = input
+	return g
+}
+
+func (g CatalogerConfig) WithExcludeIndirect(excludeIndirect bool) CatalogerConfig {
+	g.ExcludeIndirect = excludeIndirect
 	return g
 }

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -27,12 +27,14 @@ import (
 
 type goModCataloger struct {
 	usePackagesLib  bool
+	excludeIndirect bool
 	licenseResolver goLicenseResolver
 }
 
 func newGoModCataloger(opts CatalogerConfig) *goModCataloger {
 	return &goModCataloger{
 		usePackagesLib:  opts.UsePackagesLib,
+		excludeIndirect: opts.ExcludeIndirect,
 		licenseResolver: newGoLicenseResolver(modFileCatalogerName, opts),
 	}
 }
@@ -255,6 +257,10 @@ func (c *goModCataloger) catalogModules(
 	moduleToPackage := make(map[string]artifact.Identifiable)
 
 	for _, m := range modules {
+		if c.excludeIndirect && m.Indirect {
+			continue
+		}
+
 		if isRelativeImportOrMain(m.Path) {
 			// relativeImport modules are already accounted for by their full module paths at other portions of syft's cataloging
 			// example: something like ../../ found as a module for go.mod b, which is sub to go.mod a is accounted for
@@ -324,7 +330,7 @@ func buildModuleRelationships(
 }
 
 func (c *goModCataloger) parseModFileContents(reader file.LocationReadCloser) (*modfile.File, error) {
-	contents, err := io.ReadAll(reader) //nolint:gocritic // modfile.Parse requires []byte
+	contents, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read go module: %w", err)
 	}
@@ -342,6 +348,10 @@ func (c *goModCataloger) createGoModPackages(ctx context.Context, resolver file.
 	goModPackages := make(map[string]pkg.Package)
 
 	for _, m := range modFile.Require {
+		if c.excludeIndirect && m.Indirect {
+			continue
+		}
+
 		if sourceModules == nil || sourceModules[m.Mod.Path] == nil {
 			lics := c.licenseResolver.getLicenses(ctx, resolver, m.Mod.Path, m.Mod.Version)
 			goModPkg := pkg.Package{
@@ -367,6 +377,10 @@ func (c *goModCataloger) createGoModPackages(ctx context.Context, resolver file.
 // applyReplaceDirectives processes replace directives from go.mod
 func (c *goModCataloger) applyReplaceDirectives(ctx context.Context, resolver file.Resolver, modFile *modfile.File, goModPackages map[string]pkg.Package, reader file.LocationReadCloser, digests map[string]string) {
 	for _, m := range modFile.Replace {
+		if _, isContains := goModPackages[m.Old.Path]; c.excludeIndirect && !isContains {
+			continue
+		}
+
 		lics := c.licenseResolver.getLicenses(ctx, resolver, m.New.Path, m.New.Version)
 		var finalPath string
 		if !strings.HasPrefix(m.New.Path, ".") && !strings.HasPrefix(m.New.Path, "/") {

--- a/syft/pkg/cataloger/golang/parse_go_mod_test.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestParseGoMod(t *testing.T) {
 	tests := []struct {
-		fixture  string
-		expected []pkg.Package
+		fixture         string
+		expected        []pkg.Package
+		excludeIndirect bool
 	}{
 		{
 			fixture: "testdata/go-mod-fixtures/one-package/go.mod",
@@ -107,11 +108,72 @@ func TestParseGoMod(t *testing.T) {
 				},
 			},
 		},
+		{
+
+			fixture: "testdata/go-mod-fixtures/many-packages-with-indirect/go.mod",
+			expected: []pkg.Package{
+				{
+					Name:      "github.com/adrg/xdg",
+					Version:   "v0.2.1",
+					PURL:      "pkg:golang/github.com/adrg/xdg@v0.2.1",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
+					Name:      "github.com/anchore/archiver/v3",
+					Version:   "v3.5.1",
+					PURL:      "pkg:golang/github.com/anchore/archiver/v3@v3.5.1",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
+					Name:      "github.com/anchore/go-testutils",
+					Version:   "v0.0.0-20200624184116-66aa578126db",
+					PURL:      "pkg:golang/github.com/anchore/go-testutils@v0.0.0-20200624184116-66aa578126db",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
+					Name:      "github.com/anchore/go-version",
+					Version:   "v1.2.2-0.20200701162849-18adb9c92b9b",
+					PURL:      "pkg:golang/github.com/anchore/go-version@v1.2.2-0.20200701162849-18adb9c92b9b",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
+					Name:      "github.com/anchore/stereoscope",
+					Version:   "v0.0.0-20200706164556-7cf39d7f4639",
+					PURL:      "pkg:golang/github.com/anchore/stereoscope@v0.0.0-20200706164556-7cf39d7f4639",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+				{
+					Name:      "github.com/go-test/deep",
+					Version:   "v1.0.6",
+					PURL:      "pkg:golang/github.com/go-test/deep@v1.0.6",
+					Locations: file.NewLocationSet(file.NewLocation("testdata/go-mod-fixtures/many-packages-with-indirect/go.mod")),
+					Language:  pkg.Go,
+					Type:      pkg.GoModulePkg,
+					Metadata:  pkg.GolangModuleEntry{},
+				},
+			},
+			excludeIndirect: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.fixture, func(t *testing.T) {
-			c := newGoModCataloger(DefaultCatalogerConfig().WithUsePackagesLib(false))
+			c := newGoModCataloger(DefaultCatalogerConfig().WithUsePackagesLib(false).WithExcludeIndirect(test.excludeIndirect))
 			pkgtest.NewCatalogTester().
 				FromFile(t, test.fixture).
 				Expects(test.expected, nil).

--- a/syft/pkg/cataloger/golang/testdata/go-mod-fixtures/many-packages-with-indirect/go.mod
+++ b/syft/pkg/cataloger/golang/testdata/go-mod-fixtures/many-packages-with-indirect/go.mod
@@ -1,0 +1,20 @@
+module (
+	github.com/anchore/syft
+)
+
+go 1.14
+
+// github.com/bogus/package v10.10.10
+
+require (
+	github.com/adrg/xdg v0.2.1
+	github.com/anchore/go-testutils v0.0.0-20200624184116-66aa578126db // github.com/bogus/package v10.10.10
+	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
+	github.com/anchore/stereoscope v0.0.0-20200706164556-7cf39d7f4639
+	github.com/anchore/archiver/v3 v3.5.1
+	//github.com/ignore/this v9.9.9  // indirect
+	github.com/bmatcuk/doublestar v1.3.1 // indirect
+	github.com/go-playground/validator/v10 v10.30.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+	github.com/go-test/deep v1.0.6 // a comment
+)


### PR DESCRIPTION
## Summary

Added exclusion of indirect dependencies when building an SBOM file. Currently, this flag is supported for Golang projects.

Added a new bool flag, exclude-indirect. Default value is false.

## Type of change

- New feature

## Testing

Tested with own project
