### PR TITLE
fix: only parse debian/copyright as machine-readable if Format: field present

### DIFF
--- a/syft/pkg/cataloger/debian/package.go
+++ b/syft/pkg/cataloger/debian/package.go
@@ -1,6 +1,7 @@
 package debian
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -121,15 +122,27 @@ func addLicenses(ctx context.Context, resolver file.Resolver, dbLocation file.Lo
 	var licenseStrs []string
 	if copyrightReader != nil && copyrightLocation != nil {
 		defer internal.CloseAndLogError(copyrightReader, copyrightLocation.AccessPath)
-		// attach the licenses
-		licenseStrs = parseLicensesFromCopyright(copyrightReader)
-		for _, licenseStr := range licenseStrs {
-			p.Licenses.Add(pkg.NewLicenseFromLocationsWithContext(ctx, licenseStr, copyrightLocation.WithoutAnnotations()))
+		
+		// Read the entire copyright file content
+		data, err := io.ReadAll(copyrightReader)
+		if err != nil {
+			log.Tracef("failed to read copyright file (package=%s): %s", metadata.Package, err)
+			return
 		}
-		// keep a record of the file where this was discovered
-		p.Locations.Add(*copyrightLocation)
+		
+		// Only parse as machine-readable format if the file declares itself as such
+		// according to https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+		if IsMachineReadableFormat(data) {
+			// attach the licenses
+			licenseStrs = parseLicensesFromCopyright(bytes.NewReader(data))
+			for _, licenseStr := range licenseStrs {
+				p.Licenses.Add(pkg.NewLicenseFromLocationsWithContext(ctx, licenseStr, copyrightLocation.WithoutAnnotations()))
+			}
+			// keep a record of the file where this was discovered
+			p.Locations.Add(*copyrightLocation)
+		}
 	}
-	// try to use the license classifier if parsing the copyright file failed
+	// try to use the license classifier if parsing the copyright file failed or file was not machine-readable
 	if len(licenseStrs) == 0 {
 		sr, sl := fetchCopyrightContents(resolver, dbLocation, metadata)
 		if sr != nil && sl != nil {

--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -18,7 +18,27 @@ var (
 	licensePattern                 = regexp.MustCompile(`^License: (?P<license>\S*)`)
 	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
 	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
+	formatPattern                  = regexp.MustCompile(`^Format:\s*https?://`)
 )
+
+// isMachineReadableFormat checks if the copyright file declares itself as machine-readable
+// according to https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+// A file is machine-readable if it contains a "Format:" field with a valid URL.
+func isMachineReadableFormat(reader io.Reader) bool {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		if formatPattern.MatchString(scanner.Text()) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMachineReadableFormat returns true if the copyright file declares itself as
+// machine-readable format (contains a "Format:" field with a valid URL).
+func IsMachineReadableFormat(data []byte) bool {
+	return formatPattern.Match(data)
+}
 
 func parseLicensesFromCopyright(reader io.Reader) []string {
 	findings := strset.New()

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -16,6 +16,8 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 		{
 			fixture: "testdata/copyright/libc6",
 			// note: there are other licenses in this file that are not matched --we don't do full text license identification yet
+			// NOTE: This test file is NOT machine-readable format, but we test the parser behavior
+			// when files are forced through the machine-readable parser
 			expected: []string{"GPL-2", "LGPL-2.1"},
 		},
 		{
@@ -59,6 +61,47 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 
 			if diff := cmp.Diff(test.expected, actual); diff != "" {
 				t.Errorf("unexpected package licenses (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIsMachineReadableFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		expected bool
+	}{
+		{
+			name:     "machine readable format with https URL",
+			fixture:  "testdata/copyright/machine_readable",
+			expected: true,
+		},
+		{
+			name:     "non machine readable format (no Format field)",
+			fixture:  "testdata/copyright/non_machine_readable",
+			expected: false,
+		},
+		{
+			name:     "libc6 is not machine readable",
+			fixture:  "testdata/copyright/libc6",
+			expected: false,
+		},
+		{
+			name:     "python copyright is not machine readable",
+			fixture:  "testdata/copyright/python",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := os.ReadFile(test.fixture)
+			require.NoError(t, err)
+
+			actual := IsMachineReadableFormat(data)
+			if actual != test.expected {
+				t.Errorf("IsMachineReadableFormat() = %v, want %v", actual, test.expected)
 			}
 		})
 	}

--- a/syft/pkg/cataloger/debian/testdata/copyright/machine_readable
+++ b/syft/pkg/cataloger/debian/testdata/copyright/machine_readable
@@ -1,0 +1,11 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: example-package
+Source: https://example.com/source
+
+Files: *
+Copyright: 2024 Example Author <author@example.com>
+License: MIT
+
+Files: src/*.c
+Copyright: 2024 Example Author <author@example.com>
+License: Apache-2.0

--- a/syft/pkg/cataloger/debian/testdata/copyright/non_machine_readable
+++ b/syft/pkg/cataloger/debian/testdata/copyright/non_machine_readable
@@ -1,0 +1,7 @@
+This is a non-machine-readable copyright file.
+It doesn't have the Format: field.
+
+Copyright (C) 2024 Example
+All rights reserved.
+
+License: MIT


### PR DESCRIPTION
## Summary

This PR fixes the parsing of Debian copyright files to only treat files as machine-readable if they properly declare themselves as such.

## Changes

1. **Added  function** - Detects if a copyright file declares itself as machine-readable format by checking for the  field with a valid URL.

2. **Added ** - Regex pattern  to match the required Format field per the [Debian copyright format specification](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/).

3. **Updated  logic** - Now only parses copyright files using the machine-readable parser if the file contains the  field. Non-machine-readable files will be processed by the license classifier instead.

4. **Added test fixtures**:
   -  - Example machine-readable format file
   -  - Example non-machine-readable format file

5. **Added test case** -  to verify the detection logic

## Motivation

Per the [Debian copyright format 1.0 specification](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/), machine-readable format requires a mandatory  field containing a URL link to the spec. Many Debian packages contain poorly parsed copyright information that doesn't follow this format.

The current implementation tries to parse all copyright files as machine-readable, even those without the  field, leading to incorrect license parsing.

## Test Results

- Machine-readable files (with  field): ✅ Correctly identified
- Non-machine-readable files: ✅ Correctly routed to license classifier

---
*This PR is part of the syft bounty program (issue #4708)*
