### PR TITLE
feat(java): add hierarchical Maven dependency graph resolution for Java archives

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -211,7 +211,9 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 			WithUseNetwork(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Java, task.Maven), cfg.Java.UseNetwork)).
 			WithMavenBaseURL(cfg.Java.MavenURL).
 			WithArchiveTraversal(archiveSearch, cfg.Java.MaxParentRecursiveDepth).
-			WithResolveTransitiveDependencies(cfg.Java.ResolveTransitiveDependencies),
+			WithResolveTransitiveDependencies(cfg.Java.ResolveTransitiveDependencies).
+			WithUseEmbeddedPOMDependencies(cfg.Java.UseEmbeddedPOMDependencies).
+			WithMavenDependencyTreeFile(cfg.Java.MavenDependencyTree),
 	}
 }
 

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -122,6 +122,7 @@ func (cfg Catalog) ToRelationshipsConfig() cataloging.RelationshipsConfig {
 		// note: this option was surfaced in the syft application configuration before this relationships section was added
 		ExcludeBinaryPackagesWithFileOwnershipOverlap: cfg.Package.ExcludeBinaryOverlapByOwnership,
 		JavaMavenDependencyTreeFile:                   cfg.Java.MavenDependencyTree,
+		JavaUseEmbeddedPOMDependencies:                cfg.Java.UseEmbeddedPOMDependencies,
 	}
 }
 

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -121,6 +121,7 @@ func (cfg Catalog) ToRelationshipsConfig() cataloging.RelationshipsConfig {
 		PackageFileOwnershipOverlap: cfg.Relationships.PackageFileOwnershipOverlap,
 		// note: this option was surfaced in the syft application configuration before this relationships section was added
 		ExcludeBinaryPackagesWithFileOwnershipOverlap: cfg.Package.ExcludeBinaryOverlapByOwnership,
+		JavaMavenDependencyTreeFile:                   cfg.Java.MavenDependencyTree,
 	}
 }
 

--- a/cmd/syft/internal/options/format.go
+++ b/cmd/syft/internal/options/format.go
@@ -72,7 +72,7 @@ func (o Format) Encoders() ([]sbom.FormatEncoder, error) {
 	return format.EncodersConfig{
 		Template:      o.Template.config(),
 		SyftJSON:      o.SyftJSON.config(),
-		SPDXJSON:      o.SPDXJSON.config(format.AllVersions),                   // we support multiple versions, not just a single version
+		SPDXJSON:      o.SPDXJSON.config(format.AllVersions),  // we support multiple versions, not just a single version
 		SPDXTagValue:  spdxtagvalue.EncoderConfig{Version: format.AllVersions}, // we support multiple versions, not just a single version
 		CyclonedxJSON: o.CyclonedxJSON.config(format.AllVersions),              // we support multiple versions, not just a single version
 		CyclonedxXML:  o.CyclonedxXML.config(format.AllVersions),               // we support multiple versions, not just a single version

--- a/cmd/syft/internal/options/java.go
+++ b/cmd/syft/internal/options/java.go
@@ -12,6 +12,8 @@ type javaConfig struct {
 	MavenURL                      string `yaml:"maven-url" json:"maven-url" mapstructure:"maven-url"`
 	MaxParentRecursiveDepth       int    `yaml:"max-parent-recursive-depth" json:"max-parent-recursive-depth" mapstructure:"max-parent-recursive-depth"`
 	ResolveTransitiveDependencies bool   `yaml:"resolve-transitive-dependencies" json:"resolve-transitive-dependencies" mapstructure:"resolve-transitive-dependencies"`
+	UseEmbeddedPOMDependencies    bool   `yaml:"use-embedded-pom-dependencies" json:"use-embedded-pom-dependencies" mapstructure:"use-embedded-pom-dependencies"`
+	MavenDependencyTree           string `yaml:"maven-dependency-tree" json:"maven-dependency-tree" mapstructure:"maven-dependency-tree"`
 }
 
 func defaultJavaConfig() javaConfig {
@@ -46,4 +48,8 @@ build, run 'mvn help:effective-pom' before performing the scan with syft.`)
 	descriptions.Add(&o.MavenLocalRepositoryDir, `override the default location of the local Maven repository. 
 the default is the subdirectory '.m2/repository' in your home directory`)
 	descriptions.Add(&o.ResolveTransitiveDependencies, `resolve transient dependencies such as those defined in a dependency's POM on Maven central`)
+	descriptions.Add(&o.UseEmbeddedPOMDependencies, `build a dependency graph from embedded pom.xml files within JARs to determine hierarchical
+parent-child relationships instead of treating all dependencies as direct`)
+	descriptions.Add(&o.MavenDependencyTree, `path to a pre-generated Maven dependency tree file (from 'mvn dependency:tree -DoutputFile=deps.txt').
+when provided, this takes priority over embedded POM analysis for building the dependency graph`)
 }

--- a/internal/relationship/java/java_hierarchical_relationships.go
+++ b/internal/relationship/java/java_hierarchical_relationships.go
@@ -136,7 +136,7 @@ func processRelationship(
 
 	// Case 1: Has IntendedParentID — resolve deferred parent
 	if hasRelData && relData.IntendedParentID != "" {
-		return resolveIntendedParent(rel, relData, fromPkg, packages, pkgIndex, depGraph, rootPkg)
+		return resolveIntendedParent(rel, relData, fromPkg, pkgIndex, depGraph, rootPkg)
 	}
 
 	// Case 2: No IntendedParentID, but depGraph exists — enrich from tree
@@ -153,7 +153,6 @@ func resolveIntendedParent(
 	rel artifact.Relationship,
 	relData javaCataloger.DependencyRelationshipData,
 	fromPkg *pkg.Package,
-	packages *pkg.Collection,
 	pkgIndex map[string]*pkg.Package,
 	depGraph *javaCataloger.DependencyGraph,
 	rootPkg *pkg.Package,
@@ -185,7 +184,7 @@ func resolveIntendedParent(
 	if depGraph != nil {
 		parentMavenID := parseMavenID(relData.IntendedParentID)
 		parentNode := depGraph.FindNodeByMavenID(parentMavenID)
-		if ancestorPkg := findNearestAncestorInSBOM(depGraph, parentNode, pkgIndex, rootPkg); ancestorPkg != nil {
+		if ancestorPkg := findNearestAncestorInSBOM(parentNode, pkgIndex, rootPkg); ancestorPkg != nil {
 			rel.To = *ancestorPkg
 		}
 	}
@@ -225,7 +224,6 @@ func enrichFromGraph(
 // findNearestAncestorInSBOM walks up the Maven tree from a missing parent node
 // until finding an ancestor whose package IS in the SBOM.
 func findNearestAncestorInSBOM(
-	depGraph *javaCataloger.DependencyGraph,
 	missingNode *javaCataloger.DependencyNode,
 	pkgIndex map[string]*pkg.Package,
 	rootPkg *pkg.Package,

--- a/internal/relationship/java/java_hierarchical_relationships.go
+++ b/internal/relationship/java/java_hierarchical_relationships.go
@@ -17,11 +17,6 @@ import (
 // the Maven dependency tree when available.
 func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg cataloging.RelationshipsConfig) {
 	hasTreeFile := cfg.JavaMavenDependencyTreeFile != ""
-	hasEmbeddedPOMs := cfg.JavaUseEmbeddedPOMDependencies
-
-	if !hasTreeFile && !hasEmbeddedPOMs {
-		return
-	}
 
 	// Step 1: Build package index from ALL Java packages
 	pkgIndex := buildPackageIndex(accessor)

--- a/internal/relationship/java/java_hierarchical_relationships.go
+++ b/internal/relationship/java/java_hierarchical_relationships.go
@@ -1,0 +1,346 @@
+package java
+
+import (
+	"strings"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/sbomsync"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging"
+	"github.com/anchore/syft/syft/pkg"
+	javaCataloger "github.com/anchore/syft/syft/pkg/cataloger/java"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+// ResolveHierarchicalDependencies runs after all catalogers have completed. It resolves
+// deferred parent IDs in Java dependency relationships and enriches depth/scope from
+// the Maven dependency tree when available.
+func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg cataloging.RelationshipsConfig) {
+	if cfg.JavaMavenDependencyTreeFile == "" {
+		// No tree file configured — nothing to resolve or enrich.
+		// Deferred parent IDs (IntendedParentID) are only set when a dependency graph
+		// was built during cataloging, which requires either a tree file or embedded POMs.
+		// Even if embedded POMs were used, the enrichment in Phase 3 has already occurred.
+		// This post-processor only adds value when a tree file is available for global enrichment.
+		return
+	}
+
+	// Step 1: Build package index from ALL Java packages
+	pkgIndex := buildPackageIndex(accessor)
+	if len(pkgIndex) == 0 {
+		return
+	}
+
+	// Step 2: Build dependency graph from Maven tree file
+	depGraph := buildGraphFromTreeFile(cfg.JavaMavenDependencyTreeFile)
+
+	// Step 3: Process relationships
+	var updatedRelationships []artifact.Relationship
+	var rootPkg *pkg.Package
+
+	accessor.ReadFromSBOM(func(s *sbom.SBOM) {
+		// Find root package (the one that matches the graph root)
+		if depGraph != nil && depGraph.Root != nil {
+			rootID := depGraph.Root.ID
+			rootKey := javaCataloger.NewMavenID(rootID.GroupID, rootID.ArtifactID, rootID.Version).String()
+			rootPkg = findPackageByMavenID(pkgIndex, rootKey)
+		}
+
+		for _, rel := range s.Relationships {
+			newRel := processRelationship(rel, s.Artifacts.Packages, pkgIndex, depGraph, rootPkg)
+			updatedRelationships = append(updatedRelationships, newRel)
+		}
+	})
+
+	// Step 4: Write updated relationships back
+	accessor.WriteToSBOM(func(s *sbom.SBOM) {
+		s.Relationships = updatedRelationships
+	})
+}
+
+// buildPackageIndex creates a multi-tier index of Java packages for flexible matching.
+// Packages are indexed by:
+// - Full Maven ID: groupId:artifactId:version (exact)
+// - groupId:artifactId (version-flexible)
+// - artifactId only (last resort)
+func buildPackageIndex(accessor sbomsync.Accessor) map[string]*pkg.Package {
+	pkgIndex := make(map[string]*pkg.Package)
+
+	accessor.ReadFromSBOM(func(s *sbom.SBOM) {
+		for p := range s.Artifacts.Packages.Enumerate(pkg.JavaPkg, pkg.JenkinsPluginPkg) {
+			pCopy := p
+			mavenID := extractMavenID(&pCopy)
+			if mavenID == "" {
+				continue
+			}
+
+			// Tier 1: full Maven ID (exact match — highest priority, never overwritten)
+			if _, exists := pkgIndex[mavenID]; !exists {
+				pkgIndex[mavenID] = &pCopy
+			}
+
+			// Tier 2: groupId:artifactId (version-flexible)
+			gaKey := extractGroupArtifact(mavenID)
+			if gaKey != "" {
+				if _, exists := pkgIndex[gaKey]; !exists {
+					pkgIndex[gaKey] = &pCopy
+				}
+			}
+
+			// Tier 3: artifactId only (last resort)
+			artifactID := extractArtifactID(mavenID)
+			if artifactID != "" {
+				if _, exists := pkgIndex[artifactID]; !exists {
+					pkgIndex[artifactID] = &pCopy
+				}
+			}
+		}
+	})
+
+	return pkgIndex
+}
+
+// buildGraphFromTreeFile parses a Maven dependency tree file and returns a DependencyGraph.
+func buildGraphFromTreeFile(filePath string) *javaCataloger.DependencyGraph {
+	tree, err := javaCataloger.ParseMavenDependencyTreeFile(filePath)
+	if err != nil {
+		log.WithFields("error", err, "file", filePath).Warn("failed to parse Maven dependency tree file for post-processing")
+		return nil
+	}
+	return tree.ToInternalGraph()
+}
+
+// processRelationship handles a single relationship, applying the three processing cases.
+func processRelationship(
+	rel artifact.Relationship,
+	packages *pkg.Collection,
+	pkgIndex map[string]*pkg.Package,
+	depGraph *javaCataloger.DependencyGraph,
+	rootPkg *pkg.Package,
+) artifact.Relationship {
+	// Only process DependencyOf relationships
+	if rel.Type != artifact.DependencyOfRelationship {
+		return rel
+	}
+
+	// Only process relationships where "From" is a Java package
+	fromPkg := packages.Package(rel.From.ID())
+	if fromPkg == nil {
+		return rel
+	}
+	if fromPkg.Language != pkg.Java {
+		return rel
+	}
+
+	relData, hasRelData := rel.Data.(javaCataloger.DependencyRelationshipData)
+
+	// Case 1: Has IntendedParentID — resolve deferred parent
+	if hasRelData && relData.IntendedParentID != "" {
+		return resolveIntendedParent(rel, relData, fromPkg, packages, pkgIndex, depGraph, rootPkg)
+	}
+
+	// Case 2: No IntendedParentID, but depGraph exists — enrich from tree
+	if depGraph != nil {
+		return enrichFromGraph(rel, fromPkg, depGraph)
+	}
+
+	// Case 3: No tree or not found — keep original
+	return rel
+}
+
+// resolveIntendedParent handles Case 1: the relationship has a deferred IntendedParentID.
+func resolveIntendedParent(
+	rel artifact.Relationship,
+	relData javaCataloger.DependencyRelationshipData,
+	fromPkg *pkg.Package,
+	packages *pkg.Collection,
+	pkgIndex map[string]*pkg.Package,
+	depGraph *javaCataloger.DependencyGraph,
+	rootPkg *pkg.Package,
+) artifact.Relationship {
+	parentPkg := findPackageByMavenID(pkgIndex, relData.IntendedParentID)
+
+	if parentPkg != nil {
+		// Case 1a: Parent found — resolve and enrich
+		depth := relData.Depth
+		scope := relData.Scope
+
+		if depGraph != nil {
+			mavenID := extractMavenIDStruct(fromPkg)
+			if node := depGraph.FindNodeByMavenID(mavenID); node != nil {
+				depth = node.Depth - 1
+				if depth < 0 {
+					depth = 0
+				}
+				scope = node.Scope
+			}
+		}
+
+		rel.To = *parentPkg
+		rel.Data = javaCataloger.NewDependencyRelationshipData(depth, scope)
+		return rel
+	}
+
+	// Case 1b: Parent NOT found — skip to nearest ancestor
+	if depGraph != nil {
+		parentMavenID := parseMavenID(relData.IntendedParentID)
+		parentNode := depGraph.FindNodeByMavenID(parentMavenID)
+		if ancestorPkg := findNearestAncestorInSBOM(depGraph, parentNode, pkgIndex, rootPkg); ancestorPkg != nil {
+			rel.To = *ancestorPkg
+		}
+	}
+
+	// Clear IntendedParentID — resolution attempted
+	depth := relData.Depth
+	scope := relData.Scope
+	rel.Data = javaCataloger.NewDependencyRelationshipData(depth, scope)
+	return rel
+}
+
+// enrichFromGraph handles Case 2: no IntendedParentID but a dependency graph is available.
+func enrichFromGraph(
+	rel artifact.Relationship,
+	fromPkg *pkg.Package,
+	depGraph *javaCataloger.DependencyGraph,
+) artifact.Relationship {
+	mavenID := extractMavenIDStruct(fromPkg)
+	if !mavenID.Valid() {
+		return rel
+	}
+
+	node := depGraph.FindNodeByMavenID(mavenID)
+	if node == nil {
+		return rel
+	}
+
+	relDepth := node.Depth - 1
+	if relDepth < 0 {
+		relDepth = 0
+	}
+
+	rel.Data = javaCataloger.NewDependencyRelationshipData(relDepth, node.Scope)
+	return rel
+}
+
+// findNearestAncestorInSBOM walks up the Maven tree from a missing parent node
+// until finding an ancestor whose package IS in the SBOM.
+func findNearestAncestorInSBOM(
+	depGraph *javaCataloger.DependencyGraph,
+	missingNode *javaCataloger.DependencyNode,
+	pkgIndex map[string]*pkg.Package,
+	rootPkg *pkg.Package,
+) *pkg.Package {
+	if missingNode == nil {
+		return rootPkg
+	}
+
+	current := missingNode.Parent
+	for current != nil {
+		ancestorKey := javaCataloger.NewMavenID(current.ID.GroupID, current.ID.ArtifactID, current.ID.Version).String()
+		if ancestorPkg := findPackageByMavenID(pkgIndex, ancestorKey); ancestorPkg != nil {
+			return ancestorPkg
+		}
+		current = current.Parent
+	}
+
+	return rootPkg
+}
+
+// findPackageByMavenID looks up a package using 3-tier flexible matching.
+func findPackageByMavenID(pkgIndex map[string]*pkg.Package, mavenID string) *pkg.Package {
+	// Tier 1: exact match — groupId:artifactId:version
+	if p, ok := pkgIndex[mavenID]; ok {
+		return p
+	}
+
+	// Tier 2: groupId:artifactId (ignore version)
+	gaKey := extractGroupArtifact(mavenID)
+	if gaKey != "" {
+		if p, ok := pkgIndex[gaKey]; ok {
+			return p
+		}
+	}
+
+	// Tier 3: artifactId only (last resort)
+	artifactID := extractArtifactID(mavenID)
+	if artifactID != "" {
+		if p, ok := pkgIndex[artifactID]; ok {
+			return p
+		}
+	}
+
+	return nil
+}
+
+// extractMavenID returns a "groupId:artifactId:version" string from a package's metadata.
+func extractMavenID(p *pkg.Package) string {
+	if p == nil {
+		return ""
+	}
+	metadata, ok := p.Metadata.(pkg.JavaArchive)
+	if !ok {
+		return ""
+	}
+
+	groupID := ""
+	artifactID := p.Name
+	version := p.Version
+
+	if metadata.PomProperties != nil {
+		if metadata.PomProperties.GroupID != "" {
+			groupID = metadata.PomProperties.GroupID
+		}
+		if metadata.PomProperties.ArtifactID != "" {
+			artifactID = metadata.PomProperties.ArtifactID
+		}
+		if metadata.PomProperties.Version != "" {
+			version = metadata.PomProperties.Version
+		}
+	}
+
+	if groupID == "" && metadata.PomProject != nil {
+		groupID = metadata.PomProject.GroupID
+	}
+
+	if groupID == "" || artifactID == "" {
+		return ""
+	}
+
+	return groupID + ":" + artifactID + ":" + version
+}
+
+// extractMavenIDStruct returns a MavenID struct for graph lookups.
+func extractMavenIDStruct(p *pkg.Package) javaCataloger.MavenID {
+	id := extractMavenID(p)
+	if id == "" {
+		return javaCataloger.MavenID{}
+	}
+	return parseMavenID(id)
+}
+
+// parseMavenID parses a "groupId:artifactId:version" string into a MavenID.
+func parseMavenID(mavenID string) javaCataloger.MavenID {
+	parts := strings.SplitN(mavenID, ":", 3)
+	if len(parts) != 3 {
+		return javaCataloger.MavenID{}
+	}
+	return javaCataloger.NewMavenID(parts[0], parts[1], parts[2])
+}
+
+// extractGroupArtifact returns "groupId:artifactId" from a full Maven ID.
+func extractGroupArtifact(mavenID string) string {
+	parts := strings.SplitN(mavenID, ":", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[0] + ":" + parts[1]
+}
+
+// extractArtifactID returns just the artifactId from a full Maven ID.
+func extractArtifactID(mavenID string) string {
+	parts := strings.SplitN(mavenID, ":", 3)
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}

--- a/internal/relationship/java/java_hierarchical_relationships.go
+++ b/internal/relationship/java/java_hierarchical_relationships.go
@@ -16,12 +16,10 @@ import (
 // deferred parent IDs in Java dependency relationships and enriches depth/scope from
 // the Maven dependency tree when available.
 func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg cataloging.RelationshipsConfig) {
-	if cfg.JavaMavenDependencyTreeFile == "" {
-		// No tree file configured — nothing to resolve or enrich.
-		// Deferred parent IDs (IntendedParentID) are only set when a dependency graph
-		// was built during cataloging, which requires either a tree file or embedded POMs.
-		// Even if embedded POMs were used, the enrichment in Phase 3 has already occurred.
-		// This post-processor only adds value when a tree file is available for global enrichment.
+	hasTreeFile := cfg.JavaMavenDependencyTreeFile != ""
+	hasEmbeddedPOMs := cfg.JavaUseEmbeddedPOMDependencies
+
+	if !hasTreeFile && !hasEmbeddedPOMs {
 		return
 	}
 
@@ -31,8 +29,11 @@ func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg cataloging.
 		return
 	}
 
-	// Step 2: Build dependency graph from Maven tree file
-	depGraph := buildGraphFromTreeFile(cfg.JavaMavenDependencyTreeFile)
+	// Step 2: Build dependency graph from Maven tree file (nil when only embedded POMs used)
+	var depGraph *javaCataloger.DependencyGraph
+	if hasTreeFile {
+		depGraph = buildGraphFromTreeFile(cfg.JavaMavenDependencyTreeFile)
+	}
 
 	// Step 3: Process relationships
 	var updatedRelationships []artifact.Relationship

--- a/internal/relationship/java/java_hierarchical_relationships_test.go
+++ b/internal/relationship/java/java_hierarchical_relationships_test.go
@@ -1,0 +1,449 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/internal/sbomsync"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging"
+	"github.com/anchore/syft/syft/pkg"
+	javaCataloger "github.com/anchore/syft/syft/pkg/cataloger/java"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+func newTestSBOM(packages []pkg.Package, relationships []artifact.Relationship) *sbom.SBOM {
+	s := &sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: pkg.NewCollection(),
+		},
+	}
+	s.Artifacts.Packages.Add(packages...)
+	s.Relationships = relationships
+	return s
+}
+
+func javaPkg(groupID, artifactID, version string) pkg.Package {
+	p := pkg.Package{
+		Name:     artifactID,
+		Version:  version,
+		Language: pkg.Java,
+		Type:     pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    groupID,
+				ArtifactID: artifactID,
+				Version:    version,
+			},
+		},
+	}
+	p.SetID()
+	return p
+}
+
+func depOfRel(from, to pkg.Package, data interface{}) artifact.Relationship {
+	return artifact.Relationship{
+		From: from,
+		To:   to,
+		Type: artifact.DependencyOfRelationship,
+		Data: data,
+	}
+}
+
+func TestResolveHierarchicalDependencies_NoTreeFile(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	child := javaPkg("org.dep", "child", "2.0")
+
+	rel := depOfRel(child, root, nil)
+	s := newTestSBOM([]pkg.Package{root, child}, []artifact.Relationship{rel})
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{})
+
+	// No tree file — should be unchanged
+	assert.Len(t, s.Relationships, 1)
+	assert.Nil(t, s.Relationships[0].Data)
+}
+
+func TestResolveHierarchicalDependencies_WithTreeFile(t *testing.T) {
+	root := javaPkg("com.example", "my-app", "1.0.0")
+	springCore := javaPkg("org.springframework", "spring-core", "6.2.15")
+	springJcl := javaPkg("org.springframework", "spring-jcl", "6.2.15")
+
+	// Flat relationships: both point to root (simulating pre-fix behavior)
+	rel1 := depOfRel(springCore, root, nil)
+	rel2 := depOfRel(springJcl, root, nil)
+	s := newTestSBOM(
+		[]pkg.Package{root, springCore, springJcl},
+		[]artifact.Relationship{rel1, rel2},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 2)
+
+	// spring-core should be enriched as direct (depth=0)
+	data1, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, 0, data1.Depth)
+	assert.True(t, data1.IsDirectDependency)
+	assert.Equal(t, "compile", data1.Scope)
+
+	// spring-jcl should be enriched as transitive (depth=1)
+	data2, ok := s.Relationships[1].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, 1, data2.Depth)
+	assert.False(t, data2.IsDirectDependency)
+	assert.Equal(t, "compile", data2.Scope)
+}
+
+func TestResolveIntendedParent_ParentFound(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	parent := javaPkg("org.dep", "parent-lib", "2.0")
+	child := javaPkg("org.dep", "child-lib", "3.0")
+
+	// child has IntendedParentID pointing to parent-lib
+	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "compile", "org.dep:parent-lib:2.0")
+	rel := depOfRel(child, root, relData) // currently points to root (wrong)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, parent, child},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+	// Relationship should now point to parent, not root
+	assert.Equal(t, parent.ID(), s.Relationships[0].To.ID())
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Empty(t, data.IntendedParentID) // should be cleared
+}
+
+func TestResolveIntendedParent_ParentNotFound_FallsBackToAncestor(t *testing.T) {
+	root := javaPkg("com.example", "my-app", "1.0.0")
+	// spring-jcl's parent in the tree is spring-core, but spring-core is missing from SBOM
+	springJcl := javaPkg("org.springframework", "spring-jcl", "6.2.15")
+
+	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "compile", "org.springframework:spring-core:6.2.15")
+	rel := depOfRel(springJcl, root, relData)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, springJcl}, // spring-core intentionally missing
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+	// spring-core is missing; walk up tree → root (my-app) is the ancestor
+	assert.Equal(t, root.ID(), s.Relationships[0].To.ID())
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Empty(t, data.IntendedParentID)
+}
+
+func TestEnrichFromGraph_Case2(t *testing.T) {
+	// Case 2: No IntendedParentID, depGraph exists — enrich depth/scope
+	root := javaPkg("com.example", "my-app", "1.0.0")
+	jacksonDatabind := javaPkg("com.fasterxml.jackson.core", "jackson-databind", "2.19.4")
+
+	// Flat relationship with no metadata
+	rel := depOfRel(jacksonDatabind, root, nil)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, jacksonDatabind},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, 0, data.Depth) // direct dep in tree
+	assert.True(t, data.IsDirectDependency)
+	assert.Equal(t, "compile", data.Scope)
+}
+
+func TestEnrichFromGraph_TransitiveCorrection(t *testing.T) {
+	// Verify that previously-flat deps get corrected to transitive
+	root := javaPkg("com.example", "my-app", "1.0.0")
+	// jackson-core is transitive (child of jackson-databind) in the fixture
+	jacksonCore := javaPkg("com.fasterxml.jackson.core", "jackson-core", "2.19.4")
+
+	rel := depOfRel(jacksonCore, root, nil)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, jacksonCore},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, 1, data.Depth) // transitive (depth=2 in graph → relDepth=1)
+	assert.False(t, data.IsDirectDependency)
+	assert.Equal(t, "compile", data.Scope)
+}
+
+func TestNonJavaRelationshipsSkipped(t *testing.T) {
+	goPkg := pkg.Package{
+		Name:     "some-go-pkg",
+		Version:  "1.0",
+		Language: pkg.Go,
+		Type:     pkg.GoModulePkg,
+	}
+	goPkg.SetID()
+
+	root := javaPkg("com.example", "my-app", "1.0.0")
+
+	rel := depOfRel(goPkg, root, nil)
+
+	s := newTestSBOM(
+		[]pkg.Package{goPkg, root},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+	// Non-Java relationship should be untouched
+	assert.Nil(t, s.Relationships[0].Data)
+}
+
+func TestNonDependencyOfRelationshipsSkipped(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	child := javaPkg("org.dep", "child", "2.0")
+
+	rel := artifact.Relationship{
+		From: child,
+		To:   root,
+		Type: artifact.ContainsRelationship,
+	}
+
+	s := newTestSBOM(
+		[]pkg.Package{root, child},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	require.Len(t, s.Relationships, 1)
+	assert.Equal(t, artifact.ContainsRelationship, s.Relationships[0].Type)
+	assert.Nil(t, s.Relationships[0].Data)
+}
+
+func TestEmptySBOM(t *testing.T) {
+	s := newTestSBOM(nil, nil)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	// Should not panic
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt",
+	})
+
+	assert.Empty(t, s.Relationships)
+}
+
+func TestFindPackageByMavenID_FlexibleMatch(t *testing.T) {
+	p := javaPkg("com.example", "my-lib", "1.0")
+
+	pkgIndex := map[string]*pkg.Package{
+		"com.example:my-lib:1.0": &p,
+		"com.example:my-lib":     &p,
+		"my-lib":                 &p,
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		found := findPackageByMavenID(pkgIndex, "com.example:my-lib:1.0")
+		require.NotNil(t, found)
+		assert.Equal(t, p.ID(), found.ID())
+	})
+
+	t.Run("groupId:artifactId match", func(t *testing.T) {
+		found := findPackageByMavenID(pkgIndex, "com.example:my-lib:2.0")
+		require.NotNil(t, found)
+		assert.Equal(t, p.ID(), found.ID())
+	})
+
+	t.Run("artifactId-only match", func(t *testing.T) {
+		found := findPackageByMavenID(pkgIndex, "org.other:my-lib:3.0")
+		require.NotNil(t, found)
+		assert.Equal(t, p.ID(), found.ID())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		found := findPackageByMavenID(pkgIndex, "com.example:other-lib:1.0")
+		assert.Nil(t, found)
+	})
+}
+
+func TestFindNearestAncestorInSBOM(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	grandparent := javaPkg("org.dep", "grandparent", "2.0")
+
+	pkgIndex := map[string]*pkg.Package{
+		"com.example:root:1.0":    &root,
+		"com.example:root":        &root,
+		"root":                    &root,
+		"org.dep:grandparent:2.0": &grandparent,
+		"org.dep:grandparent":     &grandparent,
+		"grandparent":             &grandparent,
+	}
+
+	t.Run("returns root when node is nil", func(t *testing.T) {
+		ancestor := findNearestAncestorInSBOM(nil, nil, pkgIndex, &root)
+		require.NotNil(t, ancestor)
+		assert.Equal(t, root.ID(), ancestor.ID())
+	})
+
+	t.Run("returns root when entire chain missing", func(t *testing.T) {
+		// Create a node whose parent chain has no matches in pkgIndex
+		missingNode := &javaCataloger.DependencyNode{
+			Depth: 3,
+			Parent: &javaCataloger.DependencyNode{
+				Depth: 2,
+				Parent: &javaCataloger.DependencyNode{
+					Depth:  1,
+					Parent: nil, // chain ends without match
+				},
+			},
+		}
+
+		ancestor := findNearestAncestorInSBOM(nil, missingNode, pkgIndex, &root)
+		require.NotNil(t, ancestor)
+		assert.Equal(t, root.ID(), ancestor.ID())
+	})
+}
+
+func TestExtractMavenID(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      *pkg.Package
+		expected string
+	}{
+		{
+			name:     "nil package",
+			pkg:      nil,
+			expected: "",
+		},
+		{
+			name: "with pom properties",
+			pkg: func() *pkg.Package {
+				p := javaPkg("com.example", "my-lib", "1.0")
+				return &p
+			}(),
+			expected: "com.example:my-lib:1.0",
+		},
+		{
+			name: "missing groupId",
+			pkg: &pkg.Package{
+				Name:     "orphan",
+				Version:  "1.0",
+				Language: pkg.Java,
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						ArtifactID: "orphan",
+						Version:    "1.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "groupId from pom project fallback",
+			pkg: &pkg.Package{
+				Name:     "my-lib",
+				Version:  "1.0",
+				Language: pkg.Java,
+				Metadata: pkg.JavaArchive{
+					PomProject: &pkg.JavaPomProject{
+						GroupID: "com.fallback",
+					},
+					PomProperties: &pkg.JavaPomProperties{
+						ArtifactID: "my-lib",
+						Version:    "1.0",
+					},
+				},
+			},
+			expected: "com.fallback:my-lib:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractMavenID(tt.pkg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractGroupArtifact(t *testing.T) {
+	assert.Equal(t, "com.example:my-lib", extractGroupArtifact("com.example:my-lib:1.0"))
+	assert.Equal(t, "", extractGroupArtifact("invalid"))
+}
+
+func TestExtractArtifactID(t *testing.T) {
+	assert.Equal(t, "my-lib", extractArtifactID("com.example:my-lib:1.0"))
+	assert.Equal(t, "", extractArtifactID("invalid"))
+}
+
+func TestParseMavenID(t *testing.T) {
+	id := parseMavenID("com.example:my-lib:1.0")
+	assert.Equal(t, "com.example", id.GroupID)
+	assert.Equal(t, "my-lib", id.ArtifactID)
+	assert.Equal(t, "1.0", id.Version)
+
+	empty := parseMavenID("invalid")
+	assert.False(t, empty.Valid())
+}
+

--- a/internal/relationship/java/java_hierarchical_relationships_test.go
+++ b/internal/relationship/java/java_hierarchical_relationships_test.go
@@ -139,8 +139,10 @@ func TestResolveHierarchicalDependencies_NeitherFeatureEnabled(t *testing.T) {
 	root := javaPkg("com.example", "root", "1.0")
 	child := javaPkg("org.dep", "child", "2.0")
 
-	// Even if a relationship happens to have IntendedParentID, the post-processor
-	// should not run when neither feature is enabled
+	// Even when neither feature is explicitly enabled, the post-processor still runs
+	// but relies on per-relationship checks. Since there's an IntendedParentID and the
+	// parent ("some-parent") is NOT in the SBOM, it falls through Case 1b with no graph
+	// — the parent stays as root and IntendedParentID gets cleared.
 	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "compile", "org.dep:some-parent:1.0")
 	rel := depOfRel(child, root, relData)
 	s := newTestSBOM([]pkg.Package{root, child}, []artifact.Relationship{rel})
@@ -150,11 +152,14 @@ func TestResolveHierarchicalDependencies_NeitherFeatureEnabled(t *testing.T) {
 
 	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{})
 
-	// Should be completely unchanged — post-processor didn't run
+	// Post-processor ran — IntendedParentID cleared, parent stays as root (not found)
 	assert.Len(t, s.Relationships, 1)
 	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
 	require.True(t, ok)
-	assert.Equal(t, "org.dep:some-parent:1.0", data.IntendedParentID)
+	assert.Empty(t, data.IntendedParentID)
+	assert.Equal(t, 1, data.Depth)
+	assert.Equal(t, "compile", data.Scope)
+	assert.Equal(t, root.ID(), s.Relationships[0].To.ID())
 }
 
 func TestResolveHierarchicalDependencies_WithTreeFile(t *testing.T) {

--- a/internal/relationship/java/java_hierarchical_relationships_test.go
+++ b/internal/relationship/java/java_hierarchical_relationships_test.go
@@ -342,7 +342,7 @@ func TestFindNearestAncestorInSBOM(t *testing.T) {
 	}
 
 	t.Run("returns root when node is nil", func(t *testing.T) {
-		ancestor := findNearestAncestorInSBOM(nil, nil, pkgIndex, &root)
+		ancestor := findNearestAncestorInSBOM(nil, pkgIndex, &root)
 		require.NotNil(t, ancestor)
 		assert.Equal(t, root.ID(), ancestor.ID())
 	})
@@ -360,7 +360,7 @@ func TestFindNearestAncestorInSBOM(t *testing.T) {
 			},
 		}
 
-		ancestor := findNearestAncestorInSBOM(nil, missingNode, pkgIndex, &root)
+		ancestor := findNearestAncestorInSBOM(missingNode, pkgIndex, &root)
 		require.NotNil(t, ancestor)
 		assert.Equal(t, root.ID(), ancestor.ID())
 	})

