### PR TITLE
fix(java): merge pom-derived licenses into parent when MANIFEST already supplies one (#4747)

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -855,6 +855,15 @@ func updateParentPackage(p pkg.Package, parentPkg *pkg.Package) {
 	// we may have learned more about the type via data in the pom properties
 	parentPkg.Type = p.Type
 
+	// merge in licenses discovered from the pom.xml / maven central. The parent package already has
+	// licenses from MANIFEST.MF (Bundle-License); pom-derived licenses are typically more precise and
+	// can encode multi-license projects more cleanly, so additive merge is the right move here.
+	// LicenseSet.Add deduplicates so re-adding a license that came from MANIFEST is a no-op.
+	// See https://github.com/anchore/syft/issues/4747.
+	for _, lic := range p.Licenses.ToSlice() {
+		parentPkg.Licenses.Add(lic)
+	}
+
 	metadata, ok := p.Metadata.(pkg.JavaArchive)
 	if !ok {
 		return

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1088,6 +1088,65 @@ func Test_newPackageFromMavenData(t *testing.T) {
 	}
 }
 
+func Test_updateParentPackage_mergesLicenses(t *testing.T) {
+	// Regression test for https://github.com/anchore/syft/issues/4747:
+	// when MANIFEST.MF contributes a Bundle-License the parent package already has a
+	// LicenseSet populated. The pom-derived candidate that matches the parent later
+	// gets discarded via updateParentPackage(), so its licenses must be folded in
+	// rather than dropped — pom.xml license info is typically richer than MANIFEST.
+	ctx := pkgtest.Context(t)
+	loc := file.NewLocation("testdata/something.jar")
+
+	parentPkg := &pkg.Package{
+		Name:    "logback-core",
+		Version: "1.5.18",
+		Type:    pkg.JavaPkg,
+		// license discovered from MANIFEST.MF Bundle-License
+		Licenses: pkg.NewLicenseSet(pkg.NewLicenseFromLocationsWithContext(ctx, "EPL-1.0", loc)),
+		Metadata: pkg.JavaArchive{
+			VirtualPath: loc.Path(),
+		},
+	}
+
+	// p is the pom-derived candidate that matched parentPkg (so updateParentPackage will merge it)
+	p := pkg.Package{
+		Name:    "logback-core",
+		Version: "1.5.18",
+		Type:    pkg.JavaPkg,
+		// licenses discovered from pom.xml — multi-license, more precise
+		Licenses: pkg.NewLicenseSet(
+			pkg.NewLicenseFromLocationsWithContext(ctx, "LGPL-2.1", loc),
+			pkg.NewLicenseFromLocationsWithContext(ctx, "EPL-1.0", loc), // duplicate of MANIFEST — should be deduped
+		),
+		Metadata: pkg.JavaArchive{
+			VirtualPath: loc.Path(),
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "ch.qos.logback",
+				ArtifactID: "logback-core",
+				Version:    "1.5.18",
+			},
+		},
+	}
+
+	updateParentPackage(p, parentPkg)
+
+	// parentPkg should now carry both licenses (deduped — EPL-1.0 only appears once)
+	got := make(map[string]bool)
+	for _, lic := range parentPkg.Licenses.ToSlice() {
+		got[lic.Value] = true
+	}
+
+	wantLicenses := []string{"EPL-1.0", "LGPL-2.1"}
+	for _, w := range wantLicenses {
+		if !got[w] {
+			t.Errorf("expected merged license %q to be present on parentPkg, got: %v", w, got)
+		}
+	}
+	if len(got) != len(wantLicenses) {
+		t.Errorf("expected exactly %d licenses, got %d: %v", len(wantLicenses), len(got), got)
+	}
+}
+
 func Test_artifactIDMatchesFilename(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Description
Closes #4747.

When syft scans a Java archive whose `MANIFEST.MF` contains `Bundle-License`, the parent package gets a populated `Licenses` set up front. Later, the cataloger discovers the archive's own `pom.xml` (or resolves the upstream pom via the Maven resolver) and produces a candidate `p` whose identity matches the parent. `packageIdentitiesMatch` returns true, the candidate is folded into the parent via `updateParentPackage`, and the candidate is returned as `nil` — but the pom-derived licenses on `p` were silently dropped.

This is wrong because `pom.xml` license metadata is typically richer than `MANIFEST.MF`:
- `pom.xml` has well-defined slots for multi-license projects and explicit license expressions
- `Bundle-License` is whatever string the OSGi/build plugin happens to emit, often a single license URL even when the project is multi-licensed

`logback-core` (the issue's canonical example) advertises both EPL-1.0 and LGPL-2.1 in its parent pom, but `Bundle-License` only carries the EPL link.

## Fix
Per [@kzantow's comment on the issue](https://github.com/anchore/syft/issues/4747), `updateParentPackage` (in `syft/pkg/cataloger/java/archive_parser.go:849`) now additively merges the pom-derived licenses into the parent's `LicenseSet`:

```go
for _, lic := range p.Licenses.ToSlice() {
    parentPkg.Licenses.Add(lic)
}
```

`LicenseSet.Add` already deduplicates, so when the pom and MANIFEST share a license value (the common case for single-license projects), the result is the same single license — no duplicates introduced. When they disagree, both are preserved instead of one silently winning.

## Why additive (not replacing MANIFEST)
@kzantow flagged the regression risk in the issue: there are real-world cases where MANIFEST is more accurate than the pom. Additive merge sidesteps that — a license that was correctly attached from MANIFEST cannot be lost, and a license correctly attached from the pom cannot be lost either.

## Tests
Adds `Test_updateParentPackage_mergesLicenses` with the logback-core scenario:
- parent starts with EPL-1.0 from MANIFEST
- candidate `p` carries LGPL-2.1 plus a duplicate EPL-1.0 from pom
- after merge the parent has exactly `{EPL-1.0, LGPL-2.1}` (deduplication confirmed)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./syft/pkg/cataloger/java/ -run Test_updateParentPackage_mergesLicenses` passes
- [x] Other in-process java unit tests (`Test_newPackageFromMavenData`, `Test_artifactIDMatchesFilename`, `TestSearchMavenForLicenses`) continue to pass — no regressions on the unit-level test surface I can run locally
- [ ] Integration tests under `TestParseJar` / `TestParseNestedJar` build their fixtures via Docker (`docker create maven:...`) and require docker access from the test process; I couldn't run those locally in this environment. Happy to follow up on CI feedback if any of those fixtures need expected-license updates because of this change.