### PR TITLE
feat(cmd): log total scan duration at info level (#4587)

### DIFF
--- a/cmd/syft/internal/commands/scan.go
+++ b/cmd/syft/internal/commands/scan.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
@@ -171,6 +172,11 @@ func validateArgs(cmd *cobra.Command, args []string, err string) error {
 }
 
 func runScan(ctx context.Context, id clio.Identification, opts *scanOptions, userInput string) error {
+	scanStart := time.Now()
+	defer func() {
+		log.Infof("scan completed in %s", time.Since(scanStart).Round(time.Millisecond))
+	}()
+
 	writer, err := opts.SBOMWriter()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
Closes #4587.

Adds a single info-level log line at the end of every `syft scan` run that reports the total wall-clock time, e.g.:

```
[0003]  INFO scan completed in 2.017s
```

The implementation is the minimal version @kzantow [suggested in the issue](https://github.com/anchore/syft/issues/4587#issuecomment): track the start in `runScan` (`cmd/syft/internal/commands/scan.go:174`) and emit a single info-level log on return.

## Behavior
- Visible with `-v` (sits alongside the existing per-cataloger `task completed elapsed=...` lines).
- Not visible in the default TUI or in stdout, so SBOM piping and the default user experience are unchanged.
- The duration is rounded to the nearest millisecond to keep the output readable.

## Why an info log instead of stdout
@kzantow on the issue:
> An easy way to get that info is just to use `time`, e.g. `time syft <image>`. But I don't think anyone would be opposed to adding this information, especially for `-v` -- printing an overall time. I don't really think it's needed by default TUI output, though, given that it's pretty easy to get already with a commonly available tool or `-v` when that gets added.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./cmd/syft/internal/commands/` passes
- [x] Local end-to-end `syft -v alpine:latest` shows the new line as the final INFO entry
- [x] Local end-to-end `syft alpine:latest -o table` (no `-v`) shows the original SBOM table only — no timing pollution
- [x] `syft alpine:latest > sbom.json` (default JSON output, stdout pipe) is unaffected