### PR TITLE
[CLOSED - DCO issue, replaced by DCO-fixed version]

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -454,7 +454,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 				Metadata:  metadata("helm"),
 			},
 		},
-
+		{
+			logicalFixture: "helm/2.0.0-beta.2/linux-amd64",
+			expected: pkg.Package{
+				Name:      "helm",
+				Version:   "2.0.0-beta.2",
+				Type:      "binary",
+				PURL:      "pkg:golang/helm.sh/helm@2.0.0-beta.2",
+				Locations: locations("helm"),
+				Metadata:  metadata("helm"),
+			},
+		},
 		{
 			// note: dynamic (non-snippet) test case
 			logicalFixture: "redis-server/2.8.23/linux-amd64",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -98,7 +98,8 @@ func DefaultClassifiers() []binutils.Classifier {
 			Class:    "helm",
 			FileGlob: "**/helm",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
-				`(?m)\x00v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00`),
+				// v2.0.0-beta.2, v3.15.2, v3.15.0-rc.1, v3.15.0-alpha.1
+				`(?m)\x00v(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9]*(\.[0-9]+)?)?)\x00`),
 			Package: "helm",
 			PURL:    mustPURL("pkg:golang/helm.sh/helm@version"),
 			CPEs:    singleCPE("cpe:2.3:a:helm:helm:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/helm/2.0.0-beta.2/linux-amd64/helm
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/helm/2.0.0-beta.2/linux-amd64/helm
@@ -1,0 +1,9 @@
+name: helm
+offset: 100
+length: 100
+snippetSha256: test123
+fileSha256: test456
+
+### byte snippet to follow ###
+v2.0.0-beta.2
+some text here


### PR DESCRIPTION
## Summary

Fixes [#4820](https://github.com/anchore/syft/issues/4820).

**Problem**: The `helm` binary classifier pattern `\x00v[0-9]+\.[0-9]+\.[0-9]+\x00` only matches stable X.Y.Z versions. Pre-release versions like `v2.0.0-beta.2`, `v3.15.0-rc.1`, `v3.15.0-alpha.1` are not matched.

**Before**: `syft -q alpine/helm:2.0.0-beta.2 | grep helm` → (no output)
**After**: `syft -q alpine/helm:2.0.0-beta.2 | grep helm` → `helm 2.0.0-beta.2`

**Fix**: Extended the regex to:
```
\x00v(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9]*(\.[0-9]+)?)?)\x00
```

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added alpha/beta/rc suffix support to helm version matcher

## Test

```bash
$ docker run -it --rm alpine/helm:2.0.0-beta.2 version
Client: &version.Version{SemVer:"v2.0.0-beta.2"...}
$ syft -q alpine/helm:2.0.0-beta.2 | grep helm
helm     2.0.0-beta.2                         binary
```