--- a/internal/relationship/java/java_hierarchical_relationships_test.go
+++ b/internal/relationship/java/java_hierarchical_relationships_test.go
@@ -70,6 +70,93 @@ func TestResolveHierarchicalDependencies_NoTreeFile(t *testing.T) {
 	assert.Nil(t, s.Relationships[0].Data)
 }
 
+func TestResolveHierarchicalDependencies_EmbeddedPOMsResolveDeferredParent(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	parent := javaPkg("org.dep", "parent-lib", "2.0")
+	child := javaPkg("org.dep", "child-lib", "3.0")
+
+	// child has IntendedParentID set by the archive parser during embedded POM graph building
+	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "compile", "org.dep:parent-lib:2.0")
+	rel := depOfRel(child, root, relData) // currently points to root (wrong)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, parent, child},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	// No tree file — only embedded POMs enabled
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaUseEmbeddedPOMDependencies: true,
+	})
+
+	require.Len(t, s.Relationships, 1)
+	// Relationship should now point to parent, not root
+	assert.Equal(t, parent.ID(), s.Relationships[0].To.ID())
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Empty(t, data.IntendedParentID)
+	assert.Equal(t, 1, data.Depth)
+	assert.Equal(t, "compile", data.Scope)
+}
+
+func TestResolveHierarchicalDependencies_EmbeddedPOMsParentNotFound(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	child := javaPkg("org.dep", "child-lib", "3.0")
+
+	// child's intended parent is NOT in the SBOM
+	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "test", "org.dep:missing-parent:2.0")
+	rel := depOfRel(child, root, relData)
+
+	s := newTestSBOM(
+		[]pkg.Package{root, child},
+		[]artifact.Relationship{rel},
+	)
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	// No tree file — only embedded POMs enabled
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaUseEmbeddedPOMDependencies: true,
+	})
+
+	require.Len(t, s.Relationships, 1)
+	// Parent not found and no graph to walk — stays pointing to root
+	assert.Equal(t, root.ID(), s.Relationships[0].To.ID())
+
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Empty(t, data.IntendedParentID) // cleared after resolution attempt
+	assert.Equal(t, 1, data.Depth)
+	assert.Equal(t, "test", data.Scope)
+}
+
+func TestResolveHierarchicalDependencies_NeitherFeatureEnabled(t *testing.T) {
+	root := javaPkg("com.example", "root", "1.0")
+	child := javaPkg("org.dep", "child", "2.0")
+
+	// Even if a relationship happens to have IntendedParentID, the post-processor
+	// should not run when neither feature is enabled
+	relData := javaCataloger.NewDependencyRelationshipDataWithParent(1, "compile", "org.dep:some-parent:1.0")
+	rel := depOfRel(child, root, relData)
+	s := newTestSBOM([]pkg.Package{root, child}, []artifact.Relationship{rel})
+
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{})
+
+	// Should be completely unchanged — post-processor didn't run
+	assert.Len(t, s.Relationships, 1)
+	data, ok := s.Relationships[0].Data.(javaCataloger.DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, "org.dep:some-parent:1.0", data.IntendedParentID)
+}
+
 func TestResolveHierarchicalDependencies_WithTreeFile(t *testing.T) {
 	root := javaPkg("com.example", "my-app", "1.0.0")
 	springCore := javaPkg("org.springframework", "spring-core", "6.2.15")

--- a/internal/relationship/java/java_hierarchical_relationships_test.go
+++ b/internal/relationship/java/java_hierarchical_relationships_test.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -447,3 +448,166 @@ func TestParseMavenID(t *testing.T) {
 	assert.False(t, empty.Valid())
 }
 
+// TestEndToEnd_FullPipeline exercises the complete post-processing pipeline with the
+// Maven tree fixture. It creates a realistic SBOM with packages at various depths and
+// flat relationships (all pointing to root), then verifies the post-processor correctly
+// enriches depth/scope and re-parents transitive dependencies.
+func TestEndToEnd_FullPipeline(t *testing.T) {
+	treeFile := "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt"
+
+	// Create packages matching the fixture tree:
+	// com.example:my-app:1.0.0 (root)
+	//   +- jackson-databind (depth=1, direct)
+	//   |  +- jackson-core (depth=2, transitive)
+	//   |  \- jackson-annotations (depth=2, transitive)
+	//   +- spring-core (depth=1, direct)
+	//   |  \- spring-jcl (depth=2, transitive)
+	//   +- micrometer-core (depth=1, direct)
+	//   |  +- HdrHistogram (depth=2, transitive, runtime)
+	//   \- junit-jupiter (depth=1, test)
+	//      +- junit-jupiter-api (depth=2, test)
+	//      \- junit-jupiter-engine (depth=2, test)
+	//         \- junit-platform-engine (depth=3, test)
+	root := javaPkg("com.example", "my-app", "1.0.0")
+	jacksonDatabind := javaPkg("com.fasterxml.jackson.core", "jackson-databind", "2.19.4")
+	jacksonCore := javaPkg("com.fasterxml.jackson.core", "jackson-core", "2.19.4")
+	jacksonAnnotations := javaPkg("com.fasterxml.jackson.core", "jackson-annotations", "2.19.4")
+	springCore := javaPkg("org.springframework", "spring-core", "6.2.15")
+	springJcl := javaPkg("org.springframework", "spring-jcl", "6.2.15")
+	micrometerCore := javaPkg("io.micrometer", "micrometer-core", "1.15.7")
+	hdrHistogram := javaPkg("org.hdrhistogram", "HdrHistogram", "2.2.2")
+	junitJupiter := javaPkg("org.junit.jupiter", "junit-jupiter", "5.11.6")
+	junitApi := javaPkg("org.junit.jupiter", "junit-jupiter-api", "5.11.6")
+	junitEngine := javaPkg("org.junit.jupiter", "junit-jupiter-engine", "5.11.6")
+	junitPlatform := javaPkg("org.junit.platform", "junit-platform-engine", "1.11.6")
+
+	// Also add a package NOT in the tree (should be unchanged)
+	extraPkg := javaPkg("com.custom", "shaded-extra", "1.0")
+
+	allPkgs := []pkg.Package{
+		root, jacksonDatabind, jacksonCore, jacksonAnnotations,
+		springCore, springJcl, micrometerCore, hdrHistogram,
+		junitJupiter, junitApi, junitEngine, junitPlatform, extraPkg,
+	}
+
+	// All relationships start flat: everything points to root (simulating pre-fix behavior)
+	var flatRels []artifact.Relationship
+	for _, p := range allPkgs[1:] { // skip root
+		flatRels = append(flatRels, depOfRel(p, root, nil))
+	}
+
+	s := newTestSBOM(allPkgs, flatRels)
+	builder := sbomsync.NewBuilder(s)
+	accessor := builder.(sbomsync.Accessor)
+
+	ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+		JavaMavenDependencyTreeFile: treeFile,
+	})
+
+	require.Len(t, s.Relationships, len(allPkgs)-1) // 12 relationships (one per non-root package)
+
+	// Build a lookup: from-package-name → relationship data
+	type relInfo struct {
+		depth    int
+		isDirect bool
+		scope    string
+	}
+	relMap := make(map[string]relInfo)
+	for _, rel := range s.Relationships {
+		fromPkg := rel.From.(pkg.Package)
+		data, ok := rel.Data.(javaCataloger.DependencyRelationshipData)
+		if ok {
+			relMap[fromPkg.Name] = relInfo{depth: data.Depth, isDirect: data.IsDirectDependency, scope: data.Scope}
+		} else {
+			relMap[fromPkg.Name] = relInfo{depth: -1} // sentinel for unenriched
+		}
+	}
+
+	// Direct dependencies (depth=0)
+	for _, name := range []string{"jackson-databind", "spring-core", "micrometer-core", "junit-jupiter"} {
+		info, ok := relMap[name]
+		require.True(t, ok, "expected relationship for %s", name)
+		assert.Equal(t, 0, info.depth, "%s should be depth=0", name)
+		assert.True(t, info.isDirect, "%s should be direct", name)
+	}
+
+	// Compile scope
+	assert.Equal(t, "compile", relMap["jackson-databind"].scope)
+	assert.Equal(t, "compile", relMap["spring-core"].scope)
+	assert.Equal(t, "compile", relMap["micrometer-core"].scope)
+
+	// Test scope
+	assert.Equal(t, "test", relMap["junit-jupiter"].scope)
+
+	// Transitive dependencies (depth=1)
+	for _, name := range []string{"jackson-core", "jackson-annotations", "spring-jcl", "HdrHistogram", "junit-jupiter-api", "junit-jupiter-engine"} {
+		info, ok := relMap[name]
+		require.True(t, ok, "expected relationship for %s", name)
+		assert.Equal(t, 1, info.depth, "%s should be depth=1", name)
+		assert.False(t, info.isDirect, "%s should be transitive", name)
+	}
+
+	// Runtime scope for HdrHistogram
+	assert.Equal(t, "runtime", relMap["HdrHistogram"].scope)
+
+	// Depth=2 transitive (junit-platform-engine is 3 levels deep in tree → relDepth=2)
+	info, ok := relMap["junit-platform-engine"]
+	require.True(t, ok)
+	assert.Equal(t, 2, info.depth)
+	assert.False(t, info.isDirect)
+	assert.Equal(t, "test", info.scope)
+
+	// Package not in tree should be unchanged (no enrichment data)
+	assert.Equal(t, -1, relMap["shaded-extra"].depth, "package not in tree should have no enrichment")
+}
+
+func BenchmarkPostProcessingPipeline(b *testing.B) {
+	treeFile := "../../../syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt"
+
+	// Build a realistic SBOM with 300 packages
+	allPkgs := []pkg.Package{javaPkg("com.example", "root", "1.0.0")}
+	for i := 0; i < 50; i++ {
+		allPkgs = append(allPkgs, javaPkg("org.dep", fmt.Sprintf("direct-%d", i), fmt.Sprintf("%d.0", i)))
+		for j := 0; j < 5; j++ {
+			allPkgs = append(allPkgs, javaPkg("org.dep", fmt.Sprintf("trans-%d-%d", i, j), fmt.Sprintf("%d.%d", i, j)))
+		}
+	}
+
+	var flatRels []artifact.Relationship
+	root := allPkgs[0]
+	for _, p := range allPkgs[1:] {
+		flatRels = append(flatRels, depOfRel(p, root, nil))
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		s := newTestSBOM(allPkgs, flatRels)
+		builder := sbomsync.NewBuilder(s)
+		accessor := builder.(sbomsync.Accessor)
+		ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{
+			JavaMavenDependencyTreeFile: treeFile,
+		})
+	}
+}
+
+func BenchmarkPostProcessingPipeline_Disabled(b *testing.B) {
+	// Verify minimal overhead when feature is disabled
+	allPkgs := []pkg.Package{javaPkg("com.example", "root", "1.0.0")}
+	for i := 0; i < 300; i++ {
+		allPkgs = append(allPkgs, javaPkg("org.dep", fmt.Sprintf("lib-%d", i), fmt.Sprintf("%d.0", i)))
+	}
+
+	var flatRels []artifact.Relationship
+	root := allPkgs[0]
+	for _, p := range allPkgs[1:] {
+		flatRels = append(flatRels, depOfRel(p, root, nil))
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		s := newTestSBOM(allPkgs, flatRels)
+		builder := sbomsync.NewBuilder(s)
+		accessor := builder.(sbomsync.Accessor)
+		ResolveHierarchicalDependencies(accessor, cataloging.RelationshipsConfig{})
+	}
+}

