### PR TITLE
fix: add config option to exclude language packages with file ownership overlap

### DIFF
--- a/cmd/syft/internal/commands/cataloger_list.go
+++ b/cmd/syft/internal/commands/cataloger_list.go
@@ -15,8 +15,8 @@ import (
 	"github.com/anchore/clio"
 	"github.com/anchore/syft/cmd/syft/internal/options"
 	"github.com/anchore/syft/internal/bus"
-	"github.com/anchore/syft/internal/capabilities"
 	"github.com/anchore/syft/internal/task"
+
 	"github.com/anchore/syft/syft/cataloging"
 )
 
@@ -305,7 +305,7 @@ func formatToken(token string, selection *task.TokenSelection, included bool, de
 }
 
 func extractTaskInfo(tasks []task.Task) ([]string, map[string][]string) {
-	infos := capabilities.ExtractCatalogerInfo(tasks)
+	infos := task.ExtractCatalogerInfo(tasks)
 
 	tagsByName := make(map[string][]string)
 	var names []string

--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -123,7 +123,8 @@ func (cfg Catalog) ToRelationshipsConfig() cataloging.RelationshipsConfig {
 		PackageFileOwnership:        cfg.Relationships.PackageFileOwnership,
 		PackageFileOwnershipOverlap: cfg.Relationships.PackageFileOwnershipOverlap,
 		// note: this option was surfaced in the syft application configuration before this relationships section was added
-		ExcludeBinaryPackagesWithFileOwnershipOverlap: cfg.Package.ExcludeBinaryOverlapByOwnership,
+		ExcludeBinaryPackagesWithFileOwnershipOverlap:   cfg.Package.ExcludeBinaryOverlapByOwnership,
+		ExcludeLanguagePackagesWithFileOwnershipOverlap: cfg.Relationships.ExcludeLanguagePackagesWithFileOwnershipOverlap,
 	}
 }
 
@@ -280,6 +281,11 @@ func (cfg *Catalog) PostLoad() error {
 	// the binary package exclusion code depends on the file overlap relationships being created upstream in processing
 	if !cfg.Relationships.PackageFileOwnershipOverlap && cfg.Package.ExcludeBinaryOverlapByOwnership {
 		return fmt.Errorf("cannot enable exclude-binary-overlap-by-ownership without enabling package-file-ownership-overlap")
+	}
+
+	// the language package exclusion code depends on the file overlap relationships being created upstream in processing
+	if !cfg.Relationships.PackageFileOwnershipOverlap && cfg.Relationships.ExcludeLanguagePackagesWithFileOwnershipOverlap {
+		return fmt.Errorf("cannot enable exclude-language-packages-with-file-ownership-overlap without enabling package-file-ownership-overlap")
 	}
 
 	return nil

--- a/cmd/syft/internal/options/relationships.go
+++ b/cmd/syft/internal/options/relationships.go
@@ -5,18 +5,22 @@ import "github.com/anchore/fangs"
 var _ fangs.FieldDescriber = (*relationshipsConfig)(nil)
 
 type relationshipsConfig struct {
-	PackageFileOwnership        bool `mapstructure:"package-file-ownership" json:"package-file-ownership" yaml:"package-file-ownership"`
-	PackageFileOwnershipOverlap bool `mapstructure:"package-file-ownership-overlap" json:"package-file-ownership-overlap" yaml:"package-file-ownership-overlap"`
+	PackageFileOwnership                            bool `mapstructure:"package-file-ownership" json:"package-file-ownership" yaml:"package-file-ownership"`
+	PackageFileOwnershipOverlap                     bool `mapstructure:"package-file-ownership-overlap" json:"package-file-ownership-overlap" yaml:"package-file-ownership-overlap"`
+	ExcludeLanguagePackagesWithFileOwnershipOverlap bool `mapstructure:"exclude-language-packages-with-file-ownership-overlap" json:"exclude-language-packages-with-file-ownership-overlap" yaml:"exclude-language-packages-with-file-ownership-overlap"`
 }
 
 func defaultRelationshipsConfig() relationshipsConfig {
 	return relationshipsConfig{
-		PackageFileOwnership:        true,
-		PackageFileOwnershipOverlap: true,
+		PackageFileOwnership:                            true,
+		PackageFileOwnershipOverlap:                     true,
+		ExcludeLanguagePackagesWithFileOwnershipOverlap: false,
 	}
 }
 
 func (r *relationshipsConfig) DescribeFields(descriptions fangs.FieldDescriptionSet) {
 	descriptions.Add(&r.PackageFileOwnership, "include package-to-file relationships that indicate which files are owned by which packages")
 	descriptions.Add(&r.PackageFileOwnershipOverlap, "include package-to-package relationships that indicate one package is owned by another due to files claimed to be owned by one package are also evidence of another package's existence")
+	descriptions.Add(&r.ExcludeLanguagePackagesWithFileOwnershipOverlap, `exclude language packages from the sbom when their files are owned by an OS package
+these packages are removed to prevent duplicate entries for packages installed via system package managers`)
 }

--- a/internal/capabilities/capabilities.go
+++ b/internal/capabilities/capabilities.go
@@ -8,10 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/scylladb/go-set/strset"
 	"gopkg.in/yaml.v3"
-
-	"github.com/anchore/syft/internal/task"
 )
 
 //go:generate go run ./generate
