### PR TITLE
fix: support deno binary older versions (1.10.3 - 1.32.2)

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1343,6 +1343,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "deno/1.32.2/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.32.0",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.32.0",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
 			logicalFixture: "deno/2.0.0/linux-amd64",
 			expected: pkg.Package{
 				Name:      "deno",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -433,10 +433,12 @@ func DefaultClassifiers() []binutils.Classifier {
 		{
 			Class:    "deno-binary",
 			FileGlob: "**/deno",
-			EvidenceMatcher: m.FileContentsVersionMatcher(
-				// Deno/2.6.3
-				// Deno/1.41.0
-				`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			EvidenceMatcher: binutils.MatchAny(
+				// Deno/2.6.3, Deno/1.41.0 (newer versions)
+				m.FileContentsVersionMatcher(`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+				// deno::tools::standalone (older versions without "Deno/" prefix)
+				m.FileContentsVersionMatcher(
+					`deno::tools::standalonedeno-[a-f0-9]+release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`)),
 			Package: "deno",
 			PURL:    mustPURL("pkg:generic/deno@version"),
 			CPEs:    singleCPE("cpe:2.3:a:deno:deno:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.32.2/linux-amd64
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.32.2/linux-amd64
@@ -1,0 +1,3 @@
+deno run --allow-read=. main.js
+console.log(cli/tools/standalone.rs
+Compiledeno::tools::standalonedeno-d06fdf6add1b3c55fc5f4a24956f17a363d513a4release/v1.32.0


### PR DESCRIPTION
## Summary

Add a new EvidenceMatcher pattern to match older deno binary format which uses "deno::tools::standalonedeno-<hash>release/v<version>" instead of the newer "Deno/<version>" format.

## Fixes #4865

**Problem**: syft could not detect deno versions 1.10.3 - 1.32.2 because these older versions store version info in a different format.

**Solution**: Added a new pattern:
```
deno::tools::standalonedeno-<hash>release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)
```

## Changes

- `classifiers.go`: Added new EvidenceMatcher for older deno format
- `classifier_cataloger_test.go`: Added test case for deno/1.32.2
- Added test snippet `deno/1.32.2/linux-amd64`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)