### PR TITLE
perf(python): hoist name normalization regexp to package level

### DIFF
--- a/syft/pkg/cataloger/python/package.go
+++ b/syft/pkg/cataloger/python/package.go
@@ -11,10 +11,11 @@ import (
 	"github.com/anchore/syft/syft/pkg"
 )
 
+// https://packaging.python.org/en/latest/specifications/name-normalization/
+var nameNormalizationPattern = regexp.MustCompile(`[-_.]+`)
+
 func normalize(name string) string {
-	// https://packaging.python.org/en/latest/specifications/name-normalization/
-	re := regexp.MustCompile(`[-_.]+`)
-	normalized := re.ReplaceAllString(name, "-")
+	normalized := nameNormalizationPattern.ReplaceAllString(name, "-")
 	return strings.ToLower(normalized)
 }
 


### PR DESCRIPTION
Avoid recompiling the separator pattern on every normalize() call during cataloging.

## Description

- Hoist the `[-_.]+` regexp used by `normalize()` in the Python cataloger to a package-level variable so it is compiled once at init instead of on every package name normalization.
- `normalize()` is on the hot path when building Python packages (called for each package created from requirements, setup metadata, wheel records, etc.).

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [] Documentation (updates the documentation)
- [] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [x] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references