### PR TITLE
fix(source): treat exclude paths with trailing slash as directories

### DIFF
--- a/syft/source/directorysource/directory_source.go
+++ b/syft/source/directorysource/directory_source.go
@@ -145,6 +145,9 @@ func GetDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 		// check exclusions for supported paths, these are all relative to the "scan root"
 		if strings.HasPrefix(exclusion, "./") || strings.HasPrefix(exclusion, "*/") || strings.HasPrefix(exclusion, "**/") {
 			exclusion = strings.TrimPrefix(exclusion, "./")
+			// a trailing slash signals a directory but is otherwise discarded by doublestar.Match,
+			// causing the pattern to silently match nothing (see issue #4839)
+			exclusion = strings.TrimSuffix(exclusion, "/")
 			exclusions[idx] = root + exclusion
 		} else {
 			errors = append(errors, exclusion)

--- a/syft/source/directorysource/directory_source_test.go
+++ b/syft/source/directorysource/directory_source_test.go
@@ -177,6 +177,18 @@ func Test_DirectorySource_Exclusions(t *testing.T) {
 		},
 		{
 			input: "testdata/image-simple",
+			desc:  "exclude explicit directory with trailing slash (issue #4839)",
+			glob:  "**",
+			expected: []string{
+				"Dockerfile",
+				"file-1.txt",
+				"file-2.txt",
+				//"target/really/nested/file-3.txt", // explicitly skipped
+			},
+			exclusions: []string{"./target/"},
+		},
+		{
+			input: "testdata/image-simple",
 			desc:  "exclude explicit file relative to the root",
 			glob:  "**",
 			expected: []string{
@@ -326,6 +338,14 @@ func Test_getDirectoryExclusionFunctions_crossPlatform(t *testing.T) {
 			root:     "/",
 			path:     "/usr/var/lib",
 			exclude:  "**/var/lib",
+			finfo:    file.ManualInfo{ModeValue: os.ModeDir},
+			walkHint: fs.SkipDir,
+		},
+		{
+			desc:     "directory exclusion with trailing slash (issue #4839)",
+			root:     "/usr/var",
+			path:     "/usr/var/lib",
+			exclude:  "./lib/",
 			finfo:    file.ManualInfo{ModeValue: os.ModeDir},
 			walkHint: fs.SkipDir,
 		},


### PR DESCRIPTION
Closes #4839.

## Repro from the issue

\`\`\`sh
syft scan \$HOME/.local --exclude ./lib/   # lib/ is still indexed
syft scan \$HOME/.local --exclude ./lib    # lib/ is correctly skipped
\`\`\`

## Cause

\`GetDirectoryExclusionFunctions\` in \`syft/source/directorysource/directory_source.go\` rewrites each user-supplied exclusion to an absolute pattern (e.g. \`./lib\` → \`/abs/root/lib\`) and then matches each walked path against it via \`doublestar.Match\`. The rewrite strips a leading \`./\` but leaves a trailing \`/\` intact, so \`./lib/\` becomes \`/abs/root/lib/\`. \`doublestar.Match\` requires an exact string match, and no walked path ever ends in a slash, so the pattern silently matches nothing.

## Fix

Strip a trailing slash from the exclusion alongside the existing \`./\` strip, so \`./lib/\` and \`./lib\` produce the same compiled pattern. This also matches the documented behavior at https://oss.anchore.com/docs/guides/sbom/file-selection/#excluding-file-paths, which never says a trailing slash is meaningful.

## Tests

Two regression tests added next to the existing exclusion coverage in \`directory_source_test.go\`:

- \`Test_DirectorySource_Exclusions/exclude_explicit_directory_with_trailing_slash_(issue_#4839)\` — full directory-source path; mirrors the existing \`./target\` case but uses \`./target/\`.
- \`Test_getDirectoryExclusionFunctions_crossPlatform/directory_exclusion_with_trailing_slash_(issue_#4839)\` — unit-level; asserts \`fs.SkipDir\` is returned for a directory matched via \`./lib/\`.

Both fail on \`main\` and pass with the fix. Locally verified \`go test ./syft/source/directorysource/...\` and \`go vet ./...\` clean, plus a live syft build against a two-\`go.mod\` repro confirms \`--exclude ./lib/\` and \`--exclude ./lib\` now produce identical SBOMs.