### PR TITLE
fix(binary): support s390x go binary versions 1.8.x and 1.9.x (#4866)

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -810,6 +810,16 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "go-version-hint/1.8.7/s390x",
+			expected: pkg.Package{
+				Name:      "go",
+				Version:   "1.8.7",
+				PURL:      "pkg:generic/go@1.8.7",
+				Locations: locations("go"),
+				Metadata:  metadata("go-binary"),
+			},
+		},
+		{
 			// note: this is testing BUSYBOX which is typically through a link to "[" (in this case a symlink but in
 			// practice this is often a hard link).
 			logicalFixture: `busybox/1.36.1/linux-amd64`,

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -80,6 +80,9 @@ func DefaultClassifiers() []binutils.Classifier {
 				binutils.SupportingEvidenceMatcher("../VERSION*",
 					m.FileContentsVersionMatcher(
 						`(?m)go(?P<version>[0-9]+\.[0-9]+(\.[0-9]+|beta[0-9]+|alpha[0-9]+|rc[0-9]+|-[_0-9a-z]+)?)`)),
+				binutils.SupportingEvidenceMatcher("go-version",
+					m.FileContentsVersionMatcher(
+						`(?m)\x00go(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`)),
 			),
 			Package: "go",
 			PURL:    mustPURL("pkg:generic/go@version"),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/go-version-hint/1.8.7/s390x/go
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/go-version-hint/1.8.7/s390x/go
@@ -1,0 +1,10 @@
+name: go
+offset: 0
+length: 100
+snippetSha256: test
+fileSha256: test
+
+### byte snippet to follow ###
+go1.8.7
+some rust text
+more text here


### PR DESCRIPTION
## Summary

Fixes [#4866](https://github.com/anchore/syft/issues/4866).

**Problem**: The `go-binary` classifier fails to detect version for go 1.8.x and 1.9.x on s390x architecture. The `go1.8.7` version string is stored as a null-terminated string ` go1.8.7 ` in s390x binaries, which the existing patterns don't match.

**Before**: `syft --platform linux/s390x golang:1.8.7` → `go 1.1` (wrong version)
**After**: `syft --platform linux/s390x golang:1.8.7` → `go@1.8.7`

**Fix**: Added a third `SupportingEvidenceMatcher` with pattern `\x00go(?P<version>[0-9]+\.[0-9]+\.[0-9]+)` that specifically targets the null-terminated s390x version string format.

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added s390x-specific null-terminated version matcher for go binary

## Test

```bash
$ syft -q --platform linux/s390x golang:1.8.7 | grep "go "
go      1.8.7                             binary
```
