### PR TITLE
syft/source: trim trailing slash from --exclude paths

### DIFF
--- a/syft/source/directorysource/directory_source.go
+++ b/syft/source/directorysource/directory_source.go
@@ -145,6 +145,12 @@ func GetDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 		// check exclusions for supported paths, these are all relative to the "scan root"
 		if strings.HasPrefix(exclusion, "./") || strings.HasPrefix(exclusion, "*/") || strings.HasPrefix(exclusion, "**/") {
 			exclusion = strings.TrimPrefix(exclusion, "./")
+			// A trailing slash on the exclusion is intuitively read as "exclude
+			// the directory itself", but doublestar.Match does not treat
+			// "<root>/lib/" as matching "<root>/lib" (the path the walker sees
+			// for a directory), so the exclusion silently does nothing
+			// (issue #4839). Trim it so "./lib/" behaves the same as "./lib".
+			exclusion = strings.TrimSuffix(exclusion, "/")
 			exclusions[idx] = root + exclusion
 		} else {
 			errors = append(errors, exclusion)

--- a/syft/source/directorysource/directory_source_test.go
+++ b/syft/source/directorysource/directory_source_test.go
@@ -177,6 +177,18 @@ func Test_DirectorySource_Exclusions(t *testing.T) {
 		},
 		{
 			input: "testdata/image-simple",
+			desc:  "trailing slash on directory exclusion behaves like no slash (issue #4839)",
+			glob:  "**",
+			expected: []string{
+				"Dockerfile",
+				"file-1.txt",
+				"file-2.txt",
+				//"target/really/nested/file-3.txt", // explicitly skipped
+			},
+			exclusions: []string{"./target/"},
+		},
+		{
+			input: "testdata/image-simple",
 			desc:  "exclude explicit file relative to the root",
 			glob:  "**",
 			expected: []string{


### PR DESCRIPTION
Closes #4839.

`syft scan ... --exclude ./lib/` silently does nothing — the trailing slash makes the doublestar match miss every walked path, so the SkipDir branch is never reached. Removing the trailing slash makes the exclusion behave as expected, which is what the issue reporter discovered.

The fix is one extra `strings.TrimSuffix` in `GetDirectoryExclusionFunctions` so `./lib/` and `./lib` produce the same pattern. This matches what the docs already imply (the [exclude-file-paths guide](https://oss.anchore.com/docs/guides/sbom/file-selection/#excluding-file-paths) doesn't mention any trailing-slash exception).

### Changes
- `syft/source/directorysource/directory_source.go`: trim trailing `/` after stripping the `./` prefix in the exclusion-pattern loop. Comment explains why (path the walker sees has no trailing slash).
- `syft/source/directorysource/directory_source_test.go`: new sub-test cloning the existing "exclude explicit directory relative to the root" case but using `./target/` to lock in the new behavior.

### Verification
```
$ go test -count=1 -run Test_DirectorySource_Exclusions ./syft/source/directorysource/
ok  	github.com/anchore/syft/syft/source/directorysource	0.012s
```