--- a/internal/task/relationship_tasks.go
+++ b/internal/task/relationship_tasks.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/anchore/syft/internal/relationship"
 	"github.com/anchore/syft/internal/relationship/binary"
+	javaRelationship "github.com/anchore/syft/internal/relationship/java"
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cataloging"
@@ -54,6 +55,9 @@ func finalizeRelationships(resolver file.Resolver, builder sbomsync.Builder, cfg
 	if cfg.ExcludeBinaryPackagesWithFileOwnershipOverlap {
 		relationship.ExcludeBinariesByFileOwnershipOverlap(accessor)
 	}
+
+	// resolve hierarchical Java dependency relationships (deferred parent resolution + enrichment)
+	javaRelationship.ResolveHierarchicalDependencies(accessor, cfg)
 
 	// add the new relationships for executables to the SBOM
 	newBinaryRelationships := binary.NewDependencyRelationships(resolver, accessor)

--- a/syft/cataloging/relationships.go
+++ b/syft/cataloging/relationships.go
@@ -17,6 +17,11 @@ type RelationshipsConfig struct {
 	// JavaMavenDependencyTreeFile is the path to a pre-generated Maven dependency tree file.
 	// When provided, Java dependency relationships are enriched with accurate depth and scope during post-processing.
 	JavaMavenDependencyTreeFile string `yaml:"java-maven-dependency-tree-file" json:"java-maven-dependency-tree-file" mapstructure:"java-maven-dependency-tree-file"`
+
+	// JavaUseEmbeddedPOMDependencies indicates that the Java cataloger built a dependency graph from
+	// embedded pom.xml files. When true, the post-processor resolves deferred parent IDs in relationships
+	// even without a Maven dependency tree file.
+	JavaUseEmbeddedPOMDependencies bool `yaml:"java-use-embedded-pom-dependencies" json:"java-use-embedded-pom-dependencies" mapstructure:"java-use-embedded-pom-dependencies"`
 }
 
 func DefaultRelationshipsConfig() RelationshipsConfig {

--- a/syft/cataloging/relationships.go
+++ b/syft/cataloging/relationships.go
@@ -13,6 +13,10 @@ type RelationshipsConfig struct {
 	// For example, if a binary package representing the /bin/python binary is discovered and there is a python RPM package installed which claims to
 	// orn /bin/python, then the binary package will be excluded from the catalog altogether if this configuration is set to true.
 	ExcludeBinaryPackagesWithFileOwnershipOverlap bool `yaml:"exclude-binary-packages-with-file-ownership-overlap" json:"exclude-binary-packages-with-file-ownership-overlap" mapstructure:"exclude-binary-packages-with-file-ownership-overlap"`
+
+	// JavaMavenDependencyTreeFile is the path to a pre-generated Maven dependency tree file.
+	// When provided, Java dependency relationships are enriched with accurate depth and scope during post-processing.
+	JavaMavenDependencyTreeFile string `yaml:"java-maven-dependency-tree-file" json:"java-maven-dependency-tree-file" mapstructure:"java-maven-dependency-tree-file"`
 }
 
 func DefaultRelationshipsConfig() RelationshipsConfig {

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -677,6 +677,11 @@ func Test_lookupRelationship(t *testing.T) {
 			ty:     helpers.ContainsRelationship,
 		},
 		{
+			input:  artifact.DependencyOfRelationship,
+			exists: true,
+			ty:     helpers.DependencyOfRelationship,
+		},
+		{
 			input:   artifact.OwnershipByFileOverlapRelationship,
 			exists:  true,
 			ty:      helpers.OtherRelationship,

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -149,9 +149,8 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		return nil, nil, fmt.Errorf("could not generate package from %s: %w", j.location, err)
 	}
 
-	// find aux packages from pom.properties/pom.xml and potentially modify the existing parentPkg
-	// NOTE: we cannot generate sha1 digests from packages discovered via pom.properties/pom.xml
-	// IMPORTANT!: discoverPkgsFromAllMavenFiles may change mainPkg information, so needs to be called before SetID and before copying for relationships, etc.
+	// find aux packages from pom.properties/pom.xml and potentially modify the existing mainPkg.
+	// NOTE: cannot generate sha1 digests from these. Must be called before SetID and before copying.
 	auxPkgs, err := j.discoverPkgsFromAllMavenFiles(ctx, mainPkg)
 	if err != nil {
 		return nil, nil, err

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -56,14 +56,16 @@ var javaArchiveHashes = []crypto.Hash{
 }
 
 type archiveParser struct {
-	fileManifest intFile.ZipFileManifest
-	location     file.Location
-	archivePath  string
-	contentPath  string
-	fileInfo     archiveFilename
-	detectNested bool
-	cfg          ArchiveCatalogerConfig
-	maven        *maven.Resolver
+	fileManifest    intFile.ZipFileManifest
+	location        file.Location
+	archivePath     string
+	contentPath     string
+	fileInfo        archiveFilename
+	detectNested    bool
+	cfg             ArchiveCatalogerConfig
+	maven           *maven.Resolver
+	dependencyGraph *DependencyGraph // built from Maven tree file or embedded POMs at depth=0
+	depth           int              // nesting level: 0 = top-level archive
 }
 
 type genericArchiveParserAdapter struct {
@@ -76,16 +78,21 @@ func newGenericArchiveParserAdapter(cfg ArchiveCatalogerConfig) genericArchivePa
 
 // parseJavaArchive is a parser function for java archive contents, returning all Java libraries and nested archives
 func (gap genericArchiveParserAdapter) parseJavaArchive(ctx context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
-	return gap.processJavaArchive(ctx, reader, nil)
+	return gap.processJavaArchive(ctx, reader, nil, 0, nil)
 }
 
-// processJavaArchive processes an archive for java contents, returning all Java libraries and nested archives
-func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
+// processJavaArchive processes an archive for java contents, returning all Java libraries and nested archives.
+// depth indicates nesting level (0 = top-level), rootGraph is the dependency graph built at depth=0.
+func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package, depth int, rootGraph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	parser, cleanupFn, err := newJavaArchiveParser(ctx, reader, true, gap.cfg)
 	// note: even on error, we should always run cleanup functions
 	defer cleanupFn()
 	if err != nil {
 		return nil, nil, err
+	}
+	parser.depth = depth
+	if rootGraph != nil {
+		parser.dependencyGraph = rootGraph
 	}
 	return parser.parse(ctx, parentPkg)
 }
@@ -150,16 +157,20 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		return nil, nil, err
 	}
 
+	// build dependency graph at the root level only (depth=0)
+	shouldBuildGraph := (j.cfg.MavenDependencyTreeFile != "" || j.cfg.UseEmbeddedPOMDependencies) &&
+		mainPkg != nil && j.depth == 0
+	if shouldBuildGraph {
+		j.buildDependencyGraph(ctx, mainPkg)
+	}
+
 	if mainPkg != nil {
 		finalizePackage(mainPkg)
 		pkgs = append(pkgs, *mainPkg)
 
 		if parentPkg != nil {
-			relationships = append(relationships, artifact.Relationship{
-				From: *mainPkg,
-				To:   *parentPkg,
-				Type: artifact.DependencyOfRelationship,
-			})
+			rel := j.createMainPkgRelationship(mainPkg, parentPkg)
+			relationships = append(relationships, rel)
 		}
 	}
 
@@ -170,11 +181,8 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		pkgs = append(pkgs, *auxPkg)
 
 		if mainPkg != nil {
-			relationships = append(relationships, artifact.Relationship{
-				From: *auxPkg,
-				To:   *mainPkg,
-				Type: artifact.DependencyOfRelationship,
-			})
+			rel := j.createAuxPkgRelationship(auxPkg, mainPkg)
+			relationships = append(relationships, rel)
 		}
 	}
 
@@ -201,6 +209,82 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 	}
 
 	return pkgs, relationships, errs
+}
+
+// createMainPkgRelationship creates a relationship between a nested archive's main package and its parent.
+// When a dependency graph is available, it enriches the relationship with depth, scope, and intended parent.
+func (j *archiveParser) createMainPkgRelationship(mainPkg, parentPkg *pkg.Package) artifact.Relationship {
+	rel := artifact.Relationship{
+		From: *mainPkg,
+		To:   *parentPkg,
+		Type: artifact.DependencyOfRelationship,
+	}
+
+	if j.dependencyGraph == nil || j.depth == 0 {
+		return rel
+	}
+
+	mainID := extractMavenIDFromPackage(mainPkg)
+	if !mainID.Valid() {
+		return rel
+	}
+
+	node := j.dependencyGraph.FindNodeFlexible(mainID)
+	if node == nil {
+		return rel
+	}
+
+	relDepth := node.Depth - 1
+	if relDepth < 0 {
+		relDepth = 0
+	}
+	scope := node.Scope
+
+	var intendedParentID string
+	if node.Parent != nil {
+		intendedParentID = mavenIDKey(node.Parent.ID)
+	}
+
+	rel.Data = NewDependencyRelationshipDataWithParent(relDepth, scope, intendedParentID)
+	return rel
+}
+
+// createAuxPkgRelationship creates a relationship between an auxiliary package and the main package.
+// When a dependency graph is available, it enriches the relationship with depth, scope, and intended parent.
+func (j *archiveParser) createAuxPkgRelationship(auxPkg, mainPkg *pkg.Package) artifact.Relationship {
+	rel := artifact.Relationship{
+		From: *auxPkg,
+		To:   *mainPkg,
+		Type: artifact.DependencyOfRelationship,
+	}
+
+	if j.dependencyGraph == nil {
+		return rel
+	}
+
+	auxID := extractMavenIDFromPackage(auxPkg)
+	if !auxID.Valid() {
+		return rel
+	}
+
+	node := j.dependencyGraph.FindNodeFlexible(auxID)
+	if node == nil {
+		return rel
+	}
+
+	relDepth := node.Depth - 1
+	if relDepth < 0 {
+		relDepth = 0
+	}
+	scope := node.Scope
+
+	var intendedParentID string
+	if node.Parent != nil {
+		intendedParentID = mavenIDKey(node.Parent.ID)
+	}
+
+	rel.Data = NewDependencyRelationshipDataWithParent(relDepth, scope, intendedParentID)
+	return rel
 }
 
 // finalizePackage potentially updates some package information such as classifying the package as a Jenkins plugin,
@@ -608,30 +692,238 @@ func (j *archiveParser) getLicenseFromFileInArchive(ctx context.Context) []pkg.L
 	return identified
 }
 
