### PR TITLE
fix: support arbitrary equality (===) in python requirements.txt

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -170,7 +170,9 @@ func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Re
 }
 
 func parseVersion(version string, guessFromConstraint bool) string {
-	if isPinnedConstraint(version) {
+	if isPinnedConstraint(version) || isPinnedConstraintArbitraryEquality(version) {
+		// Strip both == and === operators to extract the version
+		version = strings.ReplaceAll(version, "===", "==")
 		return strings.TrimSpace(strings.ReplaceAll(version, "==", ""))
 	}
 
@@ -183,6 +185,12 @@ func parseVersion(version string, guessFromConstraint bool) string {
 
 func isPinnedConstraint(version string) bool {
 	return strings.Contains(version, "==") && !strings.ContainsAny(version, "*,<>!")
+}
+
+// isPinnedConstraintArbitrary equality returns true if the version string uses
+// PEP 940 arbitrary equality operator (===), e.g. "urllib3===1.26.20".
+func isPinnedConstraintArbitraryEquality(version string) bool {
+	return strings.Contains(version, "===")
 }
 
 func guessVersion(constraint string) string {

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -337,6 +337,14 @@ func Test_newRequirement(t *testing.T) {
 				Markers:           "sys_platform == 'win32'",
 			},
 		},
+		{
+			name: "arbitrary equality (===)",
+			raw:  "urllib3===1.26.20",
+			want: &unprocessedRequirement{
+				Name:              "urllib3",
+				VersionConstraint: "===1.26.20",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -398,6 +406,18 @@ func Test_parseVersion(t *testing.T) {
 			version: "~=1.2b,<=1.3a,!=1.1,!=1.2",
 			guess:   true,
 			want:    "1.3a0", // note: 1.3a == 1.3a0
+		},
+		{
+			name:    "arbitrary equality pinned",
+			version: "urllib3===1.26.20",
+			guess:   false,
+			want:    "1.26.20",
+		},
+		{
+			name:    "arbitrary equality with spaces",
+			version: "=== 1.26.20",
+			guess:   false,
+			want:    "1.26.20",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Fixes [anchore/syft#4834](https://github.com/anchore/syft/issues/4834).

The PEP 940 arbitrary equality operator (`===`) was being silently ignored when parsing `requirements.txt` files, causing packages specified with this format to be missing from the SBOM and thus not scanned for CVEs by grype.

## Problem

Running grype on a requirements.txt with `===` format silently finds 0 packages:
```bash
$ echo "urllib3===1.26.20" > requirements.txt
$ grype .   # Reports 0 packages, 0 vulnerabilities
```

While `==` format works correctly:
```bash
$ echo "urllib3==1.26.20" > requirements.txt
$ grype .   # Reports urllib3@1.26.20 with actual CVEs
```

## Solution

1. Added `isPinnedConstraintArbitraryEquality()` to detect `===` format
2. Modified `parseVersion()` to strip `===` to `==` before extracting version
3. Added unit tests for both `newRequirement()` and `parseVersion()`

## Changes

- `syft/pkg/cataloger/python/parse_requirements.go`: Support `===` in `isPinnedConstraint` and `parseVersion`
- `syft/pkg/cataloger/python/parse_requirements_test.go`: Added test cases for arbitrary equality format

## Testing

- Added `Test_newRequirement` case: "arbitrary equality (===)"
- Added `Test_parseVersion` cases: "arbitrary equality pinned", "arbitrary equality with spaces"