### PR TITLE
fix(dotnet): prefer ProductVersion when it contains semantic metadata (#4017)

### DIFF
--- a/syft/pkg/cataloger/dotnet/package.go
+++ b/syft/pkg/cataloger/dotnet/package.go
@@ -324,7 +324,7 @@ func findVersionFromVersionResources(versionResources map[string]string) string 
 	fileVersion := extractVersionFromResourcesValue(versionResources["FileVersion"])
 
 	// For Microsoft PE files, ProductVersion is the authoritative release version.
-	// FileVersion is often a CI build stamp (major.minor.<buildfate>.<buildtime>)
+	// FileVersion is often a CI build stamp (major.minor.<builddate>.<buildtime>)
 	// which numerically compares greater than the true release version (e.g.
 	// 8.0.324 > 8.0.3). When ProductVersion contains semantic metadata (+),
 	// it is always the preferred version source for release identification.

--- a/syft/pkg/cataloger/dotnet/package.go
+++ b/syft/pkg/cataloger/dotnet/package.go
@@ -323,10 +323,18 @@ func findVersionFromVersionResources(versionResources map[string]string) string 
 	productVersion := extractVersionFromResourcesValue(versionResources["ProductVersion"])
 	fileVersion := extractVersionFromResourcesValue(versionResources["FileVersion"])
 
-	// ms file ver is a ci build stamp (major.minor.<buildfate>.<buildyime>) we'll match with fewer segments
+	// For Microsoft PE files, ProductVersion is the authoritative release version.
+	// FileVersion is often a CI build stamp (major.minor.<buildfate>.<buildtime>)
+	// which numerically compares greater than the true release version (e.g.
+	// 8.0.324 > 8.0.3). When ProductVersion contains semantic metadata (+),
+	// it is always the preferred version source for release identification.
 	if isMicrosoftVersionResource(versionResources) {
 		if v := preferShorterMajorMinorMatch(productVersion, fileVersion); v != "" {
 			return v
+		}
+		// ProductVersion with + (semantic metadata like 8.0.3+commitHash) is authoritative
+		if strings.Contains(productVersion, "+") {
+			return productVersion
 		}
 	}
 

--- a/syft/pkg/cataloger/dotnet/package_test.go
+++ b/syft/pkg/cataloger/dotnet/package_test.go
@@ -320,6 +320,24 @@ func Test_NewDotnetBinaryPackage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Microsoft assembly with ProductVersion semver metadata wins over greater FileVersion",
+			versionResources: map[string]string{
+				"CompanyName":    "Microsoft Corporation",
+				"ProductName":    "Microsoft Test",
+				"FileVersion":    "9.0.99.0",
+				"ProductVersion": "8.0.3+9f4b1f5d664afdfc80e1508ab7ed099dff210fbd",
+			},
+			expectedPackage: pkg.Package{
+				Name:    "Microsoft Test",
+				Version: "8.0.3+9f4b1f5d664afdfc80e1508ab7ed099dff210fbd",
+				Metadata: pkg.DotnetPortableExecutableEntry{
+					CompanyName:    "Microsoft Corporation",
+					ProductName:    "Microsoft Test",
+					ProductVersion: "8.0.3+9f4b1f5d664afdfc80e1508ab7ed099dff210fbd",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Fixes [#4017](https://github.com/anchore/syft/issues/4017).

**Root cause**: `findVersionFromVersionResources` uses `keepGreaterSemanticVersion` to choose between `ProductVersion` and `FileVersion`. For Microsoft PE files, `FileVersion` is often a CI build stamp (e.g., `8.0.324.11423`) which semantically compares as greater than the true `ProductVersion` (e.g., `8.0.3+9f4b1f5d664afdfc80e1508ab7ed099dff210fbd`) because `324 > 3`.

**Before**: System.Text.Json → version `8.0.324.11423` (FileVersion, a build stamp)
**After**: System.Text.Json → version `8.0.3+9f4b1f5d664afdfc80e1508ab7ed099dff210fbd` (ProductVersion, the real release)

**Fix**: Added a check for `ProductVersion` containing `+` (semantic metadata suffix) before the semantic comparison. When present, `ProductVersion` is always authoritative for Microsoft PE files.

## Changes

- `syft/pkg/cataloger/dotnet/package.go`: Added check for `+` in ProductVersion before semantic comparison

## Testing

Build a self-contained .NET application and compare syft output:
```bash
dotnet publish -c Release -r linux-x64 --self-contained app.csproj
syft app -o json | jq '.artifacts[] | select(.name=="System.Text.Json") | .version'
# Before: 8.0.324.11423
# After: 8.0.3+HASH
```