+// buildDependencyGraph builds a dependency graph using the priority chain:
+// 1. Maven dependency tree file (most accurate)
+// 2. Embedded POMs (fallback)
+func (j *archiveParser) buildDependencyGraph(ctx context.Context, mainPkg *pkg.Package) {
+	// Priority 1: Maven dependency tree file
+	if j.cfg.MavenDependencyTreeFile != "" {
+		graph, err := j.buildGraphFromMavenTreeFile()
+		if err != nil {
+			log.WithFields("error", err, "file", j.cfg.MavenDependencyTreeFile).Warn("failed to parse Maven dependency tree file, falling back to embedded POMs")
+		} else if graph != nil {
+			j.dependencyGraph = graph
+			return
+		}
+	}
+
+	// Priority 2: Embedded POMs
+	if j.cfg.UseEmbeddedPOMDependencies {
+		j.buildDependencyGraphFromEmbeddedPOMs(ctx, mainPkg)
+	}
+}
+
+// buildGraphFromMavenTreeFile parses a pre-generated Maven dependency tree file and converts it to a DependencyGraph.
+func (j *archiveParser) buildGraphFromMavenTreeFile() (*DependencyGraph, error) {
+	tree, err := ParseMavenDependencyTreeFile(j.cfg.MavenDependencyTreeFile)
+	if err != nil {
+		return nil, err
+	}
+	return tree.ToInternalGraph(), nil
+}
+
+// buildDependencyGraphFromEmbeddedPOMs builds a dependency graph from POMs embedded in the archive and its nested JARs.
+func (j *archiveParser) buildDependencyGraphFromEmbeddedPOMs(ctx context.Context, mainPkg *pkg.Package) {
+	poms := j.extractUnifiedPOMs(ctx)
+	if len(poms) == 0 {
+		return
+	}
+
+	rootID := extractMavenIDFromPackage(mainPkg)
+	if !rootID.Valid() {
+		return
+	}
+
+	graph := NewDependencyGraph()
+	graph.BuildFromPOMs(ctx, poms, j.maven, rootID, j.cfg.ResolveTransitiveDependencies, DefaultMaxDepth)
+	j.dependencyGraph = graph
+}
+
+// extractUnifiedPOMs extracts and merges POMs from the root archive and all nested JARs.
+// Root POMs take precedence on duplicate keys.
+func (j *archiveParser) extractUnifiedPOMs(ctx context.Context) map[string]*maven.Project {
+	unified := make(map[string]*maven.Project)
+
+	// Start with nested JAR POMs (lower priority)
+	nestedPOMs := j.extractAllPOMsFromNestedJARs(ctx)
+	for k, v := range nestedPOMs {
+		unified[k] = v
+	}
+
+	// Root archive POMs overwrite (higher priority)
+	rootPOMs := j.extractAllPOMsByID(ctx)
+	for k, v := range rootPOMs {
+		unified[k] = v
+	}
+
+	return unified
+}
+
+// extractAllPOMsByID extracts all pom.xml files from the root archive and indexes them by resolved Maven ID.
+func (j *archiveParser) extractAllPOMsByID(ctx context.Context) map[string]*maven.Project {
+	result := make(map[string]*maven.Project)
+
+	pomPaths := j.fileManifest.GlobMatch(false, pomXMLGlob)
+	contents, err := intFile.ContentsFromZip(ctx, j.archivePath, pomPaths...)
+	if err != nil {
+		log.WithFields("error", err).Debug("failed to extract POM files from archive for graph building")
+		return result
+	}
+
+	for _, content := range contents {
+		pom, err := maven.ParsePomXML(strings.NewReader(content))
+		if err != nil || pom == nil {
+			continue
+		}
+		id := j.maven.ResolveID(ctx, pom)
+		key := mavenIDKey(id)
+		result[key] = pom
+	}
+
+	return result
+}
+
+// extractAllPOMsFromNestedJARs extracts POMs from nested JARs (e.g. BOOT-INF/lib/*.jar, WEB-INF/lib/*.jar).
+func (j *archiveParser) extractAllPOMsFromNestedJARs(ctx context.Context) map[string]*maven.Project {
+	result := make(map[string]*maven.Project)
+
+	nestedArchives := j.fileManifest.GlobMatch(false, archiveFormatGlobs...)
+	if len(nestedArchives) == 0 {
+		return result
+	}
+
+	openers, err := intFile.ExtractFromZipToUniqueTempFile(ctx, j.archivePath, j.contentPath, nestedArchives...)
+	if err != nil {
+		log.WithFields("error", err).Debug("failed to extract nested archives for POM extraction")
+		return result
+	}
+
+	for _, opener := range openers {
+		nestedPOMs := j.extractPOMsFromNestedJAR(ctx, opener)
+		for k, v := range nestedPOMs {
+			if _, exists := result[k]; !exists {
+				result[k] = v
+			}
+		}
+	}
+
+	return result
+}
+
+// extractPOMsFromNestedJAR extracts POMs from a single nested JAR.
+func (j *archiveParser) extractPOMsFromNestedJAR(ctx context.Context, opener intFile.Opener) map[string]*maven.Project {
+	result := make(map[string]*maven.Project)
+
+	rc, err := opener.Open()
+	if err != nil {
+		return result
+	}
+	defer func() {
+		if closeErr := rc.Close(); closeErr != nil {
+			log.Debugf("unable to close nested jar for POM extraction: %+v", closeErr)
+		}
+	}()
+
+	// We need to save the nested JAR to a temp file so we can read it as a zip
+	td := tmpdir.FromContext(ctx)
+	if td == nil {
+		return result
+	}
+
+	tmpFile, cleanupFn, err := td.NewFile("nested-pom-*.jar")
+	if err != nil {
+		return result
+	}
+	defer cleanupFn()
+	defer func() {
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			log.Debugf("unable to close temp file for nested POM extraction: %+v", closeErr)
+		}
+	}()
+
+	if _, err := io.Copy(tmpFile, rc); err != nil {
+		return result
+	}
+
+	nestedManifest, err := intFile.NewZipFileManifest(ctx, tmpFile.Name())
+	if err != nil {
+		return result
+	}
+
+	pomPaths := nestedManifest.GlobMatch(false, pomXMLGlob)
+	contents, err := intFile.ContentsFromZip(ctx, tmpFile.Name(), pomPaths...)
+	if err != nil {
+		return result
+	}
+
+	for _, content := range contents {
+		pom, err := maven.ParsePomXML(strings.NewReader(content))
+		if err != nil || pom == nil {
+			continue
+		}
+		id := j.maven.ResolveID(ctx, pom)
+		key := mavenIDKey(id)
+		result[key] = pom
+	}
+
+	return result
+}
+
+// extractMavenIDFromPackage extracts a Maven ID from a package's metadata.
+func extractMavenIDFromPackage(p *pkg.Package) maven.ID {
+	if p == nil {
+		return maven.ID{}
+	}
+	metadata, ok := p.Metadata.(pkg.JavaArchive)
+	if !ok {
+		return maven.ID{}
+	}
+
+	groupID := ""
+	artifactID := p.Name
+	version := p.Version
+
+	if metadata.PomProperties != nil {
+		groupID = metadata.PomProperties.GroupID
+		if metadata.PomProperties.ArtifactID != "" {
+			artifactID = metadata.PomProperties.ArtifactID
+		}
+		if metadata.PomProperties.Version != "" {
+			version = metadata.PomProperties.Version
+		}
+	}
+
+	if groupID == "" {
+		groupID = groupIDFromJavaMetadata(p.Name, metadata)
+	}
+
+	return maven.NewID(groupID, artifactID, version)
+}
+
 func (j *archiveParser) discoverPkgsFromNestedArchives(ctx context.Context, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
 	// we know that all java archives are zip formatted files, so we can use the shared zip helper
-	return discoverPkgsFromZip(ctx, j.location, j.archivePath, j.contentPath, j.fileManifest, parentPkg, j.cfg)
+	return discoverPkgsFromZip(ctx, j.location, j.archivePath, j.contentPath, j.fileManifest, parentPkg, j.cfg, j.depth+1, j.dependencyGraph)
 }
 
 // discoverPkgsFromZip finds Java archives within Java archives, returning all listed Java packages found and
 // associating each discovered package to the given parent package.
-func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	// search and parse pom.properties files & fetch the contents
 	openers, err := intFile.ExtractFromZipToUniqueTempFile(ctx, archivePath, contentPath, fileManifest.GlobMatch(false, archiveFormatGlobs...)...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to extract files from zip: %w", err)
 	}
 
-	return discoverPkgsFromOpeners(ctx, location, openers, parentPkg, cfg)
+	return discoverPkgsFromOpeners(ctx, location, openers, parentPkg, cfg, depth, graph)
 }
 
 // discoverPkgsFromOpeners finds Java archives within the given files and associates them with the given parent package.
-func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	var pkgs []pkg.Package
 	var relationships []artifact.Relationship
 
 	for pathWithinArchive, archiveOpener := range sortedIter(openers) {
-		nestedPkgs, nestedRelationships, err := discoverPkgsFromOpener(ctx, location, pathWithinArchive, archiveOpener, cfg, parentPkg)
+		nestedPkgs, nestedRelationships, err := discoverPkgsFromOpener(ctx, location, pathWithinArchive, archiveOpener, cfg, parentPkg, depth, graph)
 		if err != nil {
 			log.WithFields("location", location.Path(), "error", err).Debug("unable to discover java packages from opener")
 			continue
@@ -655,7 +947,7 @@ func discoverPkgsFromOpeners(ctx context.Context, location file.Location, opener
 }
 
 // discoverPkgsFromOpener finds Java archives within the given file.
-func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	archiveReadCloser, err := archiveOpener.Open()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to open archived file from tempdir: %w", err)
@@ -673,7 +965,7 @@ func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWit
 	nestedPkgs, nestedRelationships, err := gap.processJavaArchive(ctx, file.LocationReadCloser{
 		Location:   nestedLocation,
 		ReadCloser: archiveReadCloser,
-	}, parentPkg)
+	}, parentPkg, depth, graph)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to process nested java archive (%s): %w", pathWithinArchive, err)
 	}

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -237,17 +237,21 @@ func (j *archiveParser) createMainPkgRelationship(mainPkg, parentPkg *pkg.Packag
 		Type: artifact.DependencyOfRelationship,
 	}
 
+	// No graph or root-level archive — no enrichment possible
 	if j.dependencyGraph == nil || j.depth == 0 {
 		return rel
 	}
 
+	// Graph exists but lookup may fail — attach fallback Data for graph-miss cases
 	mainID := extractMavenIDFromPackage(mainPkg)
 	if !mainID.Valid() {
+		rel.Data = NewDependencyRelationshipData(0, "")
 		return rel
 	}
 
 	node := j.dependencyGraph.FindNodeFlexible(mainID)
 	if node == nil {
+		rel.Data = NewDependencyRelationshipData(0, "")
 		return rel
 	}
 
@@ -278,17 +282,21 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg, mainPkg *pkg.Package, p
 		Type: artifact.DependencyOfRelationship,
 	}
 
+	// No graph — no enrichment possible
 	if j.dependencyGraph == nil {
 		return rel
 	}
 
+	// Graph exists but lookup may fail — attach fallback Data for graph-miss cases
 	auxID := extractMavenIDFromPackage(auxPkg)
 	if !auxID.Valid() {
+		rel.Data = NewDependencyRelationshipData(0, "")
 		return rel
 	}
 
 	node := j.dependencyGraph.FindNodeFlexible(auxID)
 	if node == nil {
+		rel.Data = NewDependencyRelationshipData(0, "")
 		return rel
 	}
 

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -173,14 +173,32 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		}
 	}
 
+	// Build a package index for looking up packages by Maven ID.
+	// Used when the dependency graph provides hierarchical parent information.
+	pkgIndex := make(map[string]*pkg.Package)
+	if mainPkg != nil && j.dependencyGraph != nil {
+		mainID := extractMavenIDFromPackage(mainPkg)
+		if mainID.Valid() {
+			pkgIndex[mavenIDKey(mainID)] = &pkgs[0]
+		}
+	}
+
 	for i := range auxPkgs {
 		auxPkg := &auxPkgs[i]
 
 		finalizePackage(auxPkg)
 		pkgs = append(pkgs, *auxPkg)
 
+		// Index each aux package for parent resolution of subsequent packages
+		if j.dependencyGraph != nil {
+			auxID := extractMavenIDFromPackage(auxPkg)
+			if auxID.Valid() {
+				pkgIndex[mavenIDKey(auxID)] = &pkgs[len(pkgs)-1]
+			}
+		}
+
 		if mainPkg != nil {
-			rel := j.createAuxPkgRelationship(auxPkg, mainPkg)
+			rel := j.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex)
 			relationships = append(relationships, rel)
 		}
 	}
@@ -248,9 +266,12 @@ func (j *archiveParser) createMainPkgRelationship(mainPkg, parentPkg *pkg.Packag
 	return rel
 }
 
-// createAuxPkgRelationship creates a relationship between an auxiliary package and the main package.
-// When a dependency graph is available, it enriches the relationship with depth, scope, and intended parent.
-func (j *archiveParser) createAuxPkgRelationship(auxPkg, mainPkg *pkg.Package) artifact.Relationship {
+// createAuxPkgRelationship creates a relationship between an auxiliary package and its parent.
+// When a dependency graph is available, it uses the graph to determine the actual hierarchical
+// parent (which may be an intermediate dependency, not the root). When the parent is found in
+// pkgIndex, the relationship is wired directly. Otherwise, the relationship falls back to
+// mainPkg and stores intendedParentID for post-processor resolution.
+func (j *archiveParser) createAuxPkgRelationship(auxPkg, mainPkg *pkg.Package, pkgIndex map[string]*pkg.Package) artifact.Relationship {
 	rel := artifact.Relationship{
 		From: *auxPkg,
 		To:   *mainPkg,
@@ -277,12 +298,30 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg, mainPkg *pkg.Package) a
 	}
 	scope := node.Scope
 
-	var intendedParentID string
 	if node.Parent != nil {
-		intendedParentID = mavenIDKey(node.Parent.ID)
+		parentKey := mavenIDKey(node.Parent.ID)
+		parentGA := node.Parent.ID.GroupID + ":" + node.Parent.ID.ArtifactID
+
+		// Try exact match first, then groupId:artifactId prefix match
+		if parentFromIndex := pkgIndex[parentKey]; parentFromIndex != nil {
+			rel.To = *parentFromIndex
+			rel.Data = NewDependencyRelationshipData(relDepth, scope)
+			return rel
+		}
+		for key, p := range pkgIndex {
+			if strings.HasPrefix(key, parentGA+":") {
+				rel.To = *p
+				rel.Data = NewDependencyRelationshipData(relDepth, scope)
+				return rel
+			}
+		}
+
+		// Parent not in local index — store for post-processor resolution
+		rel.Data = NewDependencyRelationshipDataWithParent(relDepth, scope, parentKey)
+		return rel
 	}
 
-	rel.Data = NewDependencyRelationshipDataWithParent(relDepth, scope, intendedParentID)
+	rel.Data = NewDependencyRelationshipData(relDepth, scope)
 	return rel
 }
 

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -189,7 +189,7 @@ func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
 		assert.Equal(t, "com.example:direct:2.0", data.IntendedParentID)
 	})
 
-	// Test package not found in graph — no enrichment
+	// Test package not found in graph — fallback Data attached
 	t.Run("not found in graph", func(t *testing.T) {
 		mainPkg := &pkg.Package{
 			Name:    "unknown",
@@ -205,7 +205,11 @@ func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
 		parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
 
 		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
-		assert.Nil(t, rel.Data)
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 0, data.Depth)
+		assert.True(t, data.IsDirectDependency)
+		assert.Empty(t, data.Scope)
 	})
 }
 
@@ -338,7 +342,11 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
 
 		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex)
-		assert.Nil(t, rel.Data)
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 0, data.Depth)
+		assert.True(t, data.IsDirectDependency)
+		assert.Empty(t, data.Scope)
 	})
 }
 

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -215,7 +215,7 @@ func TestCreateAuxPkgRelationship_NoGraph(t *testing.T) {
 	auxPkg := &pkg.Package{Name: "aux", Version: "1.0"}
 	mainPkg := &pkg.Package{Name: "main", Version: "2.0"}
 
-	rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+	rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, nil)
 
 	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
 	assert.Nil(t, rel.Data)
@@ -231,7 +231,16 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		dependencyGraph: graph,
 	}
 
