### PR TITLE
fix: add nuget to TypeByName mapping for SPDX SBOM parsing

### DIFF
--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -220,7 +220,7 @@ func TypeByName(name string) Type {
 		return CondaPkg
 	case packageurl.TypePub:
 		return DartPubPkg
-	case "dotnet": // here to support legacy use cases
+	case "dotnet", "nuget": // nuget is the PURL type for .NET packages; here to support legacy use cases and SPDX SBOMs
 		return DotnetPkg
 	case packageurl.TypeCocoapods:
 		return CocoapodsPkg

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -59,6 +59,11 @@ func TestTypeFromPURL(t *testing.T) {
 			expected: DotnetPkg,
 		},
 		{
+			// nuget is the PURL type for .NET packages used in SPDX SBOMs
+			purl:     "pkg:nuget/Newtonsoft.Json@13.0.3",
+			expected: DotnetPkg,
+		},
+		{
 			purl:     "pkg:composer/laravel/laravel@5.5.0",
 			expected: PhpComposerPkg,
 		},


### PR DESCRIPTION
## Fixes #4837

### Problem
When Syft reads an SPDX SBOM containing NuGet packages (e.g. ),  had no case for , causing it to return . This routes matching through  instead of , bypassing the  config and producing false-positive CVEs in Grype.

### Fix
Added  to the existing  clause in :



 already correctly returns , so this change is consistent with the existing codebase.