### PR TITLE
syft/pkg: map "nuget" purl type to DotnetPkg in TypeByName

### DIFF
--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -220,7 +220,7 @@ func TypeByName(name string) Type {
 		return CondaPkg
 	case packageurl.TypePub:
 		return DartPubPkg
-	case "dotnet": // here to support legacy use cases
+	case "dotnet", packageurl.TypeNuget: // "dotnet" is here to support legacy use cases; "nuget" is the canonical purl type
 		return DotnetPkg
 	case packageurl.TypeCocoapods:
 		return CocoapodsPkg

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -59,6 +59,11 @@ func TestTypeFromPURL(t *testing.T) {
 			expected: DotnetPkg,
 		},
 		{
+			name:     "nuget purl maps to dotnet",
+			purl:     "pkg:nuget/Minio@7.0.0",
+			expected: DotnetPkg,
+		},
+		{
 			purl:     "pkg:composer/laravel/laravel@5.5.0",
 			expected: PhpComposerPkg,
 		},


### PR DESCRIPTION
Fixes #4837.

`TypeByName` only handled the legacy `"dotnet"` purl type. SPDX SBOMs decoded by syft contain the canonical `pkg:nuget/...` form, so `TypeByName(purl.Type)` for a NuGet package fell through to `default` and returned `UnknownPkg`. Downstream this routed matching through grype's stock CPE matcher and silently bypassed `dotnet.using-cpes=false`, producing the false-positive matches in the issue (e.g. the `Minio` NuGet client matched against the MinIO server CPE).

The mapping already existed in `LanguageByName` (`"nuget"` → `"dotnet"`) and in `grype/db/v6/vulnerability.go` (`"nuget"`, `"dotnet"` both → `DotnetPkg`); only `TypeByName` was missing it.

### Changes

- `syft/pkg/type.go`: add `packageurl.TypeNuget` to the `"dotnet"` case so both forms map to `DotnetPkg`. Comment updated to note `"dotnet"` is legacy and `"nuget"` is canonical.
- `syft/pkg/type_test.go`: add a `pkg:nuget/Minio@7.0.0 → DotnetPkg` case to `TestTypeFromPURL`.

### Verification

```
$ go test -run TestTypeFromPURL ./syft/pkg/
ok  	github.com/anchore/syft/syft/pkg	0.008s
$ go vet ./syft/pkg/
```

Credit to the issue reporter for tracing the bug all the way to the line — diff matches their suggested fix verbatim.