### PR TITLE
fix(binary): support elixir rc/beta versions with dots in suffix (#4819)

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -768,7 +768,8 @@ func DefaultClassifiers() []binutils.Classifier {
 			Class:    "elixir-binary",
 			FileGlob: "**/elixir",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
-				`(?m)ELIXIR_VERSION=(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+				// ELIXIR_VERSION=1.12.0-rc.1
+				`(?m)ELIXIR_VERSION=(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?)`),
 			Package: "elixir",
 			PURL:    mustPURL("pkg:generic/elixir@version"),
 			CPEs: []cpe.CPE{
@@ -779,7 +780,8 @@ func DefaultClassifiers() []binutils.Classifier {
 			Class:    "elixir-library",
 			FileGlob: "**/elixir/ebin/elixir.app",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
-				`(?m)\{vsn,"(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9]+)?)"\}`),
+				// {vsn,"1.12.0-rc.1"} - the dot in "rc.1" requires [a-z0-9.] not [a-z0-9]
+				`(?m)\{vsn,"(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?)"\}`),
 			Package: "elixir",
 			PURL:    mustPURL("pkg:generic/elixir@version"),
 			CPEs:    singleCPE("cpe:2.3:a:elixir-lang:elixir:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),


### PR DESCRIPTION
## Summary

Fixes [#4819](https://github.com/anchore/syft/issues/4819).

**Root cause**: The version pattern `(-[a-z0-9]+)?` in both `elixir-binary` and `elixir-library` classifiers doesn't include the dot character. Pre-release versions like `1.12.0-rc.1` have a dot in the suffix (`rc.1`), which fails to match because `.` is not in `[a-z0-9]`.

**Before**: `syft -q elixir:1.12.0-rc | grep elixir` → (no output)
**After**: `syft -q elixir:1.12.0-rc | grep elixir` → `elixir 1.12.0-rc.1`

**Fix**: Extended the suffix character class from `[a-z0-9]+` to `[a-z0-9.]+` in both elixir classifiers to capture dots in pre-release suffixes.

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Changed `-[a-z0-9]+` to `-[a-z0-9.]+` in elixir-binary and elixir-library version patterns

## Test

```bash
$ docker run -it --rm elixir:1.12.0-rc elixir -v
Elixir 1.12.0-rc.1 (compiled with Erlang/OTP 23)
$ syft -q elixir:1.12.0-rc | grep elixir
elixir    1.12.0-rc.1                          binary
```
