### PR TITLE
Enhancements to java cataloger to consider .zap files as jar files

### DIFF
--- a/syft/pkg/cataloger/java/archive_filename.go
+++ b/syft/pkg/cataloger/java/archive_filename.go
@@ -108,7 +108,7 @@ func (a archiveFilename) extension() string {
 
 func (a archiveFilename) pkgType() pkg.Type {
 	switch strings.ToLower(a.extension()) {
-	case "jar", "war", "ear", "lpkg", "par", "sar", "nar", "kar", "rar":
+	case "jar", "war", "ear", "lpkg", "par", "sar", "nar", "kar", "rar", "zap":
 		return pkg.JavaPkg
 	case "jpi", "hpi":
 		return pkg.JenkinsPluginPkg

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -48,6 +48,7 @@ var archiveFormatGlobs = []string{
 	// out of date, and they charge for their IDE. If you find an example
 	// project that we can build in CI feel free to include it
 	"**/*.rar", // Java Resource Adapter Archive
+	"**/*.zap", // ZAP add-ons https://github.com/zaproxy/zaproxy/wiki/ZapAddOns
 }
 
 // javaArchiveHashes are all the current hash algorithms used to calculate archive digests

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -351,6 +351,85 @@ func TestParseJar(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Dupicate the example-java-app-gradle test and the Makefile is adjusted to copy its jar to example-zap-addon-0.1.0.zap
+			name:    "example-zap-addon",
+			fixture: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap",
+			wantErr: require.NoError, // no nested jars
+			expected: map[string]pkg.Package{
+				"example-zap-addon": {
+					Name:     "example-zap-addon",
+					Version:  "0.1.0",
+					PURL:     "pkg:maven/example-zap-addon/example-zap-addon@0.1.0",
+					Language: pkg.Java,
+					Type:     pkg.JavaPkg,
+					Licenses: pkg.NewLicenseSet(
+						pkg.License{
+							Value:          "Apache-2.0",
+							SPDXExpression: "Apache-2.0",
+							Type:           license.Concluded,
+							Locations:      file.NewLocationSet(file.NewLocation("test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap")),
+						},
+					),
+					Metadata: pkg.JavaArchive{
+						VirtualPath: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap",
+						Manifest: &pkg.JavaManifest{
+							Main: []pkg.KeyValue{
+								{
+									Key:   "Manifest-Version",
+									Value: "1.0",
+								},
+								{
+									Key:   "Main-Class",
+									Value: "hello.HelloWorld",
+								},
+							},
+						},
+						// PomProject: &pkg.JavaPomProject{
+						// 	Path:       "META-INF/maven/io.jenkins.plugins/example-jenkins-plugin/pom.xml",
+						// 	Parent:     &pkg.JavaPomParent{GroupID: "org.jenkins-ci.plugins", ArtifactID: "plugin", Version: "4.46"},
+						// 	GroupID:    "io.jenkins.plugins",
+						// 	ArtifactID: "example-jenkins-plugin",
+						// 	Version:    "1.0-SNAPSHOT",
+						// 	Name:       "Example Jenkins Plugin",
+						// },
+					},
+				},
+				"joda-time": {
+					Name:     "joda-time",
+					Version:  "2.2",
+					PURL:     "pkg:maven/joda-time/joda-time@2.2",
+					Language: pkg.Java,
+					Type:     pkg.JavaPkg,
+					Licenses: pkg.NewLicenseSet(
+						pkg.NewLicenseFromFieldsWithContext(ctx, "Apache 2", "http://www.apache.org/licenses/LICENSE-2.0.txt", func() *file.Location {
+							l := file.NewLocation("test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap")
+							return &l
+						}()),
+					),
+					Metadata: pkg.JavaArchive{
+						// ensure that nested packages with different names than that of the parent are appended as
+						// a suffix on the virtual path with a colon separator between group name and artifact name
+						VirtualPath: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap:joda-time:joda-time",
+						PomProperties: &pkg.JavaPomProperties{
+							Path:       "META-INF/maven/joda-time/joda-time/pom.properties",
+							GroupID:    "joda-time",
+							ArtifactID: "joda-time",
+							Version:    "2.2",
+						},
+						PomProject: &pkg.JavaPomProject{
+							Path:        "META-INF/maven/joda-time/joda-time/pom.xml",
+							GroupID:     "joda-time",
+							ArtifactID:  "joda-time",
+							Version:     "2.2",
+							Name:        "Joda time",
+							Description: "Date and time library to replace JDK date handling",
+							URL:         "http://joda-time.sourceforge.net",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -354,7 +354,7 @@ func TestParseJar(t *testing.T) {
 		{
 			// Dupicate the example-java-app-gradle test and the Makefile is adjusted to copy its jar to example-zap-addon-0.1.0.zap
 			name:    "example-zap-addon",
-			fixture: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap",
+			fixture: "testdata/java-builds/packages/example-zap-addon-0.1.0.zap",
 			wantErr: require.NoError, // no nested jars
 			expected: map[string]pkg.Package{
 				"example-zap-addon": {
@@ -368,11 +368,11 @@ func TestParseJar(t *testing.T) {
 							Value:          "Apache-2.0",
 							SPDXExpression: "Apache-2.0",
 							Type:           license.Concluded,
-							Locations:      file.NewLocationSet(file.NewLocation("test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap")),
+							Locations:      file.NewLocationSet(file.NewLocation("testdata/java-builds/packages/example-zap-addon-0.1.0.zap")),
 						},
 					),
 					Metadata: pkg.JavaArchive{
-						VirtualPath: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap",
+						VirtualPath: "testdata/java-builds/packages/example-zap-addon-0.1.0.zap",
 						Manifest: &pkg.JavaManifest{
 							Main: []pkg.KeyValue{
 								{
@@ -403,14 +403,14 @@ func TestParseJar(t *testing.T) {
 					Type:     pkg.JavaPkg,
 					Licenses: pkg.NewLicenseSet(
 						pkg.NewLicenseFromFieldsWithContext(ctx, "Apache 2", "http://www.apache.org/licenses/LICENSE-2.0.txt", func() *file.Location {
-							l := file.NewLocation("test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap")
+							l := file.NewLocation("testdata/java-builds/packages/example-zap-addon-0.1.0.zap")
 							return &l
 						}()),
 					),
 					Metadata: pkg.JavaArchive{
 						// ensure that nested packages with different names than that of the parent are appended as
 						// a suffix on the virtual path with a colon separator between group name and artifact name
-						VirtualPath: "test-fixtures/java-builds/packages/example-zap-addon-0.1.0.zap:joda-time:joda-time",
+						VirtualPath: "testdata/java-builds/packages/example-zap-addon-0.1.0.zap:joda-time:joda-time",
 						PomProperties: &pkg.JavaPomProperties{
 							Path:       "META-INF/maven/joda-time/joda-time/pom.properties",
 							GroupID:    "joda-time",

--- a/syft/pkg/cataloger/java/cataloger_test.go
+++ b/syft/pkg/cataloger/java/cataloger_test.go
@@ -32,6 +32,7 @@ func Test_ArchiveCataloger_Globs(t *testing.T) {
 				"java-archives/example.far",
 				"java-archives/example.lpkg",
 				"java-archives/example.rar",
+				"java-archives/example.zap",
 				"archives/example.zip",
 				"archives/example.tar",
 				"archives/example.tar.gz",

--- a/syft/pkg/cataloger/java/testdata/glob-paths/java-archives/example.zap
+++ b/syft/pkg/cataloger/java/testdata/glob-paths/java-archives/example.zap
@@ -1,0 +1,1 @@
+example archive

--- a/syft/pkg/cataloger/java/testdata/java-builds/Makefile
+++ b/syft/pkg/cataloger/java/testdata/java-builds/Makefile
@@ -14,7 +14,7 @@ fixtures: jars archives native-image
 # requirement 2: 'fingerprint' goal to determine if the fixture input that indicates any existing cache should be busted
 fingerprint: $(FINGERPRINT_FILE)
 
-jars: $(PKGSDIR)/example-java-app-maven-0.1.0.jar $(PKGSDIR)/example-java-app-gradle-0.1.0.jar $(PKGSDIR)/example-jenkins-plugin.hpi $(PKGSDIR)/spring-boot-0.0.1-SNAPSHOT.jar
+jars: $(PKGSDIR)/example-java-app-maven-0.1.0.jar $(PKGSDIR)/example-java-app-gradle-0.1.0.jar $(PKGSDIR)/example-jenkins-plugin.hpi $(PKGSDIR)/spring-boot-0.0.1-SNAPSHOT.jar $(PKGSDIR)/example-zap-addon-0.1.0.zap
 
 archives: $(PKGSDIR)/example-java-app-maven-0.1.0.zip $(PKGSDIR)/example-java-app-maven-0.1.0.tar $(PKGSDIR)/example-java-app-maven-0.1.0.tar.gz $(PKGSDIR)/example-java-app-maven-0.1.0.tgz
 
@@ -54,6 +54,9 @@ clean-maven:
 # Gradle...
 $(PKGSDIR)/example-java-app-gradle-0.1.0.jar:
 	./build-example-java-app-gradle.sh $(PKGSDIR)
+
+$(PKGSDIR)/example-zap-addon-0.1.0.zap: $(PKGSDIR)/example-java-app-gradle-0.1.0.jar
+	cp $(PKGSDIR)/example-java-app-gradle-0.1.0.jar $(PKGSDIR)/example-zap-addon-0.1.0.zap
 
 clean-gradle:
 	rm -rf	example-java-app/.gradle \


### PR DESCRIPTION

## Description
Enabled syft's java-cataloger to identify .zap addon files as jar files see feature request: [4654](https://github.com/anchore/syft/issues/4654) for more specifics.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I have added unit tests that cover changed behavior
- [X] I have tested my code in common scenarios and confirmed there are no regressions
- [X] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4654 
