### PR TITLE
cyclonedx: import firmware-typed components as packages

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -62,7 +62,7 @@ func collectPackages(component *cyclonedx.Component, s *sbom.SBOM, idMap map[str
 	switch component.Type {
 	case cyclonedx.ComponentTypeOS:
 	case cyclonedx.ComponentTypeContainer:
-	case cyclonedx.ComponentTypeApplication, cyclonedx.ComponentTypeFramework, cyclonedx.ComponentTypeLibrary, cyclonedx.ComponentTypeMachineLearningModel:
+	case cyclonedx.ComponentTypeApplication, cyclonedx.ComponentTypeFramework, cyclonedx.ComponentTypeLibrary, cyclonedx.ComponentTypeMachineLearningModel, cyclonedx.ComponentTypeFirmware:
 		p := decodeComponent(component)
 		idMap[component.BOMRef] = p
 		if component.BOMRef != "" {

--- a/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
@@ -259,6 +259,30 @@ func Test_decode(t *testing.T) {
 	}
 }
 
+func Test_decode_includesFirmwareComponents(t *testing.T) {
+	// CycloneDX BOMs that describe firmware (e.g. u-boot) use
+	// component type "firmware". Prior to issue #2537 the decoder skipped
+	// these and downstream tools (e.g. grype) reported zero matches.
+	bom := cyclonedx.BOM{
+		Components: &[]cyclonedx.Component{
+			{
+				BOMRef:     "u-boot",
+				Type:       cyclonedx.ComponentTypeFirmware,
+				Name:       "u-boot",
+				Version:    "2024.04",
+				PackageURL: "pkg:generic/u-boot@2024.04",
+			},
+		},
+	}
+	model, err := ToSyftModel(&bom)
+	require.NoError(t, err)
+
+	pkgs := model.Artifacts.Packages.Sorted()
+	require.Len(t, pkgs, 1, "firmware component should be imported as a package")
+	assert.Equal(t, "u-boot", pkgs[0].Name)
+	assert.Equal(t, "2024.04", pkgs[0].Version)
+}
+
 func Test_relationshipDirection(t *testing.T) {
 	cyclonedx_bom := cyclonedx.BOM{Metadata: nil,
 		Components: &[]cyclonedx.Component{


### PR DESCRIPTION
Closes anchore/grype#2537.

The CycloneDX decoder filters on a hard-coded set of component types (`application` / `framework` / `library` / `machine-learning-model`). Anything else — including `firmware` — fell through silently, so a BOM describing u-boot or other firmware ended up with no packages, and grype reported no matches even though valid CVEs exist.

@kzantow confirmed in the issue:

> we currently are not importing `firmware` component types … It looks like we _should_ just need to add `firmware`, this is ready for anyone to work on; see the link above for the section of code that needs a change and please add a test if someone is able to get to this before us.

### Changes
- `syft/format/internal/cyclonedxutil/helpers/decoder.go`: add `cyclonedx.ComponentTypeFirmware` alongside `Application` / `Framework` / `Library` / `MachineLearningModel` in `collectPackages`.
- `decoder_test.go`: new `Test_decode_includesFirmwareComponents` — constructs a single-firmware-component BOM and asserts the package is imported with the right name and version.

### Verification
```
$ go test -count=1 -run 'Test_decode_includesFirmwareComponents|Test_decode$' \
    ./syft/format/internal/cyclonedxutil/helpers/
ok  	github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers	0.026s
```