### PR TITLE
fix(binary): support julia alpha/beta/rc versions in binary cataloger (#4867)

### DIFF
--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -89,7 +89,7 @@ func DefaultClassifiers() []binutils.Classifier {
 			Class:    "julia-binary",
 			FileGlob: "**/libjulia-internal.so",
 			EvidenceMatcher: m.FileContentsVersionMatcher(
-				`(?m)__init__\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00verify`),
+				`(?m)__init__\x00(?P<version>[0-9]+\.[0-9]+\.[0-9]+(-alpha[0-9]+|-beta[0-9]+|-rc[0-9]+)?)\x00verify`),
 			Package: "julia",
 			PURL:    mustPURL("pkg:generic/julia@version"),
 			CPEs:    singleCPE("cpe:2.3:a:julialang:julia:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),


### PR DESCRIPTION
## Summary

Fixes [#4867](https://github.com/anchore/syft/issues/4867).

**Problem**: The julia-binary classifier only matches `X.Y.Z` version format. Pre-release versions like `1.9.0-alpha1` are not detected.

**Fix**: Extended the version regex to support `-alphaN`, `-betaN`, `-rcN` suffixes.

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Added pre-release version support to julia-binary matcher

## Test

```bash
$ syft -q julia:1.9.0-alpha1 | grep julia
julia    1.9.0-alpha1                          binary
```
