### PR TITLE
fix: normalize trailing slash in exclude paths for directory matching (#4839)

### DIFF
--- a/syft/source/directorysource/directory_source.go
+++ b/syft/source/directorysource/directory_source.go
@@ -160,7 +160,14 @@ func GetDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 			for _, exclusion := range exclusions {
 				// this is required to handle Windows filepaths
 				path = filepath.ToSlash(path)
-				matches, err := doublestar.Match(exclusion, path)
+				// doublestar.Match treats trailing slashes as significant (a/b/ only matches directory a/b/,
+				// not nested paths a/b/c). Normalize by stripping trailing slash so --exclude ./folder/
+				// correctly matches both the directory ./folder/ and all nested paths ./folder/...
+				exclusionPattern := exclusion
+				if strings.HasSuffix(exclusionPattern, "/") {
+					exclusionPattern = strings.TrimSuffix(exclusionPattern, "/")
+				}
+				matches, err := doublestar.Match(exclusionPattern, path)
 				if err != nil {
 					return nil
 				}


### PR DESCRIPTION
## Summary

Fixes [#4839](https://github.com/anchore/syft/issues/4839).

**Problem**: When using `--exclude ./path/to/folder/` with a trailing slash, the directory and its contents are not excluded. This is because `doublestar.Match` treats trailing slashes as significant: the pattern `./folder/` only matches the directory `./folder/` exactly, but not nested paths like `./folder/file.txt`.

**Before**: `syft --exclude ./boot/ /` → `./boot/` not excluded (trailing slash ignored)
**After**: `syft --exclude ./boot/ /` → `./boot/` and all contents correctly excluded

**Fix**: Normalize the exclusion pattern by stripping the trailing slash before calling `doublestar.Match`. This ensures `--exclude ./folder/` matches both `./folder/` (the directory itself) and `./folder/...` (all nested content).

## Changes

- `syft/source/directorysource/directory_source.go`: Strip trailing slash from exclusion pattern before glob matching

## Test

```bash
mkdir -p /tmp/syft-test/boot /tmp/syft-test/data
touch /tmp/syft-test/boot/secret.txt /tmp/syft-test/data/file.txt
syft --exclude /tmp/syft-test/boot/ /tmp/syft-test/ -o json | jq '.artifacts[].name'
# Before: includes "boot" entries
# After: only "data" entries
```
