### PR TITLE
fix: support go binary older versions (1.8.x, 1.9.x) on s390x

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -707,6 +707,16 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "go/1.8.7",
+			expected: pkg.Package{
+				Name:      "go",
+				Version:   "1.8.7",
+				PURL:      "pkg:generic/go@1.8.7",
+				Locations: locations("go"),
+				Metadata:  metadata("go-binary"),
+			},
+		},
+		{
 			logicalFixture: "node/0.10.48/linux-amd64",
 			expected: pkg.Package{
 				Name:      "node",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -74,6 +74,9 @@ func DefaultClassifiers() []binutils.Classifier {
 			EvidenceMatcher: binutils.MatchAny(
 				m.FileContentsVersionMatcher(
 					`(?m)go(?P<version>[0-9]+\.[0-9]+(\.[0-9]+|beta[0-9]+|alpha[0-9]+|rc[0-9]+)?)\x00`),
+				// Match go version without null terminator (e.g., "go1.8.7" from s390x images)
+				m.FileContentsVersionMatcher(
+					`(?m)go(?P<version>[0-9]+\.[0-9]+\.[0-9]+)(?=\s|$|[^\x00])`),
 				binutils.SupportingEvidenceMatcher("VERSION*",
 					m.FileContentsVersionMatcher(
 						`(?m)go(?P<version>[0-9]+\.[0-9]+(\.[0-9]+|beta[0-9]+|alpha[0-9]+|rc[0-9]+|-[_0-9a-z]+)?)`)),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/go/1.8.7/linux-s390x
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/go/1.8.7/linux-s390x
@@ -1,0 +1,1 @@
+go1.8.7Go cmd/compile go1.8.7


### PR DESCRIPTION
## Summary

Add a new regex pattern to match "go1.8.7" without null terminator, which is the format used in s390x architecture images.

## Fixes #4866

**Problem**: syft could not detect go versions 1.8.x and 1.9.x on linux/s390x images because the version string "go1.8.7" appears without a null terminator.

**Solution**: Added a new EvidenceMatcher pattern `go(?P<version>[0-9]+\.[0-9]+\.[0-9]+)` that matches version strings without requiring  termination.

## Changes

- `classifiers.go`: Added new version matcher for go binary without null terminator
- `classifier_cataloger_test.go`: Added test case for go/1.8.7
- Added test snippet `go/1.8.7/linux-s390x`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)