### PR TITLE
feat: add .bpl file support to PE cataloger

### DIFF
--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -15,7 +15,7 @@ import (
 // NewPEPackageCataloger returns a cataloger that interprets packages from DLL and EXE files.
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe")
+		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {


### PR DESCRIPTION
## Summary

Add support for Borland Package Library () files in the PE binary package cataloger.

## Changes

- Add  glob pattern to  in 
- BPL files are PE-format DLLs used by Borland Delphi/C++Builder
- Fixes #4664

## Testing

The cataloger will now detect packages from  files alongside existing  and  support.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)