### PR TITLE
dotnet: emit microsoft:.net CPE for unified .NET (5+)

### DIFF
--- a/syft/pkg/cataloger/dotnet/package.go
+++ b/syft/pkg/cataloger/dotnet/package.go
@@ -99,20 +99,46 @@ func runtimeCPEs(ver string) []cpe.CPE {
 		}
 	}
 
-	productName := "dotnet"
+	version := fmt.Sprintf("%d.%d", majorVersion, minorVersion)
+
 	if majorVersion < 5 {
-		productName = "dotnet_core"
+		// .NET Core 1.x – 3.x: NVD's canonical CPE is "microsoft:dotnet_core".
+		return []cpe.CPE{
+			{
+				Attributes: cpe.Attributes{
+					Part:    "a",
+					Vendor:  "microsoft",
+					Product: "dotnet_core",
+					Version: version,
+				},
+				// we didn't find this in the underlying material, but this is the convention in NVD and we are certain this is a runtime package
+				Source: cpe.DeclaredSource,
+			},
+		}
 	}
 
+	// Unified .NET (5+): NVD has settled on "microsoft:.net" (issue #4738);
+	// e.g. CVE-2025-21171 uses cpe:2.3:a:microsoft:.net:9.0.0:*:*:*:*:*:*:*.
+	// Emit "microsoft:.net" first so it is preferred for matching, and keep
+	// "microsoft:dotnet" as well for backwards compatibility with consumers
+	// that historically matched against the old form.
 	return []cpe.CPE{
 		{
 			Attributes: cpe.Attributes{
 				Part:    "a",
 				Vendor:  "microsoft",
-				Product: productName,
-				Version: fmt.Sprintf("%d.%d", majorVersion, minorVersion),
+				Product: ".net",
+				Version: version,
 			},
-			// we didn't find this in the underlying material, but this is the convention in NVD and we are certain this is a runtime package
+			Source: cpe.DeclaredSource,
+		},
+		{
+			Attributes: cpe.Attributes{
+				Part:    "a",
+				Vendor:  "microsoft",
+				Product: "dotnet",
+				Version: version,
+			},
 			Source: cpe.DeclaredSource,
 		},
 	}

--- a/syft/pkg/cataloger/dotnet/package_test.go
+++ b/syft/pkg/cataloger/dotnet/package_test.go
@@ -472,6 +472,15 @@ func TestRuntimeCPEs(t *testing.T) {
 					Attributes: cpe.Attributes{
 						Part:    "a",
 						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "5.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
 						Product: "dotnet",
 						Version: "5.0",
 					},
@@ -483,6 +492,15 @@ func TestRuntimeCPEs(t *testing.T) {
 			name:    ".NET 6.0",
 			version: "6.0",
 			expected: []cpe.CPE{
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "6.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
 				{
 					Attributes: cpe.Attributes{
 						Part:    "a",
@@ -502,6 +520,15 @@ func TestRuntimeCPEs(t *testing.T) {
 					Attributes: cpe.Attributes{
 						Part:    "a",
 						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "8.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
 						Product: "dotnet",
 						Version: "8.0",
 					},
@@ -513,6 +540,15 @@ func TestRuntimeCPEs(t *testing.T) {
 			name:    ".NET 10.0 (future version)",
 			version: "10.0",
 			expected: []cpe.CPE{
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "10.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
 				{
 					Attributes: cpe.Attributes{
 						Part:    "a",
@@ -532,6 +568,15 @@ func TestRuntimeCPEs(t *testing.T) {
 					Attributes: cpe.Attributes{
 						Part:    "a",
 						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "6.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
 						Product: "dotnet",
 						Version: "6.0",
 					},
@@ -543,6 +588,15 @@ func TestRuntimeCPEs(t *testing.T) {
 			name:    "Assumed minor version",
 			version: "6",
 			expected: []cpe.CPE{
+				{
+					Attributes: cpe.Attributes{
+						Part:    "a",
+						Vendor:  "microsoft",
+						Product: ".net",
+						Version: "6.0",
+					},
+					Source: cpe.DeclaredSource,
+				},
 				{
 					Attributes: cpe.Attributes{
 						Part:    "a",


### PR DESCRIPTION
Closes #4738.

NVD's canonical CPE for the unified .NET platform is `microsoft:.net` (e.g. [CVE-2025-21171](https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2025-21171) uses `cpe:2.3:a:microsoft:.net:9.0.0:*:*:*:*:*:*:*`). Syft was emitting `microsoft:dotnet` for `majorVersion >= 5`, which doesn't match anything in NVD and caused silent false-negative CVE matching for self-contained .NET runtime packages (Dependency-Track was the reporter's case; the same applies for any consumer that goes through the SBOM's CPE field).

### Changes
- `syft/pkg/cataloger/dotnet/package.go`: for major >= 5, emit two CPEs — `microsoft:.net:<major>.<minor>` (NVD-canonical, listed first so it takes precedence) and `microsoft:dotnet:<major>.<minor>` (legacy, kept for backwards compatibility with consumers that historically matched the old vendor:product). For major < 5 the existing `microsoft:dotnet_core` is unchanged.
- `syft/pkg/cataloger/dotnet/package_test.go`: extend `TestRuntimeCPEs` cases for 5.0/6.0/8.0/10.0 + the patch/assumed-minor cases to expect both CPEs in the new order.

### Verification
```
$ go test -count=1 -run TestRuntimeCPEs ./syft/pkg/cataloger/dotnet/
ok  	github.com/anchore/syft/syft/pkg/cataloger/dotnet	0.025s
```