### PR TITLE
cyclonedx: preserve metadata.component name and version on decode

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -231,6 +231,8 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 
 		return source.Description{
 			ID:       "",
+			Name:     c.Name,
+			Version:  c.Version,
 			Supplier: supplier,
 			// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
 
@@ -247,11 +249,21 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 		// TODO: this is lossy... we can't know if this is a file or a directory
 		return source.Description{
 			ID:       "",
+			Name:     c.Name,
+			Version:  c.Version,
 			Supplier: supplier,
 			Metadata: source.FileMetadata{Path: c.Name},
 		}
 	}
-	return source.Description{}
+	// All other component types (application, library, framework, ...) — the
+	// caller's BOM had a metadata.component with a name/version that they care
+	// about; surface them on the Description even if we don't have a
+	// dedicated Metadata shape for the type yet (issue anchore/grype#2418).
+	return source.Description{
+		Name:     c.Name,
+		Version:  c.Version,
+		Supplier: supplier,
+	}
 }
 
 // if there is more than one tool in meta.Tools' list the last item will be used

--- a/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
@@ -259,6 +259,34 @@ func Test_decode(t *testing.T) {
 	}
 }
 
+func Test_extractComponents_preservesMainComponentVersion(t *testing.T) {
+	// Issue anchore/grype#2418: a CycloneDX BOM with metadata.component.version
+	// (e.g. produced by `syft … --source-version=0.1.0`) was decoded back into
+	// a source.Description with empty Name/Version, so re-emitting CycloneDX
+	// dropped the field entirely.
+	for _, ct := range []cyclonedx.ComponentType{
+		cyclonedx.ComponentTypeApplication,
+		cyclonedx.ComponentTypeLibrary,
+		cyclonedx.ComponentTypeFramework,
+		cyclonedx.ComponentTypeContainer,
+		cyclonedx.ComponentTypeFile,
+	} {
+		t.Run(string(ct), func(t *testing.T) {
+			meta := &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    ct,
+					Name:    "my-project",
+					Version: "0.1.0",
+				},
+			}
+			d := extractComponents(meta)
+			assert.Equal(t, "my-project", d.Name)
+			assert.Equal(t, "0.1.0", d.Version)
+		})
+	}
+}
+
+
 func Test_relationshipDirection(t *testing.T) {
 	cyclonedx_bom := cyclonedx.BOM{Metadata: nil,
 		Components: &[]cyclonedx.Component{


### PR DESCRIPTION
Closes anchore/grype#2418.

`extractComponents` only filled in `source.Description.Name`/`Version` for the `Container` and `File` branches. Every other component type — including `application`, which is what `syft … --source-version=0.1.0` produces — fell through to `return source.Description{}`. Round-tripping a CycloneDX BOM through Grype silently lost the main-component version.

@kzantow pointed at this exact function as the fix site:
> It looks like we should update this function to have the correct data in as many cases as we can: https://github.com/anchore/syft/blob/main/syft/format/internal/cyclonedxutil/helpers/decoder.go#L218

### Changes
- `decoder.go::extractComponents`:
  - set `Name` and `Version` on the `Container` and `File` branches (they were available on `meta.Component` but not being populated).
  - add a fallback `return source.Description{Name, Version, Supplier}` at the end of the switch so every other component type surfaces those fields rather than silently dropping them.
- `decoder_test.go`: new `Test_extractComponents_preservesMainComponentVersion` table-tests application / library / framework / container / file all retain `Name` and `Version`.

### Verification
```
$ go test -count=1 -run 'Test_extractComponents_preservesMainComponentVersion|Test_decode_includesFirmwareComponents|Test_decode$' \
    ./syft/format/internal/cyclonedxutil/helpers/
ok  	github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers	0.021s
```