### PR TITLE
chore(deps): restore Go version to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/syft
 
-go 1.26.2
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.8 (pre-#4773). Bumped in #4773 (merge 5b58ec96b7dcf39e6be556312de0fc9fcab5dd18).