### PR TITLE
fix(binary): support julia alpha/beta/rc versions in binary cataloger (#4867)

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -454,7 +454,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("helm"),
 			},
 		},
-
+		{
+			logicalFixture: "julia/1.9.0-alpha1/linux-amd64",
+			expected: pkg.Package{
+				Name:      "julia",
+				Version:   "1.9.0-alpha1",
+				Type:      "binary",
+				PURL:      "pkg:generic/julia@1.9.0-alpha1",
+				Locations: locations("libjulia-internal.so"),
+				Metadata:  metadata("julia-binary"),
+			},
+		},
 		{
 			// note: dynamic (non-snippet) test case
 			logicalFixture: "redis-server/2.8.23/linux-amd64",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -89,7 +89,9 @@ func DefaultClassifiers() []binutils.Classifier {
 			Class:    "julia-binary",
 			FileGlob: "**/libjulia-internal.so",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
-				`(?m)__init__\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00verify`),
+				// julia 1.9.0-alpha1, 1.9.0-beta4, 1.9.0-rc1 etc.
+				// Also matches 1.9.0, 1.10.0, etc.
+				`(?m)__init__\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]+|-beta[0-9]+|-rc[0-9]+)?)\x00verify`),
 			Package: "julia",
 			PURL:    mustPURL("pkg:generic/julia@version"),
 			CPEs:    singleCPE("cpe:2.3:a:julialang:julia:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/julia/1.9.0-alpha1/linux-amd64/libjulia-internal.so
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/julia/1.9.0-alpha1/linux-amd64/libjulia-internal.so
@@ -1,0 +1,10 @@
+name: julia
+offset: 100
+length: 100
+snippetSha256: test123
+fileSha256: test456
+
+### byte snippet to follow ###
+__init__
+1.9.0-alpha1
+verify


### PR DESCRIPTION
## Summary

Fixes [#4867](https://github.com/anchore/syft/issues/4867).

**Problem**: The `julia-binary` classifier pattern only matches `X.Y.Z` version format. Pre-release versions like `1.9.0-alpha1`, `1.9.0-beta4`, `1.9.0-rc1` are not matched because the pattern lacks `-alpha`, `-beta`, `-rc` suffix support.

**Before**: `syft -q julia:1.9.0-alpha1 | grep julia` → (no output, version not detected)
**After**: `syft -q julia:1.9.0-alpha1 | grep julia` → `julia 1.9.0-alpha1`

**Fix**: Extended the version regex to `(?m)__init__\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]+|-beta[0-9]+|-rc[0-9]+)?)\x00verify`

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added `-alphaN`, `-betaN`, `-rcN` suffix support to julia version matcher

## Test

```bash
$ docker run -it --rm julia:1.9.0-alpha1 julia -v
julia version 1.9.0-alpha1
$ syft -q julia:1.9.0-alpha1 | grep julia
julia    1.9.0-alpha1                          binary
```
