### PR TITLE
Adds a binary classifier that identifies the syft tool itself

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -2227,6 +2227,127 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("envoy-binary"),
 			},
 		},
+		{
+			logicalFixture: "syft/0.90.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "0.90.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@0.90.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/0.95.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "0.95.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@0.95.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/0.100.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "0.100.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@0.100.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.0.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.0.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.0.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.5.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.5.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.5.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.10.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.10.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.10.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.15.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.15.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.15.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.20.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.20.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.20.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.30.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.30.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.30.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.40.0/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.40.0",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.40.0",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
+		{
+			logicalFixture: "syft/1.40.1/linux-arm64",
+			expected: pkg.Package{
+				Name:      "syft",
+				Version:   "1.40.1",
+				Type:      "binary",
+				PURL:      "pkg:golang/github.com/anchore/syft@1.40.1",
+				Locations: locations("syft"),
+				Metadata:  metadata("syft-binary"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -905,6 +905,15 @@ func DefaultClassifiers() []binutils.Classifier {
 			PURL:    mustPURL("pkg:generic/mongodb@version"),
 			CPEs:    singleCPE("cpe:2.3:a:mongodb:mongodb:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
+		{
+			Class:    "syft-binary",
+			FileGlob: "**/{syft,syft.exe}",
+			EvidenceMatcher: m.FileContentsVersionMatcher(
+				`main\.version=(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.+-]+)?) -X main\.gitCommit=`),
+			Package: "syft",
+			PURL:    mustPURL("pkg:golang/github.com/anchore/syft@version"),
+			CPEs:    singleCPE("cpe:2.3:a:anchore:syft:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},		
 	}
 
 	return append(classifiers, defaultJavaClassifiers()...)

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.100.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.100.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 26210001
+length: 120
+snippetSha256: dafd94f56023e568de19d10d76ae5abf904023adab880e5f52125f73cf336bc6
+fileSha256: 36c4eb071c1598c3be89ebc35aec5f305ab60f35f04708025b02a01e2189041d
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=0.100.0 -X main.gitCommit=a16a4ad6c993aaaa1ec502667c215b0e8c8e51ff -X main.buildDate=20

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.90.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.90.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 23090470
+length: 120
+snippetSha256: 779e5a8f3efdd5a4eb076ad4b2b7be6bea3425709e21e908ccd8295af95d6f9b
+fileSha256: 47e66a694c76eb182ea301367f933b3f6c04e3a4be4a7e42d66692ee82c02d3e
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=0.90.0 -X main.gitCommit=b82c0ffc3417bdc8c38f4633af95a668ec29fa35 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.95.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/0.95.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 25922466
+length: 120
+snippetSha256: d089b39be64753189e22d3413f0730813a62ee994ac0e041aeb952ffdd3c5404
+fileSha256: 81a462ccecc7ffb275a7d124cd9a09e9126b3ade3fb731a48885fcddf8a412f2
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=0.95.0 -X main.gitCommit=9b98785aab9346999a0b5e9f5e4b4e63a1b1916c -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.0.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.0.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 26659980
+length: 120
+snippetSha256: 7d89639f7bc5d60ace7cb8b9996c5c6bdaa2b55c467700c6ad5b1187c0993964
+fileSha256: ca84cb8a2d8a77ef01255db916349358e655f25e134dc5f27d1ce6de9c5ef50a
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.0.0 -X main.gitCommit=356f7c92b464b69be3a2a898cd98a63037eeadcc -X main.buildDate=2024

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.10.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.10.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 27630702
+length: 120
+snippetSha256: d0ed815d096a5c9fc549f17afdc22fb578187327713b4acd6ed08a7ace61c29e
+fileSha256: d01948036ea23ea97edf925fca79501f761fd4c6d08355543e8b29e38855b8ab
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.10.0 -X main.gitCommit=a4b5dcd0df80f6a58c8610e25104647710c1da5d -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.15.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.15.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 27874483
+length: 120
+snippetSha256: 9eb7c7847b0ac73518f3c82f1ed1d54f507ed084bb473b6d24540c89b7d4b58f
+fileSha256: 3458f61d39ccf9772c12c5184adb3ccdf0f6cdc173b96d75d1008db83848d7ed
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.15.0 -X main.gitCommit=55cc1877ef246d8cabfd9bbeb0a8747b59c03431 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.20.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.20.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 29881075
+length: 120
+snippetSha256: a84715c3e105c9f093fadc45c3fa3e29782321f0265f44c0ad089d0e554be8a8
+fileSha256: e8bd8ce134258c58e2a30c34127e50d9486ca610bee0b2a95275c53e90633264
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.20.0 -X main.gitCommit=46522bcc5dff8b65b61a7cda1393abe515802306 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.30.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.30.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 37420351
+length: 120
+snippetSha256: 78586e9285b087732229768eb8393b0de8c8022ded7570d1df05a09bb0aed642
+fileSha256: debb354974d9e04fd1829e9e2009ad39c5b54be5c110929d8115007fc87be671
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.30.0 -X main.gitCommit=49736e7c4acd3cb1aed2d3a8c8cdcd696ac77166 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.40.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.40.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 48390105
+length: 120
+snippetSha256: f41e41057d579c8f4cd64b5429a943fa133bb90346bf4f3300b4e171d36ba6e4
+fileSha256: 51ad2273ad3316e9d33e3f5b73f56971252858433b94f5d8538f0fbca1f66378
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.40.0 -X main.gitCommit=11e871566b35765fe69da439fa3beaef123bc143 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.40.1/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.40.1/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 48426084
+length: 120
+snippetSha256: 2c2692349fa0d28e2f102209f563df59e19493265aef59d4c3c3db45a281f523
+fileSha256: 68967aab81ecd98328172a7ca5ab46e05783ee0b8caf87c6a7c52e62004232d8
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.40.1 -X main.gitCommit=63927ab49feea10a7fd88191acd615667227d338 -X main.buildDate=202

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.5.0/linux-arm64/syft
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/syft/1.5.0/linux-arm64/syft
@@ -1,0 +1,8 @@
+name: syft
+offset: 26992815
+length: 120
+snippetSha256: 5341e05e726b0c367f6b7d4a768e947f8f631698901382b4f52f5f11efb6891a
+fileSha256: 6daf8fff84fd4fa917eb68c2c4e198a70add240f1c1ab6e358edfd2a5973b66a
+
+### byte snippet to follow ###
+dflags '-static' -X main.version=1.5.0 -X main.gitCommit=ac34808b9c55bb274b1205f9b5d9cf495239577d -X main.buildDate=2024

--- a/syft/pkg/cataloger/binary/testdata/config.yaml
+++ b/syft/pkg/cataloger/binary/testdata/config.yaml
@@ -1379,3 +1379,90 @@ from-images:
         platform: linux/amd64
     paths:
       - /usr/local/bin/envoy
+  - name: syft
+    version: 0.90.0
+    images:
+      - ref: anchore/syft:v0.90.0@sha256:69d84e41b7efd62c0fa6978e01cde25464fa41bdad36068e1a53046e8c590588
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 0.95.0
+    images:
+      - ref: anchore/syft:v0.95.0@sha256:1b01bd140e0e72090a3707397b0d6db582b72697b79a167e5bc405845c561ae0
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 0.100.0
+    images:
+      - ref: anchore/syft:v0.100.0@sha256:df7b07bfadff45e0135d74f22478f47b16ac6aff4e8dbd93133fcae3bbbb790d
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.0.0
+    images:
+      - ref: anchore/syft:v1.0.0@sha256:e3e918dcd6bf1610335d614428fe4444511f0f29c219ff54a02d3dd4501f91db
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.5.0
+    images:
+      - ref: anchore/syft:v1.5.0@sha256:7e622b5d92a6ec0727fb4bd48046b644f459c33b54e9ea9025a764d324177cd2
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.10.0
+    images:
+      - ref: anchore/syft:v1.10.0@sha256:4243162c3ac33d107a8d9981e2d41b7888b66f12d9bd547124644391be796763
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.15.0
+    images:
+      - ref: anchore/syft:v1.15.0@sha256:92b229ac1d84cd9627624a951e26a78333b26a5f34c9999629ba96e90751c971
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.20.0
+    images:
+      - ref: anchore/syft:v1.20.0@sha256:b46e597614ddc78621e560af3fabf9346e35462ea1c886a38b30bcc7ca601a73
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.30.0
+    images:
+      - ref: anchore/syft:v1.30.0@sha256:bd5357d2cd087f03af748dac24df48bfbc1723080d78f75f69aca1f2d429060e
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.40.0
+    images:
+      - ref: anchore/syft:v1.40.0@sha256:11a68ff5cd49a1579e1f05b061a96edf0a5add161ea5f38d62fc979704c46918
+        platform: linux/arm64
+    paths:
+      - /syft
+
+  - name: syft
+    version: 1.40.1
+    images:
+      - ref: anchore/syft:v1.40.1@sha256:fba42bf6d51cfb2411618f8fe645f2cf4f6ffdedd69fd7ef12fdfb064a409f70
+        platform: linux/arm64
+    paths:
+      - /syft


### PR DESCRIPTION
  Adds a `syft-binary` classifier so syft identifies itself when scanning images/filesystems containing a syft binary. Matches the goreleaser ldflag      
  string embedded in release binaries, anchored on ` -X main.gitCommit=` to avoid false-matching syft's own help text.
                                                                                                                                                          
  ## Type of change                                      

  - [x] New feature

  ## Checklist

  - [x] Unit tests added (11 versions, `0.90.0` → `1.40.1`)                                                                                               
  - [x] Tested against `anchore/syft:*` images, no regressions