### PR TITLE
fix(lua-rockspec): handle empty and whitespace-only rockspec files gracefully

### DIFF
--- a/syft/pkg/cataloger/lua/rockspec_parser.go
+++ b/syft/pkg/cataloger/lua/rockspec_parser.go
@@ -63,8 +63,11 @@ func parseRockspecBlock(data []byte, i *int, locals map[string]string) ([]rocksp
 
 	parsing.SkipWhitespace(data, i)
 
-	if *i >= len(data) && len(out) > 0 {
-		return nil, fmt.Errorf("unexpected end of block at %d", *i)
+	if *i >= len(data) {
+		if len(out) > 0 {
+			return nil, fmt.Errorf("unexpected end of block at %d", *i)
+		}
+		return out, nil
 	}
 
 	c := data[*i]

--- a/syft/pkg/cataloger/lua/rockspec_parser_test.go
+++ b/syft/pkg/cataloger/lua/rockspec_parser_test.go
@@ -15,6 +15,17 @@ func Test_parseRockspecData(t *testing.T) {
 		wantErr require.ErrorAssertionFunc
 	}{
 		{
+			name:    "empty file",
+			content: ``,
+		},
+		{
+			name: "whitespace only",
+			content: `
+
+
+`,
+		},
+		{
 			name: "basic valid content",
 			content: `
 foo = "bar"


### PR DESCRIPTION
Closes #4824.

## Problem

Scanning a container image that contains an empty `.rockspec` file causes syft to panic with `runtime error: index out of range [0] with length 0`.

The bug is in `parseRockspecBlock` at `syft/pkg/cataloger/lua/rockspec_parser.go:66`:

```go
if *i >= len(data) && len(out) > 0 {
    return nil, fmt.Errorf("unexpected end of block at %d", *i)
}
c := data[*i]
```

The guard condition requires `len(out) > 0` — for an empty file, `out` is empty and `data` is empty, so the guard falls through to `c := data[0]`, which panics.

## Fix

Split the guard so empty input returns gracefully:

```go
if *i >= len(data) {
    if len(out) > 0 {
        return nil, fmt.Errorf("unexpected end of block at %d", *i)
    }
    return out, nil
}
c := data[*i]
```

Preserves the existing "unexpected end of block" error for partial content; returns an empty block cleanly for empty or whitespace-only input.

## Tests

Added two cases to `rockspec_parser_test.go`: `empty file` and `whitespace only` — both expect no error and empty result.