### PR TITLE
fix(format): decode SBOMs encoded as UTF-16 or with a UTF-8 BOM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 require (
 	github.com/pb33f/ordered-map/v2 v2.3.1
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
+	golang.org/x/text v0.38.0
 	howett.net/plist v1.0.1
 )
 
@@ -314,7 +315,6 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/api v0.271.0 // indirect

--- a/syft/format/decoders_collection_test.go
+++ b/syft/format/decoders_collection_test.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -8,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 
 	"github.com/anchore/syft/syft/format/spdxjson"
 	"github.com/anchore/syft/syft/format/syftjson"
@@ -48,6 +52,61 @@ func TestDecodeUnseekable(t *testing.T) {
 	_, formatID, _, err := Decode(unseekableReader)
 	assert.NoError(t, err)
 	assert.Equal(t, spdxjson.ID, formatID)
+}
+
+// TestDecodeWithBOMEncoding pins the end-to-end behavior from issue #4916: a
+// syft-json SBOM produced with a UTF-8 BOM (older tools) or in UTF-16LE / UTF-16BE
+// (e.g. PowerShell's `>` redirect on Windows) must still be identified as syftjson
+// and decode without error. The byte-level transcoding in stream.SeekableReader is
+// covered by its own unit tests; this asserts the user-facing invariant the issue
+// actually complained about, at the format.Identify / format.Decode boundary.
+func TestDecodeWithBOMEncoding(t *testing.T) {
+	utf8Content, err := os.ReadFile("testdata/alpine-syft.json")
+	require.NoError(t, err)
+
+	cases := []struct {
+		name   string
+		encode func([]byte) ([]byte, error)
+	}{
+		{
+			name: "utf-8 with BOM",
+			encode: func(b []byte) ([]byte, error) {
+				return append([]byte{0xEF, 0xBB, 0xBF}, b...), nil
+			},
+		},
+		{
+			name: "utf-16le with BOM",
+			encode: func(b []byte) ([]byte, error) {
+				enc := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder()
+				out, _, encErr := transform.Bytes(enc, b)
+				return out, encErr
+			},
+		},
+		{
+			name: "utf-16be with BOM",
+			encode: func(b []byte) ([]byte, error) {
+				enc := unicode.UTF16(unicode.BigEndian, unicode.UseBOM).NewEncoder()
+				out, _, encErr := transform.Bytes(enc, b)
+				return out, encErr
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := tc.encode(utf8Content)
+			require.NoError(t, err)
+
+			id, version := Identify(bytes.NewReader(encoded))
+			assert.Equal(t, syftjson.ID, id, "Identify should detect syft-json after BOM transcoding")
+			assert.NotEmpty(t, version)
+
+			decodedSBOM, formatID, _, err := Decode(bytes.NewReader(encoded))
+			assert.NoError(t, err)
+			assert.Equal(t, syftjson.ID, formatID)
+			assert.NotNil(t, decodedSBOM)
+		})
+	}
 }
 
 func TestFormats_EmptyInput(t *testing.T) {

--- a/syft/format/internal/stream/seekable_reader.go
+++ b/syft/format/internal/stream/seekable_reader.go
@@ -1,9 +1,14 @@
 package stream
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 // SeekableReader takes an io.Reader and returns an io.ReadSeeker relative to the current position of the reader.
@@ -11,21 +16,76 @@ import (
 // reader prior to the location when this reader is provided. An example is a reader with multiple JSON
 // documents separated by newlines (JSONL). After reading the first document, if a call is made to decode
 // the second and Seek(0, SeekStart) is called it would reset the overall reader back to the first document.
+//
+// If the input begins with a UTF-8, UTF-16LE, or UTF-16BE byte order mark, the content is transcoded to UTF-8
+// before being returned. This lets format identifiers always operate on UTF-8 regardless of how the SBOM was
+// produced (notably, PowerShell's `>` operator emits UTF-16LE on Windows).
 func SeekableReader(reader io.Reader) (io.ReadSeeker, error) {
 	if reader == nil {
 		return nil, fmt.Errorf("no bytes provided")
 	}
 
-	if r, ok := reader.(io.ReadSeeker); ok {
+	head, rest, err := peekHead(reader, 3)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasBOM(head) {
+		decoded, err := io.ReadAll(transform.NewReader(rest, unicode.BOMOverride(unicode.UTF8.NewDecoder()))) //nolint:gocritic // buffering normalized content to make it seekable
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(decoded), nil
+	}
+
+	if r, ok := rest.(io.ReadSeeker); ok {
 		return getOffsetReadSeeker(r)
 	}
 
-	content, err := io.ReadAll(reader) //nolint:gocritic // buffering non-seekable to seekable reader
+	content, err := io.ReadAll(rest) //nolint:gocritic // buffering non-seekable to seekable reader
 	if err != nil {
 		return nil, err
 	}
 
 	return bytes.NewReader(content), nil
+}
+
+// peekHead returns up to n bytes from the start of r along with a reader that yields the original stream
+// contents starting from the same position (the peeked bytes are not consumed). For an io.ReadSeeker we
+// read then seek back; otherwise we wrap in a bufio.Reader and Peek.
+func peekHead(r io.Reader, n int) ([]byte, io.Reader, error) {
+	if rs, ok := r.(io.ReadSeeker); ok {
+		buf := make([]byte, n)
+		start, err := rs.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, nil, err
+		}
+		read, err := io.ReadFull(rs, buf)
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, nil, err
+		}
+		if _, err := rs.Seek(start, io.SeekStart); err != nil {
+			return nil, nil, err
+		}
+		return buf[:read], rs, nil
+	}
+
+	br := bufio.NewReader(r)
+	head, _ := br.Peek(n) // may return fewer than n bytes on short input; that's fine
+	return head, br, nil
+}
+
+// hasBOM reports whether the given bytes begin with a UTF-8, UTF-16LE, or UTF-16BE byte order mark.
+func hasBOM(head []byte) bool {
+	switch {
+	case len(head) >= 3 && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF:
+		return true
+	case len(head) >= 2 && head[0] == 0xFF && head[1] == 0xFE:
+		return true
+	case len(head) >= 2 && head[0] == 0xFE && head[1] == 0xFF:
+		return true
+	}
+	return false
 }
 
 type offsetReadSeeker struct {

--- a/syft/format/internal/stream/seekable_reader_test.go
+++ b/syft/format/internal/stream/seekable_reader_test.go
@@ -5,9 +5,30 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/stretchr/testify/require"
 )
+
+func utf8WithBOM(s string) []byte {
+	return append([]byte{0xEF, 0xBB, 0xBF}, []byte(s)...)
+}
+
+func utf16LEWithBOM(s string) []byte {
+	out := []byte{0xFF, 0xFE}
+	for _, r := range utf16.Encode([]rune(s)) {
+		out = append(out, byte(r&0xFF), byte(r>>8))
+	}
+	return out
+}
+
+func utf16BEWithBOM(s string) []byte {
+	out := []byte{0xFE, 0xFF}
+	for _, r := range utf16.Encode([]rune(s)) {
+		out = append(out, byte(r>>8), byte(r&0xFF))
+	}
+	return out
+}
 
 func TestSeekableReader(t *testing.T) {
 	tests := []struct {
@@ -97,6 +118,83 @@ func TestSeekableReader(t *testing.T) {
 				content, err := io.ReadAll(got)
 				require.NoError(t, err)
 				require.Equal(t, []byte{4, 5}, content)
+			},
+		},
+		{
+			name:  "utf-8 BOM is stripped (non-seekable input)",
+			input: bytes.NewBuffer(utf8WithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader) // BOM path buffers, so result is *bytes.Reader
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "utf-8 BOM is stripped (seekable input)",
+			input: bytes.NewReader(utf8WithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "utf-16LE is transcoded to utf-8 (non-seekable input)",
+			input: bytes.NewBuffer(utf16LEWithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "utf-16LE is transcoded to utf-8 (seekable input)",
+			input: bytes.NewReader(utf16LEWithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "utf-16BE is transcoded to utf-8 (non-seekable input)",
+			input: bytes.NewBuffer(utf16BEWithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "utf-16BE is transcoded to utf-8 (seekable input)",
+			input: bytes.NewReader(utf16BEWithBOM("hello world!")),
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("hello world!"), content)
+			},
+		},
+		{
+			name:  "non-BOM input shorter than peek length",
+			input: bytes.NewBufferString("a"), // only 1 byte, can't even fill a BOM check
+			assert: func(input io.Reader, got io.ReadSeeker) {
+				_, ok := got.(*bytes.Reader)
+				require.True(t, ok)
+				content, err := io.ReadAll(got)
+				require.NoError(t, err)
+				require.Equal(t, []byte("a"), content)
 			},
 		},
 	}
@@ -223,4 +321,69 @@ func moveOffset(t *testing.T, reader io.ReadSeeker, offset int64) io.Reader {
 	require.NoError(t, err)
 	require.Equal(t, offset, pos)
 	return reader
+}
+
+func Test_hasBOM(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		want bool
+	}{
+		{name: "empty", in: []byte{}, want: false},
+		{name: "short non-BOM", in: []byte{0xEF}, want: false},
+		{name: "utf-8 BOM", in: []byte{0xEF, 0xBB, 0xBF}, want: true},
+		{name: "utf-8 BOM with content", in: []byte{0xEF, 0xBB, 0xBF, 'a', 'b'}, want: true},
+		{name: "utf-16LE BOM", in: []byte{0xFF, 0xFE}, want: true},
+		{name: "utf-16BE BOM", in: []byte{0xFE, 0xFF}, want: true},
+		{name: "plain JSON {", in: []byte{'{'}, want: false},
+		{name: "plain ascii", in: []byte("hello"), want: false},
+		{name: "near-miss EF BB without BF", in: []byte{0xEF, 0xBB, 0xCC}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, hasBOM(tt.in))
+		})
+	}
+}
+
+func Test_peekHead_preservesReaderPosition(t *testing.T) {
+	t.Run("seekable reader, position restored", func(t *testing.T) {
+		r := bytes.NewReader([]byte("ABCDEFG"))
+		head, rest, err := peekHead(r, 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ABC"), head)
+		// rest should yield the original content from the start
+		content, err := io.ReadAll(rest)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ABCDEFG"), content)
+	})
+	t.Run("seekable reader with offset, position restored to that offset", func(t *testing.T) {
+		r := bytes.NewReader([]byte("ABCDEFG"))
+		_, err := r.Seek(2, io.SeekStart)
+		require.NoError(t, err)
+		head, rest, err := peekHead(r, 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("CDE"), head)
+		content, err := io.ReadAll(rest)
+		require.NoError(t, err)
+		require.Equal(t, []byte("CDEFG"), content)
+	})
+	t.Run("non-seekable reader, peeked bytes still available in rest", func(t *testing.T) {
+		r := bytes.NewBufferString("ABCDEFG")
+		head, rest, err := peekHead(r, 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ABC"), head)
+		content, err := io.ReadAll(rest)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ABCDEFG"), content)
+	})
+	t.Run("short input returns what is available", func(t *testing.T) {
+		r := bytes.NewBufferString("AB")
+		head, rest, err := peekHead(r, 3)
+		require.NoError(t, err)
+		require.Equal(t, []byte("AB"), head)
+		content, err := io.ReadAll(rest)
+		require.NoError(t, err)
+		require.Equal(t, []byte("AB"), content)
+	})
 }


### PR DESCRIPTION
Fixes #4916.

## Problem

Running `syft.exe scan dir:X -o json > sbom.json` from PowerShell on Windows produces an SBOM file encoded as UTF-16LE (the OS-level default for PowerShell's `>` operator). `grype sbom:sbom.json` and `syft convert sbom.json -o ...` then fail with `unable to decode sbom: sbom format not recognized`, because the per-format `Identify` methods only recognize UTF-8 byte sequences. Verified on current versions (grype v0.112.0, syft `main`):

| Input encoding | First bytes | `format.Identify` result |
|---|---|---|
| UTF-8 (no BOM) | `7b 22 61 ...` (`{"a...`) | `syft-json v16.1.3` |
| UTF-16LE BOM | `ff fe 7b 00 22 00 61 00 ...` | rejected → `format not recognized` |

Same SBOM content, only the on-disk encoding differs.

## Fix

Detect a leading UTF-8 BOM (`EF BB BF`), UTF-16LE BOM (`FF FE`), or UTF-16BE BOM (`FE FF`) at `SeekableReader` — the single funnel `DecoderCollection.{Decode,Identify}` use for every SBOM input — and transcode the content to UTF-8 via `golang.org/x/text/encoding/unicode.BOMOverride` before per-format identification.

The peek-and-branch shape preserves the existing fast path for `io.ReadSeeker` inputs (and its offset-aware contract for JSONL-style multi-document readers) when no BOM is present; we only buffer when transcoding is required.

Scope is limited to BOM-marked encodings — UTF-8, UTF-16LE, UTF-16BE — per [@willmurphyscode's confirmation on #4916](https://github.com/anchore/syft/issues/4916#issuecomment-4439773801-followup). No heuristic detection of unmarked Windows-1252 etc. (too easy to misclassify legitimate binary content).

`golang.org/x/text` was already an indirect dep; this PR promotes it to direct.

## Test plan

- [x] 7 new cases in `TestSeekableReader` covering UTF-8 BOM / UTF-16LE / UTF-16BE with both seekable and non-seekable inputs, plus short-input edge case
- [x] New `Test_hasBOM` covering 9 cases (each BOM variant, near-miss, empty, short, plain JSON, plain ASCII)
- [x] New `Test_peekHead_preservesReaderPosition` covering 4 cases (seekable at 0, seekable at non-zero offset, non-seekable, short input — verifies the seek-back contract that the offset-aware fast path depends on)
- [x] Existing 7 `TestSeekableReader` cases unchanged and passing (no-BOM path is byte-for-byte unchanged)
- [x] End-to-end smoke: the actual PowerShell-generated UTF-16LE file from the issue's repro is now correctly identified as `syft-json v16.1.3`, decoded without error, and yields the expected package count
- [x] `golangci-lint run --tests=false` clean on the modified file
