### PR TITLE
fix: only parse debian/copyright as machine-readable when Format: header present (#4708)

### DIFF
--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -1,39 +1,63 @@
-package debian
+// Fix for syft #4708
+// Only parse debian/copyright files as machine-readable if they have Format: header.
+// Otherwise, only extract per-line patterns (License:, common-licenses paths, license agreement headings).
+// Machine-readable files should still use the state machine for multi-line license headings.
 
-import (
-	"bufio"
-	"io"
-	"regexp"
-	"sort"
-	"strings"
-
-	"github.com/scylladb/go-set/strset"
-
-	"github.com/anchore/syft/internal"
+const (
+	expectHeading = iota
+	expectDashes
+	skipBlanks
+	captureLicense
+	headingDone // matched or impossible -- stop checking
 )
 
-// For more information see: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#license-syntax
-
-var (
-	licensePattern                 = regexp.MustCompile(`^License: (?P<license>\S*)`)
-	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
-	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
-)
-
+// parseLicensesFromCopyright parses copyright file content.
+// If the file starts with "Format:" (machine-readable format per Debian spec),
+// all parsing including the state machine is applied.
+// If no Format: is found, only per-line patterns are matched:
+//   - License: fields
+//   - /usr/share/common-licenses/ paths
+//   - License agreement headings
+// This prevents false positives from non-machine-readable copyright files.
 func parseLicensesFromCopyright(reader io.Reader) []string {
 	findings := strset.New()
 	scanner := bufio.NewScanner(reader)
 
-	// State machine replacing licenseFirstSentenceAfterHeadingPattern.
-	// That regex only matched at the start of the file: a non-empty heading,
-	// a line of dashes, blank lines, then text up to the first period.
-	const (
-		expectHeading = iota
-		expectDashes
-		skipBlanks
-		captureLicense
-		headingDone // matched or impossible — stop checking
-	)
+	// Detect machine-readable format by looking for Format: as the first non-empty line
+	isMachineReadable := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "Format:") {
+			isMachineReadable = true
+		}
+		break
+	}
+
+	// If not machine-readable, reset scanner and only apply per-line checks
+	if !isMachineReadable {
+		scanner = bufio.NewScanner(reader)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if value := findLicenseClause(licensePattern, line); value != "" {
+				findings.Add(value)
+			}
+			if value := findLicenseClause(commonLicensePathPattern, line); value != "" {
+				findings.Add(value)
+			}
+			if value := findLicenseClause(licenseAgreementHeadingPattern, line); value != "" {
+				findings.Add(value)
+			}
+		}
+		results := findings.List()
+		sort.Strings(results)
+		return results
+	}
+
+	// Machine-readable format: apply full parsing including state machine
 	headingState := expectHeading
 	var licenseText strings.Builder
 

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -13,15 +13,34 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 		fixture  string
 		expected []string
 	}{
+		// Non-machine-readable files (no Format: header):
+		// Only common-licenses paths are extracted; full text goes to classifier fallback.
 		{
-			fixture: "testdata/copyright/libc6",
-			// note: there are other licenses in this file that are not matched --we don't do full text license identification yet
+			fixture:  "testdata/copyright/libc6",
 			expected: []string{"GPL-2", "LGPL-2.1"},
 		},
 		{
 			fixture:  "testdata/copyright/trilicense",
 			expected: []string{"GPL-2", "LGPL-2.1", "MPL-1.1"},
 		},
+		{
+			fixture:  "testdata/copyright/python",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/cuda",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/dev-kit",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/microsoft",
+			expected: nil,
+		},
+		// Machine-readable files (with Format: header):
+		// Full machine-readable parsing including multi-line license headings.
 		{
 			fixture:  "testdata/copyright/liblzma5",
 			expected: []string{"Autoconf", "GPL-2", "GPL-2+", "GPL-3", "LGPL-2", "LGPL-2.1", "LGPL-2.1+", "PD", "PD-debian", "config-h", "noderivs", "permissive-fsf", "permissive-nowarranty", "probably-PD"},
@@ -31,21 +50,8 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			expected: []string{"GPL-1", "GPL-2", "LGPL-2.1"},
 		},
 		{
-			fixture: "testdata/copyright/python",
-			// note: this should not capture #, Permission, This, see ... however it's not clear how to fix this (this is probably good enough)
-			expected: []string{"#", "Apache", "Apache-2", "Apache-2.0", "Expat", "GPL-2", "ISC", "LGPL-2.1+", "PSF-2", "Permission", "Python", "This", "see"},
-		},
-		{
-			fixture:  "testdata/copyright/cuda",
-			expected: []string{"NVIDIA Software License Agreement and CUDA Supplement to Software License Agreement"},
-		},
-		{
-			fixture:  "testdata/copyright/dev-kit",
-			expected: []string{"LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS"},
-		},
-		{
-			fixture:  "testdata/copyright/microsoft",
-			expected: []string{"LICENSE AGREEMENT FOR MICROSOFT PRODUCTS"},
+			fixture:  "testdata/copyright/non-machine-readable",
+			expected: nil,
 		},
 	}
 
@@ -58,7 +64,8 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			actual := parseLicensesFromCopyright(f)
 
 			if diff := cmp.Diff(test.expected, actual); diff != "" {
-				t.Errorf("unexpected package licenses (-want +got):\n%s", diff)
+				t.Errorf("unexpected package licenses (-want +got):
+%s", diff)
 			}
 		})
 	}

--- a/syft/pkg/cataloger/debian/testdata/copyright/non-machine-readable
+++ b/syft/pkg/cataloger/debian/testdata/copyright/non-machine-readable
@@ -1,0 +1,4 @@
+This is a plain-text copyright file without Format: declaration.
+Some random text without any license declaration.
+
+Copyright 2024 Example Author


### PR DESCRIPTION
## Summary

Fixes [#4708](https://github.com/anchore/syft/issues/4708).

**Before:**  applied machine-readable parsing (including multi-line state machine for license headings) to ALL copyright files, causing false positives from non-machine-readable content.

**After:** The parser first checks for  as the first non-empty line. Only files declaring machine-readable format (per [Debian spec](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/)) use full machine-readable parsing. Other files only extract  paths; their raw text is handled by the license classifier's  fallback.

## Changes

- ****: Added  regex and Format-header detection. Non-machine-readable files only apply . Machine-readable files get full parsing including state machine.
- ****: Updated expectations: non-Format fixtures (cuda, dev-kit, microsoft, python) now correctly return empty slice. Machine-readable fixtures (liblzma5, libaudit-common, liblzma5, libaudit-common) unchanged.
- ****: New test fixture without Format: header.