-	t.Run("aux package found in graph as direct", func(t *testing.T) {
+	rootPkg := &pkg.Package{Name: "root", Version: "1.0"}
+	libAPkg := &pkg.Package{Name: "lib-a", Version: "2.0"}
+
+	// Build a pkgIndex that contains both root and lib-a
+	pkgIndex := map[string]*pkg.Package{
+		"com.example:root:1.0": rootPkg,
+		"org.dep:lib-a:2.0":   libAPkg,
+	}
+
+	t.Run("aux package found in graph as direct - parent resolved", func(t *testing.T) {
 		auxPkg := &pkg.Package{
 			Name:    "lib-a",
 			Version: "2.0",
@@ -245,17 +254,20 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		}
 		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
 
-		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex)
 
 		require.NotNil(t, rel.Data)
 		data := rel.Data.(DependencyRelationshipData)
 		assert.Equal(t, 0, data.Depth)
 		assert.True(t, data.IsDirectDependency)
 		assert.Equal(t, "compile", data.Scope)
-		assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+		// Parent resolved from pkgIndex -- no IntendedParentID needed
+		assert.Empty(t, data.IntendedParentID)
+		// rel.To should be the root package (parent in graph)
+		assert.Equal(t, rootPkg.Name, rel.To.(pkg.Package).Name)
 	})
 
-	t.Run("aux package found in graph as transitive", func(t *testing.T) {
+	t.Run("aux package found in graph as transitive - parent resolved", func(t *testing.T) {
 		auxPkg := &pkg.Package{
 			Name:    "lib-b",
 			Version: "3.0",
@@ -269,14 +281,46 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		}
 		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
 
-		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex)
 
 		require.NotNil(t, rel.Data)
 		data := rel.Data.(DependencyRelationshipData)
 		assert.Equal(t, 1, data.Depth)
 		assert.False(t, data.IsDirectDependency)
 		assert.Equal(t, "runtime", data.Scope)
-		assert.Equal(t, "org.dep:lib-a:2.0", data.IntendedParentID)
+		// Parent resolved from pkgIndex -- no IntendedParentID needed
+		assert.Empty(t, data.IntendedParentID)
+		// rel.To should be lib-a (the actual parent in the graph)
+		assert.Equal(t, libAPkg.Name, rel.To.(pkg.Package).Name)
+	})
+
+	t.Run("aux package found in graph but parent not in index - deferred", func(t *testing.T) {
+		auxPkg := &pkg.Package{
+			Name:    "lib-a",
+			Version: "2.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "org.dep",
+					ArtifactID: "lib-a",
+					Version:    "2.0",
+				},
+			},
+		}
+		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		// Empty pkgIndex -- parent can't be resolved locally
+		emptyIndex := map[string]*pkg.Package{}
+
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, emptyIndex)
+
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 0, data.Depth)
+		assert.Equal(t, "compile", data.Scope)
+		// Parent not found -- stored for post-processor
+		assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+		// rel.To remains mainPkg (fallback)
+		assert.Equal(t, mainPkg.Name, rel.To.(pkg.Package).Name)
 	})
 
 	t.Run("aux package not in graph", func(t *testing.T) {
@@ -293,7 +337,7 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		}
 		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
 
-		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex)
 		assert.Nil(t, rel.Data)
 	})
 }

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -1,0 +1,510 @@
+package java
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+func TestExtractMavenIDFromPackage(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      *pkg.Package
+		expected maven.ID
+	}{
+		{
+			name:     "nil package",
+			pkg:      nil,
+			expected: maven.ID{},
+		},
+		{
+			name: "no java metadata",
+			pkg: &pkg.Package{
+				Name:    "some-pkg",
+				Version: "1.0",
+			},
+			expected: maven.ID{},
+		},
+		{
+			name: "with pom properties",
+			pkg: &pkg.Package{
+				Name:    "some-pkg",
+				Version: "1.0",
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "com.example",
+						ArtifactID: "some-pkg",
+						Version:    "1.0",
+					},
+				},
+			},
+			expected: maven.NewID("com.example", "some-pkg", "1.0"),
+		},
+		{
+			name: "pom properties version overrides package version",
+			pkg: &pkg.Package{
+				Name:    "my-lib",
+				Version: "2.0",
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "org.test",
+						ArtifactID: "my-lib",
+						Version:    "2.1",
+					},
+				},
+			},
+			expected: maven.NewID("org.test", "my-lib", "2.1"),
+		},
+		{
+			name: "pom properties without artifactId uses package name",
+			pkg: &pkg.Package{
+				Name:    "fallback-name",
+				Version: "3.0",
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID: "org.fallback",
+						Version: "3.0",
+					},
+				},
+			},
+			expected: maven.NewID("org.fallback", "fallback-name", "3.0"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractMavenIDFromPackage(tt.pkg)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreateMainPkgRelationship_NoGraph(t *testing.T) {
+	parser := &archiveParser{
+		depth: 1,
+	}
+
+	mainPkg := &pkg.Package{Name: "child", Version: "1.0"}
+	parentPkg := &pkg.Package{Name: "parent", Version: "2.0"}
+
+	rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+
+	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+	assert.Nil(t, rel.Data)
+}
+
+func TestCreateMainPkgRelationship_DepthZero(t *testing.T) {
+	graph := NewDependencyGraph()
+	graph.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	graph.AddNode(maven.NewID("com.example", "child", "2.0"), "compile", graph.Root)
+
+	parser := &archiveParser{
+		depth:           0,
+		dependencyGraph: graph,
+	}
+
+	mainPkg := &pkg.Package{
+		Name:    "child",
+		Version: "2.0",
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "child",
+				Version:    "2.0",
+			},
+		},
+	}
+	parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+	rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+
+	// At depth=0, graph enrichment should NOT be applied (root level relationships don't need it)
+	assert.Nil(t, rel.Data)
+}
+
+func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	directNode := graph.AddNode(maven.NewID("com.example", "direct", "2.0"), "compile", root)
+	graph.AddNode(maven.NewID("com.example", "transitive", "3.0"), "runtime", directNode)
+
+	parser := &archiveParser{
+		depth:           1,
+		dependencyGraph: graph,
+	}
+
+	// Test direct dependency (depth=1 in graph → relDepth=0)
+	t.Run("direct dependency", func(t *testing.T) {
+		mainPkg := &pkg.Package{
+			Name:    "direct",
+			Version: "2.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "com.example",
+					ArtifactID: "direct",
+					Version:    "2.0",
+				},
+			},
+		}
+		parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 0, data.Depth)
+		assert.True(t, data.IsDirectDependency)
+		assert.Equal(t, "compile", data.Scope)
+		assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+	})
+
+	// Test transitive dependency (depth=2 in graph → relDepth=1)
+	t.Run("transitive dependency", func(t *testing.T) {
+		mainPkg := &pkg.Package{
+			Name:    "transitive",
+			Version: "3.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "com.example",
+					ArtifactID: "transitive",
+					Version:    "3.0",
+				},
+			},
+		}
+		parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 1, data.Depth)
+		assert.False(t, data.IsDirectDependency)
+		assert.Equal(t, "runtime", data.Scope)
+		assert.Equal(t, "com.example:direct:2.0", data.IntendedParentID)
+	})
+
+	// Test package not found in graph — no enrichment
+	t.Run("not found in graph", func(t *testing.T) {
+		mainPkg := &pkg.Package{
+			Name:    "unknown",
+			Version: "9.9",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "com.other",
+					ArtifactID: "unknown",
+					Version:    "9.9",
+				},
+			},
+		}
+		parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+		assert.Nil(t, rel.Data)
+	})
+}
+
+func TestCreateAuxPkgRelationship_NoGraph(t *testing.T) {
+	parser := &archiveParser{}
+
+	auxPkg := &pkg.Package{Name: "aux", Version: "1.0"}
+	mainPkg := &pkg.Package{Name: "main", Version: "2.0"}
+
+	rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+
+	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+	assert.Nil(t, rel.Data)
+}
+
+func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	directNode := graph.AddNode(maven.NewID("org.dep", "lib-a", "2.0"), "compile", root)
+	graph.AddNode(maven.NewID("org.dep", "lib-b", "3.0"), "runtime", directNode)
+
+	parser := &archiveParser{
+		dependencyGraph: graph,
+	}
+
+	t.Run("aux package found in graph as direct", func(t *testing.T) {
+		auxPkg := &pkg.Package{
+			Name:    "lib-a",
+			Version: "2.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "org.dep",
+					ArtifactID: "lib-a",
+					Version:    "2.0",
+				},
+			},
+		}
+		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 0, data.Depth)
+		assert.True(t, data.IsDirectDependency)
+		assert.Equal(t, "compile", data.Scope)
+		assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+	})
+
+	t.Run("aux package found in graph as transitive", func(t *testing.T) {
+		auxPkg := &pkg.Package{
+			Name:    "lib-b",
+			Version: "3.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "org.dep",
+					ArtifactID: "lib-b",
+					Version:    "3.0",
+				},
+			},
+		}
+		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+
+		require.NotNil(t, rel.Data)
+		data := rel.Data.(DependencyRelationshipData)
+		assert.Equal(t, 1, data.Depth)
+		assert.False(t, data.IsDirectDependency)
+		assert.Equal(t, "runtime", data.Scope)
+		assert.Equal(t, "org.dep:lib-a:2.0", data.IntendedParentID)
+	})
+
+	t.Run("aux package not in graph", func(t *testing.T) {
+		auxPkg := &pkg.Package{
+			Name:    "not-in-graph",
+			Version: "1.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "com.unknown",
+					ArtifactID: "not-in-graph",
+					Version:    "1.0",
+				},
+			},
+		}
+		mainPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+		rel := parser.createAuxPkgRelationship(auxPkg, mainPkg)
+		assert.Nil(t, rel.Data)
+	})
+}
+
+func TestCreateMainPkgRelationship_FlexibleMatch(t *testing.T) {
+	// Test that version mismatches are handled via flexible matching (Tier 2: groupId:artifactId)
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	graph.AddNode(maven.NewID("org.dep", "lib-a", "2.0"), "compile", root)
+
+	parser := &archiveParser{
+		depth:           1,
+		dependencyGraph: graph,
+	}
+
+	// Package has version 2.1 but graph has 2.0 — should match via groupId:artifactId
+	mainPkg := &pkg.Package{
+		Name:    "lib-a",
+		Version: "2.1",
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "org.dep",
+				ArtifactID: "lib-a",
+				Version:    "2.1",
+			},
+		},
+	}
+	parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+
+	rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+	require.NotNil(t, rel.Data)
+	data := rel.Data.(DependencyRelationshipData)
+	assert.Equal(t, 0, data.Depth)
+	assert.Equal(t, "compile", data.Scope)
+}
+
+func TestBuildGraphFromMavenTreeFile(t *testing.T) {
+	parser := &archiveParser{
+		cfg: ArchiveCatalogerConfig{
+			MavenDependencyTreeFile: "testdata/maven-dependency-tree.txt",
+		},
+	}
+
+	graph, err := parser.buildGraphFromMavenTreeFile()
+	require.NoError(t, err)
+	require.NotNil(t, graph)
+	assert.Equal(t, 16, graph.Size())
+	assert.Equal(t, "my-app", graph.Root.ID.ArtifactID)
+}
+
+func TestBuildGraphFromMavenTreeFile_NotFound(t *testing.T) {
+	parser := &archiveParser{
+		cfg: ArchiveCatalogerConfig{
+			MavenDependencyTreeFile: "testdata/nonexistent-file.txt",
+		},
+	}
+
+	graph, err := parser.buildGraphFromMavenTreeFile()
+	assert.Error(t, err)
+	assert.Nil(t, graph)
+}
+
+func TestBuildDependencyGraph_PriorityChain(t *testing.T) {
+	t.Run("maven tree file takes priority", func(t *testing.T) {
+		parser := &archiveParser{
+			cfg: ArchiveCatalogerConfig{
+				MavenDependencyTreeFile:    "testdata/maven-dependency-tree.txt",
+				UseEmbeddedPOMDependencies: true,
+			},
+		}
+
+		mainPkg := &pkg.Package{
+			Name:    "my-app",
+			Version: "1.0.0",
+			Metadata: pkg.JavaArchive{
+				PomProperties: &pkg.JavaPomProperties{
+					GroupID:    "com.example",
+					ArtifactID: "my-app",
+					Version:    "1.0.0",
+				},
+			},
+		}
+
+		parser.buildDependencyGraph(nil, mainPkg)
+
+		require.NotNil(t, parser.dependencyGraph)
+		// The fixture has 16 nodes, so if the tree file was used, we get 16
+		assert.Equal(t, 16, parser.dependencyGraph.Size())
+	})
+
+	t.Run("no graph when both features disabled", func(t *testing.T) {
+		parser := &archiveParser{
+			cfg: ArchiveCatalogerConfig{},
+		}
+
+		mainPkg := &pkg.Package{
+			Name:    "my-app",
+			Version: "1.0.0",
+			Metadata: pkg.JavaArchive{},
+		}
+
+		parser.buildDependencyGraph(nil, mainPkg)
+		assert.Nil(t, parser.dependencyGraph)
+	})
+
+	t.Run("graceful degradation on bad tree file with embedded POMs disabled", func(t *testing.T) {
+		parser := &archiveParser{
+			cfg: ArchiveCatalogerConfig{
+				MavenDependencyTreeFile:    "testdata/nonexistent-file.txt",
+				UseEmbeddedPOMDependencies: false,
+			},
+		}
+
+		mainPkg := &pkg.Package{
+			Name:    "my-app",
+			Version: "1.0.0",
+			Metadata: pkg.JavaArchive{},
+		}
+
+		parser.buildDependencyGraph(nil, mainPkg)
+		// No graph — tree file failed and embedded POMs disabled
+		assert.Nil(t, parser.dependencyGraph)
+	})
+}
+
+func TestDepthConversion(t *testing.T) {
+	// Verify the depth conversion: graph_depth - 1 = relationship_depth
+	// Graph: 0=root, 1=direct, 2=transitive
+	// Relationship: 0=direct, 1=first-level transitive
+
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	direct := graph.AddNode(maven.NewID("com.example", "direct", "2.0"), "compile", root)
+	graph.AddNode(maven.NewID("com.example", "transitive", "3.0"), "runtime", direct)
+
+	// Root: graph depth=0, should never create a relationship (it IS the root)
+	assert.Equal(t, 0, root.Depth)
+
+	// Direct: graph depth=1, relationship depth should be 0
+	directNode := graph.FindNode(maven.NewID("com.example", "direct", "2.0"))
+	require.NotNil(t, directNode)
+	relDepth := directNode.Depth - 1
+	assert.Equal(t, 0, relDepth)
+
+	// Transitive: graph depth=2, relationship depth should be 1
+	transitiveNode := graph.FindNode(maven.NewID("com.example", "transitive", "3.0"))
+	require.NotNil(t, transitiveNode)
+	relDepth = transitiveNode.Depth - 1
+	assert.Equal(t, 1, relDepth)
+}
+
+func TestBuildGraphFromMavenTreeFile_Integration(t *testing.T) {
+	// Integration test: parse the fixture and verify graph structure matches expectations
+	input := `com.example:root:jar:1.0
++- org.dep:direct-a:jar:2.0:compile
+|  \- org.dep:transitive-b:jar:3.0:runtime
+\- org.dep:direct-c:jar:4.0:test
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+
+	graph := tree.ToInternalGraph()
+	require.NotNil(t, graph)
+
+	// Verify the graph can be used for relationship creation
+	parser := &archiveParser{
+		depth:           1,
+		dependencyGraph: graph,
+	}
+
+	// Package "direct-a" should be found at depth 1
+	directPkg := &pkg.Package{
+		Name:    "direct-a",
+		Version: "2.0",
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "org.dep",
+				ArtifactID: "direct-a",
+				Version:    "2.0",
+			},
+		},
+	}
+	parentPkg := &pkg.Package{Name: "root", Version: "1.0"}
+	rel := parser.createMainPkgRelationship(directPkg, parentPkg)
+
+	require.NotNil(t, rel.Data)
+	data := rel.Data.(DependencyRelationshipData)
+	assert.Equal(t, 0, data.Depth)
+	assert.True(t, data.IsDirectDependency)
+	assert.Equal(t, "compile", data.Scope)
+	assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+
+	// Package "transitive-b" should be found at depth 2, parent = direct-a
+	transPkg := &pkg.Package{
+		Name:    "transitive-b",
+		Version: "3.0",
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "org.dep",
+				ArtifactID: "transitive-b",
+				Version:    "3.0",
+			},
+		},
+	}
+	rel = parser.createMainPkgRelationship(transPkg, parentPkg)
+
+	require.NotNil(t, rel.Data)
+	data = rel.Data.(DependencyRelationshipData)
+	assert.Equal(t, 1, data.Depth)
+	assert.False(t, data.IsDirectDependency)
+	assert.Equal(t, "runtime", data.Scope)
+	assert.Equal(t, "org.dep:direct-a:2.0", data.IntendedParentID)
+}

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -663,7 +663,7 @@ func TestParseNestedJar(t *testing.T) {
 			actual, _, err := gap.processJavaArchive(pkgtest.Context(t), file.LocationReadCloser{
 				Location:   file.NewLocation(fixture.Name()),
 				ReadCloser: fixture,
-			}, nil)
+			}, nil, 0, nil)
 			require.NoError(t, err)
 
 			expectedNameVersionPairSet := strset.New()

--- a/syft/pkg/cataloger/java/config.go
+++ b/syft/pkg/cataloger/java/config.go
@@ -33,6 +33,18 @@ type ArchiveCatalogerConfig struct {
 	// ResolveTransitiveDependencies enables resolving transitive dependencies for java packages found within archives.
 	// app-config: java.resolve-transitive-dependencies
 	ResolveTransitiveDependencies bool `yaml:"resolve-transitive-dependencies" json:"resolve-transitive-dependencies" mapstructure:"resolve-transitive-dependencies"`
+
+	// UseEmbeddedPOMDependencies enables building a dependency graph from embedded pom.xml files within JARs.
+	// When enabled, the <dependencies> sections of embedded POMs are used to determine hierarchical parent-child
+	// relationships instead of treating all dependencies as direct.
+	// app-config: java.use-embedded-pom-dependencies
+	UseEmbeddedPOMDependencies bool `yaml:"use-embedded-pom-dependencies" json:"use-embedded-pom-dependencies" mapstructure:"use-embedded-pom-dependencies"`
+
+	// MavenDependencyTreeFile specifies the path to a pre-generated Maven dependency tree file.
+	// Generate with: mvn dependency:tree -DoutputFile=dependency-tree.txt
+	// When provided, this takes priority over embedded POM analysis for building the dependency graph.
+	// app-config: java.maven-dependency-tree
+	MavenDependencyTreeFile string `yaml:"maven-dependency-tree" json:"maven-dependency-tree" mapstructure:"maven-dependency-tree"`
 }
 
 func DefaultArchiveCatalogerConfig() ArchiveCatalogerConfig {
@@ -45,6 +57,8 @@ func DefaultArchiveCatalogerConfig() ArchiveCatalogerConfig {
 		MavenBaseURL:                  strings.Join(mavenCfg.Repositories, ","),
 		MaxParentRecursiveDepth:       mavenCfg.MaxParentRecursiveDepth,
 		ResolveTransitiveDependencies: false,
+		UseEmbeddedPOMDependencies:    false,
+		MavenDependencyTreeFile:       "",
 	}
 }
 
@@ -78,6 +92,16 @@ func (j ArchiveCatalogerConfig) WithResolveTransitiveDependencies(resolveTransit
 func (j ArchiveCatalogerConfig) WithArchiveTraversal(search cataloging.ArchiveSearchConfig, maxDepth int) ArchiveCatalogerConfig {
 	j.MaxParentRecursiveDepth = maxDepth
 	j.ArchiveSearchConfig = search
+	return j
+}
+
+func (j ArchiveCatalogerConfig) WithUseEmbeddedPOMDependencies(input bool) ArchiveCatalogerConfig {
+	j.UseEmbeddedPOMDependencies = input
+	return j
+}
+
+func (j ArchiveCatalogerConfig) WithMavenDependencyTreeFile(input string) ArchiveCatalogerConfig {
+	j.MavenDependencyTreeFile = input
 	return j
 }
 

--- a/syft/pkg/cataloger/java/dependency_graph.go
+++ b/syft/pkg/cataloger/java/dependency_graph.go
@@ -1,0 +1,213 @@
+package java
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+const DefaultMaxDepth = 10
+
+type DependencyNode struct {
+	ID       maven.ID
+	Scope    string
+	Parent   *DependencyNode
+	Children []*DependencyNode
+	Depth    int
+}
+
+type DependencyGraph struct {
+	Root    *DependencyNode
+	NodeMap map[string]*DependencyNode
+}
+
+func NewDependencyGraph() *DependencyGraph {
+	return &DependencyGraph{
+		NodeMap: make(map[string]*DependencyNode),
+	}
+}
+
+func (g *DependencyGraph) SetRoot(id maven.ID) *DependencyNode {
+	key := mavenIDKey(id)
+	node := &DependencyNode{
+		ID:    id,
+		Depth: 0,
+	}
+	g.Root = node
+	g.NodeMap[key] = node
+	return node
+}
+
+func (g *DependencyGraph) AddNode(id maven.ID, scope string, parent *DependencyNode) *DependencyNode {
+	key := mavenIDKey(id)
+	if existing, ok := g.NodeMap[key]; ok {
+		return existing
+	}
+
+	depth := 0
+	if parent != nil {
+		depth = parent.Depth + 1
+	}
+
+	node := &DependencyNode{
+		ID:     id,
+		Scope:  scope,
+		Parent: parent,
+		Depth:  depth,
+	}
+
+	if parent != nil {
+		parent.Children = append(parent.Children, node)
+	}
+
+	g.NodeMap[key] = node
+	return node
+}
+
+func (g *DependencyGraph) FindNode(id maven.ID) *DependencyNode {
+	return g.NodeMap[mavenIDKey(id)]
+}
+
+// FindNodeFlexible performs 4-tier matching to handle version mismatches and groupId changes.
+func (g *DependencyGraph) FindNodeFlexible(id maven.ID) *DependencyNode {
+	key := mavenIDKey(id)
+
+	// Tier 1: exact match
+	if node, ok := g.NodeMap[key]; ok {
+		log.WithFields("mavenID", key, "matchType", "exact").Trace("dependency graph: found node")
+		return node
+	}
+
+	gaKey := id.GroupID + ":" + id.ArtifactID
+
+	// Tier 2: groupId:artifactId (ignore version)
+	for k, node := range g.NodeMap {
+		parts := strings.SplitN(k, ":", 3)
+		if len(parts) >= 2 && parts[0]+":"+parts[1] == gaKey {
+			log.WithFields("mavenID", key, "matchType", "groupId:artifactId", "matchedKey", k).Trace("dependency graph: found node")
+			return node
+		}
+	}
+
+	avKey := id.ArtifactID + ":" + id.Version
+
+	// Tier 3: artifactId:version (ignore groupId)
+	for k, node := range g.NodeMap {
+		parts := strings.SplitN(k, ":", 3)
+		if len(parts) == 3 && parts[1]+":"+parts[2] == avKey {
+			log.WithFields("mavenID", key, "matchType", "artifactId:version", "matchedKey", k).Trace("dependency graph: found node")
+			return node
+		}
+	}
+
+	// Tier 4: artifactId only
+	for k, node := range g.NodeMap {
+		parts := strings.SplitN(k, ":", 3)
+		if len(parts) >= 2 && parts[1] == id.ArtifactID {
+			log.WithFields("mavenID", key, "matchType", "artifactId", "matchedKey", k).Trace("dependency graph: found node")
+			return node
+		}
+	}
+
+	log.WithFields("mavenID", key).Trace("dependency graph: node not found")
+	return nil
+}
+
+// FindNodeByMavenID is the bridge for external packages using the exported MavenID type.
+func (g *DependencyGraph) FindNodeByMavenID(id MavenID) *DependencyNode {
+	return g.FindNodeFlexible(id.toInternalID())
+}
+
+func (g *DependencyGraph) Size() int {
+	return len(g.NodeMap)
+}
+
+// BuildFromPOMs builds the dependency graph by recursively walking embedded POMs.
+func (g *DependencyGraph) BuildFromPOMs(
+	ctx context.Context,
+	poms map[string]*maven.Project,
+	resolver *maven.Resolver,
+	rootID maven.ID,
+	resolveTransitive bool,
+	maxDepth int,
+) {
+	g.SetRoot(rootID)
+
+	rootPom := poms[mavenIDKey(rootID)]
+	if rootPom == nil && resolveTransitive {
+		var err error
+		rootPom, err = resolver.FindPom(ctx, rootID.GroupID, rootID.ArtifactID, rootID.Version)
+		if err != nil {
+			log.WithFields("error", err, "mavenID", mavenIDKey(rootID)).Debug("failed to find root POM for graph building")
+		}
+	}
+	if rootPom == nil {
+		return
+	}
+
+	visited := make(map[string]bool)
+	g.buildFromPOM(ctx, poms, resolver, rootPom, g.Root, visited, resolveTransitive, maxDepth, 0)
+}
+
+func (g *DependencyGraph) buildFromPOM(
+	ctx context.Context,
+	poms map[string]*maven.Project,
+	resolver *maven.Resolver,
+	pom *maven.Project,
+	parentNode *DependencyNode,
+	visited map[string]bool,
+	resolveTransitive bool,
+	maxDepth int,
+	currentDepth int,
+) {
+	if currentDepth >= maxDepth {
+		return
+	}
+
+	pomKey := mavenIDKey(resolver.ResolveID(ctx, pom))
+	if visited[pomKey] {
+		return
+	}
+	visited[pomKey] = true
+
+	for _, dep := range maven.DirectPomDependencies(pom) {
+		depID := resolver.ResolveDependencyID(ctx, pom, dep)
+		if !depID.Valid() {
+			continue
+		}
+
+		scope := resolver.ResolveProperty(ctx, pom, dep.Scope)
+
+		depKey := mavenIDKey(depID)
+		existing := g.NodeMap[depKey]
+		if existing != nil {
+			continue
+		}
+
+		depNode := g.AddNode(depID, scope, parentNode)
+
+		depPom := poms[depKey]
+		if depPom == nil && resolveTransitive {
+			var err error
+			depPom, err = resolver.FindPom(ctx, depID.GroupID, depID.ArtifactID, depID.Version)
+			if err != nil {
+				log.WithFields("error", err, "mavenID", depKey).Trace("failed to find dependency POM for graph building")
+			}
+		}
+		if depPom != nil {
+			branchVisited := make(map[string]bool, len(visited))
+			for k, v := range visited {
+				branchVisited[k] = v
+			}
+			g.buildFromPOM(ctx, poms, resolver, depPom, depNode, branchVisited, resolveTransitive, maxDepth, currentDepth+1)
+		}
+	}
+}
+
+// mavenIDKey returns a colon-separated key for use in the NodeMap.
+func mavenIDKey(id maven.ID) string {
+	return fmt.Sprintf("%s:%s:%s", id.GroupID, id.ArtifactID, id.Version)
+}

--- a/syft/pkg/cataloger/java/dependency_graph_test.go
+++ b/syft/pkg/cataloger/java/dependency_graph_test.go
@@ -2,6 +2,7 @@ package java
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -324,3 +325,28 @@ func strPtr(s string) *string {
 	return &s
 }
 
+func BenchmarkFindNodeFlexible(b *testing.B) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	for i := 0; i < 50; i++ {
+		directNode := g.AddNode(maven.NewID("org.dep", fmt.Sprintf("direct-%d", i), fmt.Sprintf("%d.0", i)), "compile", root)
+		for j := 0; j < 5; j++ {
+			g.AddNode(maven.NewID("org.dep", fmt.Sprintf("trans-%d-%d", i, j), fmt.Sprintf("%d.%d", i, j)), "compile", directNode)
+		}
+	}
+
+	lookups := make([]maven.ID, 0, 300)
+	for i := 0; i < 50; i++ {
+		for j := 0; j < 5; j++ {
+			lookups = append(lookups, maven.NewID("org.dep", fmt.Sprintf("trans-%d-%d", i, j), fmt.Sprintf("%d.%d", i, j)))
+		}
+		lookups = append(lookups, maven.NewID("org.dep", fmt.Sprintf("direct-%d", i), fmt.Sprintf("%d.0", i)))
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, id := range lookups {
+			g.FindNodeFlexible(id)
+		}
+	}
+}

--- a/syft/pkg/cataloger/java/dependency_graph_test.go
+++ b/syft/pkg/cataloger/java/dependency_graph_test.go
@@ -1,0 +1,326 @@
+package java
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+func TestDependencyGraph_SetRoot(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+
+	assert.NotNil(t, root)
+	assert.Equal(t, 0, root.Depth)
+	assert.Nil(t, root.Parent)
+	assert.Equal(t, g.Root, root)
+	assert.Equal(t, 1, g.Size())
+}
+
+func TestDependencyGraph_AddNode_WithParent(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+
+	child := g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+	assert.Equal(t, 1, child.Depth)
+	assert.Equal(t, "compile", child.Scope)
+	assert.Equal(t, root, child.Parent)
+	assert.Contains(t, root.Children, child)
+	assert.Equal(t, 2, g.Size())
+
+	grandchild := g.AddNode(maven.NewID("org.dep", "grandchild", "3.0"), "runtime", child)
+	assert.Equal(t, 2, grandchild.Depth)
+	assert.Equal(t, child, grandchild.Parent)
+}
+
+func TestDependencyGraph_AddNode_DuplicateReturnsExisting(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+
+	first := g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+	second := g.AddNode(maven.NewID("org.dep", "child", "2.0"), "runtime", root)
+
+	assert.Same(t, first, second)
+	assert.Equal(t, "compile", second.Scope) // keeps original scope
+	assert.Equal(t, 2, g.Size())
+}
+
+func TestDependencyGraph_AddNode_NilParent(t *testing.T) {
+	g := NewDependencyGraph()
+	node := g.AddNode(maven.NewID("com.example", "orphan", "1.0"), "compile", nil)
+	assert.Equal(t, 0, node.Depth)
+	assert.Nil(t, node.Parent)
+}
+
+func TestDependencyGraph_FindNode_ExactMatch(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+
+	found := g.FindNode(maven.NewID("org.dep", "child", "2.0"))
+	assert.NotNil(t, found)
+	assert.Equal(t, "child", found.ID.ArtifactID)
+
+	notFound := g.FindNode(maven.NewID("org.dep", "child", "9.9"))
+	assert.Nil(t, notFound)
+}
+
+func TestDependencyGraph_FindNodeFlexible_Tier1_Exact(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+
+	found := g.FindNodeFlexible(maven.NewID("org.dep", "child", "2.0"))
+	require.NotNil(t, found)
+	assert.Equal(t, "child", found.ID.ArtifactID)
+}
+
+func TestDependencyGraph_FindNodeFlexible_Tier2_GroupArtifact(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+
+	// version differs (BOM-managed)
+	found := g.FindNodeFlexible(maven.NewID("org.dep", "child", "3.5"))
+	require.NotNil(t, found)
+	assert.Equal(t, "2.0", found.ID.Version) // returns the graph's version
+}
+
+func TestDependencyGraph_FindNodeFlexible_Tier3_ArtifactVersion(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.ow2.asm", "asm", "9.0"), "compile", root)
+
+	// groupId changed (e.g., org.ow2.asm -> org.objectweb.asm)
+	found := g.FindNodeFlexible(maven.NewID("org.objectweb.asm", "asm", "9.0"))
+	require.NotNil(t, found)
+	assert.Equal(t, "org.ow2.asm", found.ID.GroupID)
+}
+
+func TestDependencyGraph_FindNodeFlexible_Tier4_ArtifactOnly(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.unique", "unique-lib", "1.0"), "compile", root)
+
+	// both groupId and version differ
+	found := g.FindNodeFlexible(maven.NewID("com.other", "unique-lib", "99.0"))
+	require.NotNil(t, found)
+	assert.Equal(t, "org.unique", found.ID.GroupID)
+}
+
+func TestDependencyGraph_FindNodeFlexible_NotFound(t *testing.T) {
+	g := NewDependencyGraph()
+	g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+
+	found := g.FindNodeFlexible(maven.NewID("org.nonexistent", "nope", "1.0"))
+	assert.Nil(t, found)
+}
+
+func TestDependencyGraph_FindNodeByMavenID(t *testing.T) {
+	g := NewDependencyGraph()
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	g.AddNode(maven.NewID("org.dep", "child", "2.0"), "compile", root)
+
+	found := g.FindNodeByMavenID(NewMavenID("org.dep", "child", "2.0"))
+	require.NotNil(t, found)
+	assert.Equal(t, "child", found.ID.ArtifactID)
+}
+
+func TestDependencyGraph_BuildFromPOMs_SimpleTree(t *testing.T) {
+	ctx := context.Background()
+
+	rootPom := &maven.Project{}
+	rootPom.GroupID = strPtr("com.example")
+	rootPom.ArtifactID = strPtr("root")
+	rootPom.Version = strPtr("1.0")
+	rootPom.Dependencies = &[]maven.Dependency{
+		{
+			GroupID:    strPtr("org.dep"),
+			ArtifactID: strPtr("child-a"),
+			Version:    strPtr("2.0"),
+			Scope:      strPtr("compile"),
+		},
+	}
+
+	childPom := &maven.Project{}
+	childPom.GroupID = strPtr("org.dep")
+	childPom.ArtifactID = strPtr("child-a")
+	childPom.Version = strPtr("2.0")
+	childPom.Dependencies = &[]maven.Dependency{
+		{
+			GroupID:    strPtr("org.transitive"),
+			ArtifactID: strPtr("trans-b"),
+			Version:    strPtr("3.0"),
+			Scope:      strPtr("runtime"),
+		},
+	}
+
+	poms := map[string]*maven.Project{
+		"com.example:root:1.0": rootPom,
+		"org.dep:child-a:2.0":  childPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+	g := NewDependencyGraph()
+	rootID := maven.NewID("com.example", "root", "1.0")
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, false, DefaultMaxDepth)
+
+	assert.Equal(t, 3, g.Size())
+
+	root := g.FindNode(rootID)
+	require.NotNil(t, root)
+	assert.Equal(t, 0, root.Depth)
+
+	childA := g.FindNode(maven.NewID("org.dep", "child-a", "2.0"))
+	require.NotNil(t, childA)
+	assert.Equal(t, 1, childA.Depth)
+	assert.Equal(t, "compile", childA.Scope)
+	assert.Equal(t, root, childA.Parent)
+
+	transB := g.FindNode(maven.NewID("org.transitive", "trans-b", "3.0"))
+	require.NotNil(t, transB)
+	assert.Equal(t, 2, transB.Depth)
+	assert.Equal(t, "runtime", transB.Scope)
+	assert.Equal(t, childA, transB.Parent)
+}
+
+func TestDependencyGraph_BuildFromPOMs_DiamondDependency(t *testing.T) {
+	ctx := context.Background()
+
+	// root -> A -> C, root -> B -> C
+	rootPom := &maven.Project{}
+	rootPom.GroupID = strPtr("com.example")
+	rootPom.ArtifactID = strPtr("root")
+	rootPom.Version = strPtr("1.0")
+	rootPom.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("a"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("b"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomA := &maven.Project{}
+	pomA.GroupID = strPtr("org.dep")
+	pomA.ArtifactID = strPtr("a")
+	pomA.Version = strPtr("1.0")
+	pomA.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.shared"), ArtifactID: strPtr("c"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomB := &maven.Project{}
+	pomB.GroupID = strPtr("org.dep")
+	pomB.ArtifactID = strPtr("b")
+	pomB.Version = strPtr("1.0")
+	pomB.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.shared"), ArtifactID: strPtr("c"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	poms := map[string]*maven.Project{
+		"com.example:root:1.0": rootPom,
+		"org.dep:a:1.0":        pomA,
+		"org.dep:b:1.0":        pomB,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, maven.NewID("com.example", "root", "1.0"), false, DefaultMaxDepth)
+
+	// C should appear once, first-wins (through A)
+	assert.Equal(t, 4, g.Size())
+
+	nodeC := g.FindNode(maven.NewID("org.shared", "c", "1.0"))
+	require.NotNil(t, nodeC)
+	assert.Equal(t, 2, nodeC.Depth)
+}
+
+func TestDependencyGraph_BuildFromPOMs_RespectsMaxDepth(t *testing.T) {
+	ctx := context.Background()
+
+	// root -> a -> b -> c (max depth = 2 should cut off c)
+	rootPom := &maven.Project{}
+	rootPom.GroupID = strPtr("com.example")
+	rootPom.ArtifactID = strPtr("root")
+	rootPom.Version = strPtr("1.0")
+	rootPom.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("a"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomA := &maven.Project{}
+	pomA.GroupID = strPtr("org.dep")
+	pomA.ArtifactID = strPtr("a")
+	pomA.Version = strPtr("1.0")
+	pomA.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("b"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomB := &maven.Project{}
+	pomB.GroupID = strPtr("org.dep")
+	pomB.ArtifactID = strPtr("b")
+	pomB.Version = strPtr("1.0")
+	pomB.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("c"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	poms := map[string]*maven.Project{
+		"com.example:root:1.0": rootPom,
+		"org.dep:a:1.0":        pomA,
+		"org.dep:b:1.0":        pomB,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, maven.NewID("com.example", "root", "1.0"), false, 2)
+
+	// root + a + b = 3 (c cut off at maxDepth=2)
+	assert.Equal(t, 3, g.Size())
+	assert.Nil(t, g.FindNode(maven.NewID("org.dep", "c", "1.0")))
+}
+
+func TestDependencyGraph_BuildFromPOMs_CycleDetection(t *testing.T) {
+	ctx := context.Background()
+
+	// root -> a -> b -> a (cycle)
+	rootPom := &maven.Project{}
+	rootPom.GroupID = strPtr("com.example")
+	rootPom.ArtifactID = strPtr("root")
+	rootPom.Version = strPtr("1.0")
+	rootPom.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("a"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomA := &maven.Project{}
+	pomA.GroupID = strPtr("org.dep")
+	pomA.ArtifactID = strPtr("a")
+	pomA.Version = strPtr("1.0")
+	pomA.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("b"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	pomB := &maven.Project{}
+	pomB.GroupID = strPtr("org.dep")
+	pomB.ArtifactID = strPtr("b")
+	pomB.Version = strPtr("1.0")
+	pomB.Dependencies = &[]maven.Dependency{
+		{GroupID: strPtr("org.dep"), ArtifactID: strPtr("a"), Version: strPtr("1.0"), Scope: strPtr("compile")},
+	}
+
+	poms := map[string]*maven.Project{
+		"com.example:root:1.0": rootPom,
+		"org.dep:a:1.0":        pomA,
+		"org.dep:b:1.0":        pomB,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, maven.NewID("com.example", "root", "1.0"), false, DefaultMaxDepth)
+
+	// Should complete without infinite loop: root + a + b = 3
+	assert.Equal(t, 3, g.Size())
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+

--- a/syft/pkg/cataloger/java/maven_id.go
+++ b/syft/pkg/cataloger/java/maven_id.go
@@ -1,0 +1,35 @@
+package java
+
+import (
+	"fmt"
+
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+// MavenID is an exported wrapper around the internal maven.ID type, allowing
+// packages outside the java cataloger to work with Maven coordinates.
+type MavenID struct {
+	GroupID    string
+	ArtifactID string
+	Version    string
+}
+
+func NewMavenID(groupID, artifactID, version string) MavenID {
+	return MavenID{
+		GroupID:    groupID,
+		ArtifactID: artifactID,
+		Version:    version,
+	}
+}
+
+func (m MavenID) String() string {
+	return fmt.Sprintf("%s:%s:%s", m.GroupID, m.ArtifactID, m.Version)
+}
+
+func (m MavenID) Valid() bool {
+	return m.GroupID != "" && m.ArtifactID != "" && m.Version != ""
+}
+
+func (m MavenID) toInternalID() maven.ID {
+	return maven.NewID(m.GroupID, m.ArtifactID, m.Version)
+}

--- a/syft/pkg/cataloger/java/maven_tree_parser.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser.go
@@ -1,0 +1,255 @@
+package java
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+// MavenTreeNode represents a single node in a parsed Maven dependency tree.
+type MavenTreeNode struct {
+	GroupID    string
+	ArtifactID string
+	Version    string
+	Packaging  string
+	Scope      string
+	Optional   bool
+	Parent     *MavenTreeNode
+	Children   []*MavenTreeNode
+	Depth      int
+}
+
+func (n *MavenTreeNode) id() maven.ID {
+	return maven.NewID(n.GroupID, n.ArtifactID, n.Version)
+}
+
+// MavenTree represents the full parsed Maven dependency tree.
+type MavenTree struct {
+	Root    *MavenTreeNode
+	NodeMap map[string]*MavenTreeNode
+}
+
+func newMavenTree() *MavenTree {
+	return &MavenTree{
+		NodeMap: make(map[string]*MavenTreeNode),
+	}
+}
+
+// ParseMavenDependencyTreeFile parses a Maven dependency tree from a file path.
+func ParseMavenDependencyTreeFile(filePath string) (*MavenTree, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open Maven dependency tree file: %w", err)
+	}
+	defer f.Close()
+	return ParseMavenDependencyTree(f)
+}
+
+// ParseMavenDependencyTree parses the text output of `mvn dependency:tree`.
+func ParseMavenDependencyTree(reader io.Reader) (*MavenTree, error) {
+	tree := newMavenTree()
+	var nodeStack []*MavenTreeNode
+
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if isMavenOutputNoise(line) {
+			continue
+		}
+
+		node := parseMavenTreeLine(line)
+		if node == nil {
+			continue
+		}
+
+		key := fmt.Sprintf("%s:%s:%s", node.GroupID, node.ArtifactID, node.Version)
+		tree.NodeMap[key] = node
+
+		if node.Depth == 0 {
+			tree.Root = node
+			nodeStack = []*MavenTreeNode{node}
+		} else {
+			// extend stack capacity if needed
+			for len(nodeStack) <= node.Depth {
+				nodeStack = append(nodeStack, nil)
+			}
+
+			parent := nodeStack[node.Depth-1]
+			if parent != nil {
+				node.Parent = parent
+				parent.Children = append(parent.Children, node)
+			}
+			nodeStack[node.Depth] = node
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading Maven dependency tree: %w", err)
+	}
+
+	if tree.Root == nil {
+		return nil, fmt.Errorf("no root node found in Maven dependency tree")
+	}
+
+	return tree, nil
+}
+
+// parseMavenTreeLine parses a single line from Maven dependency tree output.
+func parseMavenTreeLine(line string) *MavenTreeNode {
+	depth, coords := extractDepthAndCoordinates(line)
+	if coords == "" {
+		return nil
+	}
+
+	// strip annotations like "(scope managed from X.Y.Z)"
+	if idx := strings.Index(coords, " ("); idx != -1 {
+		suffix := coords[idx:]
+		if strings.Contains(suffix, "managed from") {
+			coords = coords[:idx]
+		}
+	}
+
+	// check and strip "(optional)" suffix
+	optional := false
+	if strings.HasSuffix(coords, " (optional)") {
+		optional = true
+		coords = strings.TrimSuffix(coords, " (optional)")
+	}
+
+	parts := strings.Split(coords, ":")
+	node := &MavenTreeNode{
+		Depth:    depth,
+		Optional: optional,
+	}
+
+	switch len(parts) {
+	case 4:
+		// root format: groupId:artifactId:packaging:version
+		node.GroupID = parts[0]
+		node.ArtifactID = parts[1]
+		node.Packaging = parts[2]
+		node.Version = parts[3]
+	case 5:
+		// standard: groupId:artifactId:packaging:version:scope
+		node.GroupID = parts[0]
+		node.ArtifactID = parts[1]
+		node.Packaging = parts[2]
+		node.Version = parts[3]
+		node.Scope = parts[4]
+	case 6:
+		// with classifier: groupId:artifactId:packaging:classifier:version:scope
+		node.GroupID = parts[0]
+		node.ArtifactID = parts[1]
+		node.Packaging = parts[2]
+		// parts[3] is classifier — not stored but consumed
+		node.Version = parts[4]
+		node.Scope = parts[5]
+	default:
+		return nil
+	}
+
+	if node.GroupID == "" || node.ArtifactID == "" || node.Version == "" {
+		return nil
+	}
+
+	return node
+}
+
+// extractDepthAndCoordinates parses tree-drawing characters to determine depth
+// and extracts the Maven coordinate string that follows.
+func extractDepthAndCoordinates(line string) (int, string) {
+	depth := 0
+	i := 0
+
+	for i < len(line) {
+		remaining := line[i:]
+
+		// child branch: "+- "
+		if strings.HasPrefix(remaining, "+- ") {
+			depth++
+			return depth, line[i+3:]
+		}
+
+		// last child: "\- "
+		if strings.HasPrefix(remaining, "\\- ") {
+			depth++
+			return depth, line[i+3:]
+		}
+
+		// continuation: "|  " (pipe + 2 spaces)
+		if strings.HasPrefix(remaining, "|  ") {
+			depth++
+			i += 3
+			continue
+		}
+
+		// spacing: "   " (3 spaces)
+		if strings.HasPrefix(remaining, "   ") {
+			depth++
+			i += 3
+			continue
+		}
+
+		// no tree prefix — this is a root node or unrecognized format
+		break
+	}
+
+	// if we consumed nothing, this is the root line (depth 0)
+	if i == 0 {
+		return 0, strings.TrimSpace(line)
+	}
+
+	// if we consumed some prefix but didn't hit "+- " or "\- ", skip the line
+	return depth, ""
+}
+
+// isMavenOutputNoise returns true for lines that are Maven console output, not tree data.
+func isMavenOutputNoise(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	prefixes := []string{
+		"[INFO]",
+		"[WARNING]",
+		"[ERROR]",
+		"[DEBUG]",
+		"---",
+		"Downloaded",
+		"Downloading",
+		"Progress",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(trimmed, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ToInternalGraph converts the parsed MavenTree into a DependencyGraph.
+func (t *MavenTree) ToInternalGraph() *DependencyGraph {
+	if t.Root == nil {
+		return NewDependencyGraph()
+	}
+
+	graph := NewDependencyGraph()
+	rootNode := graph.SetRoot(t.Root.id())
+	rootNode.Scope = t.Root.Scope
+
+	convertChildrenToGraph(t.Root, rootNode, graph)
+
+	return graph
+}
+
+func convertChildrenToGraph(treeNode *MavenTreeNode, graphParent *DependencyNode, graph *DependencyGraph) {
+	for _, child := range treeNode.Children {
+		graphChild := graph.AddNode(child.id(), child.Scope, graphParent)
+		convertChildrenToGraph(child, graphChild, graph)
+	}
+}

--- a/syft/pkg/cataloger/java/maven_tree_parser.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser.go
@@ -233,6 +233,9 @@ func isMavenOutputNoise(line string) bool {
 		"Downloading",
 		"Progress",
 		"BUILD",
+		"Finished",
+		"Total time",
+		"Building ",
 	}
 	for _, p := range prefixes {
 		if strings.HasPrefix(trimmed, p) {

--- a/syft/pkg/cataloger/java/maven_tree_parser.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser.go
@@ -56,7 +56,7 @@ func ParseMavenDependencyTree(reader io.Reader) (*MavenTree, error) {
 
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := stripMavenLogPrefix(scanner.Text())
 
 		if strings.TrimSpace(line) == "" {
 			continue
@@ -211,18 +211,28 @@ func extractDepthAndCoordinates(line string) (int, string) {
 	return depth, ""
 }
 
+// stripMavenLogPrefix removes a leading Maven log-level prefix such as "[INFO] "
+// from a line so the remaining content can be parsed as tree data.
+func stripMavenLogPrefix(line string) string {
+	trimmed := strings.TrimSpace(line)
+	for _, prefix := range []string{"[INFO] ", "[WARNING] ", "[ERROR] ", "[DEBUG] "} {
+		if strings.HasPrefix(trimmed, prefix) {
+			return trimmed[len(prefix):]
+		}
+	}
+	return line
+}
+
 // isMavenOutputNoise returns true for lines that are Maven console output, not tree data.
+// It expects the log-level prefix (e.g. "[INFO] ") to already be stripped.
 func isMavenOutputNoise(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	prefixes := []string{
-		"[INFO]",
-		"[WARNING]",
-		"[ERROR]",
-		"[DEBUG]",
 		"---",
 		"Downloaded",
 		"Downloading",
 		"Progress",
+		"BUILD",
 	}
 	for _, p := range prefixes {
 		if strings.HasPrefix(trimmed, p) {

--- a/syft/pkg/cataloger/java/maven_tree_parser_test.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser_test.go
@@ -1,0 +1,355 @@
+package java
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMavenTreeLine_RootNode(t *testing.T) {
+	node := parseMavenTreeLine("com.example:my-app:jar:1.0.0")
+	require.NotNil(t, node)
+	assert.Equal(t, "com.example", node.GroupID)
+	assert.Equal(t, "my-app", node.ArtifactID)
+	assert.Equal(t, "jar", node.Packaging)
+	assert.Equal(t, "1.0.0", node.Version)
+	assert.Empty(t, node.Scope)
+	assert.Equal(t, 0, node.Depth)
+}
+
+func TestParseMavenTreeLine_DirectDependency(t *testing.T) {
+	node := parseMavenTreeLine("+- org.springframework:spring-core:jar:5.3.0:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "org.springframework", node.GroupID)
+	assert.Equal(t, "spring-core", node.ArtifactID)
+	assert.Equal(t, "jar", node.Packaging)
+	assert.Equal(t, "5.3.0", node.Version)
+	assert.Equal(t, "compile", node.Scope)
+	assert.Equal(t, 1, node.Depth)
+}
+
+func TestParseMavenTreeLine_NestedDependency(t *testing.T) {
+	node := parseMavenTreeLine("|  +- org.springframework:spring-jcl:jar:5.3.0:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "spring-jcl", node.ArtifactID)
+	assert.Equal(t, "compile", node.Scope)
+	assert.Equal(t, 2, node.Depth)
+}
+
+func TestParseMavenTreeLine_LastChild(t *testing.T) {
+	node := parseMavenTreeLine("|  \\- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "jakarta.annotation-api", node.ArtifactID)
+	assert.Equal(t, 2, node.Depth)
+}
+
+func TestParseMavenTreeLine_DeepNesting(t *testing.T) {
+	// 4 levels deep: |  |  |  \-
+	node := parseMavenTreeLine("|  |  |  \\- org.ow2.asm:asm-commons:jar:9.6:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "asm-commons", node.ArtifactID)
+	assert.Equal(t, 4, node.Depth)
+}
+
+func TestParseMavenTreeLine_WithClassifier(t *testing.T) {
+	node := parseMavenTreeLine("+- io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.100:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "io.netty", node.GroupID)
+	assert.Equal(t, "netty-transport-native-epoll", node.ArtifactID)
+	assert.Equal(t, "jar", node.Packaging)
+	assert.Equal(t, "4.1.100", node.Version)
+	assert.Equal(t, "compile", node.Scope)
+	assert.Equal(t, 1, node.Depth)
+}
+
+func TestParseMavenTreeLine_Optional(t *testing.T) {
+	node := parseMavenTreeLine("+- com.google.code.findbugs:jsr305:jar:3.0.2:compile (optional)")
+	require.NotNil(t, node)
+	assert.Equal(t, "jsr305", node.ArtifactID)
+	assert.Equal(t, "3.0.2", node.Version)
+	assert.Equal(t, "compile", node.Scope)
+	assert.True(t, node.Optional)
+}
+
+func TestParseMavenTreeLine_ManagedScope(t *testing.T) {
+	node := parseMavenTreeLine("|  +- commons-io:commons-io:jar:2.11.0:compile (scope managed from runtime)")
+	require.NotNil(t, node)
+	assert.Equal(t, "commons-io", node.ArtifactID)
+	assert.Equal(t, "2.11.0", node.Version)
+	assert.Equal(t, "compile", node.Scope)
+	assert.False(t, node.Optional)
+}
+
+func TestParseMavenTreeLine_PomPackaging(t *testing.T) {
+	node := parseMavenTreeLine("+- org.springframework.boot:spring-boot-starter:pom:3.5.9:compile")
+	require.NotNil(t, node)
+	assert.Equal(t, "pom", node.Packaging)
+	assert.Equal(t, "spring-boot-starter", node.ArtifactID)
+}
+
+func TestParseMavenTreeLine_Malformed(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{"too few parts", "+- groupId:artifactId"},
+		{"too many parts", "+- a:b:c:d:e:f:g"},
+		{"empty groupId", "+- :artifactId:jar:1.0:compile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := parseMavenTreeLine(tt.line)
+			assert.Nil(t, node)
+		})
+	}
+}
+
+func TestIsMavenOutputNoise(t *testing.T) {
+	noiseLines := []string{
+		"[INFO] --- dependency:3.6.0:tree (default-cli) @ my-app ---",
+		"[WARNING] Some warning",
+		"[ERROR] Some error",
+		"[DEBUG] Debug output",
+		"--- maven-dependency-plugin:3.6.0:tree ---",
+		"Downloaded from central: https://repo.maven.apache.org/...",
+		"Downloading from central: https://repo.maven.apache.org/...",
+		"Progress (1): some-artifact.pom",
+	}
+	for _, line := range noiseLines {
+		assert.True(t, isMavenOutputNoise(line), "expected noise: %s", line)
+	}
+
+	validLines := []string{
+		"com.example:my-app:jar:1.0.0",
+		"+- org.dep:child:jar:2.0:compile",
+		"|  \\- org.dep:grandchild:jar:3.0:runtime",
+	}
+	for _, line := range validLines {
+		assert.False(t, isMavenOutputNoise(line), "expected NOT noise: %s", line)
+	}
+}
+
+func TestExtractDepthAndCoordinates(t *testing.T) {
+	tests := []struct {
+		line          string
+		expectedDepth int
+		expectedCoord string
+	}{
+		{
+			"com.example:my-app:jar:1.0.0",
+			0,
+			"com.example:my-app:jar:1.0.0",
+		},
+		{
+			"+- org.dep:child:jar:2.0:compile",
+			1,
+			"org.dep:child:jar:2.0:compile",
+		},
+		{
+			"\\- org.dep:last:jar:2.0:compile",
+			1,
+			"org.dep:last:jar:2.0:compile",
+		},
+		{
+			"|  +- org.dep:nested:jar:3.0:compile",
+			2,
+			"org.dep:nested:jar:3.0:compile",
+		},
+		{
+			"|  \\- org.dep:nested-last:jar:3.0:compile",
+			2,
+			"org.dep:nested-last:jar:3.0:compile",
+		},
+		{
+			"|  |  +- org.dep:deep:jar:4.0:compile",
+			3,
+			"org.dep:deep:jar:4.0:compile",
+		},
+		{
+			"   \\- org.dep:spaced:jar:2.0:compile",
+			2,
+			"org.dep:spaced:jar:2.0:compile",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			depth, coords := extractDepthAndCoordinates(tt.line)
+			assert.Equal(t, tt.expectedDepth, depth)
+			assert.Equal(t, tt.expectedCoord, coords)
+		})
+	}
+}
+
+func TestParseMavenDependencyTree_FullTree(t *testing.T) {
+	input := `com.example:my-app:jar:1.0.0
++- org.springframework:spring-core:jar:5.3.0:compile
+|  \- org.springframework:spring-jcl:jar:5.3.0:compile
++- com.fasterxml.jackson.core:jackson-databind:jar:2.13.0:compile
+|  +- com.fasterxml.jackson.core:jackson-core:jar:2.13.0:compile
+|  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.0:compile
+\- org.junit.jupiter:junit-jupiter:jar:5.8.0:test
+   \- org.junit.jupiter:junit-jupiter-api:jar:5.8.0:test
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, tree.Root)
+
+	// root
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Equal(t, 0, tree.Root.Depth)
+	assert.Nil(t, tree.Root.Parent)
+	assert.Len(t, tree.Root.Children, 3)
+
+	// direct deps
+	springCore := tree.Root.Children[0]
+	assert.Equal(t, "spring-core", springCore.ArtifactID)
+	assert.Equal(t, 1, springCore.Depth)
+	assert.Equal(t, "compile", springCore.Scope)
+	assert.Equal(t, tree.Root, springCore.Parent)
+	assert.Len(t, springCore.Children, 1)
+
+	// transitive
+	springJcl := springCore.Children[0]
+	assert.Equal(t, "spring-jcl", springJcl.ArtifactID)
+	assert.Equal(t, 2, springJcl.Depth)
+	assert.Equal(t, springCore, springJcl.Parent)
+
+	// jackson-databind with 2 children
+	databind := tree.Root.Children[1]
+	assert.Equal(t, "jackson-databind", databind.ArtifactID)
+	assert.Len(t, databind.Children, 2)
+
+	// test scope last child
+	junit := tree.Root.Children[2]
+	assert.Equal(t, "junit-jupiter", junit.ArtifactID)
+	assert.Equal(t, "test", junit.Scope)
+	assert.Len(t, junit.Children, 1)
+
+	// total nodes
+	assert.Len(t, tree.NodeMap, 8)
+}
+
+func TestParseMavenDependencyTree_EmptyInput(t *testing.T) {
+	_, err := ParseMavenDependencyTree(strings.NewReader(""))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no root node found")
+}
+
+func TestParseMavenDependencyTree_OnlyNoise(t *testing.T) {
+	input := `[INFO] --- dependency:3.6.0:tree ---
+[INFO]
+[INFO] BUILD SUCCESS
+`
+	_, err := ParseMavenDependencyTree(strings.NewReader(input))
+	assert.Error(t, err)
+}
+
+func TestParseMavenDependencyTree_WithNoiseLines(t *testing.T) {
+	input := `[INFO] --- dependency:3.6.0:tree ---
+com.example:my-app:jar:1.0.0
+[INFO]
++- org.dep:child:jar:2.0:compile
+[INFO] BUILD SUCCESS
+`
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Len(t, tree.Root.Children, 1)
+}
+
+func TestParseMavenDependencyTreeFile(t *testing.T) {
+	tree, err := ParseMavenDependencyTreeFile("testdata/maven-dependency-tree.txt")
+	require.NoError(t, err)
+	require.NotNil(t, tree.Root)
+
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Equal(t, "com.example", tree.Root.GroupID)
+	assert.Equal(t, "1.0.0", tree.Root.Version)
+
+	// 5 direct deps: spring-boot-starter, jackson-databind, spring-core, micrometer-core, junit-jupiter
+	assert.Len(t, tree.Root.Children, 5)
+
+	// deepest node: junit-platform-engine at depth 3
+	engine := tree.NodeMap["org.junit.platform:junit-platform-engine:1.11.6"]
+	require.NotNil(t, engine)
+	assert.Equal(t, 3, engine.Depth)
+	assert.Equal(t, "test", engine.Scope)
+
+	// total nodes in fixture
+	assert.Len(t, tree.NodeMap, 16)
+}
+
+func TestParseMavenDependencyTreeFile_NotFound(t *testing.T) {
+	_, err := ParseMavenDependencyTreeFile("testdata/nonexistent-file.txt")
+	assert.Error(t, err)
+}
+
+func TestMavenTree_ToInternalGraph(t *testing.T) {
+	input := `com.example:root:jar:1.0
++- org.dep:direct-a:jar:2.0:compile
+|  \- org.dep:transitive-b:jar:3.0:runtime
+\- org.dep:direct-c:jar:4.0:test
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+
+	graph := tree.ToInternalGraph()
+	require.NotNil(t, graph)
+	assert.Equal(t, 4, graph.Size())
+
+	// root at depth 0
+	root := graph.Root
+	require.NotNil(t, root)
+	assert.Equal(t, "root", root.ID.ArtifactID)
+	assert.Equal(t, 0, root.Depth)
+
+	// direct-a at depth 1
+	directA := graph.FindNode(tree.Root.Children[0].id())
+	require.NotNil(t, directA)
+	assert.Equal(t, 1, directA.Depth)
+	assert.Equal(t, "compile", directA.Scope)
+	assert.Equal(t, root, directA.Parent)
+
+	// transitive-b at depth 2
+	transB := graph.FindNode(tree.Root.Children[0].Children[0].id())
+	require.NotNil(t, transB)
+	assert.Equal(t, 2, transB.Depth)
+	assert.Equal(t, "runtime", transB.Scope)
+	assert.Equal(t, directA, transB.Parent)
+
+	// direct-c at depth 1
+	directC := graph.FindNode(tree.Root.Children[1].id())
+	require.NotNil(t, directC)
+	assert.Equal(t, 1, directC.Depth)
+	assert.Equal(t, "test", directC.Scope)
+}
+
+func TestMavenTree_ToInternalGraph_EmptyRoot(t *testing.T) {
+	tree := &MavenTree{}
+	graph := tree.ToInternalGraph()
+	assert.NotNil(t, graph)
+	assert.Equal(t, 0, graph.Size())
+}
+
+func BenchmarkParseMavenDependencyTree(b *testing.B) {
+	// build a moderately sized tree input (~100 nodes)
+	var sb strings.Builder
+	sb.WriteString("com.example:root:jar:1.0.0\n")
+	for i := 0; i < 20; i++ {
+		sb.WriteString(fmt.Sprintf("+- org.dep:direct-%d:jar:%d.0:compile\n", i, i))
+		for j := 0; j < 4; j++ {
+			sb.WriteString(fmt.Sprintf("|  +- org.dep:trans-%d-%d:jar:%d.%d:compile\n", i, j, i, j))
+		}
+	}
+	input := sb.String()
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = ParseMavenDependencyTree(strings.NewReader(input))
+	}
+}

--- a/syft/pkg/cataloger/java/maven_tree_parser_test.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser_test.go
@@ -116,6 +116,9 @@ func TestIsMavenOutputNoise(t *testing.T) {
 		"Progress (1): some-artifact.pom",
 		"BUILD SUCCESS",
 		"BUILD FAILURE",
+		"Finished at: 2026-04-18T13:19:27-04:00",
+		"Total time:  1.430 s",
+		"Building my-app 1.0.0-SNAPSHOT",
 	}
 	for _, line := range noiseLines {
 		assert.True(t, isMavenOutputNoise(line), "expected noise: %s", line)
@@ -354,6 +357,43 @@ func TestParseMavenDependencyTreeFile(t *testing.T) {
 
 	// total nodes in fixture
 	assert.Len(t, tree.NodeMap, 16)
+}
+
+func TestParseMavenDependencyTree_FullMavenOutputWithBannerAndFooter(t *testing.T) {
+	// Simulates raw `mvn dependency:tree` output with banner, [INFO] prefixes, and footer.
+	// This reproduces a bug where "Finished at: <timestamp>" was parsed as a depth=0 node
+	// because the timestamp's colons matched the groupId:artifactId:packaging:version:scope format.
+	input := `[INFO] -------------< com.example:my-app >-------------
+[INFO] Building my-app 1.0.0
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO]
+[INFO] --- dependency:3.7.0:tree (default-cli) @ my-app ---
+[INFO] com.example:my-app:jar:1.0.0
+[INFO] +- org.springframework:spring-core:jar:5.3.0:compile
+[INFO] |  \- org.springframework:spring-jcl:jar:5.3.0:compile
+[INFO] \- com.fasterxml.jackson.core:jackson-databind:jar:2.13.0:compile
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  1.430 s
+[INFO] Finished at: 2026-04-18T13:19:27-04:00
+[INFO] ------------------------------------------------------------------------
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, tree.Root)
+
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Equal(t, "com.example", tree.Root.GroupID)
+	assert.Equal(t, "1.0.0", tree.Root.Version)
+	assert.Len(t, tree.Root.Children, 2)
+	assert.Len(t, tree.NodeMap, 4)
+
+	springCore := tree.Root.Children[0]
+	assert.Equal(t, "spring-core", springCore.ArtifactID)
+	assert.Len(t, springCore.Children, 1)
 }
 
 func TestParseMavenDependencyTreeFile_NotFound(t *testing.T) {

--- a/syft/pkg/cataloger/java/maven_tree_parser_test.go
+++ b/syft/pkg/cataloger/java/maven_tree_parser_test.go
@@ -108,15 +108,14 @@ func TestParseMavenTreeLine_Malformed(t *testing.T) {
 }
 
 func TestIsMavenOutputNoise(t *testing.T) {
+	// isMavenOutputNoise expects log-level prefixes to already be stripped
 	noiseLines := []string{
-		"[INFO] --- dependency:3.6.0:tree (default-cli) @ my-app ---",
-		"[WARNING] Some warning",
-		"[ERROR] Some error",
-		"[DEBUG] Debug output",
-		"--- maven-dependency-plugin:3.6.0:tree ---",
+		"--- dependency:3.6.0:tree (default-cli) @ my-app ---",
 		"Downloaded from central: https://repo.maven.apache.org/...",
 		"Downloading from central: https://repo.maven.apache.org/...",
 		"Progress (1): some-artifact.pom",
+		"BUILD SUCCESS",
+		"BUILD FAILURE",
 	}
 	for _, line := range noiseLines {
 		assert.True(t, isMavenOutputNoise(line), "expected noise: %s", line)
@@ -247,7 +246,6 @@ func TestParseMavenDependencyTree_OnlyNoise(t *testing.T) {
 	_, err := ParseMavenDependencyTree(strings.NewReader(input))
 	assert.Error(t, err)
 }
-
 func TestParseMavenDependencyTree_WithNoiseLines(t *testing.T) {
 	input := `[INFO] --- dependency:3.6.0:tree ---
 com.example:my-app:jar:1.0.0
@@ -259,6 +257,81 @@ com.example:my-app:jar:1.0.0
 	require.NoError(t, err)
 	assert.Equal(t, "my-app", tree.Root.ArtifactID)
 	assert.Len(t, tree.Root.Children, 1)
+}
+
+func TestParseMavenDependencyTree_WithInfoPrefix(t *testing.T) {
+	input := `[INFO] com.example:my-app:jar:1.0.0
+[INFO] +- org.springframework:spring-core:jar:5.3.0:compile
+[INFO] |  \- org.springframework:spring-jcl:jar:5.3.0:compile
+[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.0:compile
+[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.13.0:compile
+[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.0:compile
+[INFO] \- org.junit.jupiter:junit-jupiter:jar:5.8.0:test
+[INFO]    \- org.junit.jupiter:junit-jupiter-api:jar:5.8.0:test
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, tree.Root)
+
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Equal(t, "com.example", tree.Root.GroupID)
+	assert.Len(t, tree.Root.Children, 3)
+
+	springCore := tree.Root.Children[0]
+	assert.Equal(t, "spring-core", springCore.ArtifactID)
+	assert.Equal(t, 1, springCore.Depth)
+	assert.Len(t, springCore.Children, 1)
+
+	springJcl := springCore.Children[0]
+	assert.Equal(t, "spring-jcl", springJcl.ArtifactID)
+	assert.Equal(t, 2, springJcl.Depth)
+
+	junit := tree.Root.Children[2]
+	assert.Equal(t, "junit-jupiter", junit.ArtifactID)
+	assert.Equal(t, "test", junit.Scope)
+	assert.Len(t, junit.Children, 1)
+
+	assert.Len(t, tree.NodeMap, 8)
+}
+
+func TestParseMavenDependencyTree_WithInfoPrefixAndNoise(t *testing.T) {
+	input := `[INFO] --- dependency:3.6.0:tree (default-cli) @ my-app ---
+[INFO] com.example:my-app:jar:1.0.0
+[INFO] +- org.dep:child-a:jar:2.0:compile
+[INFO] |  \- org.dep:transitive-b:jar:3.0:runtime
+[INFO] \- org.dep:child-c:jar:4.0:test
+[INFO] BUILD SUCCESS
+`
+
+	tree, err := ParseMavenDependencyTree(strings.NewReader(input))
+	require.NoError(t, err)
+	require.NotNil(t, tree.Root)
+
+	assert.Equal(t, "my-app", tree.Root.ArtifactID)
+	assert.Len(t, tree.Root.Children, 2)
+	assert.Len(t, tree.NodeMap, 4)
+}
+
+func TestStripMavenLogPrefix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"[INFO] com.example:my-app:jar:1.0.0", "com.example:my-app:jar:1.0.0"},
+		{"[INFO] +- org.dep:child:jar:2.0:compile", "+- org.dep:child:jar:2.0:compile"},
+		{"[INFO] |  \\- org.dep:grandchild:jar:3.0:runtime", "|  \\- org.dep:grandchild:jar:3.0:runtime"},
+		{"[WARNING] Some warning", "Some warning"},
+		{"[ERROR] Some error", "Some error"},
+		{"[DEBUG] Debug output", "Debug output"},
+		{"com.example:my-app:jar:1.0.0", "com.example:my-app:jar:1.0.0"},
+		{"+- org.dep:child:jar:2.0:compile", "+- org.dep:child:jar:2.0:compile"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, stripMavenLogPrefix(tt.input))
+		})
+	}
 }
 
 func TestParseMavenDependencyTreeFile(t *testing.T) {

--- a/syft/pkg/cataloger/java/relationship_metadata.go
+++ b/syft/pkg/cataloger/java/relationship_metadata.go
@@ -1,0 +1,27 @@
+package java
+
+// DependencyRelationshipData carries hierarchical dependency information through the
+// deferred parent resolution pipeline. Stored in artifact.Relationship.Data.
+type DependencyRelationshipData struct {
+	Depth              int    `json:"depth"`
+	Scope              string `json:"scope,omitempty"`
+	IsDirectDependency bool   `json:"isDirectDependency"`
+	IntendedParentID   string `json:"intendedParentId,omitempty"`
+}
+
+func NewDependencyRelationshipData(depth int, scope string) DependencyRelationshipData {
+	return DependencyRelationshipData{
+		Depth:              depth,
+		Scope:              scope,
+		IsDirectDependency: depth == 0,
+	}
+}
+
+func NewDependencyRelationshipDataWithParent(depth int, scope string, intendedParentID string) DependencyRelationshipData {
+	return DependencyRelationshipData{
+		Depth:              depth,
+		Scope:              scope,
+		IsDirectDependency: depth == 0,
+		IntendedParentID:   intendedParentID,
+	}
+}

--- a/syft/pkg/cataloger/java/relationship_metadata_test.go
+++ b/syft/pkg/cataloger/java/relationship_metadata_test.go
@@ -1,0 +1,58 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDependencyRelationshipData_DirectDependency(t *testing.T) {
+	data := NewDependencyRelationshipData(0, "compile")
+	assert.Equal(t, 0, data.Depth)
+	assert.Equal(t, "compile", data.Scope)
+	assert.True(t, data.IsDirectDependency)
+	assert.Empty(t, data.IntendedParentID)
+}
+
+func TestNewDependencyRelationshipData_TransitiveDependency(t *testing.T) {
+	data := NewDependencyRelationshipData(1, "runtime")
+	assert.Equal(t, 1, data.Depth)
+	assert.Equal(t, "runtime", data.Scope)
+	assert.False(t, data.IsDirectDependency)
+	assert.Empty(t, data.IntendedParentID)
+}
+
+func TestNewDependencyRelationshipData_DeepTransitive(t *testing.T) {
+	data := NewDependencyRelationshipData(5, "test")
+	assert.Equal(t, 5, data.Depth)
+	assert.Equal(t, "test", data.Scope)
+	assert.False(t, data.IsDirectDependency)
+}
+
+func TestNewDependencyRelationshipDataWithParent(t *testing.T) {
+	data := NewDependencyRelationshipDataWithParent(2, "compile", "org.springframework:spring-core:5.3.0")
+	assert.Equal(t, 2, data.Depth)
+	assert.Equal(t, "compile", data.Scope)
+	assert.False(t, data.IsDirectDependency)
+	assert.Equal(t, "org.springframework:spring-core:5.3.0", data.IntendedParentID)
+}
+
+func TestNewDependencyRelationshipDataWithParent_DirectWithParent(t *testing.T) {
+	data := NewDependencyRelationshipDataWithParent(0, "compile", "com.example:root:1.0")
+	assert.True(t, data.IsDirectDependency)
+	assert.Equal(t, "com.example:root:1.0", data.IntendedParentID)
+}
+
+func TestDependencyRelationshipData_ZeroValue(t *testing.T) {
+	var data DependencyRelationshipData
+	assert.Equal(t, 0, data.Depth)
+	assert.Empty(t, data.Scope)
+	assert.False(t, data.IsDirectDependency)
+	assert.Empty(t, data.IntendedParentID)
+}
+
+func TestNewDependencyRelationshipData_EmptyScope(t *testing.T) {
+	data := NewDependencyRelationshipData(0, "")
+	assert.True(t, data.IsDirectDependency)
+	assert.Empty(t, data.Scope)
+}

--- a/syft/pkg/cataloger/java/tar_wrapped_archive_parser.go
+++ b/syft/pkg/cataloger/java/tar_wrapped_archive_parser.go
@@ -80,5 +80,5 @@ func discoverPkgsFromTar(ctx context.Context, location file.Location, archivePat
 		return nil, nil, fmt.Errorf("unable to extract files from tar: %w", err)
 	}
 
-	return discoverPkgsFromOpeners(ctx, location, openers, nil, cfg)
+	return discoverPkgsFromOpeners(ctx, location, openers, nil, cfg, 0, nil)
 }

