### PR TITLE
fix: skip permission-denied paths instead of crashing on directory walk (#3258)

### DIFF
--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -216,6 +216,12 @@ func (r *directoryIndexer) indexBranch(root string, stager *progress.AtomicStage
 		lstat, err := os.Lstat(targetPath)
 		newRoot, err := r.indexPath(targetPath, lstat, err)
 		if err != nil && !errors.Is(err, ErrSkipPath) && !errors.Is(err, fs.SkipDir) {
+			// file access errors (e.g. permission denied on restricted directories like /boot/grub2)
+			// should not stop the walk -- skip and continue, matching filepath.Walk behavior.
+			// Only fail for truly unexpected errors (ErrSkipPath and fs.SkipDir are expected/safe).
+			if r.isFileAccessErr(targetPath, err) {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("unable to index ancestor path=%q: %w", targetPath, err)
 		}
 		if newRoot != "" {


### PR DESCRIPTION
## Summary

Fixes [#3258](https://github.com/anchore/syft/issues/3258).

When scanning a directory with excluded paths, syft would crash if it encountered permission-denied directories (e.g., `/boot/grub2` owned by root) during the ancestor path walk, even when those paths were excluded.

**Before:** `unable to index ancestor path="/boot/grub2": permission denied` → syft exits with error
**After:** Permission-denied paths are skipped and logged, scan continues

The fix adds `r.isFileAccessErr(targetPath, err)` check at line 218 of `directory_indexer.go`. When `os.Lstat` fails with a file access error, the ancestor walk continues instead of returning an error. This matches the behavior of `filepath.Walk` which skips permission errors.

## Changes

- `syft/internal/fileresolver/directory_indexer.go`: Skip file access errors in `indexBranch` ancestor walk instead of returning an error

## Test

```bash
$ sudo -u nobody syft / --exclude ./boot --exclude ./web
# Previously: crash on permission denied
# Now: logs warning and continues
```

## Related

This was discussed in syft#3258 with the suggestion that excluded paths should not be accessed at all. While the ideal long-term fix would prevent access to excluded paths entirely, this change provides immediate relief by making permission errors non-fatal.
