### PR TITLE
fix: add nuget to TypeByName mapping for SPDX SBOM parsing (#4837)

### DIFF
--- a/syft/pkg/type.go
+++ b/syft/pkg/type.go
@@ -220,7 +220,7 @@ func TypeByName(name string) Type {
 		return CondaPkg
 	case packageurl.TypePub:
 		return DartPubPkg
-	case "dotnet": // here to support legacy use cases
+	case "dotnet", "nuget": // here to support legacy use cases
 		return DotnetPkg
 	case packageurl.TypeCocoapods:
 		return CocoapodsPkg

--- a/syft/pkg/type_test.go
+++ b/syft/pkg/type_test.go
@@ -59,6 +59,11 @@ func TestTypeFromPURL(t *testing.T) {
 			expected: DotnetPkg,
 		},
 		{
+			// nuget is the PURL type for .NET packages (e.g. pkg:nuget/Newtonsoft.Json@13.0.3)
+			purl:     "pkg:nuget/Newtonsoft.Json@13.0.3",
+			expected: DotnetPkg,
+		},
+		{
 			purl:     "pkg:composer/laravel/laravel@5.5.0",
 			expected: PhpComposerPkg,
 		},


### PR DESCRIPTION
## Summary

Fixes [#4837](https://github.com/anchore/syft/issues/4837).

Adds `nuget` to the `TypeByName` mapping so that `pkg:nuget/*` PURLs are correctly identified as `DotnetPkg` in SPDX SBOM output, preventing them from appearing as `UnknownPkg`.

**Before:** `pkg:nuget/Newtonsoft.Json@13.0.1` → `UnknownPkg`
**After:** `pkg:nuget/Newtonsoft.Json@13.0.1` → `DotnetPkg`

## Changes

- `syft/pkg/type.go`: Added `nuget` alongside `dotnet` in the `TypeByName` switch case
- `syft/pkg/type_test.go`: Added test case for `pkg:nuget/*` PURL type detection

## Test

```bash
$ go test ./syft/pkg/... -run TestTypeFromPURL -v
PASS
```