--- a/syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt
+++ b/syft/pkg/cataloger/java/testdata/maven-dependency-tree.txt
@@ -1,0 +1,16 @@
+com.example:my-app:jar:1.0.0
++- org.springframework.boot:spring-boot-starter:pom:3.5.9:compile
+|  +- org.springframework.boot:spring-boot:jar:3.5.9:compile
+|  \- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
++- com.fasterxml.jackson.core:jackson-databind:jar:2.19.4:compile
+|  +- com.fasterxml.jackson.core:jackson-core:jar:2.19.4:compile
+|  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.19.4:compile
++- org.springframework:spring-core:jar:6.2.15:compile
+|  \- org.springframework:spring-jcl:jar:6.2.15:compile
++- io.micrometer:micrometer-core:jar:1.15.7:compile
+|  +- org.hdrhistogram:HdrHistogram:jar:2.2.2:runtime
+|  \- org.latencyutils:LatencyUtils:jar:2.0.3:runtime
+\- org.junit.jupiter:junit-jupiter:jar:5.11.6:test
+   +- org.junit.jupiter:junit-jupiter-api:jar:5.11.6:test
+   \- org.junit.jupiter:junit-jupiter-engine:jar:5.11.6:test
+      \- org.junit.platform:junit-platform-engine:jar:1.11.6:test