@@ -105,28 +102,4 @@ func Packages() ([]CatalogerEntry, error) {
 type CatalogerInfo struct {
 	Name      string
 	Selectors []string // tags for cataloger name selection
-}
-
-// ExtractCatalogerInfo extracts cataloger names and their selection tags from tasks
-func ExtractCatalogerInfo(tasks []task.Task) []CatalogerInfo {
-	var infos []CatalogerInfo
-
-	for _, tsk := range tasks {
-		var selectors []string
-		name := tsk.Name()
-
-		if s, ok := tsk.(task.Selector); ok {
-			set := strset.New(s.Selectors()...)
-			set.Remove(name)
-			selectors = set.List()
-			sort.Strings(selectors)
-		}
-
-		infos = append(infos, CatalogerInfo{
-			Name:      name,
-			Selectors: selectors,
-		})
-	}
-
-	return infos
 }

--- a/internal/capabilities/internal/cataloger_names.go
+++ b/internal/capabilities/internal/cataloger_names.go
@@ -17,7 +17,10 @@ func AllPackageCatalogerInfo() ([]capabilities.CatalogerInfo, error) {
 		return nil, fmt.Errorf("unable to create pkg cataloger tasks: %w", err)
 	}
 
-	infos := capabilities.ExtractCatalogerInfo(allPkgTasks)
+	var infos []capabilities.CatalogerInfo
+	for _, info := range task.ExtractCatalogerInfo(allPkgTasks) {
+		infos = append(infos, capabilities.CatalogerInfo(info))
+	}
 
 	// sort by name for consistency
 	sort.Slice(infos, func(i, j int) bool {

--- a/internal/relationship/exclude_language_packages_by_file_ownership_overlap.go
+++ b/internal/relationship/exclude_language_packages_by_file_ownership_overlap.go
@@ -1,0 +1,67 @@
+package relationship
+
+import (
+	"slices"
+
+	"github.com/anchore/syft/internal/sbomsync"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+var (
+	languageCatalogerTypes = []pkg.Type{
+		pkg.PythonPkg,
+		pkg.GemPkg,
+		pkg.NpmPkg,
+		pkg.PhpComposerPkg,
+		pkg.PhpPeclPkg,
+		pkg.Rpkg,
+		pkg.LuaRocksPkg,
+		pkg.ErlangOTPPkg,
+	}
+)
+
+func ExcludeLanguagePackagesByFileOwnershipOverlap(accessor sbomsync.Accessor) {
+	accessor.WriteToSBOM(func(s *sbom.SBOM) {
+		for _, r := range s.Relationships {
+			if idToRemove := excludeLanguagePackageByFileOwnershipOverlap(r, s.Artifacts.Packages); idToRemove != "" {
+				s.Artifacts.Packages.Delete(idToRemove)
+				s.Relationships = RemoveRelationshipsByID(s.Relationships, idToRemove)
+			}
+		}
+	})
+}
+
+// excludeLanguagePackageByFileOwnershipOverlap will remove language packages that are owned by OS packages.
+// This was implemented as a way to help resolve: https://github.com/anchore/syft/issues/4760
+func excludeLanguagePackageByFileOwnershipOverlap(r artifact.Relationship, c *pkg.Collection) artifact.ID {
+	if artifact.OwnershipByFileOverlapRelationship != r.Type {
+		return ""
+	}
+
+	parent := c.Package(r.From.ID())
+	if parent == nil {
+		return ""
+	}
+
+	child := c.Package(r.To.ID())
+	if child == nil {
+		return ""
+	}
+
+	return identifyOverlappingLanguageRelationship(parent, child)
+}
+
+// identifyOverlappingLanguageRelationship indicates the package ID to remove if this is an OS pkg -> language pkg relationship.
+func identifyOverlappingLanguageRelationship(parent *pkg.Package, child *pkg.Package) artifact.ID {
+	if !slices.Contains(osCatalogerTypes, parent.Type) {
+		return ""
+	}
+
+	if slices.Contains(languageCatalogerTypes, child.Type) {
+		return child.ID()
+	}
+
+	return ""
+}

--- a/internal/relationship/exclude_language_packages_by_file_ownership_overlap.go
+++ b/internal/relationship/exclude_language_packages_by_file_ownership_overlap.go
@@ -2,25 +2,111 @@ package relationship
 
 import (
 	"slices"
+	"sync"
 
+	"github.com/scylladb/go-set/strset"
+
+	"github.com/anchore/syft/internal/capabilities"
+	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
+
+	// register the embedded cataloger capability files that languageCatalogerTypes derives from;
+	// without this import, consumers that never link syft/pkg/cataloger (library use) would derive
+	// an empty set and the exclusion would silently do nothing
+	_ "github.com/anchore/syft/syft/pkg/cataloger"
 )
 
-var (
-	languageCatalogerTypes = []pkg.Type{
-		pkg.PythonPkg,
-		pkg.GemPkg,
-		pkg.NpmPkg,
-		pkg.PhpComposerPkg,
-		pkg.PhpPeclPkg,
-		pkg.Rpkg,
-		pkg.LuaRocksPkg,
-		pkg.ErlangOTPPkg,
+// binaryExtractedLanguageTypes are language types whose packages are components extracted from a single
+// OS-owned binary or fat archive. Deleting them on OS file ownership would drop distinct components
+// (with their own identities, versions, PURLs and licenses) that the OS package does not replace: an rpm
+// owning /usr/bin/foo must not delete the Go modules built into foo.
+//
+// This is an explicit list rather than a set derived from the "binary" cataloger selector, because the
+// selector does not decide the question: several types are emitted by both an extractor and a
+// discrete-unit cataloger (npm by dotnet-deps-binary-cataloger and javascript-package-cataloger,
+// go-module by go-module-binary-cataloger and go-module-file-cataloger), and which emitter dominates in
+// practice is not recorded in the capability data.
+var binaryExtractedLanguageTypes = []pkg.Type{
+	pkg.GoModulePkg,           // modules built into a binary
+	pkg.RustPkg,               // crates built into a binary
+	pkg.DotnetPkg,             // deps of a .NET binary
+	pkg.GraalVMNativeImagePkg, // SBOM embedded in a native image
+	pkg.JavaPkg,               // (nested) JARs inside an OS-owned archive
+}
+
+// languageTypeExceptions are types included even though no "language"-tagged cataloger emits them.
+var languageTypeExceptions = map[pkg.Type]string{
+	// php-pecl is emitted only by the deprecated (DeprecatedTag, not language-tagged) pecl cataloger;
+	// its packages still overlap OS packages until the cataloger is removed in syft v2.0.
+	pkg.PhpPeclPkg: "deprecated php-pecl cataloger (not language-tagged)",
+}
+
+// languageCatalogerTypes returns the package types an OS package can subsume when it owns their files:
+// language packages installed as discrete units, for which OS file-ownership overlap means the distro
+// repackaged the same thing. The set is derived from syft's own cataloger capabilities so that
+// catalogers added later are covered without touching this file:
+//
+//	{types of "language"-tagged catalogers} \ osCatalogerTypes \ binaryExtractedLanguageTypes
+//	                                        (+ languageTypeExceptions)
+//
+// This keys on pkg.Type, a coarse proxy; a per-package rule (installed vs manifest-declared evidence)
+// is tracked in https://github.com/anchore/syft/issues/4974.
+//
+// The capability files are compiled in via go:embed and registered by the blank import above, so a
+// failed derivation indicates a build problem. In that case exclude nothing (warned once): dropping
+// packages from the SBOM on incomplete information is the worse failure.
+var languageCatalogerTypes = sync.OnceValue(deriveLanguageCatalogerTypes)
+
+func deriveLanguageCatalogerTypes() map[pkg.Type]struct{} {
+	catalogers, err := capabilities.Packages()
+	if err != nil {
+		log.WithFields("error", err).Warn("unable to load cataloger capabilities; exclude-language-packages-with-file-ownership-overlap will not exclude anything")
+		return nil
 	}
-)
+
+	osTypes := strset.New()
+	for _, ty := range osCatalogerTypes {
+		osTypes.Add(string(ty))
+	}
+
+	extracted := strset.New()
+	for _, ty := range binaryExtractedLanguageTypes {
+		extracted.Add(string(ty))
+	}
+
+	included := strset.New()
+	for _, c := range catalogers {
+		if !slices.Contains(c.Selectors, "language") {
+			continue
+		}
+		included.Add(catalogerPackageTypes(c)...)
+	}
+
+	out := make(map[pkg.Type]struct{})
+	for _, pt := range included.List() {
+		if osTypes.Has(pt) || extracted.Has(pt) {
+			continue
+		}
+		out[pkg.Type(pt)] = struct{}{}
+	}
+	for ty := range languageTypeExceptions {
+		out[ty] = struct{}{}
+	}
+
+	return out
+}
+
+// catalogerPackageTypes collects the package types a cataloger emits, from the entry and its parsers.
+func catalogerPackageTypes(c capabilities.CatalogerEntry) []string {
+	pts := append([]string{}, c.PackageTypes...)
+	for _, p := range c.Parsers {
+		pts = append(pts, p.PackageTypes...)
+	}
+	return pts
+}
 
 func ExcludeLanguagePackagesByFileOwnershipOverlap(accessor sbomsync.Accessor) {
 	accessor.WriteToSBOM(func(s *sbom.SBOM) {
@@ -59,7 +145,7 @@ func identifyOverlappingLanguageRelationship(parent *pkg.Package, child *pkg.Pac
 		return ""
 	}
 
-	if slices.Contains(languageCatalogerTypes, child.Type) {
+	if _, ok := languageCatalogerTypes()[child.Type]; ok {
 		return child.ID()
 	}
 

--- a/internal/relationship/exclude_language_packages_by_file_ownership_overlap_test.go
+++ b/internal/relationship/exclude_language_packages_by_file_ownership_overlap_test.go
@@ -1,0 +1,192 @@
+package relationship
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func Test_excludeLanguagePackageByFileOwnershipOverlap(t *testing.T) {
+	tests := []struct {
+		name         string
+		parent       *pkg.Package
+		child        *pkg.Package
+		shouldRemove bool
+	}{
+		{
+			name: "OS package owns Python package - should remove Python package",
+			parent: &pkg.Package{
+				Name: "python3-django-deb",
+				Type: pkg.DebPkg,
+			},
+			child: &pkg.Package{
+				Name: "django",
+				Type: pkg.PythonPkg,
+			},
+			shouldRemove: true,
+		},
+		{
+			name: "Binary to Python - should not remove",
+			parent: &pkg.Package{
+				Name: "python-binary",
+				Type: pkg.BinaryPkg,
+			},
+			child: &pkg.Package{
+				Name: "django-py",
+				Type: pkg.PythonPkg,
+			},
+			shouldRemove: false,
+		},
+		{
+			name: "APK package owns Ruby package - should remove Ruby package",
+			parent: &pkg.Package{
+				Name: "ruby-rails-apk",
+				Type: pkg.ApkPkg,
+			},
+			child: &pkg.Package{
+				Name: "rails",
+				Type: pkg.GemPkg,
+			},
+			shouldRemove: true,
+		},
+		{
+			name: "RPM package owns NPM package - should remove NPM package",
+			parent: &pkg.Package{
+				Name: "nodejs-express-rpm",
+				Type: pkg.RpmPkg,
+			},
+			child: &pkg.Package{
+				Name: "express",
+				Type: pkg.NpmPkg,
+			},
+			shouldRemove: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.parent.SetID()
+			tt.child.SetID()
+
+			collection := pkg.NewCollection()
+			collection.Add(*tt.parent)
+			collection.Add(*tt.child)
+
+			rel := artifact.Relationship{
+				From: *tt.parent,
+				To:   *tt.child,
+				Type: artifact.OwnershipByFileOverlapRelationship,
+			}
+
+			result := excludeLanguagePackageByFileOwnershipOverlap(rel, collection)
+
+			if tt.shouldRemove {
+				assert.Equal(t, tt.child.ID(), result, "should remove child package")
+				assert.NotEqual(t, artifact.ID(""), result, "child ID must not be empty for a real assertion")
+			} else {
+				assert.Equal(t, artifact.ID(""), result, "should not remove any package")
+			}
+		})
+	}
+}
+
+func Test_identifyOverlappingLanguageRelationship(t *testing.T) {
+	tests := []struct {
+		name         string
+		parent       *pkg.Package
+		child        *pkg.Package
+		shouldRemove bool
+	}{
+		{
+			name: "deb owns python - remove python",
+			parent: &pkg.Package{
+				Name: "python3-django-deb",
+				Type: pkg.DebPkg,
+			},
+			child: &pkg.Package{
+				Name: "django",
+				Type: pkg.PythonPkg,
+			},
+			shouldRemove: true,
+		},
+		{
+			name: "apk owns npm - remove npm",
+			parent: &pkg.Package{
+				Name: "nodejs-express-apk",
+				Type: pkg.ApkPkg,
+			},
+			child: &pkg.Package{
+				Name: "express",
+				Type: pkg.NpmPkg,
+			},
+			shouldRemove: true,
+		},
+		{
+			name: "rpm owns ruby - remove ruby",
+			parent: &pkg.Package{
+				Name: "ruby-rails-rpm",
+				Type: pkg.RpmPkg,
+			},
+			child: &pkg.Package{
+				Name: "rails",
+				Type: pkg.GemPkg,
+			},
+			shouldRemove: true,
+		},
+		{
+			name: "binary owns python - keep both",
+			parent: &pkg.Package{
+				Name: "python-binary",
+				Type: pkg.BinaryPkg,
+			},
+			child: &pkg.Package{
+				Name: "django-py",
+				Type: pkg.PythonPkg,
+			},
+			shouldRemove: false,
+		},
+		{
+			name: "deb owns deb - keep both",
+			parent: &pkg.Package{
+				Name: "libfoo-deb",
+				Type: pkg.DebPkg,
+			},
+			child: &pkg.Package{
+				Name: "libbar-deb",
+				Type: pkg.DebPkg,
+			},
+			shouldRemove: false,
+		},
+		{
+			name: "python owns python - keep both",
+			parent: &pkg.Package{
+				Name: "django-parent",
+				Type: pkg.PythonPkg,
+			},
+			child: &pkg.Package{
+				Name: "django-child",
+				Type: pkg.PythonPkg,
+			},
+			shouldRemove: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.parent.SetID()
+			tt.child.SetID()
+
+			result := identifyOverlappingLanguageRelationship(tt.parent, tt.child)
+
+			if tt.shouldRemove {
+				assert.Equal(t, tt.child.ID(), result, "should remove child package")
+				assert.NotEqual(t, artifact.ID(""), result, "child ID must not be empty for a real assertion")
+			} else {
+				assert.Equal(t, artifact.ID(""), result, "should not remove any package")
+			}
+		})
+	}
+}

--- a/internal/relationship/exclude_language_packages_by_file_ownership_overlap_test.go
+++ b/internal/relationship/exclude_language_packages_by_file_ownership_overlap_test.go
@@ -137,6 +137,34 @@ func Test_identifyOverlappingLanguageRelationship(t *testing.T) {
 			shouldRemove: true,
 		},
 		{
+			// java-archive is binary-extracted (see binaryExtractedLanguageTypes): a JAR the deb owns may
+			// contain nested components the deb does not subsume, so we must NOT delete it on overlap.
+			name: "deb owns java archive - keep java (binary-extracted, not subsumed)",
+			parent: &pkg.Package{
+				Name: "libreoffice-java-common",
+				Type: pkg.DebPkg,
+			},
+			child: &pkg.Package{
+				Name: "some-jar",
+				Type: pkg.JavaPkg,
+			},
+			shouldRemove: false,
+		},
+		{
+			// go modules are extracted from a single OS-owned binary; deleting them would drop distinct
+			// components (their identities/versions/licenses) the OS package does not replace.
+			name: "deb owns go binary - keep go modules (binary-extracted, not subsumed)",
+			parent: &pkg.Package{
+				Name: "golang-github-foo-dev",
+				Type: pkg.DebPkg,
+			},
+			child: &pkg.Package{
+				Name: "github.com/foo/bar",
+				Type: pkg.GoModulePkg,
+			},
+			shouldRemove: false,
+		},
+		{
 			name: "binary owns python - keep both",
 			parent: &pkg.Package{
 				Name: "python-binary",

--- a/internal/relationship/exclude_language_packages_completeness_test.go
+++ b/internal/relationship/exclude_language_packages_completeness_test.go
@@ -1,0 +1,164 @@
+package relationship
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// capCataloger is the slice of a cataloger capability file we care about here.
+type capCataloger struct {
+	Name         string   `yaml:"name"`
+	Selectors    []string `yaml:"selectors"`
+	PackageTypes []string `yaml:"package_types"`
+	Parsers      []struct {
+		PackageTypes []string `yaml:"package_types"`
+	} `yaml:"parsers"`
+}
+
+// loadLanguageCatalogers reads syft's own cataloger capability files and returns the "language"-tagged
+// catalogers. It reads the YAMLs directly rather than through capabilities.Packages() so the expected
+// set stays independent of the production loader it is checking.
+func loadLanguageCatalogers(t *testing.T) []capCataloger {
+	t.Helper()
+	files, err := filepath.Glob(filepath.Join("..", "..", "syft", "pkg", "cataloger", "*", "capabilities.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no cataloger capability files found; fix the relative path")
+
+	var out []capCataloger
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		require.NoError(t, err)
+		var doc struct {
+			Catalogers []capCataloger `yaml:"catalogers"`
+		}
+		require.NoError(t, yaml.Unmarshal(data, &doc), "parsing %s", f)
+		for _, c := range doc.Catalogers {
+			if slices.Contains(c.Selectors, "language") {
+				out = append(out, c)
+			}
+		}
+	}
+	require.NotEmpty(t, out, "found zero language-tagged catalogers; capability schema may have changed")
+	return out
+}
+
+func (c capCataloger) types() []string {
+	pts := append([]string{}, c.PackageTypes...)
+	for _, p := range c.Parsers {
+		pts = append(pts, p.PackageTypes...)
+	}
+	return pts
+}
+
+// isBinaryExtractor reports whether a cataloger extracts components from a single binary/archive
+// artifact (so OS ownership of that artifact does not subsume the components).
+func (c capCataloger) isBinaryExtractor() bool {
+	if slices.Contains(c.Selectors, "binary") {
+		return true
+	}
+	// some extractors are not tagged with the "binary" selector (e.g. dotnet-deps-binary-cataloger),
+	// so also match the cataloger name shape.
+	for _, frag := range []string{"binary", "native-image", "archive"} {
+		if strings.Contains(c.Name, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_languageCatalogerTypes_matchesLanguageTag enforces the inclusion rule documented on
+// languageCatalogerTypes:
+//
+//	languageCatalogerTypes == {types of "language"-tagged catalogers} \ osCatalogerTypes
+//	                          \ binaryExtractedLanguageTypes  (+ documented exceptions)
+//
+// The expectation is derived from syft's own cataloger capability files, so a new language cataloger
+// (or a new pkg.Type on one) fails this test until the lists are updated — an omission can no longer
+// slip through silently (the original hand-maintained list missed 9 such installed-package types).
+func Test_languageCatalogerTypes_matchesLanguageTag(t *testing.T) {
+	// exercise the production exception set rather than a copy of it, so the two cannot drift apart
+	// while both stay individually plausible.
+	exceptions := languageTypeExceptions
+
+	cats := loadLanguageCatalogers(t)
+
+	osTypes := map[string]struct{}{}
+	for _, ty := range osCatalogerTypes {
+		osTypes[string(ty)] = struct{}{}
+	}
+	excluded := map[string]struct{}{}
+	for _, ty := range binaryExtractedLanguageTypes {
+		excluded[string(ty)] = struct{}{}
+	}
+
+	// every excluded type must actually be (a) emitted by a language-tagged cataloger and (b) emitted by
+	// a binary/archive extractor — otherwise the exclusion is stale or unjustified.
+	emittedByExtractor := map[string]bool{}
+	languageTagged := map[string]struct{}{}
+	for _, c := range cats {
+		for _, pt := range c.types() {
+			languageTagged[pt] = struct{}{}
+			if c.isBinaryExtractor() {
+				emittedByExtractor[pt] = true
+			}
+		}
+	}
+	for _, ty := range binaryExtractedLanguageTypes {
+		s := string(ty)
+		_, isLang := languageTagged[s]
+		require.True(t, isLang, "binaryExtractedLanguageTypes lists %q but no language-tagged cataloger emits it", s)
+		require.True(t, emittedByExtractor[s], "binaryExtractedLanguageTypes lists %q but no binary/archive extractor emits it; exclusion unjustified", s)
+	}
+
+	// derive expected: language-tagged, minus OS types, minus binary-extracted types
+	want := map[string]struct{}{}
+	for s := range languageTagged {
+		if _, isOS := osTypes[s]; isOS {
+			continue
+		}
+		if _, isExcluded := excluded[s]; isExcluded {
+			continue
+		}
+		want[s] = struct{}{}
+	}
+
+	// every documented exception must actually be present in the production list (else the exception is dead
+	// and the list silently lost a type) — this guards the false-pass codex flagged.
+	listed := languageCatalogerTypes()
+	for ty, reason := range exceptions {
+		_, ok := listed[ty]
+		require.True(t, ok, "exception %q (%s) is documented but missing from languageCatalogerTypes", ty, reason)
+	}
+
+	got := map[string]struct{}{}
+	for ty := range languageCatalogerTypes() {
+		if _, ok := exceptions[ty]; ok {
+			continue // exceptions are allowed to be absent from the derived set
+		}
+		got[string(ty)] = struct{}{}
+	}
+
+	var missing, extra []string
+	for s := range want {
+		if _, ok := got[s]; !ok {
+			missing = append(missing, s)
+		}
+	}
+	for s := range got {
+		if _, ok := want[s]; !ok {
+			extra = append(extra, s)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+
+	require.Empty(t, missing, "installed-package language types missing from languageCatalogerTypes (add them, or document an exception): %v", missing)
+	require.Empty(t, extra, "types in languageCatalogerTypes that are not installed-package language types (remove them, exclude as binary-extracted, or add to exceptions): %v", extra)
+}

--- a/internal/task/cataloger_info.go
+++ b/internal/task/cataloger_info.go
@@ -1,0 +1,37 @@
+package task
+
+import (
+	"sort"
+
+	"github.com/scylladb/go-set/strset"
+)
+
+// CatalogerInfo is a cataloger's name and the selection tags that match it.
+type CatalogerInfo struct {
+	Name      string
+	Selectors []string
+}
+
+// ExtractCatalogerInfo extracts cataloger names and their selection tags from tasks
+func ExtractCatalogerInfo(tasks []Task) []CatalogerInfo {
+	var infos []CatalogerInfo
+
+	for _, tsk := range tasks {
+		var selectors []string
+		name := tsk.Name()
+
+		if s, ok := tsk.(Selector); ok {
+			set := strset.New(s.Selectors()...)
+			set.Remove(name)
+			selectors = set.List()
+			sort.Strings(selectors)
+		}
+
+		infos = append(infos, CatalogerInfo{
+			Name:      name,
+			Selectors: selectors,
+		})
+	}
+
+	return infos
+}

--- a/internal/task/relationship_tasks.go
+++ b/internal/task/relationship_tasks.go
@@ -55,6 +55,12 @@ func finalizeRelationships(resolver file.Resolver, builder sbomsync.Builder, cfg
 		relationship.ExcludeBinariesByFileOwnershipOverlap(accessor)
 	}
 
+	// conditionally remove language packages based on file ownership overlap relationships found
+	// https://github.com/anchore/syft/issues/4760
+	if cfg.ExcludeLanguagePackagesWithFileOwnershipOverlap {
+		relationship.ExcludeLanguagePackagesByFileOwnershipOverlap(accessor)
+	}
+
 	// add the new relationships for executables to the SBOM
 	newBinaryRelationships := binary.NewDependencyRelationships(resolver, accessor)
 	accessor.WriteToSBOM(func(s *sbom.SBOM) {

--- a/syft/cataloging/relationships.go
+++ b/syft/cataloging/relationships.go
@@ -13,13 +13,19 @@ type RelationshipsConfig struct {
 	// For example, if a binary package representing the /bin/python binary is discovered and there is a python RPM package installed which claims to
 	// orn /bin/python, then the binary package will be excluded from the catalog altogether if this configuration is set to true.
 	ExcludeBinaryPackagesWithFileOwnershipOverlap bool `yaml:"exclude-binary-packages-with-file-ownership-overlap" json:"exclude-binary-packages-with-file-ownership-overlap" mapstructure:"exclude-binary-packages-with-file-ownership-overlap"`
+
+	// ExcludeLanguagePackagesWithFileOwnershipOverlap will exclude language packages from the package catalog that are evident by files also owned by another package.
+	// For example, if a Python package is discovered via pip and there is a python3-django deb package installed which claims to own the same files,
+	// then the Python package will be excluded from the catalog altogether if this configuration is set to true.
+	ExcludeLanguagePackagesWithFileOwnershipOverlap bool `yaml:"exclude-language-packages-with-file-ownership-overlap" json:"exclude-language-packages-with-file-ownership-overlap" mapstructure:"exclude-language-packages-with-file-ownership-overlap"`
 }
 
 func DefaultRelationshipsConfig() RelationshipsConfig {
 	return RelationshipsConfig{
-		PackageFileOwnership:                          true,
-		PackageFileOwnershipOverlap:                   true,
-		ExcludeBinaryPackagesWithFileOwnershipOverlap: true,
+		PackageFileOwnership:                            true,
+		PackageFileOwnershipOverlap:                     true,
+		ExcludeBinaryPackagesWithFileOwnershipOverlap:   true,
+		ExcludeLanguagePackagesWithFileOwnershipOverlap: false,
 	}
 }
 
@@ -35,5 +41,10 @@ func (c RelationshipsConfig) WithPackageFileOwnershipOverlap(overlap bool) Relat
 
 func (c RelationshipsConfig) WithExcludeBinaryPackagesWithFileOwnershipOverlap(exclude bool) RelationshipsConfig {
 	c.ExcludeBinaryPackagesWithFileOwnershipOverlap = exclude
+	return c
+}
+
+func (c RelationshipsConfig) WithExcludeLanguagePackagesWithFileOwnershipOverlap(exclude bool) RelationshipsConfig {
+	c.ExcludeLanguagePackagesWithFileOwnershipOverlap = exclude
 	return c
 }

--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -467,6 +467,11 @@ func (c *CreateSBOMConfig) validate() error {
 			return fmt.Errorf("invalid configuration: to exclude binary packages based on file ownership overlap relationships, cataloging file ownership overlap relationships must be enabled")
 		}
 	}
+	if c.Relationships.ExcludeLanguagePackagesWithFileOwnershipOverlap {
+		if !c.Relationships.PackageFileOwnershipOverlap {
+			return fmt.Errorf("invalid configuration: to exclude language packages based on file ownership overlap relationships, cataloging file ownership overlap relationships must be enabled")
+		}
+	}
 	return nil
 }
 

--- a/syft/create_sbom_config_test.go
+++ b/syft/create_sbom_config_test.go
@@ -554,6 +554,16 @@ func TestCreateSBOMConfig_validate(t *testing.T) {
 				),
 			wantErr: assert.Error,
 		},
+		{
+			name: "incompatible ExcludeLanguagePackagesWithFileOwnershipOverlap selection",
+			cfg: DefaultCreateSBOMConfig().
+				WithRelationshipsConfig(
+					cataloging.DefaultRelationshipsConfig().
+						WithExcludeLanguagePackagesWithFileOwnershipOverlap(true).
+						WithPackageFileOwnershipOverlap(false),
+				),
+			wantErr: assert.Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #4760.

## Cause

When OS packages (deb, apk, rpm) install language packages (Python, Ruby, npm, etc.) via system package managers, syft catalogs both the OS package and the language package. The file ownership overlap relationship exists between them, but there was no mechanism to deduplicate.

The existing `exclude-binary-overlap-by-ownership` option handles binary packages, but an equivalent for language packages was missing.

## Fix

Adds a `relationships.exclude-language-packages-with-file-ownership-overlap` config option (named after the library field in `RelationshipsConfig`) that removes language packages when they have a file ownership overlap relationship with an OS package. This mirrors the existing binary exclusion logic. The option defaults to `false` to avoid changing existing behavior.

The set of excludable package types is derived at runtime from syft's own cataloger capability data: every type emitted by a `language`-tagged cataloger is a candidate, minus OS types and an explicit list of binary-extracted types (go-module, rust-crate, dotnet, graalvm-native-image, java-archive) whose packages are components pulled out of a single OS-owned binary or archive. A completeness test derives the expected set independently from the capability YAML files, so a new language cataloger fails CI until it is classified.

The implementation follows the same pattern as `ExcludeBinaryPackagesByFileOwnershipOverlap`: iterate relationships, identify OS-parent/language-child pairs, and delete the child package.

## Tests

Unit tests cover:
- OS → language package overlap (deb→python, apk→npm, rpm→ruby) — child removed
- Binary → language package overlap — both kept
- OS → OS overlap — both kept
- Language → language overlap — both kept
- Completeness: derived exclusion set matches the capability data, exceptions stay live
- Config validation (CLI and library) rejects enabling the exclusion without overlap relationships

Signed-off-by: June Kim <kimjune01@gmail.com>


---

*Edited 2026-07-20, alongside a rebase onto main and a force-push. Changes from the originally reviewed version: the exclusion list is now derived from cataloger capability data instead of hardcoded (per the review), the config option moved from `package.exclude-language-overlap-by-ownership` to `relationships.exclude-language-packages-with-file-ownership-overlap`, and library-side config validation was added. Earlier review comments referencing the old flag name or the hardcoded list predate this edit.*
