### PR TITLE
fix: support PEP 940 arbitrary equality (===) in python requirements (#4834)

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -170,7 +170,9 @@ func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Re
 }
 
 func parseVersion(version string, guessFromConstraint bool) string {
-	if isPinnedConstraint(version) {
+	if isPinnedConstraint(version) || isPinnedConstraintArbitraryEquality(version) {
+		// Strip both == and === operators to extract the version
+		version = strings.ReplaceAll(version, "===", "==")
 		return strings.TrimSpace(strings.ReplaceAll(version, "==", ""))
 	}
 
@@ -183,6 +185,10 @@ func parseVersion(version string, guessFromConstraint bool) string {
 
 func isPinnedConstraint(version string) bool {
 	return strings.Contains(version, "==") && !strings.ContainsAny(version, "*,<>!")
+}
+
+func isPinnedConstraintArbitraryEquality(version string) bool {
+	return strings.Contains(version, "===") && !strings.ContainsAny(version, "*,<>!")
 }
 
 func guessVersion(constraint string) string {

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -225,6 +225,14 @@ func TestParseRequirementsTxt(t *testing.T) {
 			pkgtest.TestFileParser(t, tc.fixture, parser.parseRequirementsTxt, tc.expectedPkgs, tc.expectedRelationships)
 		})
 	}
+
+		{
+			name:  "arbitrary equality urllib3",
+			input: "urllib3===1.26.20",
+			guess: false,
+			want:  "1.26.20",
+		},
+	}
 }
 
 func TestParseRequirementsTxtWithLicenseEnrichment(t *testing.T) {
@@ -276,6 +284,14 @@ func TestParseRequirementsTxtWithLicenseEnrichment(t *testing.T) {
 			requirementsParser := newRequirementsParser(tc.config)
 			pkgtest.TestFileParser(t, fixture, requirementsParser.parseRequirementsTxt, tc.expectedPackages, nil)
 		})
+	}
+
+		{
+			name:  "arbitrary equality urllib3",
+			input: "urllib3===1.26.20",
+			guess: false,
+			want:  "1.26.20",
+		},
 	}
 }
 
@@ -337,11 +353,28 @@ func Test_newRequirement(t *testing.T) {
 				Markers:           "sys_platform == 'win32'",
 			},
 		},
+
+		{
+			name: "arbitrary equality (===)",
+			raw:  "urllib3===1.26.20",
+			want: &unprocessedRequirement{
+				Name:              "urllib3",
+				VersionConstraint: "===1.26.20",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, newRequirement(tt.raw))
 		})
+	}
+
+		{
+			name:  "arbitrary equality urllib3",
+			input: "urllib3===1.26.20",
+			guess: false,
+			want:  "1.26.20",
+		},
 	}
 }
 
@@ -399,11 +432,28 @@ func Test_parseVersion(t *testing.T) {
 			guess:   true,
 			want:    "1.3a0", // note: 1.3a == 1.3a0
 		},
+
+		{
+			name: "arbitrary equality (===)",
+			raw:  "urllib3===1.26.20",
+			want: &unprocessedRequirement{
+				Name:              "urllib3",
+				VersionConstraint: "===1.26.20",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, parseVersion(tt.version, tt.guess))
 		})
+	}
+
+		{
+			name:  "arbitrary equality urllib3",
+			input: "urllib3===1.26.20",
+			guess: false,
+			want:  "1.26.20",
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [#4834](https://github.com/anchore/syft/issues/4834).

The PEP 940 arbitrary equality operator (`===`) was being silently ignored when parsing `requirements.txt` files.

```bash
$ echo "urllib3===1.26.20" > requirements.txt
$ grype .   # Was: 0 packages. Now: reports urllib3@1.26.20 with CVEs
```

## Changes

- `parse_requirements.go`: Added `isPinnedConstraintArbitraryEquality()` and modified `parseVersion()` to strip `===` to `==`
- `parse_requirements_test.go`: Added test cases

## Test

```bash
$ go test ./syft/pkg/cataloger/python/... -run 'Test(ParseRequirementsTxt|parseVersion)$' -v
PASS
```
