### PR TITLE
cpegenerate: add tcpdump as alternate vendor for libpcap apk

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -397,6 +397,12 @@ var defaultCandidateAdditions = buildCandidateLookup(
 		},
 		{
 			pkg.ApkPkg,
+			// libpcap CVEs in NVD use vendor "tcpdump" (issue #4712).
+			candidateKey{PkgName: "libpcap"},
+			candidateAddition{AdditionalVendors: []string{"tcpdump"}},
+		},
+		{
+			pkg.ApkPkg,
 			candidateKey{PkgName: "alsa"},
 			candidateAddition{AdditionalVendors: []string{"alsa-project"}},
 		},


### PR DESCRIPTION
Closes #4712.

NVD records libpcap vulnerabilities under vendor `tcpdump`, not `libpcap`. For example [CVE-2024-8006](https://nvd.nist.gov/vuln/detail/CVE-2024-8006) uses `cpe:2.3:a:tcpdump:libpcap:...`. So when syft scans an alpine image with `libpcap` installed, the emitted `cpe:2.3:a:libpcap:libpcap:1.10.4-r1:*:*:*:*:*:*:*` matches nothing and grype returns no CVEs.

This adds a candidate-addition entry under `pkg.ApkPkg` for `libpcap` so the generated CPE set also includes `cpe:2.3:a:tcpdump:libpcap:<version>:*:*:*:*:*:*:*`. The libpcap-vendor variant is kept for backwards compatibility (consumers that have already pinned to it). Pattern matches the existing entries for things like `glibc → gnu`, `glib → gnome`, `make → gnu`.

### Verification
```
$ go test -count=1 -short ./syft/pkg/cataloger/internal/cpegenerate/
ok  	github.com/anchore/syft/syft/pkg/cataloger/internal/cpegenerate	0.042s
```