### PR TITLE
fix(binary): support deno versions 1.10.3 - 1.32.2 in binary cataloger

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1541,6 +1541,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "deno/1.10.3/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.10.3",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.10.3",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
 			logicalFixture: "deno/2.6.3/linux-amd64",
 			expected: pkg.Package{
 				Name:      "deno",


### PR DESCRIPTION
## Summary

Fixes [#4865](https://github.com/anchore/syft/issues/4865).

**Problem**: The `deno-binary` classifier only matched the `Deno/X.Y.Z` string pattern found in newer deno binaries (1.32.3+). Versions 1.10.3 through 1.32.2 embed the version differently (via Rust binary metadata), causing syft to report `deno` with no version.

**Before**: `syft denoland/deno:1.32.2` -> `deno` (no version)
**After**: `syft denoland/deno:1.32.2` -> `deno@1.32.2`

**Fix**: Added a secondary `FileContentsVersionMatcher` pattern to detect `deno X.Y.Z` in older Rust binary string tables, covering versions 1.10.3 through 1.32.2.

**DCO Sign-off**: Each commit includes proper `Signed-off-by: tjhub1983 <tjhub1983@users.noreply.github.com>` as required by the DCO.

---

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
