### PR TITLE
feat(debian): detect Format header + URL-based license lookup in copyright (first step of #4708)

### DIFF
--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 
 	"github.com/anchore/syft/internal"
+	"github.com/anchore/syft/internal/spdxlicense"
 )
 
 // For more information see: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-syntax
@@ -18,6 +19,16 @@ var (
 	licensePattern                 = regexp.MustCompile(`^License: (?P<license>\S*)`)
 	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
 	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
+
+	// formatHeaderPattern matches the deb822 machine-readable copyright format
+	// declaration (https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/).
+	// The Format: header is the canonical signal that the file is structured.
+	formatHeaderPattern = regexp.MustCompile(`^Format:\s*(?P<url>https?://\S+)`)
+
+	// urlPattern matches URLs that may point at a license text. We intentionally
+	// stop at common non-URL trailing punctuation (.,;:)) so that ".html.", "(URL)"
+	// etc. don't pollute the lookup key.
+	urlPattern = regexp.MustCompile(`https?://[^\s<>"\\)\]]+`)
 )
 
 func parseLicensesFromCopyright(reader io.Reader) []string {
@@ -49,6 +60,14 @@ func parseLicensesFromCopyright(reader io.Reader) []string {
 		}
 		if value := findLicenseClause(licenseAgreementHeadingPattern, line); value != "" {
 			findings.Add(value)
+		}
+		// resolve any URLs on the line against the SPDX seeAlso URL table so that
+		// references like "License: see http://www.apache.org/licenses/LICENSE-2.0"
+		// surface a concrete SPDX ID even when the short-name field is missing.
+		// The Format: header itself participates in the same lookup so that any
+		// future variants of the deb822 spec URL register cleanly without special-casing.
+		for _, id := range licenseIDsFromURLs(line) {
+			findings.Add(id)
 		}
 
 		// multi-line heading detection (only at start of file)
@@ -110,6 +129,43 @@ func findLicenseClause(pattern *regexp.Regexp, line string) string {
 	}
 
 	return ensureIsSingleLicense(candidate)
+}
+
+// hasMachineReadableFormat reports whether the given debian/copyright content
+// declares itself in the deb822 machine-readable copyright format by exposing
+// a top-level "Format:" header pointing at the spec.
+//
+// Per https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/ the
+// Format field is mandatory and must appear in the first stanza, so the check
+// only walks lines until the first blank line (stanza terminator).
+func hasMachineReadableFormat(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == "" {
+			return false
+		}
+		if formatHeaderPattern.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// licenseIDsFromURLs returns SPDX license IDs for any URLs on the given line
+// that match an entry in the SPDX seeAlso URL table.
+func licenseIDsFromURLs(line string) []string {
+	matches := urlPattern.FindAllString(line, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	var ids []string
+	for _, raw := range matches {
+		// strip common trailing punctuation that a URL would not legitimately end with
+		trimmed := strings.TrimRight(raw, ".,;:")
+		if info, ok := spdxlicense.LicenseByURL(trimmed); ok && info.ID != "" {
+			ids = append(ids, info.ID)
+		}
+	}
+	return ids
 }
 
 var multiLicenseExceptions = []string{

--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 
 	"github.com/anchore/syft/internal"
+	"github.com/anchore/syft/internal/spdxlicense"
 )
 
 // For more information see: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-syntax
@@ -19,6 +20,11 @@ var (
 	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
 	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
 	formatHeaderPattern            = regexp.MustCompile(`^Format:\s*https?://www\.debian\.org/doc/packaging-manuals/copyright-format/`)
+
+	// urlPattern matches URLs that may point at a license text. We intentionally
+	// stop at common non-URL trailing punctuation (.,;:)) so that ".html.", "(URL)"
+	// etc. don't pollute the lookup key.
+	urlPattern = regexp.MustCompile(`https?://[^\s<>"\\)\]]+`)
 )
 
 // heading-detection states. Replaces licenseFirstSentenceAfterHeadingPattern,
@@ -61,6 +67,13 @@ func parseLicensesFromCopyright(reader io.Reader) []string {
 			if value := findLicenseClause(p, line); value != "" {
 				findings.Add(value)
 			}
+		}
+
+		// resolve any URLs on the line against the SPDX seeAlso URL table so that
+		// references like "License: Apache-2.0\n see http://www.apache.org/licenses/LICENSE-2.0"
+		// surface a concrete SPDX ID even when the short-name field is missing.
+		for _, id := range licenseIDsFromURLs(line) {
+			findings.Add(id)
 		}
 
 		var found string
@@ -133,6 +146,24 @@ func findLicenseClause(pattern *regexp.Regexp, line string) string {
 	}
 
 	return ensureIsSingleLicense(candidate)
+}
+
+// licenseIDsFromURLs returns SPDX license IDs for any URLs on the given line
+// that match an entry in the SPDX seeAlso URL table.
+func licenseIDsFromURLs(line string) []string {
+	matches := urlPattern.FindAllString(line, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	var ids []string
+	for _, raw := range matches {
+		// strip common trailing punctuation that a URL would not legitimately end with
+		trimmed := strings.TrimRight(raw, ".,;:")
+		if info, ok := spdxlicense.LicenseByURL(trimmed); ok && info.ID != "" {
+			ids = append(ids, info.ID)
+		}
+	}
+	return ids
 }
 
 var multiLicenseExceptions = []string{

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,19 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			fixture:  "testdata/copyright/microsoft",
 			expected: []string{"LICENSE AGREEMENT FOR MICROSOFT PRODUCTS"},
 		},
+		{
+			// machine-readable file with both License: short-name fields and
+			// embedded license-text URLs; URL-detection is additive on top of
+			// the existing License: field captures.
+			fixture:  "testdata/copyright/format-header",
+			expected: []string{"Apache-2.0", "MIT"},
+		},
+		{
+			// no License: short-name fields anywhere, but a clear seeAlso URL
+			// for MIT — exercises URL-only detection.
+			fixture:  "testdata/copyright/url-only-license",
+			expected: []string{"MIT"},
+		},
 	}
 
 	for _, test := range tests {
@@ -60,6 +74,107 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			if diff := cmp.Diff(test.expected, actual); diff != "" {
 				t.Errorf("unexpected package licenses (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestHasMachineReadableFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "deb822 spec URL is the canonical Format header",
+			content: `Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: foo
+
+Files: *
+License: MIT
+`,
+			want: true,
+		},
+		{
+			name: "http (not https) Format URL is also accepted",
+			content: `Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: foo
+`,
+			want: true,
+		},
+		{
+			name: "Format header may sit below other first-stanza fields",
+			content: `Upstream-Name: foo
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Source: https://example.com/foo
+`,
+			want: true,
+		},
+		{
+			name:    "Format-less narrative copyright is not machine-readable",
+			content: "This package was put together by Example.\n\nIt was downloaded from https://example.com/foo.\n",
+			want:    false,
+		},
+		{
+			name: "Format appearing only after the first stanza must not count",
+			content: `Upstream-Name: foo
+
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+`,
+			want: false,
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    false,
+		},
+		{
+			name:    "Format without scheme does not match — the spec requires an http(s) URL",
+			content: "Format: copyright-format/1.0\n",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasMachineReadableFormat(tt.content))
+		})
+	}
+}
+
+func TestLicenseIDsFromURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "Apache 2.0 seeAlso URL",
+			line: "See http://www.apache.org/licenses/LICENSE-2.0 for details.",
+			want: []string{"Apache-2.0"},
+		},
+		{
+			name: "MIT seeAlso URL with https",
+			line: "https://opensource.org/licenses/MIT",
+			want: []string{"MIT"},
+		},
+		{
+			name: "trailing punctuation is stripped before lookup",
+			line: "(see http://www.apache.org/licenses/LICENSE-2.0.)",
+			want: []string{"Apache-2.0"},
+		},
+		{
+			name: "non-license URL does not produce a finding",
+			line: "Source: https://example.com/foo",
+			want: nil,
+		},
+		{
+			name: "no URL on the line",
+			line: "License: GPL-2",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, licenseIDsFromURLs(tt.line))
 		})
 	}
 }

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,6 +53,13 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			// no Format header; not machine-readable, returns nil
 			fixture:  "testdata/copyright/microsoft",
 			expected: nil,
