### PR TITLE
fix: update jruby download URLs from S3 to GitHub Releases

### DIFF
--- a/syft/pkg/cataloger/binary/testdata/image-jruby/Dockerfile
+++ b/syft/pkg/cataloger/binary/testdata/image-jruby/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 alpine:latest AS builder
 
-RUN wget -O jruby_windows_9_3_15_0.exe https://s3.amazonaws.com/jruby.org/downloads/9.3.15.0/jruby_windows_9_3_15_0.exe
+RUN wget -O jruby_windows_9_3_15_0.exe https://github.com/jruby/jruby/releases/download/9.3.15.0/jruby_windows_9_3_15_0.exe
 
 FROM scratch
 

--- a/syft/pkg/cataloger/dotnet/testdata/image-net8-app/Dockerfile
+++ b/syft/pkg/cataloger/dotnet/testdata/image-net8-app/Dockerfile
@@ -73,7 +73,7 @@ RUN dotnet publish -r $RUNTIME --no-restore -o /app
 #   > Humanizer.Core.zh-Hant         2.14.1
 
 # lets pull in a file that is not related at all and in fact is not a .NET binary either (this should be ignored)
-RUN wget -O /app/jruby_windows_9_3_15_0.exe https://s3.amazonaws.com/jruby.org/downloads/9.3.15.0/jruby_windows_9_3_15_0.exe
+RUN wget -O /app/jruby_windows_9_3_15_0.exe https://github.com/jruby/jruby/releases/download/9.3.15.0/jruby_windows_9_3_15_0.exe
 
 FROM busybox
 WORKDIR /app


### PR DESCRIPTION
The jruby download URL is no longer accessible, this fallsback to using the github release for these assets.