### PR TITLE
internal/file: propagate non-EOF errors out of safeCopy

### DIFF
--- a/internal/file/copy.go
+++ b/internal/file/copy.go
@@ -12,8 +12,20 @@ const perFileReadLimit = 2 * GB
 // protect against decompression bomb attacks.
 func safeCopy(writer io.Writer, reader io.Reader) error {
 	numBytes, err := io.Copy(writer, io.LimitReader(reader, perFileReadLimit))
-	if numBytes >= perFileReadLimit || errors.Is(err, io.EOF) {
+	if numBytes >= perFileReadLimit {
 		return fmt.Errorf("zip read limit hit (potential decompression bomb attack)")
+	}
+	// Propagate decompression / read errors up to the caller. io.Copy
+	// on the happy path returns (n, nil); the only way err is non-nil
+	// here is that the underlying reader surfaced a real failure
+	// ("flate: corrupt input before offset X" on a mangled ZIP entry,
+	// a network-backed reader erroring mid-stream, etc.). The previous
+	// implementation dropped that error and the caller stored a
+	// partial / empty buffer as a "successful" extract, which silently
+	// downgraded Java cataloger output and caused SBOM scanners to
+	// miss known CVEs (#4806).
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("failed to read archive entry: %w", err)
 	}
 	return nil
 }

--- a/internal/file/copy_test.go
+++ b/internal/file/copy_test.go
@@ -1,0 +1,64 @@
+package file
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// errReader returns a deterministic non-EOF error after emitting some
+// bytes, mimicking what compress/flate does when it hits a corrupt
+// stream mid-entry.
+type errReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+func TestSafeCopy(t *testing.T) {
+	t.Run("clean copy returns nil", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := safeCopy(&buf, strings.NewReader("hello")); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := buf.String(); got != "hello" {
+			t.Fatalf("unexpected buffer contents: %q", got)
+		}
+	})
+
+	t.Run("propagates decompression error", func(t *testing.T) {
+		// #4806: safeCopy used to drop non-EOF errors, so the caller
+		// would persist a partial buffer as a successful extract and
+		// downstream catalogers silently read empty manifests.
+		sentinel := errors.New("flate: corrupt input before offset 42")
+		var buf bytes.Buffer
+		err := safeCopy(&buf, &errReader{data: []byte("partial"), err: sentinel})
+		if err == nil {
+			t.Fatalf("expected error to be returned, got nil")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("error does not wrap sentinel: %v", err)
+		}
+	})
+
+	t.Run("EOF is not treated as an error", func(t *testing.T) {
+		// The old code had a dead io.EOF branch that labelled clean
+		// reads as decompression bombs; keep the happy path clean.
+		var buf bytes.Buffer
+		err := safeCopy(&buf, io.LimitReader(strings.NewReader("abc"), 3))
+		if err != nil {
+			t.Fatalf("unexpected error on clean copy: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #4806.

`safeCopy`'s old `numBytes >= perFileReadLimit || errors.Is(err, io.EOF)` check collapsed two independent conditions:

- The `io.EOF` branch is dead code — `io.Copy` consumes EOF internally and returns `(n, nil)` on a clean end-of-stream.
- The real bug is that any other non-EOF error from `io.Copy` — `flate: corrupt input before offset X` on a mangled zip entry, a truncated tar stream, a network-backed reader erroring mid-read — was dropped because the function fell through to `return nil`.

The Java cataloger's `ContentsFromZip` / `ContentsFromTar` visitors then stored the partial/empty buffer as a "successful" extract, downstream parsers silently skipped it, and package names + versions drawn from `pom.properties` / `META-INF/MANIFEST.MF` were replaced by less-specific filename fallbacks. SBOM-based CVE scanners missed known vulnerabilities on crafted artifacts.

## Fix

Split the two concerns:

- Size-hit → `zip read limit hit (potential decompression bomb attack)` (unchanged).
- Any non-nil non-EOF error from `io.Copy` → `failed to read archive entry: <wrapped error>`.
- Clean copies still return `nil`.

## Tests

New `internal/file/copy_test.go::TestSafeCopy` covers:
- clean copy → `nil` + expected contents
- `errReader` returning a sentinel error → `errors.Is(err, sentinel)` holds (fails on master, passes here)
- `io.EOF` is not mistaken for a bomb

`go test ./internal/file/...` green; `go vet` clean; `go build` clean.
