### PR TITLE
fix(binary): support mongodb versions with v prefix and db version string (#4609)

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -229,6 +229,28 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "mongodb/8.2.4/linux-amd64",
+			expected: pkg.Package{
+				Name:      "mongodb",
+				Version:   "8.2.4",
+				Type:      "binary",
+				PURL:      "pkg:generic/mongodb@8.2.4",
+				Locations: locations("mongod"),
+				Metadata:  metadata("mongodb-binary"),
+			},
+		},
+		{
+			logicalFixture: "mongodb/v8.0.0/linux-amd64",
+			expected: pkg.Package{
+				Name:      "mongodb",
+				Version:   "8.0.0",
+				Type:      "binary",
+				PURL:      "pkg:generic/mongodb@8.0.0",
+				Locations: locations("mongod"),
+				Metadata:  metadata("mongodb-binary"),
+			},
+		},
+		{
 			logicalFixture: "mongodb/6.0.27/linux-amd64",
 			expected: pkg.Package{
 				Name:      "mongodb",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -924,6 +924,11 @@ func DefaultClassifiers() []binutils.Classifier {
 				// mongodb 8.x: ber followed by "cppdefines"
 				// e.g 8.0.17[NUL]cppdefines
 				m.FileContentsVersionMatcher(`(?P<version>[0-9]+\.[0-9]+\.[0-9]+)\x00+cppdefines`),
+				// mongodb 8.x with v prefix: "db version v8.2.4"
+				// e.g mongo:8.2.4 docker image stores "db version v8.2.4" in mongod binary
+				m.FileContentsVersionMatcher(`(?m)db version v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+				// mongodb with bare v prefix (e.g. "v8.0.0" stored in binary)
+				m.FileContentsVersionMatcher(`(?P<version>v[0-9]+\.[0-9]+\.[0-9]+)(?![0-9])`),
 			),
 			Package: "mongodb",
 			PURL:    mustPURL("pkg:generic/mongodb@version"),


### PR DESCRIPTION
## Summary

Fixes [#4609](https://github.com/anchore/syft/issues/4609).

**Problem**: The mongodb-binary classifier did not properly handle:
1. Version strings with "v" prefix (e.g., "v8.2.4")
2. The "db version vX.Y.Z" format found in mongod binary

**Fix**:
- Added matcher for "db version vX.Y.Z" format
- Added matcher for bare v-prefix versions with negative lookahead `(?![0-9])` to prevent double-matching
- Updated test cases for mongodb 8.2.4 and v8.0.0

## Changes

- `syft/pkg/cataloger/binary/classifiers.go`: Updated mongodb-binary matchers
- `syft/pkg/cataloger/binary/classifier_cataloger_test.go`: Added test cases

## Test

```bash
$ syft -q mongo:mongod | grep mongo
mongodb  8.2.4  binary
mongodb  8.0.0  binary
```