--- a/syft/pkg/cataloger/java/zip_wrapped_archive_parser.go
+++ b/syft/pkg/cataloger/java/zip_wrapped_archive_parser.go
@@ -52,5 +52,5 @@ func (gzp genericZipWrappedJavaArchiveParser) parseZipWrappedJavaArchive(ctx con
 	}
 
 	// look for java archives within the zip archive
-	return discoverPkgsFromZip(ctx, reader.Location, archivePath, contentPath, fileManifest, nil, gzp.cfg)
+	return discoverPkgsFromZip(ctx, reader.Location, archivePath, contentPath, fileManifest, nil, gzp.cfg, 0, nil)
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes along with any relevant motivation and context -->
This PR adds hierarchical dependency graph resolution for Java archives, replacing the current flat model where all nested JARs are treated as direct dependencies. The feature is opt-in via two new configuration options and is off by default, ensuring zero behavioral change for existing users.

## The Problem: 

When Syft catalogs a Java archive (e.g., a Spring Boot fat JAR), every nested JAR gets a dependency-of relationship pointing directly to the root archive. There's no way to distinguish direct vs. transitive dependencies or know which dependency pulled in which.

## The Solution: 
This PR builds a proper dependency tree that captures parent-child relationships, depth, and Maven scope, using either a pre-generated mvn dependency:tree file or embedded pom.xml files within the archive.

