### PR TITLE
fix: resolve yarn lock aliases to source package

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_yarn_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_yarn_lock.go
@@ -25,6 +25,11 @@ import (
 )
 
 var (
+	// packageAliasExp matches aliased yarn dependencies and captures the
+	// underlying npm package name instead of the local alias.
+	// For example: "old-async@npm:async@0.9.2" returns "async".
+	packageAliasExp = regexp.MustCompile(`^"?(?:@\w[\w-_.]*\/)?\w[\w-_.]*@npm:((?:@\w[\w-_.]*\/)?\w[\w-_.]*)@`)
+
 	// packageNameExp matches the name of the dependency in yarn.lock
 	// including scope/namespace prefix if found.
 	// For example: "aws-sdk@2.706.0" returns "aws-sdk"
@@ -305,6 +310,9 @@ func (a genericYarnLockAdapter) parseYarnLock(ctx context.Context, resolver file
 }
 
 func findPackageName(line string) string {
+	if matches := packageAliasExp.FindStringSubmatch(line); len(matches) >= 2 {
+		return matches[1]
+	}
 	if matches := packageNameExp.FindStringSubmatch(line); len(matches) >= 2 {
 		return matches[1]
 	}

--- a/syft/pkg/cataloger/javascript/parse_yarn_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_yarn_lock_test.go
@@ -709,6 +709,18 @@ func TestParseYarnFindPackageNames(t *testing.T) {
 			expected: "color-convert",
 		},
 		{
+			line:     `"old-async@npm:async@0.9.2":`,
+			expected: "async",
+		},
+		{
+			line:     `"old-foo@npm:@scope/foo@1.2.3":`,
+			expected: "@scope/foo",
+		},
+		{
+			line:     `"@scope/old-foo@npm:@scope/foo@1.2.3":`,
+			expected: "@scope/foo",
+		},
+		{
 			line:     `"@npmcorp/code-frame@^7.1.0", "@npmcorp/code-frame@^7.10.4":`,
 			expected: "@npmcorp/code-frame",
 		},


### PR DESCRIPTION
## Description

Yarn lock entries that use npm aliases now resolve to the underlying npm package name instead of the local alias name. For example, `old-async@npm:async@0.9.2` is cataloged as `async@0.9.2`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4833

Verification:
- `GOTOOLCHAIN=local go test ./syft/pkg/cataloger/javascript -run TestParseYarnFindPackageNames`
- `GOTOOLCHAIN=local go test ./syft/pkg/cataloger/javascript`
- `git diff --check`
