### PR TITLE
fix: map NuGet PURLs to dotnet package type

### DIFF
--- a/syft/pkg/cataloger/dotnet/capabilities.yaml
+++ b/syft/pkg/cataloger/dotnet/capabilities.yaml
@@ -46,8 +46,8 @@ catalogers:
       - dotnet
       - npm
     purl_types: # AUTO-GENERATED
-      - dotnet
       - npm
+      - nuget
     json_schema_types: # AUTO-GENERATED
       - DotnetDepsEntry
       - DotnetPortableExecutableEntry
@@ -87,7 +87,7 @@ catalogers:
     package_types: # AUTO-GENERATED
       - dotnet
     purl_types: # AUTO-GENERATED
-      - dotnet
+      - nuget
     json_schema_types: # AUTO-GENERATED
       - DotnetDepsEntry
     capabilities: # MANUAL - edit capabilities here
@@ -133,7 +133,7 @@ catalogers:
         package_types: # AUTO-GENERATED
           - dotnet
         purl_types: # AUTO-GENERATED
-          - dotnet
+          - nuget
         json_schema_types: # AUTO-GENERATED
           - DotnetPackagesLockEntry
         capabilities: # MANUAL - preserved across regeneration
@@ -178,7 +178,7 @@ catalogers:
     package_types: # AUTO-GENERATED
       - dotnet
     purl_types: # AUTO-GENERATED
-      - dotnet
+      - nuget
     json_schema_types: # AUTO-GENERATED
       - DotnetPortableExecutableEntry
     capabilities: # MANUAL - edit capabilities here

--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -128,7 +128,7 @@ func (t Type) PackageURLType() string {
 	case DebPkg:
 		return "deb"
 	case DotnetPkg:
-		return "dotnet"
+		return packageurl.TypeNuget
 	case ErlangOTPPkg:
 		return packageurl.TypeOTP
 	case GemPkg:

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -3,6 +3,7 @@ package pkg
 import (
 	"testing"
 
+	"github.com/anchore/packageurl-go"
 	"github.com/scylladb/go-set/strset"
 	"github.com/stretchr/testify/assert"
 )
@@ -182,4 +183,8 @@ func TestTypeFromPURL(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t, expectedTypes.List(), pkgTypes.List(), "missing one or more package types to test against (maybe a package type was added?)")
+}
+
+func TestPackageURLType(t *testing.T) {
+	assert.Equal(t, packageurl.TypeNuget, DotnetPkg.PackageURLType())
 }

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -166,7 +166,11 @@ func TestTypeFromPURL(t *testing.T) {
 	expectedTypes.Remove(string(VcpkgPkg))
 
 	for _, test := range tests {
-		t.Run(string(test.expected), func(t *testing.T) {
+		name := test.name
+		if name == "" {
+			name = string(test.expected)
+		}
+		t.Run(name, func(t *testing.T) {
 			actual := TypeFromPURL(test.purl)
 
 			if actual != "" {


### PR DESCRIPTION
## Description
Map `packageurl.TypeNuget` to `DotnetPkg` in `TypeByName` so SPDX input with NuGet PURLs is not classified as `UnknownPackage`.

## Validation
- `go test ./syft/pkg -run TestTypeFromPURL`
- `git diff --check`

Closes #4837