### PR TITLE
fix(java): add spring-ldap-core to groupId map

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
@@ -382,6 +382,7 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"spring-jmx":                                  "org.springframework",
 	"spring-jpa":                                  "org.springframework",
 	"spring-ldap":                                 "org.springframework",
+	"spring-ldap-core":                           "org.springframework.ldap",
 	"spring-messaging":                            "org.springframework",
 	"spring-mock":                                 "org.springframework",
 	"spring-ojb":                                  "org.springframework",


### PR DESCRIPTION
## Summary

Fixes #4030

When syft scans a Maven project using `spring-boot-starter-data-ldap`, the generated SBOM incorrectly sets the PURL groupId for `spring-ldap-core` to `spring-ldap-core` (the artifact name) instead of the correct `org.springframework.ldap`.

## Root Cause

The `DefaultArtifactIDToGroupID` map in `java_groupid_map.go` had no entry for `spring-ldap-core`. The PURL generator's `groupIDFromKnownPackageList()` function (step 3 of the fallback chain) returned empty, causing the groupId to fall back to the artifact name.

## Fix

Added `"spring-ldap-core": "org.springframework.ldap"` to the mapping file, placed alphabetically after the existing `"spring-ldap"` entry at line 384.

## Changes

- `syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go`: 1 line added (`+1 -0`)

## Testing

- **spring-boot-starter-data-ldap dependency**: PURL now resolves to `pkg:maven/org.springframework.ldap/spring-ldap-core@VERSION` ✅
- **spring-ldap artifact (existing)**: PURL remains `pkg:maven/org.springframework/spring-ldap@VERSION` ✅
- **Other spring framework artifacts**: Unaffected — no regressions ✅