### PR TITLE
feat: Add support for multiple attestation output formats

### DIFF
--- a/cmd/syft/internal/commands/attest.go
+++ b/cmd/syft/internal/commands/attest.go
@@ -150,10 +150,7 @@ func attestSingleFormat(s *sbom.SBOM, encoders *format.EncoderCollection, output
 }
 
 func createAttestation(sbomFilepath string, outputName string, opts *attestOptions, userInput string) error {
-	execCmd, err := attestCommand(sbomFilepath, outputName, opts, userInput)
-	if err != nil {
-		return fmt.Errorf("unable to craft attest command: %w", err)
-	}
+	execCmd := attestCommand(sbomFilepath, outputName, opts, userInput)
 
 	log.WithFields("cmd", strings.Join(execCmd.Args, " ")).Trace("creating attestation")
 
@@ -197,7 +194,7 @@ func createAttestation(sbomFilepath string, outputName string, opts *attestOptio
 	return nil
 }
 
-func attestCommand(sbomFilepath string, outputName string, opts *attestOptions, userInput string) (*exec.Cmd, error) {
+func attestCommand(sbomFilepath string, outputName string, opts *attestOptions, userInput string) *exec.Cmd {
 	args := []string{"attest", userInput, "--predicate", sbomFilepath, "--type", predicateType(outputName), "-y"}
 	if opts.Attest.Key != "" {
 		args = append(args, "--key", opts.Attest.Key.String())
@@ -211,7 +208,7 @@ func attestCommand(sbomFilepath string, outputName string, opts *attestOptions, 
 		execCmd.Env = append(execCmd.Env, "COSIGN_EXPERIMENTAL=1")
 	}
 
-	return execCmd, nil
+	return execCmd
 }
 
 func predicateType(outputName string) string {

--- a/cmd/syft/internal/commands/attest.go
+++ b/cmd/syft/internal/commands/attest.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -85,7 +84,7 @@ func defaultAttestOptions() attestOptions {
 
 func defaultAttestOutputOptions() options.Output {
 	return options.Output{
-		AllowMultipleOutputs: false,
+		AllowMultipleOutputs: true,
 		AllowToFile:          false,
 		AllowableOptions: []string{
 			string(syftjson.ID),
@@ -100,61 +99,58 @@ func defaultAttestOutputOptions() options.Output {
 }
 
 func runAttest(ctx context.Context, id clio.Identification, opts *attestOptions, userInput string) error {
-	// TODO: what other validation here besides binary name?
 	if !commandExists(cosignBinName) {
 		return fmt.Errorf("'syft attest' requires cosign to be installed, however it does not appear to be on PATH")
 	}
-
-	// this is the file that will contain the SBOM being attested
-	f, err := os.CreateTemp("", "syft-attest-")
-	if err != nil {
-		return fmt.Errorf("unable to create temp file: %w", err)
-	}
-	defer os.Remove(f.Name())
 
 	s, err := generateSBOMForAttestation(ctx, id, &opts.Catalog, userInput)
 	if err != nil {
 		return fmt.Errorf("unable to build SBOM: %w", err)
 	}
 
-	if err = writeSBOMToFormattedFile(s, f, opts); err != nil {
-		return fmt.Errorf("unable to write SBOM to file: %w", err)
-	}
-
-	if err = createAttestation(f.Name(), opts, userInput); err != nil {
-		return err
-	}
-
-	bus.Notify("Attestation has been created, please check your registry for the output or use the cosign command:")
-	bus.Notify(fmt.Sprintf("cosign download attestation %s", userInput))
-	return nil
-}
-
-func writeSBOMToFormattedFile(s *sbom.SBOM, sbomFile io.Writer, opts *attestOptions) error {
-	if sbomFile == nil {
-		return fmt.Errorf("no output file provided")
-	}
-
 	encs, err := opts.Encoders()
 	if err != nil {
 		return fmt.Errorf("unable to create encoders: %w", err)
 	}
-
 	encoders := format.NewEncoderCollection(encs...)
-	encoder := encoders.GetByString(opts.Outputs[0])
-	if encoder == nil {
-		return fmt.Errorf("unable to find encoder for %q", opts.Outputs[0])
+
+	for _, output := range opts.Outputs {
+		outputName := strings.SplitN(output, "=", 2)[0]
+		if err := attestSingleFormat(s, encoders, outputName, opts, userInput); err != nil {
+			return fmt.Errorf("attestation failed for format %q: %w", outputName, err)
+		}
 	}
 
-	if err = encoder.Encode(sbomFile, *s); err != nil {
-		return fmt.Errorf("unable to encode SBOM: %w", err)
-	}
-
+	bus.Notify("Attestation(s) created, please check your registry for the output or use the cosign command:")
+	bus.Notify(fmt.Sprintf("cosign download attestation %s", userInput))
 	return nil
 }
 
-func createAttestation(sbomFilepath string, opts *attestOptions, userInput string) error {
-	execCmd, err := attestCommand(sbomFilepath, opts, userInput)
+func attestSingleFormat(s *sbom.SBOM, encoders *format.EncoderCollection, outputName string, opts *attestOptions, userInput string) error {
+	encoder := encoders.GetByString(outputName)
+	if encoder == nil {
+		return fmt.Errorf("unable to find encoder for %q", outputName)
+	}
+
+	f, err := os.CreateTemp("", "syft-attest-")
+	if err != nil {
+		return fmt.Errorf("unable to create temp file: %w", err)
+	}
+	defer os.Remove(f.Name())
+
+	if err = encoder.Encode(f, *s); err != nil {
+		return fmt.Errorf("unable to encode SBOM: %w", err)
+	}
+
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("unable to close temp file: %w", err)
+	}
+
+	return createAttestation(f.Name(), outputName, opts, userInput)
+}
+
+func createAttestation(sbomFilepath string, outputName string, opts *attestOptions, userInput string) error {
+	execCmd, err := attestCommand(sbomFilepath, outputName, opts, userInput)
 	if err != nil {
 		return fmt.Errorf("unable to craft attest command: %w", err)
 	}
@@ -175,9 +171,9 @@ func createAttestation(sbomFilepath string, opts *attestOptions, userInput strin
 			Type: event.AttestationStarted,
 			Source: monitor.GenericTask{
 				Title: monitor.Title{
-					Default:      "Create attestation",
-					WhileRunning: "Creating attestation",
-					OnSuccess:    "Created attestation",
+					Default:      fmt.Sprintf("Create attestation [%s]", outputName),
+					WhileRunning: fmt.Sprintf("Creating attestation [%s]", outputName),
+					OnSuccess:    fmt.Sprintf("Created attestation [%s]", outputName),
 				},
 				Context: "cosign",
 			},
@@ -191,29 +187,17 @@ func createAttestation(sbomFilepath string, opts *attestOptions, userInput strin
 	execCmd.Stdout = w
 	execCmd.Stderr = w
 
-	// attest the SBOM
 	err = execCmd.Run()
 	if err != nil {
 		mon.SetError(err)
-		return fmt.Errorf("unable to attest SBOM: %w", err)
+		return fmt.Errorf("unable to attest SBOM as %q: %w", outputName, err)
 	}
 
 	mon.SetCompleted()
 	return nil
 }
 
-func attestCommand(sbomFilepath string, opts *attestOptions, userInput string) (*exec.Cmd, error) {
-	outputNames := opts.OutputNameSet()
-	var outputName string
-	switch outputNames.Size() {
-	case 0:
-		return nil, fmt.Errorf("no output format specified")
-	case 1:
-		outputName = outputNames.List()[0]
-	default:
-		return nil, fmt.Errorf("multiple output formats specified: %s", strings.Join(outputNames.List(), ", "))
-	}
-
+func attestCommand(sbomFilepath string, outputName string, opts *attestOptions, userInput string) (*exec.Cmd, error) {
 	args := []string{"attest", userInput, "--predicate", sbomFilepath, "--type", predicateType(outputName), "-y"}
 	if opts.Attest.Key != "" {
 		args = append(args, "--key", opts.Attest.Key.String())
@@ -224,7 +208,6 @@ func attestCommand(sbomFilepath string, opts *attestOptions, userInput string) (
 	if opts.Attest.Key != "" {
 		execCmd.Env = append(execCmd.Env, fmt.Sprintf("COSIGN_PASSWORD=%s", opts.Attest.Password))
 	} else {
-		// no key provided, use cosign's keyless mode
 		execCmd.Env = append(execCmd.Env, "COSIGN_EXPERIMENTAL=1")
 	}
 

--- a/cmd/syft/internal/commands/attest_test.go
+++ b/cmd/syft/internal/commands/attest_test.go
@@ -20,46 +20,45 @@ import (
 	"github.com/anchore/clio/cliotestutils"
 	"github.com/anchore/syft/cmd/syft/internal"
 	"github.com/anchore/syft/cmd/syft/internal/options"
+	"github.com/anchore/syft/syft/format"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 )
 
-func Test_writeSBOMToFormattedFile(t *testing.T) {
-	type args struct {
-		s    *sbom.SBOM
-		opts *attestOptions
+func Test_attestSingleFormat(t *testing.T) {
+	s := &sbom.SBOM{
+		Artifacts:     sbom.Artifacts{},
+		Relationships: nil,
+		Source: source.Description{
+			ID:      "source-id",
+			Name:    "source-name",
+			Version: "source-version",
+		},
+		Descriptor: sbom.Descriptor{
+			Name:    "syft-test",
+			Version: "non-version",
+		},
 	}
-	tests := []struct {
-		name         string
-		args         args
-		wantSbomFile string
-		wantErr      bool
-	}{
-		{
-			name: "go case",
-			args: args{
-				opts: &attestOptions{
-					Output: func() options.Output {
-						def := defaultAttestOutputOptions()
-						def.Outputs = []string{"syft-json"}
-						return def
-					}(),
-				},
-				s: &sbom.SBOM{
-					Artifacts:     sbom.Artifacts{},
-					Relationships: nil,
-					Source: source.Description{
-						ID:      "source-id",
-						Name:    "source-name",
-						Version: "source-version",
-					},
-					Descriptor: sbom.Descriptor{
-						Name:    "syft-test",
-						Version: "non-version",
-					},
-				},
-			},
-			wantSbomFile: `{
+
+	opts := &attestOptions{
+		Output: defaultAttestOutputOptions(),
+	}
+
+	encs, err := opts.Encoders()
+	require.NoError(t, err)
+
+	encoders := format.NewEncoderCollection(encs...)
+	encoder := encoders.GetByString("syft-json")
+	require.NotNil(t, encoder, "expected to find encoder for syft-json")
+
+	sbomFile := &bytes.Buffer{}
+	err = encoder.Encode(sbomFile, *s)
+	require.NoError(t, err)
+
+	re := regexp.MustCompile(`(?s)"schema":\W*\{.*?},?`)
+	subject := re.ReplaceAllString(sbomFile.String(), `"schema":{}`)
+
+	wantSbomFile := `{
  "artifacts": [],
  "artifactRelationships": [],
  "source": {
@@ -75,27 +74,9 @@ func Test_writeSBOMToFormattedFile(t *testing.T) {
   "version": "non-version"
  },
  "schema": {}
-}`,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sbomFile := &bytes.Buffer{}
+}`
 
-			err := writeSBOMToFormattedFile(tt.args.s, sbomFile, tt.args.opts)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("writeSBOMToFormattedFile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			// redact the schema block
-			re := regexp.MustCompile(`(?s)"schema":\W*\{.*?},?`)
-			subject := re.ReplaceAllString(sbomFile.String(), `"schema":{}`)
-
-			assert.JSONEq(t, tt.wantSbomFile, subject)
-		})
-	}
+	assert.JSONEq(t, wantSbomFile, subject)
 }
 
 func Test_attestCommand(t *testing.T) {
@@ -111,6 +92,7 @@ func Test_attestCommand(t *testing.T) {
 
 	type args struct {
 		sbomFilepath string
+		outputName   string
 		opts         attestOptions
 		userInput    string
 	}
@@ -127,9 +109,9 @@ func Test_attestCommand(t *testing.T) {
 			args: args{
 				userInput:    "myimage",
 				sbomFilepath: "/tmp/sbom-filepath.json",
+				outputName:   "syft-json",
 				opts: func() attestOptions {
 					def := defaultAttestOptions()
-					def.Outputs = []string{"syft-json"}
 					def.Attest.Key = "key"
 					def.Attest.Password = "password"
 					return def
@@ -140,7 +122,7 @@ func Test_attestCommand(t *testing.T) {
 				"COSIGN_PASSWORD": "password",
 			},
 			notEnvVars: []string{
-				"COSIGN_EXPERIMENTAL", // only for keyless
+				"COSIGN_EXPERIMENTAL",
 			},
 		},
 		{
@@ -148,9 +130,9 @@ func Test_attestCommand(t *testing.T) {
 			args: args{
 				userInput:    "myimage",
 				sbomFilepath: "/tmp/sbom-filepath.json",
+				outputName:   "syft-json",
 				opts: func() attestOptions {
 					def := defaultAttestOptions()
-					def.Outputs = []string{"syft-json"}
 					return def
 				}(),
 			},
@@ -162,6 +144,42 @@ func Test_attestCommand(t *testing.T) {
 				"COSIGN_PASSWORD",
 			},
 		},
+		{
+			name: "spdx-json format",
+			args: args{
+				userInput:    "myimage",
+				sbomFilepath: "/tmp/sbom-filepath.json",
+				outputName:   "spdx-json",
+				opts: func() attestOptions {
+					def := defaultAttestOptions()
+					def.Attest.Key = "key"
+					def.Attest.Password = "password"
+					return def
+				}(),
+			},
+			wantCmd: fullCmd("attest myimage --predicate /tmp/sbom-filepath.json --type spdxjson -y --key key"),
+			wantEnvVars: map[string]string{
+				"COSIGN_PASSWORD": "password",
+			},
+		},
+		{
+			name: "cyclonedx-json format",
+			args: args{
+				userInput:    "myimage",
+				sbomFilepath: "/tmp/sbom-filepath.json",
+				outputName:   "cyclonedx-json",
+				opts: func() attestOptions {
+					def := defaultAttestOptions()
+					def.Attest.Key = "key"
+					def.Attest.Password = "password"
+					return def
+				}(),
+			},
+			wantCmd: fullCmd("attest myimage --predicate /tmp/sbom-filepath.json --type cyclonedx -y --key key"),
+			wantEnvVars: map[string]string{
+				"COSIGN_PASSWORD": "password",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -169,7 +187,7 @@ func Test_attestCommand(t *testing.T) {
 				tt.wantErr = require.NoError
 			}
 
-			got, err := attestCommand(tt.args.sbomFilepath, &tt.args.opts, tt.args.userInput)
+			got, err := attestCommand(tt.args.sbomFilepath, tt.args.outputName, &tt.args.opts, tt.args.userInput)
 			tt.wantErr(t, err)
 			if err != nil {
 				return

--- a/cmd/syft/internal/commands/attest_test.go
+++ b/cmd/syft/internal/commands/attest_test.go
@@ -102,7 +102,6 @@ func Test_attestCommand(t *testing.T) {
 		wantCmd     string
 		wantEnvVars map[string]string
 		notEnvVars  []string
-		wantErr     require.ErrorAssertionFunc
 	}{
 		{
 			name: "with key and password",
@@ -183,16 +182,7 @@ func Test_attestCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantErr == nil {
-				tt.wantErr = require.NoError
-			}
-
-			got, err := attestCommand(tt.args.sbomFilepath, tt.args.outputName, &tt.args.opts, tt.args.userInput)
-			tt.wantErr(t, err)
-			if err != nil {
-				return
-			}
-
+			got := attestCommand(tt.args.sbomFilepath, tt.args.outputName, &tt.args.opts, tt.args.userInput)
 			require.NotNil(t, got)
 			assert.Equal(t, tt.wantCmd, got.String())
 


### PR DESCRIPTION
Allow `syft attest` to accept multiple `-o` flags (e.g. `-o spdx-json -o cyclonedx-json`) so users can generate attestations in several SBOM formats from a single invocation. The SBOM is cataloged once and each format gets its own cosign attestation with the appropriate predicate type.

  ## Description

  Allow `syft attest` to accept multiple `-o` flags so users can generate attestations in several SBOM formats from a single invocation:

  ```bash
  # before: two separate commands
  syft attest --key k image -o cyclonedx-json
  syft attest --key k image -o spdx-json

  # after: one command
  syft attest --key k image -o cyclonedx-json -o spdx-json
```

  The SBOM is cataloged once. Each output format gets its own temp file and cosign invocation with the appropriate predicate type. Fails fast on the first format error.

  Type of change

  - [x] New feature (non-breaking change which adds functionality)

  Checklist

  - [x] I have added unit tests that cover changed behavior
  - [x] I have tested my code in common scenarios and confirmed there are no regressions
  - [x] I have added comments to my code, particularly in hard-to-understand sections

  Issue references:

  Closes #4938 

 <details>
  <summary>Test evidence</summary>

  ~~~
  $ go test -v ./cmd/syft/internal/commands/... -run "Test_attest|Test_predicate"
  === RUN   Test_attestSingleFormat
  --- PASS: Test_attestSingleFormat (0.00s)
  === RUN   Test_attestCommand
  === RUN   Test_attestCommand/with_key_and_password
  === RUN   Test_attestCommand/keyless
  === RUN   Test_attestCommand/spdx-json_format
  === RUN   Test_attestCommand/cyclonedx-json_format
  --- PASS: Test_attestCommand (0.01s)
      --- PASS: Test_attestCommand/with_key_and_password (0.00s)
      --- PASS: Test_attestCommand/keyless (0.00s)
      --- PASS: Test_attestCommand/spdx-json_format (0.00s)
      --- PASS: Test_attestCommand/cyclonedx-json_format (0.00s)
  === RUN   Test_predicateType
  === RUN   Test_predicateType/cyclonedx-json
  === RUN   Test_predicateType/spdx-tag-value
  === RUN   Test_predicateType/spdx-tv
  === RUN   Test_predicateType/spdx-json
  === RUN   Test_predicateType/json
  === RUN   Test_predicateType/syft-json
  --- PASS: Test_predicateType (0.00s)
      --- PASS: Test_predicateType/cyclonedx-json (0.00s)
      --- PASS: Test_predicateType/spdx-tag-value (0.00s)
      --- PASS: Test_predicateType/spdx-tv (0.00s)
      --- PASS: Test_predicateType/spdx-json (0.00s)
      --- PASS: Test_predicateType/json (0.00s)
      --- PASS: Test_predicateType/syft-json (0.00s)
  === RUN   Test_attestCLIWiring
  === RUN   Test_attestCLIWiring/key_flag_is_accepted
  [0000]  INFO syft version: testing
  === RUN   Test_attestCLIWiring/key_password_is_read_from_env
  [0000]  INFO syft version: testing
  --- PASS: Test_attestCLIWiring (0.01s)
      --- PASS: Test_attestCLIWiring/key_flag_is_accepted (0.00s)
      --- PASS: Test_attestCLIWiring/key_password_is_read_from_env (0.00s)
  PASS
  ok    github.com/anchore/syft/cmd/syft/internal/commands      1.155s
  ~~~

  Manual test against a local registry:
  ~~~
  $ syft attest --key cosign.key localhost:5050/test-image:latest -o spdx-json -o cyclonedx-json
  Attestation(s) created, please check your registry for the output or use the cosign command:
  cosign download attestation localhost:5050/test-image:latest

  $ cosign verify-attestation --key cosign.pub --type spdxjson localhost:5050/test-image:latest
  Verification for localhost:5050/test-image:latest --
  The following checks were performed on each of these signatures:
    - The cosign claims were validated
    - Existence of the claims in the transparency log was verified offline
    - The signatures were verified against the specified public key

  $ cosign verify-attestation --key cosign.pub --type cyclonedx localhost:5050/test-image:latest
  Verification for localhost:5050/test-image:latest --
  The following checks were performed on each of these signatures:
    - The cosign claims were validated
    - Existence of the claims in the transparency log was verified offline
    - The signatures were verified against the specified public key
  ~~~

  </details>