### PR TITLE
fix: parse arbitrary equality python requirements

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -170,8 +170,8 @@ func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Re
 }
 
 func parseVersion(version string, guessFromConstraint bool) string {
-	if isPinnedConstraint(version) {
-		return strings.TrimSpace(strings.ReplaceAll(version, "==", ""))
+	if version := parsePinnedVersion(version); version != "" {
+		return version
 	}
 
 	if guessFromConstraint {
@@ -181,15 +181,26 @@ func parseVersion(version string, guessFromConstraint bool) string {
 	return ""
 }
 
-func isPinnedConstraint(version string) bool {
-	return strings.Contains(version, "==") && !strings.ContainsAny(version, "*,<>!")
+func parsePinnedVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if strings.ContainsAny(version, "*,<>!") {
+		return ""
+	}
+
+	for _, operator := range []string{"===", "=="} {
+		if strings.HasPrefix(version, operator) && !strings.HasPrefix(version, operator+"=") {
+			return strings.TrimSpace(strings.TrimPrefix(version, operator))
+		}
+	}
+
+	return ""
 }
 
 func guessVersion(constraint string) string {
 	// handle "2.8.*" -> "2.8.0"
 	constraint = strings.ReplaceAll(constraint, "*", "0")
-	if isPinnedConstraint(constraint) {
-		return strings.TrimSpace(strings.ReplaceAll(constraint, "==", ""))
+	if version := parsePinnedVersion(constraint); version != "" {
+		return version
 	}
 
 	constraints := strings.Split(constraint, ",")

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -30,6 +30,18 @@ func TestParseRequirementsTxt(t *testing.T) {
 			},
 		},
 		{
+			Name:      "urllib3",
+			Version:   "1.26.20",
+			PURL:      "pkg:pypi/urllib3@1.26.20",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "urllib3",
+				VersionConstraint: "===1.26.20",
+			},
+		},
+		{
 			Name:      "foo",
 			Version:   "1.0.0",
 			PURL:      "pkg:pypi/foo@1.0.0",
@@ -295,6 +307,14 @@ func Test_newRequirement(t *testing.T) {
 			},
 		},
 		{
+			name: "arbitrary equality",
+			raw:  "urllib3===1.26.20",
+			want: &unprocessedRequirement{
+				Name:              "urllib3",
+				VersionConstraint: "===1.26.20",
+			},
+		},
+		{
 			name: "comment + constraint",
 			raw:  "Mopidy-Dirble ~= 1.1 # Compatible release. Same as >= 1.1, == 1.*",
 			want: &unprocessedRequirement{
@@ -362,6 +382,11 @@ func Test_parseVersion(t *testing.T) {
 			name:    "exact constraint",
 			version: " == 1.0.0 ",
 			want:    "1.0.0",
+		},
+		{
+			name:    "arbitrary equality constraint",
+			version: " === 1.26.20 ",
+			want:    "1.26.20",
 		},
 		{
 			name:    "resolve lowest, simple constraint",

--- a/syft/pkg/cataloger/python/testdata/requires/requirements.txt
+++ b/syft/pkg/cataloger/python/testdata/requires/requirements.txt
@@ -1,4 +1,5 @@
  flask == 4.0.0
+urllib3===1.26.20
 # a line that is ignored
 sqlalchemy >= 1.0.0, <= 2.0.0, != 3.0.0, <= 3.0.0
  foo == 1.0.0 # a comment that needs to be ignored


### PR DESCRIPTION
## Summary
- Parse Python requirements pinned with the PEP 440 arbitrary equality operator (`===`).
- Preserve the original version constraint metadata while using the pinned version value for the package version.
- Add regression coverage for `urllib3===1.26.20` in the requirements parser.

Fixes #4834

## Test commands
- `GOTOOLCHAIN=local go test ./syft/pkg/cataloger/python -run 'Test(ParseRequirementsTxt|_newRequirement|_parseVersion)$'`
- `GOTOOLCHAIN=local go test ./syft/pkg/cataloger/python`
- `git diff --check`
