### PR TITLE
fix(java): skip META-INF/maven pom.xml in pom cataloger

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -3,6 +3,7 @@ package java
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/anchore/syft/internal"
@@ -40,6 +41,9 @@ func (p pomXMLCataloger) Catalog(ctx context.Context, fileResolver file.Resolver
 	var poms []*maven.Project
 	pomLocations := map[*maven.Project]file.Location{}
 	for _, pomLocation := range locations {
+		if isArchiveMetaPom(pomLocation) {
+			continue
+		}
 		pom, err := readPomFromLocation(fileResolver, pomLocation)
 		if err != nil || pom == nil {
 			log.WithFields("error", err, "pomLocation", pomLocation).Debug("error while reading pom")
@@ -297,6 +301,22 @@ func pomParent(ctx context.Context, r *maven.Resolver, pom *maven.Project) *pkg.
 		ArtifactID: artifactID,
 		Version:    version,
 	}
+}
+
+// isArchiveMetaPom returns true if the pom.xml location is inside a META-INF/maven directory,
+// indicating it is archive metadata embedded by the Maven build process rather than a project
+// pom.xml. These embedded pom.xml files are verbatim copies of the original build POM with
+// potentially unresolved ${property} references and dependency versions inherited from parent
+// POMs that are not available inside the archive. The java-archive-cataloger already uses
+// pom.properties (which always contains resolved values) to identify these archives, so the
+// pom cataloger should skip them to avoid creating phantom dependency packages.
+//
+// Match on a directory boundary ("/META-INF/maven/" or a "META-INF/maven/" prefix) to avoid
+// catching paths that happen to contain the substring elsewhere (e.g. a file literally named
+// "X-META-INF/maven/").
+func isArchiveMetaPom(location file.Location) bool {
+	p := filepath.ToSlash(location.Path())
+	return strings.Contains(p, "/META-INF/maven/") || strings.HasPrefix(p, "META-INF/maven/")
 }
 
 func cleanDescription(original string) (cleaned string) {

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -690,6 +690,123 @@ func getCommonsTextExpectedPackages(resolved bool) expected {
 	return expected{pkgs, relationships}
 }
 
+func Test_isArchiveMetaPom(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "META-INF maven pom",
+			path:     "META-INF/maven/com.example/my-lib/pom.xml",
+			expected: true,
+		},
+		{
+			name:     "nested META-INF maven pom",
+			path:     "some/path/META-INF/maven/org.apache/commons/pom.xml",
+			expected: true,
+		},
+		{
+			name:     "project pom.xml",
+			path:     "pom.xml",
+			expected: false,
+		},
+		{
+			name:     "module pom.xml",
+			path:     "submodule/pom.xml",
+			expected: false,
+		},
+		{
+			name:     "META-INF but not maven",
+			path:     "META-INF/pom.xml",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loc := file.NewLocation(test.path)
+			assert.Equal(t, test.expected, isArchiveMetaPom(loc))
+		})
+	}
+}
+
+func Test_pomCatalogerSkipsMetaInfPoms(t *testing.T) {
+	// A directory that only contains a pom.xml under META-INF/maven/ should produce
+	// no packages, since these are archive metadata not project files.
+	cat := NewPomCataloger(ArchiveCatalogerConfig{
+		ArchiveSearchConfig: cataloging.ArchiveSearchConfig{
+			IncludeIndexedArchives:   true,
+			IncludeUnindexedArchives: true,
+		},
+	})
+
+	pkgtest.NewCatalogTester().
+		FromDirectory(t, "testdata/pom/meta-inf-archive").
+		Expects(nil, nil).
+		TestCataloger(t, cat)
+}
+
+func Test_pomCatalogerSkipsMetaInfButKeepsProjectPom(t *testing.T) {
+	// When a directory contains both a project pom.xml and a META-INF/maven pom.xml,
+	// only the project pom.xml should be cataloged. The META-INF pom.xml and its
+	// dependencies should be ignored.
+	pomLocation := file.NewLocationSet(file.NewLocation("pom.xml"))
+
+	myApp := pkg.Package{
+		Name:      "my-app",
+		Version:   "2.0.0",
+		PURL:      "pkg:maven/org.anchore/my-app@2.0.0",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: pomLocation,
+		Metadata: pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    "org.anchore",
+				ArtifactID: "my-app",
+				Version:    "2.0.0",
+			},
+		},
+	}
+	finalizePackage(&myApp)
+
+	guava := pkg.Package{
+		Name:      "guava",
+		Version:   "31.1-jre",
+		PURL:      "pkg:maven/com.google.guava/guava@31.1-jre",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: pomLocation,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.google.guava",
+				ArtifactID: "guava",
+			},
+		},
+	}
+	finalizePackage(&guava)
+
+	expectedPkgs := []pkg.Package{myApp, guava}
+	expectedRelationships := []artifact.Relationship{
+		{
+			From: guava,
+			To:   myApp,
+			Type: artifact.DependencyOfRelationship,
+		},
+	}
+
+	cat := NewPomCataloger(ArchiveCatalogerConfig{
+		ArchiveSearchConfig: cataloging.ArchiveSearchConfig{
+			IncludeIndexedArchives:   true,
+			IncludeUnindexedArchives: true,
+		},
+	})
+
+	pkgtest.TestCataloger(t, "testdata/pom/mixed-meta-inf-and-project", cat, expectedPkgs, expectedRelationships)
+}
+
 func expectedTransientPackageData() expected {
 	epl2 := pkg.NewLicenseSet(pkg.License{
 		Value: "Eclipse Public License v2.0",

--- a/syft/pkg/cataloger/java/testdata/pom/meta-inf-archive/META-INF/maven/com.example/my-lib/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/meta-inf-archive/META-INF/maven/com.example/my-lib/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>my-lib</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.phantom</groupId>
+            <artifactId>phantom-dep</artifactId>
+            <version>${phantom.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testonly</groupId>
+            <artifactId>test-dep</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/META-INF/maven/com.example/embedded-lib/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/META-INF/maven/com.example/embedded-lib/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>embedded-lib</artifactId>
+    <version>3.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.phantom</groupId>
+            <artifactId>should-not-appear</artifactId>
+            <version>${unresolvable.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.anchore</groupId>
+    <artifactId>my-app</artifactId>
+    <version>2.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description

The java-pom-cataloger globs `**/pom.xml` and parses every match as a project POM. When a JAR has been extracted into directory form before scanning (e.g. `unzip foo.jar -d /scan && syft /scan`, or a Dockerfile that unpacks a JAR at build time), the resolver indexes the `META-INF/maven/<groupId>/<artifactId>/pom.xml` that the [maven-archiver plugin](https://maven.apache.org/shared/maven-archiver/index.html) embeds. Those files are build metadata, not project source.

The embedded POMs are verbatim copies of the build pom, including `${...}` properties and parent-inherited dependency versions that aren't resolvable from the archive contents alone. Parsing them produces phantom dependency packages whose versions render as `UNKNOWN` (or empty / literal `${something}`) in the SBOM.

This change skips any pom.xml whose path contains a `META-INF/maven/` segment, anchored on a directory boundary so unrelated paths that happen to contain the substring aren't caught.

### Reproduction

Take any production-built fat JAR with a `<parent>` reference and properties defined in the parent. Apache Kafka 4.1.1 ships `commons-lang3-3.18.0.jar` as one of its libs, whose embedded pom.xml inherits from `org.apache.commons:commons-parent:85` and uses `${commons.text.version}` / `${jmh.version}` / etc.

```sh
mkdir /tmp/demo && cd /tmp/demo
unzip -q /path/to/commons-lang3-3.18.0.jar
syft dir:.
```

On `main`:

```
NAME                      VERSION  TYPE
commons-lang3             3.18.0   java-archive
commons-text              1.13.1   java-archive
easymock                  5.6.0    java-archive
jmh-core                  1.37     java-archive
jmh-generator-annprocess  1.37     java-archive
jsr305                    3.0.2    java-archive
junit-jupiter             UNKNOWN  java-archive
junit-pioneer             UNKNOWN  java-archive
```

`junit-jupiter` and `junit-pioneer` are phantom: their versions are defined in commons-parent (not present in the archive), so the resolver bails and `UNKNOWN` ends up in the SBOM. The other six are dependency-side artifacts pulled from a build-time POM that the user never asked syft to look at; they propagate to vulnerability scans even when their versions happen to be literal.

With this PR:

```
No packages discovered
```

### Trade-off

maven-archiver writes `pom.properties` next to the pom.xml, with fully-resolved coordinates. The java-archive-cataloger reads it when processing a JAR file, but there's no equivalent path for directory scans today, so extracted-JAR scans no longer get a main package from the embedded metadata after this change. The trade is intentional: phantom deps with bogus versions actively pollute vulnerability scans, while a missing main package can be recovered later (e.g. from a future directory-aware pom.properties cataloger).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

None.