+		},
+		{
+			// machine-readable file (has a Format header, so it passes the gate)
+			// carrying both License: short-name fields and embedded license-text
+			// URLs. URL detection is additive on top of the License: captures.
+			fixture:  "testdata/copyright/format-header",
+			expected: []string{"Apache-2.0", "MIT"},
 		},
 	}
 
@@ -135,5 +143,44 @@ License: LGPL-2.1
 	actual := parseLicensesFromCopyright(strings.NewReader(content))
 	if actual != nil {
 		t.Errorf("expected nil for non-machine-readable file, got %v", actual)
+	}
+}
+
+func TestLicenseIDsFromURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "Apache 2.0 seeAlso URL",
+			line: "See http://www.apache.org/licenses/LICENSE-2.0 for details.",
+			want: []string{"Apache-2.0"},
+		},
+		{
+			name: "MIT seeAlso URL with https",
+			line: "https://opensource.org/licenses/MIT",
+			want: []string{"MIT"},
+		},
+		{
+			name: "trailing punctuation is stripped before lookup",
+			line: "(see http://www.apache.org/licenses/LICENSE-2.0.)",
+			want: []string{"Apache-2.0"},
+		},
+		{
+			name: "non-license URL does not produce a finding",
+			line: "Source: https://example.com/foo",
+			want: nil,
+		},
+		{
+			name: "no URL on the line",
+			line: "License: GPL-2",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, licenseIDsFromURLs(tt.line))
+		})
 	}
 }

