### PR TITLE
binary/pe-cataloger: glob .bpl files alongside .dll and .exe

### DIFF
--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -12,10 +12,14 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pe"
 )
 
-// NewPEPackageCataloger returns a cataloger that interprets packages from DLL and EXE files.
+// NewPEPackageCataloger returns a cataloger that interprets packages from PE
+// files. The default extensions covered are .dll, .exe, and .bpl. The latter
+// is the Borland Package Library used by Delphi and C++Builder; .bpl files
+// are standard Windows PE binaries with a different filename convention
+// (issue #4664).
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe")
+		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {


### PR DESCRIPTION
Closes #4664.

`.bpl` (Borland Package Library) files are standard Windows PE binaries used by Delphi and C++Builder; they have the same structure as `.dll`, just a different filename convention. The reporter confirmed that renaming `example.bpl` to `example.dll` lets the existing PE cataloger pick them up unchanged — so all that was needed was the additional glob.

### Changes
- `syft/pkg/cataloger/binary/pe_package_cataloger.go`: add `**/*.bpl` to `WithParserByGlobs` and document why in a short doc-comment.

### Testing notes
Did not add a new image fixture — the issue's reporter already verified the parser side works for `.bpl` content. Happy to add one if you'd like (the existing `Test_PEPackageCataloger` builds image fixtures from Dockerfiles, so a `.bpl`-fixture image would slot in there).