### New configuration options

Configuration (new CLI/YAML options):
| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `java.use-embedded-pom-dependencies` | bool | `false` | Build graph from embedded `pom.xml` files within JARs |
| `java.maven-dependency-tree` | string | `""` | Path to pre-generated `mvn dependency:tree` output file |

When maven-dependency-tree is provided, it takes priority over embedded POM analysis.

### Example usage

  #### Option A: Using a pre-generated Maven dependency tree (most accurate)

Generate the tree file from your project
  `mvn dependency:tree -DoutputFile=deps.txt`

Scan with hierarchical resolution
 ```
syft scan dir:./target \
    -o spdx-json \
    --java-maven-dependency-tree deps.txt
```

 #### Option B: Using embedded POMs (no build tools required)

```
  syft scan ./app.jar \
    -o cyclonedx-json \
    --java-use-embedded-pom-dependencies
```

 #### Option C: Via .syft.yaml configuration

```
  java:
    maven-dependency-tree: ./deps.txt
    # OR
    use-embedded-pom-dependencies: true
```

### Example relationship output changes

  Before (flat model) — all dependencies point to root:

```
  spring-jcl            ──dependency-of──▶  my-app
  spring-core           ──dependency-of──▶  my-app
  jackson-databind      ──dependency-of──▶  my-app
  jackson-core          ──dependency-of──▶  my-app
  jackson-annotations   ──dependency-of──▶  my-app
```

  After (hierarchical model) — relationships reflect the actual Maven tree:

```
  spring-jcl            ──dependency-of──▶  spring-core          {depth: 1, scope: "compile"}
  spring-core           ──dependency-of──▶  my-app               {depth: 0, scope: "compile"}
  jackson-core          ──dependency-of──▶  jackson-databind     {depth: 1, scope: "compile"}
  jackson-annotations   ──dependency-of──▶  jackson-databind     {depth: 1, scope: "compile"}
  jackson-databind      ──dependency-of──▶  my-app               {depth: 0, scope: "compile"}
```

Each relationship carries DependencyRelationshipData:
```
  {
    "depth": 1,
    "scope": "compile",
    "isDirectDependency": false
  }
```

Note Regarding Relationship Metadata:

- Syft JSON — `r.Data` is written to Metadata field on the relationship model. So depth/scope/isDirectDependency are preserved in Syft JSON output.
- SPDX — only writes `RefA`, Relationship (type string), `RefB`, and `RelationshipComment`. Data is dropped.                                                                                                                 
- CycloneDX — only writes the dependency graph structure (who depends on whom). Data is dropped.

So the DependencyRelationshipData survives in Syft JSON only. In SPDX and CycloneDX, the structural benefit is preserved (correct parent-child edges), but the metadata (depth, scope, isDirectDependency) is lost.

### How graph resolution works

1. Graph building (during cataloging, depth=0 only): Priority chain is Maven tree file → embedded POMs
2. Relationship enrichment (during cataloging): Each relationship gets depth, scope, and intended parent from the graph. When the intended parent package hasn't been cataloged yet, the parent Maven ID is stored as intendedParentID for deferred resolution
3. Post-processing (after all catalogers complete): ResolveHierarchicalDependencies runs in the relationship finalization pipeline, resolving deferred parent IDs via a 3-tier package index (exact → groupId:artifactId → artifactId). 

 
Falls back to the nearest ancestor present in the SBOM when the intended parent package isn't found

### Validated against

- Real-world 461-node Maven dependency tree (68 direct deps, max depth 7) with classifiers, [INFO] prefixes, [WARNING] blocks, and Maven banner/footer noise — all parsed correctly
- Existing test suite passes with no regressions

#### What changed

New files (8):
- syft/pkg/cataloger/java/dependency_graph.go — DependencyGraph/DependencyNode in-memory tree with 4-tier flexible matching (exact → GA → AV → artifactId)
- syft/pkg/cataloger/java/maven_id.go — Exported MavenID wrapper for cross-package use
- syft/pkg/cataloger/java/maven_tree_parser.go — Parses mvn dependency:tree text output (4/5/6-part coordinates, classifiers, [INFO] prefixes, optional markers, managed from annotations)
- syft/pkg/cataloger/java/relationship_metadata.go — DependencyRelationshipData carried on artifact.Relationship.Data
- internal/relationship/java/java_hierarchical_relationships.go — Post-processor that resolves deferred parent IDs and enriches relationships after all catalogers complete

Modified files (5):
- syft/pkg/cataloger/java/archive_parser.go — Builds dependency graph at depth=0, enriches relationships with depth/scope/intended-parent during cataloging
- syft/pkg/cataloger/java/config.go — Two new config fields: UseEmbeddedPOMDependencies, MavenDependencyTreeFile
- cmd/syft/internal/options/java.go — Corresponding CLI/YAML options
- syft/cataloging/relationships.go — Passes Java config through to post-processor
- internal/task/relationship_tasks.go — Hooks post-processor into relationship finalization pipeline

Tests (5 new test files, ~1,700 lines):
- Unit tests for dependency graph, tree parser, relationship metadata
- End-to-end integration test with benchmarks
- SPDX DependencyOf relationship lookup test

Co-Authored-By: Claude Code
 
## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation (updates the documentation)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->

Create to fix DCO issues on original PR #4803