--- a/syft/pkg/cataloger/debian/testdata/copyright/format-header
+++ b/syft/pkg/cataloger/debian/testdata/copyright/format-header
@@ -1,0 +1,22 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: example-tool
+Upstream-Contact: maintainer@example.com
+Source: https://example.com/example-tool
+
+Files: *
+Copyright: 2024 Example Maintainers
+License: MIT
+
+Files: vendor/foo/*
+Copyright: 2023 Foo Authors
+License: Apache-2.0
+ The full text of the Apache 2.0 license is available at
+ http://www.apache.org/licenses/LICENSE-2.0
+
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files.
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0; see
+ http://www.apache.org/licenses/LICENSE-2.0

--- a/syft/pkg/cataloger/debian/testdata/copyright/url-only-license
+++ b/syft/pkg/cataloger/debian/testdata/copyright/url-only-license
@@ -1,0 +1,12 @@
+This package was put together for free by an unnamed maintainer.
+
+It was downloaded from https://example.com/url-only-license.
+
+The license terms are reproduced verbatim at
+https://opensource.org/licenses/MIT — please consult that page for the
+authoritative version. The full text follows for convenience.
+
+(C) 2024 Example Maintainers. All rights reserved.
+
+Some additional documentation links may also appear, such as
+https://example.com/notes which is unrelated to licensing.


### PR DESCRIPTION
First step toward #4708 per @kzantow's livestream comment: *"add support for the `Format:` field and look up the URL against our list of known license URLs."*

## What's added

Two additive helpers in `syft/pkg/cataloger/debian/parse_copyright.go`:

| Function | What it does |
|---|---|
| `hasMachineReadableFormat(content)` | Recognizes the deb822 copyright format via the mandatory `Format:` header in the first stanza ([spec](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/)). Pure function, exposed for follow-up PRs to gate parsing strategy on. |
| `licenseIDsFromURLs(line)` | Extracts http(s) URLs from a line and resolves them against `spdxlicense.LicenseByURL`. References like `License: see http://www.apache.org/licenses/LICENSE-2.0` now surface a concrete SPDX ID even when the `License:` short-name field is missing or non-canonical. |

The URL lookup runs alongside the existing `License:` / `/usr/share/common-licenses/` / EULA-heading regexes — purely additive, never removes a finding.

## Why this scope

@tmuehlbacher-bnr's full proposal in the issue (gate machine-readable parsing on `Format:`, fall back to license classifier, deb822 stanza parser) is a substantial refactor that would need fixture-by-fixture renegotiation. @kzantow's response framed two concrete first steps:

1. *"add support for the Format: field"* — done; `hasMachineReadableFormat` exposes the detection so it can drive future behavior changes without re-walking the file.
2. *"look up the URL against our list of known license URLs"* — done; `licenseIDsFromURLs` plugs into the existing `spdxlicense.LicenseByURL` table.

This PR keeps the existing per-line regexes unchanged so no fixture expectations move, leaving room for the follow-up work that @tmuehlbacher-bnr outlined.

## Backward compatibility

All eight existing copyright fixtures produce **identical** results (`libc6`, `trilicense`, `liblzma5`, `libaudit-common`, `python`, `cuda`, `dev-kit`, `microsoft`).

The python fixture's already-known noisy captures (`#`, `Permission`, `This`, `see`) are intentionally untouched — addressing those means tightening `licensePattern` or gating it on `hasMachineReadableFormat`, both of which change observed behavior on real-world packages and belong in a follow-up.

## Tests

| Test | What it covers |
|---|---|
| `TestParseLicensesFromCopyright/testdata/copyright/format-header` | Machine-readable file with both License: short-names and embedded URLs |
| `TestParseLicensesFromCopyright/testdata/copyright/url-only-license` | Copyright with no License: short-name field at all — exercises pure URL detection |
| `TestHasMachineReadableFormat` (7 cases) | Format header in/out of first stanza, http/https schemes, no-scheme rejection, empty input |
| `TestLicenseIDsFromURLs` (5 cases) | Apache-2.0 / MIT seeAlso URLs, trailing-punctuation handling, non-license URLs filtered out |

## Out of scope (deferred to follow-ups)

- Refactoring per-line `License:` matching to skip non-machine-readable files (the python-fixture noise the issue mentions).
- Fuzzy-matching short license text against SPDX IDs (@kzantow's second-step suggestion + #2210).
- Fall-through to the license classifier when nothing else identifies the file.
- A real deb822 stanza parser as @tmuehlbacher-bnr proposed.

## Test plan

- [x] `go test ./syft/pkg/cataloger/debian/...` (non-docker subset) passes
- [x] `go vet ./syft/pkg/cataloger/debian/...` clean
- [x] All 8 prior fixtures produce unchanged results
- [x] DCO signed