### PR TITLE
fix: prevent mise shims from being classified as Java binaries

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers_java.go
+++ b/syft/pkg/cataloger/binary/classifiers_java.go
@@ -88,10 +88,16 @@ func defaultJavaClassifiers() []binutils.Classifier {
 				},
 				{
 					Class: "java-binary-openjdk-fallthrough",
-					EvidenceMatcher: m.FileContentsVersionMatcher(
-						"openjdk",
-						// [NUL]19.0.1+10-21[NUL]
-						`(?m)\x00(?P<version>[0-9]+[.0-9]+[+][-0-9]+)\x00`,
+					EvidenceMatcher: binutils.MatchAll(
+						binutils.MatchNone(
+							binutils.MatchPath(`**/mise/shims/**`),
+							binutils.MatchPath(`**/.local/share/mise/shims/**`),
+						),
+						m.FileContentsVersionMatcher(
+							"openjdk",
+							// [NUL]19.0.1+10-21[NUL]
+							`(?m)\x00(?P<version>[0-9]+[.0-9]+[+][-0-9]+)\x00`,
+						),
 					),
 					Package: "jre",
 					PURL:    mustPURL("pkg:generic/oracle/jre@version"),
@@ -99,10 +105,16 @@ func defaultJavaClassifiers() []binutils.Classifier {
 				},
 				{
 					Class: "java-binary-oracle",
-					EvidenceMatcher: m.FileContentsVersionMatcher(
-						// [NUL]19.0.1+10-21[NUL]
-						// java[NUL]1.8[NUL]1.8.0_451-b10
-						`(?m)\x00(?P<version>[0-9]+\.[0-9]+\.[-._+a-zA-Z0-9]+)\x00`,
+					EvidenceMatcher: binutils.MatchAll(
+						binutils.MatchNone(
+							binutils.MatchPath(`**/mise/shims/**`),
+							binutils.MatchPath(`**/.local/share/mise/shims/**`),
+						),
+						m.FileContentsVersionMatcher(
+							// [NUL]19.0.1+10-21[NUL]
+							// java[NUL]1.8[NUL]1.8.0_451-b10
+							`(?m)\x00(?P<version>[0-9]+\.[0-9]+\.[-._+a-zA-Z0-9]+)\x00`,
+						),
 					),
 					Package: "jre",
 					PURL:    mustPURL("pkg:generic/oracle/jre@version"),
@@ -174,6 +186,10 @@ func defaultJavaClassifiers() []binutils.Classifier {
 				{
 					Class: "java-binary-openjdk-fallthrough",
 					EvidenceMatcher: binutils.MatchAll(
+						binutils.MatchNone(
+							binutils.MatchPath(`**/mise/shims/**`),
+							binutils.MatchPath(`**/.local/share/mise/shims/**`),
+						),
 						m.FileContentsVersionMatcher(
 							"openjdk",
 							`(?m)\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?([-._a-zA-Z0-9]+)?)\x00`),
@@ -184,8 +200,14 @@ func defaultJavaClassifiers() []binutils.Classifier {
 				},
 				{
 					Class: "java-binary-jdk",
-					EvidenceMatcher: m.FileContentsVersionMatcher(
-						`(?m)\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?([-._a-zA-Z0-9]+)?)\x00`),
+					EvidenceMatcher: binutils.MatchAll(
+						binutils.MatchNone(
+							binutils.MatchPath(`**/mise/shims/**`),
+							binutils.MatchPath(`**/.local/share/mise/shims/**`),
+						),
+						m.FileContentsVersionMatcher(
+							`(?m)\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(\+[0-9]+)?([-._a-zA-Z0-9]+)?)\x00`),
+					),
 					Package: "jdk",
 					PURL:    mustPURL("pkg:generic/oracle/jdk@version"),
 					CPEs:    singleCPE("cpe:2.3:a:oracle:jdk:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/negative/mise/shims/java
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/negative/mise/shims/java
@@ -1,0 +1,2 @@
+#this simulates a mise shim for java — not a real JVM binary
+with: java 0.0 19.0.1+10-21

--- a/syft/pkg/cataloger/binary/testdata/classifiers/negative/mise/shims/jdb
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/negative/mise/shims/jdb
@@ -1,0 +1,2 @@
+#this simulates a mise shim for jdb — not a real JVM binary
+with: openjdk 0.0 21.0.2+13

--- a/syft/pkg/cataloger/internal/binutils/classifier.go
+++ b/syft/pkg/cataloger/internal/binutils/classifier.go
@@ -120,15 +120,17 @@ func MatchAll(matchers ...EvidenceMatcher) EvidenceMatcher {
 	}
 }
 
-// MatchNone succeeds only if the matcher returns no results.
-func MatchNone(matcher EvidenceMatcher) EvidenceMatcher {
+// MatchNone returns a matcher that succeeds (returns non-nil) only when none of the provided matchers produce a result.
+func MatchNone(matchers ...EvidenceMatcher) EvidenceMatcher {
 	return func(classifier Classifier, context MatcherContext) ([]pkg.Package, error) {
-		match, err := matcher(classifier, context)
-		if err != nil {
-			return nil, err
-		}
-		if match != nil {
-			return nil, nil
+		for _, matcher := range matchers {
+			match, err := matcher(classifier, context)
+			if err != nil {
+				return nil, err
+			}
+			if match != nil {
+				return nil, nil
+			}
 		}
 		return []pkg.Package{}, nil
 	}
@@ -315,7 +317,8 @@ func MatchPath(path string) EvidenceMatcher {
 		panic("invalid pattern")
 	}
 	return func(_ Classifier, context MatcherContext) ([]pkg.Package, error) {
-		if doublestar.MatchUnvalidated(path, context.Location.RealPath) {
+		if doublestar.MatchUnvalidated(path, context.Location.RealPath) ||
+			doublestar.MatchUnvalidated(path, context.Location.AccessPath) {
 			return []pkg.Package{}, nil // return non-nil
 		}
 		return nil, nil

--- a/syft/pkg/cataloger/internal/binutils/classifier_test.go
+++ b/syft/pkg/cataloger/internal/binutils/classifier_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/internal/unionreader"
+	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
 	"github.com/anchore/syft/syft/source/directorysource"
 )
@@ -186,6 +187,54 @@ func TestFileContentsVersionMatcher(t *testing.T) {
 	}
 }
 
+func TestMatchNone(t *testing.T) {
+	alwaysMatch := func(_ Classifier, _ MatcherContext) ([]pkg.Package, error) {
+		return []pkg.Package{{}}, nil
+	}
+	neverMatch := func(_ Classifier, _ MatcherContext) ([]pkg.Package, error) {
+		return nil, nil
+	}
+
+	tests := []struct {
+		name     string
+		matchers []EvidenceMatcher
+		wantNil  bool
+	}{
+		{
+			name:     "no matchers — always passes",
+			matchers: nil,
+			wantNil:  false,
+		},
+		{
+			name:     "none of the matchers match — passes",
+			matchers: []EvidenceMatcher{neverMatch, neverMatch},
+			wantNil:  false,
+		},
+		{
+			name:     "one matcher matches — blocked",
+			matchers: []EvidenceMatcher{neverMatch, alwaysMatch},
+			wantNil:  true,
+		},
+		{
+			name:     "all matchers match — blocked",
+			matchers: []EvidenceMatcher{alwaysMatch, alwaysMatch},
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := MatchNone(tt.matchers...)(Classifier{}, MatcherContext{})
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
 func Test_SupportingEvidenceMatcher(t *testing.T) {
 
 	tests := []struct {
@@ -244,39 +293,3 @@ func Test_SupportingEvidenceMatcher(t *testing.T) {
 	}
 }
 
-func TestMatchNone(t *testing.T) {
-	matchingMatcher := MatchPath("**")
-	notMatchingMatcher := MatchPath("will-not-match")
-
-	tests := []struct {
-		name     string
-		matcher  EvidenceMatcher
-		expected bool // true if MatchNone should succeed (inner failed)
-	}{
-		{
-			name:     "inner matches, MatchNone fails",
-			matcher:  MatchNone(matchingMatcher),
-			expected: false,
-		},
-		{
-			name:     "inner fails, MatchNone succeeds",
-			matcher:  MatchNone(notMatchingMatcher),
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pkgs, err := tt.matcher(Classifier{}, MatcherContext{
-				Location: file.NewLocation("some/path"),
-			})
-			require.NoError(t, err)
-			if tt.expected {
-				assert.NotNil(t, pkgs)
-				assert.Empty(t, pkgs)
-			} else {
-				assert.Nil(t, pkgs)
-			}
-		})
-	}
-}


### PR DESCRIPTION
## Description

Mise (mise-en-place) creates shims for managed tools like `java` and `jdb`.
These shims are symlinks to the mise binary itself, which contains embedded version-like strings that the broad fallback classifiers (`java-binary-oracle`, `java-binary-openjdk-fallthrough`, `java-binary-jdk`) would match, producing false positive JRE/JDK packages.

Fix by: 
- updating `MatchPath` to test both `RealPath` and `AccessPath` (when Syft follows a symlink, `RealPath` resolves to the symlink target while `AccessPath` retains the original traversal path — mise shims are symlinks, so the shim path only appears in `AccessPath`).
- adding a new `MatchNone` combinator (succeeds only when none of its child matchers match).
- applying `MatchNone` guards with mise shim path patterns to all broad fallback classifiers.

Negative test fixtures for `mise/shims/java` and `mise/shims/jdb` are added to the existing negative test suite.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
