### PR TITLE
feat(binary): add ingress-nginx binary classifier (#4818)

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -894,6 +894,18 @@ func DefaultClassifiers() []binutils.Classifier {
 			CPEs:    singleCPE("cpe:2.3:a:envoyproxy:envoy:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
 		},
 		{
+		{
+			Class:    "ingress-nginx-binary",
+			FileGlob: "**/nginx-ingress-controller",
+			EvidenceMatcher: m.FileContentsVersionMatcher(
+				// v1.15.1 (newer), 0.30.0 (older), Release:       v1.15.1
+				// Also matches v0.34.0 and other versions
+				`(?m)(?:Release:\s*)?v?(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			Package: "ingress-nginx",
+			PURL:    mustPURL("pkg:generic/ingress-nginx@version"),
+			CPEs:    singleCPE("cpe:2.3:a:nginx:ingress-nginx:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),
+		},
+		{
 			Class:    "mongodb-binary",
 			FileGlob: "**/mongod",
 			EvidenceMatcher: binutils.MatchAny(


### PR DESCRIPTION
## Summary

Fixes [#4818](https://github.com/anchore/syft/issues/4818).

**Problem**: syft does not have a binary classifier for ingress-nginx (`nginx-ingress-controller`). As a result, syft only detects it as a `go-module` with `UNKNOWN` version. This prevents CVE scanning (e.g., CVE-2025-1974) from matching ingress-nginx specifically.

**Before**: `syft ... ingress-nginx:v1.15.1 | grep ingress` → `k8s.io/ingress-nginx UNKNOWN go-module`
**After**: `syft ... ingress-nginx:v1.15.1 | grep ingress` → `ingress-nginx 1.15.1`

**Fix**: Added `ingress-nginx-binary` classifier that matches `**/nginx-ingress-controller` and extracts the version from embedded version strings (e.g., `v1.15.1`, `v0.34.0`, `0.30.0`).

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added ingress-nginx-binary classifier with CPE

## Test

```bash
$ docker run -it --rm registry.k8s.io/ingress-nginx/controller:v1.15.1 /nginx-ingress-controller --version
Release:       v1.15.1

$ syft -q registry.k8s.io/ingress-nginx/controller:v1.15.1 | grep ingress
ingress-nginx  1.15.1                          binary
```
