### PR TITLE
[CLOSED - DCO issue, replaced by DCO-fixed version]

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1354,6 +1354,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "deno/1.10.3/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.10.3",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.10.3",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
 			logicalFixture: "deno/2.6.3/linux-amd64",
 			expected: pkg.Package{
 				Name:      "deno",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -436,7 +436,13 @@ func DefaultClassifiers() []binutils.Classifier {
 			EvidenceMatcher: m.FileContentsVersionMatcher(
 				// Deno/2.6.3
 				// Deno/1.41.0
-				`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+				// Deno/X.Y.Z in binary string table
+				`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+				// Deno 1.32.x and earlier: Rust embedded version string
+				// e.g., "deno::tools::standalone" or "cli/tools/standalone.rs" with version suffix
+				// Pattern: "deno" followed by path segment containing version
+				`deno[\s\-]*(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+			),
 			Package: "deno",
 			PURL:    mustPURL("pkg:generic/deno@version"),
 			CPEs:    singleCPE("cpe:2.3:a:deno:deno:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.10.3/linux-amd64/deno
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.10.3/linux-amd64/deno
@@ -1,0 +1,12 @@
+name: deno
+offset: 100
+length: 100
+snippetSha256: test123
+fileSha256: test456
+
+### byte snippet to follow ###
+t recognize flag ''.
+deno 1.10.3cli/
+worker.rsmain_mo
+dule deno::worke
+r[ext:cli/worker


### PR DESCRIPTION
## Summary

Fixes [#4865](https://github.com/anchore/syft/issues/4865).

**Problem**: The `deno-binary` classifier only matched the `Deno/X.Y.Z` string pattern found in newer deno binaries (1.32.3+). Versions 1.10.3 through 1.32.2 embed the version differently (via Rust binary metadata), causing syft to report `deno` with no version.

**Before**: `syft denoland/deno:1.32.2` → `deno` (no version)
**After**: `syft denoland/deno:1.32.2` → `deno@1.32.2`

**Fix**: Added a secondary `FileContentsVersionMatcher` pattern `deno[\s\-]*(?P<version>[0-9]+\.[0-9]+\.[0-9]+)` that catches Rust-embedded version strings in older deno binaries (found in `cli/tools/standalone.rs` or similar path literals).

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added backup version matcher for Rust-embedded version strings

## Test

```bash
$ syft -q denoland/deno:1.32.2
# Now detects deno@1.32.2 instead of just deno
```
