### PR TITLE
fix: strip gemspec homepage URLs containing Ruby interpolation

### DIFF
--- a/syft/pkg/cataloger/ruby/parse_gemspec.go
+++ b/syft/pkg/cataloger/ruby/parse_gemspec.go
@@ -29,6 +29,8 @@ type gemData struct {
 // match example:      Al\u003Ex   --->   003E
 var unicodePattern = regexp.MustCompile(`\\u(?P<unicode>[0-9A-F]{4})`)
 
+var interpolationPattern = regexp.MustCompile(`#\{[^}]*\}`)
+
 var patterns = map[string]*regexp.Regexp{
 	// match example:       name = "railties".freeze   --->   railties
 	"name": regexp.MustCompile(`.*\.name\s*=\s*["']{1}(?P<name>.*)["']{1} *`),
@@ -97,6 +99,9 @@ func parseGemSpecEntries(ctx context.Context, resolver file.Resolver, _ *generic
 	}
 
 	if fields["name"] != "" && fields["version"] != "" {
+		if homepage, ok := fields["homepage"].(string); ok && interpolationPattern.MatchString(homepage) {
+			delete(fields, "homepage")
+		}
 		var metadata gemData
 		if err := mapstructure.Decode(fields, &metadata); err != nil {
 			return nil, nil, fmt.Errorf("unable to decode gem metadata: %w", err)

--- a/syft/pkg/cataloger/ruby/parse_gemspec_test.go
+++ b/syft/pkg/cataloger/ruby/parse_gemspec_test.go
@@ -35,3 +35,30 @@ func TestParseGemspec(t *testing.T) {
 
 	pkgtest.TestFileParser(t, fixture, parseGemSpecEntries, []pkg.Package{expectedPkg}, nil)
 }
+
+func TestParseGemspecWithInterpolation(t *testing.T) {
+	fixture := "testdata/formatador.gemspec"
+	ctx := context.TODO()
+	locations := file.NewLocationSet(file.NewLocation(fixture))
+
+	var expectedPkg = pkg.Package{
+		Name:      "formatador",
+		Version:   "1.0.0",
+		PURL:      "pkg:gem/formatador@1.0.0",
+		Locations: locations,
+		Type:      pkg.GemPkg,
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicenseFromLocationsWithContext(ctx, "MIT", file.NewLocation(fixture)),
+		),
+		Language: pkg.Ruby,
+		Metadata: pkg.RubyGemspec{
+			Name:     "formatador",
+			Version:  "1.0.0",
+			Files:    []string{"lib/formatador.rb"},
+			Authors:  []string{"geemus"},
+			Homepage: "",
+		},
+	}
+
+	pkgtest.TestFileParser(t, fixture, parseGemSpecEntries, []pkg.Package{expectedPkg}, nil)
+}

--- a/syft/pkg/cataloger/ruby/testdata/formatador.gemspec
+++ b/syft/pkg/cataloger/ruby/testdata/formatador.gemspec
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = "formatador".freeze
+  s.version = "1.0.0"
+
+  s.authors = ["geemus".freeze]
+  s.files = ["lib/formatador.rb".freeze]
+  s.homepage = "https://github.com/geemus/#{s.name}".freeze
+  s.licenses = ["MIT".freeze]
+end


### PR DESCRIPTION
## Description

Ruby gemspec files can contain string interpolation patterns like `#{s.name}` in homepage URLs. Since syft reads gemspecs as raw text without evaluating Ruby code, these patterns end up as literal strings in the output SBOM.

For example, the `formatador` gem defines `s.homepage = "https://github.com/geemus/#{s.name}"` which should resolve to `https://github.com/geemus/formatador`, but syft outputs the literal string containing `#{s.name}`.

This produces invalid URLs that fail CycloneDX schema validation:
```
"$.components[1117].externalReferences[0].url: does not match the iri-reference pattern must be a valid RFC 3987 IRI-reference"
```

## Change

Added detection of Ruby interpolation patterns (`#{...}`) in parsed gemspec homepage values. When detected, the homepage field is omitted from the package metadata rather than emitting an invalid URL.

Also added a test case using a fixture that mimics the formatador gem's gemspec.

## Alternative considered

Evaluating the interpolation was rejected because it would require a full Ruby runtime. Stripping URLs with `{` and `}` characters broadly was also considered but the regex-based approach targeting `#{...}` patterns is more precise and avoids false positives.

Closes #4720