### PR TITLE
fix: only parse debian/copyright as machine-readable when Format: header present (#4708)

### DIFF
--- a/syft/pkg/cataloger/debian/parse_copyright.go
+++ b/syft/pkg/cataloger/debian/parse_copyright.go
@@ -18,21 +18,44 @@ var (
 	licensePattern                 = regexp.MustCompile(`^License: (?P<license>\S*)`)
 	commonLicensePathPattern       = regexp.MustCompile(`/usr/share/common-licenses/(?P<license>[0-9A-Za-z_.\-]+)`)
 	licenseAgreementHeadingPattern = regexp.MustCompile(`(?i)^\s*(?P<license>LICENSE AGREEMENT(?: FOR .+?)?)\s*$`)
+	formatPattern                  = regexp.MustCompile(`^Format:\s*`)
 )
+
+// parseLicensesFromCopyright extracts license information from Debian copyright files.
+//
+// Machine-readable format detection:
+//   - Files with "Format:" as the first non-empty line are parsed using the full
+//     machine-readable syntax (per Debian spec), including multi-line license headings.
+//   - Files without "Format:" return no extracted licenses, allowing the raw content
+//     to be used by the license classifier as .text.content fallback.
+//
+// This prevents false positives from non-machine-readable copyright files.
 
 func parseLicensesFromCopyright(reader io.Reader) []string {
 	findings := strset.New()
 	scanner := bufio.NewScanner(reader)
 
-	// State machine replacing licenseFirstSentenceAfterHeadingPattern.
-	// That regex only matched at the start of the file: a non-empty heading,
-	// a line of dashes, blank lines, then text up to the first period.
+	// Detect machine-readable format by looking for Format: as the first non-empty line
+	isMachineReadable := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if formatPattern.MatchString(trimmed) {
+			isMachineReadable = true
+		}
+		break
+	}
+
+	// State machine for multi-line license headings (machine-readable format only)
 	const (
 		expectHeading = iota
 		expectDashes
 		skipBlanks
 		captureLicense
-		headingDone // matched or impossible — stop checking
+		headingDone // matched or impossible -- stop checking
 	)
 	headingState := expectHeading
 	var licenseText strings.Builder
@@ -40,47 +63,55 @@ func parseLicensesFromCopyright(reader io.Reader) []string {
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// per-line regex checks (applied to every line)
-		if value := findLicenseClause(licensePattern, line); value != "" {
-			findings.Add(value)
-		}
-		if value := findLicenseClause(commonLicensePathPattern, line); value != "" {
-			findings.Add(value)
-		}
-		if value := findLicenseClause(licenseAgreementHeadingPattern, line); value != "" {
-			findings.Add(value)
-		}
+		// per-line regex checks (applied to every line for machine-readable files)
+		if isMachineReadable {
+			if value := findLicenseClause(licensePattern, line); value != "" {
+				findings.Add(value)
+			}
+			if value := findLicenseClause(commonLicensePathPattern, line); value != "" {
+				findings.Add(value)
+			}
+			if value := findLicenseClause(licenseAgreementHeadingPattern, line); value != "" {
+				findings.Add(value)
+			}
 
-		// multi-line heading detection (only at start of file)
-		switch headingState {
-		case expectHeading:
-			if strings.TrimSpace(line) != "" {
-				headingState = expectDashes
-			} else {
-				headingState = headingDone
-			}
-		case expectDashes:
-			trimmed := strings.TrimSpace(line)
-			if len(trimmed) > 0 && strings.Trim(trimmed, "-") == "" {
-				headingState = skipBlanks
-			} else {
-				headingState = headingDone
-			}
-		case skipBlanks:
-			if strings.TrimSpace(line) != "" {
-				headingState = captureLicense
+			// multi-line heading detection (only at start of file, machine-readable only)
+			switch headingState {
+			case expectHeading:
+				if strings.TrimSpace(line) != "" {
+					headingState = expectDashes
+				} else {
+					headingState = headingDone
+				}
+			case expectDashes:
+				trimmed := strings.TrimSpace(line)
+				if len(trimmed) > 0 && strings.Trim(trimmed, "-") == "" {
+					headingState = skipBlanks
+				} else {
+					headingState = headingDone
+				}
+			case skipBlanks:
+				if strings.TrimSpace(line) != "" {
+					headingState = captureLicense
+					licenseText.WriteString(line)
+					if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
+						findings.Add(value)
+						headingState = headingDone
+					}
+				}
+			case captureLicense:
+				licenseText.WriteString(" ")
 				licenseText.WriteString(line)
 				if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
 					findings.Add(value)
 					headingState = headingDone
 				}
 			}
-		case captureLicense:
-			licenseText.WriteString(" ")
-			licenseText.WriteString(line)
-			if value := extractUpToFirstPeriod(licenseText.String()); value != "" {
+		} else {
+			// Non-machine-readable: only extract common-licenses paths (backward compat)
+			// For other content, use license classifier's .text.content fallback
+			if value := findLicenseClause(commonLicensePathPattern, line); value != "" {
 				findings.Add(value)
-				headingState = headingDone
 			}
 		}
 	}

--- a/syft/pkg/cataloger/debian/parse_copyright_test.go
+++ b/syft/pkg/cataloger/debian/parse_copyright_test.go
@@ -13,15 +13,34 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 		fixture  string
 		expected []string
 	}{
+		// Non-machine-readable files (no Format: header):
+		// Only common-licenses paths are extracted; full text goes to classifier fallback.
 		{
-			fixture: "testdata/copyright/libc6",
-			// note: there are other licenses in this file that are not matched --we don't do full text license identification yet
+			fixture:  "testdata/copyright/libc6",
 			expected: []string{"GPL-2", "LGPL-2.1"},
 		},
 		{
 			fixture:  "testdata/copyright/trilicense",
 			expected: []string{"GPL-2", "LGPL-2.1", "MPL-1.1"},
 		},
+		{
+			fixture:  "testdata/copyright/python",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/cuda",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/dev-kit",
+			expected: nil,
+		},
+		{
+			fixture:  "testdata/copyright/microsoft",
+			expected: nil,
+		},
+		// Machine-readable files (with Format: header):
+		// Full machine-readable parsing including multi-line license headings.
 		{
 			fixture:  "testdata/copyright/liblzma5",
 			expected: []string{"Autoconf", "GPL-2", "GPL-2+", "GPL-3", "LGPL-2", "LGPL-2.1", "LGPL-2.1+", "PD", "PD-debian", "config-h", "noderivs", "permissive-fsf", "permissive-nowarranty", "probably-PD"},
@@ -31,21 +50,8 @@ func TestParseLicensesFromCopyright(t *testing.T) {
 			expected: []string{"GPL-1", "GPL-2", "LGPL-2.1"},
 		},
 		{
-			fixture: "testdata/copyright/python",
-			// note: this should not capture #, Permission, This, see ... however it's not clear how to fix this (this is probably good enough)
-			expected: []string{"#", "Apache", "Apache-2", "Apache-2.0", "Expat", "GPL-2", "ISC", "LGPL-2.1+", "PSF-2", "Permission", "Python", "This", "see"},
-		},
-		{
-			fixture:  "testdata/copyright/cuda",
-			expected: []string{"NVIDIA Software License Agreement and CUDA Supplement to Software License Agreement"},
-		},
-		{
-			fixture:  "testdata/copyright/dev-kit",
-			expected: []string{"LICENSE AGREEMENT FOR NVIDIA SOFTWARE DEVELOPMENT KITS"},
-		},
-		{
-			fixture:  "testdata/copyright/microsoft",
-			expected: []string{"LICENSE AGREEMENT FOR MICROSOFT PRODUCTS"},
+			fixture:  "testdata/copyright/non-machine-readable",
+			expected: nil,
 		},
 	}
 

--- a/syft/pkg/cataloger/debian/testdata/copyright/non-machine-readable
+++ b/syft/pkg/cataloger/debian/testdata/copyright/non-machine-readable
@@ -1,0 +1,7 @@
+This is a plain-text copyright file without Format: declaration.
+Some random text without any license declaration.
+
+Copyright 2024 Example Author
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software to deal in the Software without restriction.


### PR DESCRIPTION
## Summary

Fixes [#4708](https://github.com/anchore/syft/issues/4708).

Previously, `parseLicensesFromCopyright` applied machine-readable parsing to ALL copyright files, causing false positives from non-machine-readable content. Now it first checks for `Format:` as the first non-empty line. Only files declaring machine-readable format use full parsing.

**Before:** All copyright files parsed with machine-readable logic → false positives
**After:** Only `Format:`-declared files use machine-readable parsing; others fall back to classifier

## Changes

- `parse_copyright.go`: Added `formatPattern` and Format-header detection at file start
- `parse_copyright_test.go`: Updated expectations for non-Format fixtures
- `testdata/copyright/non-machine-readable`: New test fixture without Format: header

## Test

```bash
$ go test ./syft/pkg/cataloger/debian/... -run TestParseLicensesFromCopyright -v
PASS
```
