### PR TITLE
update deno classifier

### DIFF
--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1409,6 +1409,39 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "deno/1.16.4/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.16.4",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.16.4",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
+			logicalFixture: "deno/1.28.3/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.28.3",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.28.3",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
+			logicalFixture: "deno/1.29.4/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.29.4",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.29.4",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
 			logicalFixture: "deno/1.41.0/linux-amd64",
 			expected: pkg.Package{
 				Name:      "deno",

--- a/syft/pkg/cataloger/binary/classifier_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/classifier_cataloger_test.go
@@ -1409,6 +1409,17 @@ func Test_Cataloger_PositiveCases(t *testing.T) {
 			},
 		},
 		{
+			logicalFixture: "deno/1.10.3/linux-amd64",
+			expected: pkg.Package{
+				Name:      "deno",
+				Version:   "1.10.3",
+				Type:      "binary",
+				PURL:      "pkg:generic/deno@1.10.3",
+				Locations: locations("deno"),
+				Metadata:  metadata("deno-binary"),
+			},
+		},
+		{
 			logicalFixture: "deno/1.16.4/linux-amd64",
 			expected: pkg.Package{
 				Name:      "deno",

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -538,6 +538,10 @@ func DefaultClassifiers() []binutils.Classifier {
 					// cli/tools/standalone.rsdeno-ab286750a8c87215a9651efb11fcc620f29140051.16.4release/vdlwindows
 					`deno-[0-9a-z]{40}(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
 				),
+				m.FileContentsVersionMatcher(
+					// 1.10.31567c1013cc8ff12cf039137792da66a1d0015b5DENO_UNSTABLE_COVERAGE_DIRNo current directorycli/main
+					`(?P<version>[0-9]+\.[0-9]+\.[0-9]+)[0-9a-z]{40}DENO`,
+				),
 			),
 			Package: "deno",
 			PURL:    mustPURL("pkg:generic/deno@version"),

--- a/syft/pkg/cataloger/binary/classifiers.go
+++ b/syft/pkg/cataloger/binary/classifiers.go
@@ -523,10 +523,22 @@ func DefaultClassifiers() []binutils.Classifier {
 		{
 			Class:    "deno-binary",
 			FileGlob: "**/deno",
-			EvidenceMatcher: m.FileContentsVersionMatcher(
-				// Deno/2.6.3
-				// Deno/1.41.0
-				`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`),
+			EvidenceMatcher: binutils.MatchAny(
+				m.FileContentsVersionMatcher(
+					// Deno/2.6.3
+					// Deno/1.41.0
+					`Deno/(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+				),
+				m.FileContentsVersionMatcher(
+					// deno::tools::standalonedeno-65db94feba9d4d51a09b74629f566dbc90484fbarelease/v1.29.4windows
+					// cli/tools/standalone.rsdeno-74064c9d8c222b33b2a552ea0af1054f57002a96release/v1.28.3windows
+					`deno-[0-9a-z]{40}release/v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+				),
+				m.FileContentsVersionMatcher(
+					// cli/tools/standalone.rsdeno-ab286750a8c87215a9651efb11fcc620f29140051.16.4release/vdlwindows
+					`deno-[0-9a-z]{40}(?P<version>[0-9]+\.[0-9]+\.[0-9]+)`,
+				),
+			),
 			Package: "deno",
 			PURL:    mustPURL("pkg:generic/deno@version"),
 			CPEs:    singleCPE("cpe:2.3:a:deno:deno:*:*:*:*:*:*:*:*", cpe.NVDDictionaryLookupSource),

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.10.3/linux-amd64/deno
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.10.3/linux-amd64/deno
@@ -1,0 +1,9 @@
+name: deno
+offset: 31454975
+length: 120
+snippetSha256: 30ab01cb89ba17c770cca7d60e12f2c2119fd8db2b389636053bad1146ac83df
+fileSha256: 68ec2c702e9c21e47d5557c603080932ffa24627b463b4a5a4e2ed4ff00f7d5d
+
+### byte snippet to follow ###
+s already installed
+1.10.31567c1013cc8ff12cf039137792da66a1d0015b5DENO_UNSTABLE_COVERAGE_DIRNo current directorycli/main

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.16.4/linux-amd64/deno
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.16.4/linux-amd64/deno
@@ -1,0 +1,9 @@
+name: deno
+offset: 4219127
+length: 120
+snippetSha256: 97e369d4eed74c5b1ff7d578c9de100c71136dfcc54f19455b2938671d1a9640
+fileSha256: f3af5cf3838c0cd01de1acaaa716de804ad08c716927af1848aa9664b96a737c
+
+### byte snippet to follow ###
+g ctrl+d or close()
+Error: cli/tools/standalone.rsdeno-ab286750a8c87215a9651efb11fcc620f29140051.16.4release/vdlwindowsh

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.28.3/linux-amd64/deno
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.28.3/linux-amd64/deno
@@ -1,0 +1,9 @@
+name: deno
+offset: 5079501
+length: 110
+snippetSha256: aa6181b1204d821493756007090ad81677a26f20de0efe9c53bdf401b54849fd
+fileSha256: 3373cbed016860095b01f693a58181c4cf1ac9d6ab7bd5dbca5f684788402919
+
+### byte snippet to follow ###
+n to exit
+cli/tools/standalone.rsdeno-74064c9d8c222b33b2a552ea0af1054f57002a96release/v1.28.3windowshttps://dl

--- a/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.29.4/linux-amd64/deno
+++ b/syft/pkg/cataloger/binary/testdata/classifiers/snippets/deno/1.29.4/linux-amd64/deno
@@ -1,0 +1,9 @@
+name: deno
+offset: 5116362
+length: 220
+snippetSha256: 786a6c5d8be76e3c6e628cd2400c6ed5a7a7cfc75b135e8e7f1375f55dc28787
+fileSha256: d9c8a385c3704e220b1722c642f22e32f8f267013742f9b44d68c67bb5f9232d
+
+### byte snippet to follow ###
+ument. For example:
+    deno run --allow-read=. main.js./$deno$eval.console.log(cli/tools/standalone.rsCompiledeno::tools::standalonedeno-65db94feba9d4d51a09b74629f566dbc90484fbarelease/v1.29.4windowshttps://dl.deno.land

--- a/syft/pkg/cataloger/binary/testdata/config.yaml
+++ b/syft/pkg/cataloger/binary/testdata/config.yaml
@@ -124,6 +124,14 @@ from-images:
       - /usr/lib/dart/bin/dart
 
   - name: deno
+    version: 1.10.3
+    images:
+      - ref: denoland/deno:1.10.3@sha256:9687db39d68333fce31f371734a1b982092507606508289a5c7a24cfc5fe6ee2
+        platform: linux/amd64
+    paths:
+      - /usr/bin/deno
+
+  - name: deno
     version: 1.16.4
     images:
       - ref: denoland/deno:1.16.4@sha256:027868eb6f079ef290957bcda05280a6b08ff86baf549bc6eff5c17467a44d41

--- a/syft/pkg/cataloger/binary/testdata/config.yaml
+++ b/syft/pkg/cataloger/binary/testdata/config.yaml
@@ -124,6 +124,30 @@ from-images:
       - /usr/lib/dart/bin/dart
 
   - name: deno
+    version: 1.16.4
+    images:
+      - ref: denoland/deno:1.16.4@sha256:027868eb6f079ef290957bcda05280a6b08ff86baf549bc6eff5c17467a44d41
+        platform: linux/amd64
+    paths:
+      - /usr/bin/deno
+
+  - name: deno
+    version: 1.28.3
+    images:
+      - ref: denoland/deno:1.28.3@sha256:8636e6ac55fbd4687c111eb4b798b1772d43874c53647ca4a2bad6d1962643f0
+        platform: linux/amd64
+    paths:
+      - /usr/bin/deno
+
+  - name: deno
+    version: 1.29.4
+    images:
+      - ref: denoland/deno:1.29.4@sha256:f5b5a4678b18884724b277a4eb5490a978eab2da5a47461766df9fb59ebb08b6
+        platform: linux/amd64
+    paths:
+      - /usr/bin/deno
+
+  - name: deno
     version: 1.41.0
     images:
       - ref: denoland/deno:1.41.0


### PR DESCRIPTION
## Description

This PR updates deno classifier to support old versions

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4865

----

<details>

```
$ go test -v ./syft/pkg/cataloger/binary -run Test_Cataloger_PositiveCases/deno
=== RUN   Test_Cataloger_PositiveCases
=== RUN   Test_Cataloger_PositiveCases/deno/1.10.3/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/1.10.3/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.16.4/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/1.16.4/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.28.3/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/1.28.3/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.29.4/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/1.29.4/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.41.0/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/1.41.0/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/2.0.0/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/2.0.0/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/2.6.3/linux-amd64
    snippet_or_binary.go:50: using snippet for "deno/2.6.3/linux-amd64"
--- PASS: Test_Cataloger_PositiveCases (0.71s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.10.3/linux-amd64 (0.09s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.16.4/linux-amd64 (0.09s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.28.3/linux-amd64 (0.10s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.29.4/linux-amd64 (0.09s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.41.0/linux-amd64 (0.12s)
    --- PASS: Test_Cataloger_PositiveCases/deno/2.0.0/linux-amd64 (0.12s)
    --- PASS: Test_Cataloger_PositiveCases/deno/2.6.3/linux-amd64 (0.10s)
PASS
ok      github.com/anchore/syft/syft/pkg/cataloger/binary       0.726s

$ go test -v ./syft/pkg/cataloger/binary -run Test_Cataloger_PositiveCases/deno -must-use-original-binaries
=== RUN   Test_Cataloger_PositiveCases
=== RUN   Test_Cataloger_PositiveCases/deno/1.10.3/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/1.10.3/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.16.4/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/1.16.4/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.28.3/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/1.28.3/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.29.4/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/1.29.4/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/1.41.0/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/1.41.0/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/2.0.0/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/2.0.0/linux-amd64"
=== RUN   Test_Cataloger_PositiveCases/deno/2.6.3/linux-amd64
    snippet_or_binary.go:62: forcing the use of the original binary for "deno/2.6.3/linux-amd64"
--- PASS: Test_Cataloger_PositiveCases (1.98s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.10.3/linux-amd64 (1.65s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.16.4/linux-amd64 (0.08s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.28.3/linux-amd64 (0.06s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.29.4/linux-amd64 (0.06s)
    --- PASS: Test_Cataloger_PositiveCases/deno/1.41.0/linux-amd64 (0.04s)
    --- PASS: Test_Cataloger_PositiveCases/deno/2.0.0/linux-amd64 (0.04s)
    --- PASS: Test_Cataloger_PositiveCases/deno/2.6.3/linux-amd64 (0.04s)
PASS
ok      github.com/anchore/syft/syft/pkg/cataloger/binary       1.998s
```

```
$ for i in 1.32.2 1.31.3 1.30.3 1.29.4 1.28.3 1.27.2 1.26.2 1.25.4 1.24.3 1.23.4 1.22.3 1.21.3 1.20.6 1.19.3 1.18.2 1.17.3 1.16.4 1.15.3 1.14.3 1.13.2 1.12.2 1.11.5 1.10.3  ; do echo $i; go run ./cmd/syft -q denoland/deno:$i | grep deno; done
1.32.2
deno                    1.32.0                        binary
1.31.3
deno                    1.31.3                        binary
1.30.3
deno                    1.30.3                        binary
1.29.4
deno                    1.29.4                        binary
1.28.3
deno                    1.28.3                        binary
1.27.2
deno                    1.27.2                        binary
1.26.2
deno                    1.26.2                        binary
1.25.4
deno                    1.25.4                        binary
1.24.3
deno                    1.24.3                        binary
1.23.4
deno                    1.23.4                        binary
1.22.3
deno                    1.22.3                        binary
1.21.3
deno                    1.21.3                        binary
1.20.6
deno                    1.20.6                        binary
1.19.3
deno                    1.19.3                        binary
1.18.2
deno                    1.18.2                        binary
1.17.3
deno                    1.17.3                        binary
1.16.4
deno                    1.16.4                        binary
1.15.3
deno                    1.15.3                        binary
1.14.3
deno                    1.14.3                        binary
1.13.2
deno                    1.13.2                        binary
1.12.2
deno                    1.12.2                  binary
1.11.5
deno                    1.11.5                  binary
1.10.3
deno                    1.10.3                  binary
```

</details>