### PR TITLE
Add hierarchical dependency resolution from embedded POM files

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -211,7 +211,8 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 			WithUseNetwork(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Java, task.Maven), cfg.Java.UseNetwork)).
 			WithMavenBaseURL(cfg.Java.MavenURL).
 			WithArchiveTraversal(archiveSearch, cfg.Java.MaxParentRecursiveDepth).
-			WithResolveTransitiveDependencies(cfg.Java.ResolveTransitiveDependencies),
+			WithResolveTransitiveDependencies(cfg.Java.ResolveTransitiveDependencies).
+			WithUseEmbeddedPOMDependencies(cfg.Java.UseEmbeddedPOMDependencies),
 	}
 }
 

--- a/cmd/syft/internal/options/java.go
+++ b/cmd/syft/internal/options/java.go
@@ -12,6 +12,7 @@ type javaConfig struct {
 	MavenURL                      string `yaml:"maven-url" json:"maven-url" mapstructure:"maven-url"`
 	MaxParentRecursiveDepth       int    `yaml:"max-parent-recursive-depth" json:"max-parent-recursive-depth" mapstructure:"max-parent-recursive-depth"`
 	ResolveTransitiveDependencies bool   `yaml:"resolve-transitive-dependencies" json:"resolve-transitive-dependencies" mapstructure:"resolve-transitive-dependencies"`
+	UseEmbeddedPOMDependencies    bool   `yaml:"use-embedded-pom-dependencies" json:"use-embedded-pom-dependencies" mapstructure:"use-embedded-pom-dependencies"`
 }
 
 func defaultJavaConfig() javaConfig {
@@ -24,6 +25,7 @@ func defaultJavaConfig() javaConfig {
 		MavenLocalRepositoryDir:       def.MavenLocalRepositoryDir,
 		MavenURL:                      def.MavenBaseURL,
 		ResolveTransitiveDependencies: def.ResolveTransitiveDependencies,
+		UseEmbeddedPOMDependencies:    def.UseEmbeddedPOMDependencies,
 	}
 }
 
@@ -46,4 +48,6 @@ build, run 'mvn help:effective-pom' before performing the scan with syft.`)
 	descriptions.Add(&o.MavenLocalRepositoryDir, `override the default location of the local Maven repository. 
 the default is the subdirectory '.m2/repository' in your home directory`)
 	descriptions.Add(&o.ResolveTransitiveDependencies, `resolve transient dependencies such as those defined in a dependency's POM on Maven central`)
+	descriptions.Add(&o.UseEmbeddedPOMDependencies, `build a hierarchical dependency graph from embedded pom.xml files within archives.
+When enabled, dependency relationships are wired to their actual Maven parent rather than all pointing to the root archive`)
 }

--- a/internal/task/relationship_tasks.go
+++ b/internal/task/relationship_tasks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg/cataloger/java"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 )
@@ -23,13 +24,16 @@ func (s sourceIdentifierAdapter) ID() artifact.ID {
 	return artifact.ID(s.desc.ID)
 }
 
-func NewRelationshipsTask(cfg cataloging.RelationshipsConfig, src source.Description) Task {
+func NewRelationshipsTask(cfg cataloging.RelationshipsConfig, javaCfg java.ArchiveCatalogerConfig, src source.Description) Task {
 	fn := func(_ context.Context, resolver file.Resolver, builder sbomsync.Builder) error {
 		finalizeRelationships(
 			resolver,
 			builder,
 			cfg,
 			&sourceIdentifierAdapter{desc: src})
+
+		accessor := builder.(sbomsync.Accessor)
+		java.ResolveHierarchicalDependencies(accessor, javaCfg)
 
 		return nil
 	}

--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -420,7 +420,7 @@ func (c *CreateSBOMConfig) scopeTasks() []task.Task {
 func (c *CreateSBOMConfig) relationshipTasks(src source.Description) []task.Task {
 	var tsks []task.Task
 
-	if t := task.NewRelationshipsTask(c.Relationships, src); t != nil {
+	if t := task.NewRelationshipsTask(c.Relationships, c.Packages.JavaArchive, src); t != nil {
 		tsks = append(tsks, t)
 	}
 	return tsks

--- a/syft/format/common/spdxhelpers/to_format_model_test.go
+++ b/syft/format/common/spdxhelpers/to_format_model_test.go
@@ -677,6 +677,11 @@ func Test_lookupRelationship(t *testing.T) {
 			ty:     helpers.ContainsRelationship,
 		},
 		{
+			input:  artifact.DependencyOfRelationship,
+			exists: true,
+			ty:     helpers.DependencyOfRelationship,
+		},
+		{
 			input:   artifact.OwnershipByFileOverlapRelationship,
 			exists:  true,
 			ty:      helpers.OtherRelationship,

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -1098,6 +1098,9 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 	auxID := extractMavenIDFromPackage(auxPkg)
 	node := j.dependencyGraph.FindNode(auxID)
 	if node == nil {
+		node = j.dependencyGraph.FindNodeByGA(auxID.GroupID, auxID.ArtifactID)
+	}
+	if node == nil {
 		return artifact.Relationship{
 			From: *auxPkg,
 			To:   *mainPkg,
@@ -1115,7 +1118,7 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 			}
 		}
 		// parent not in this archive's packages — defer for post-processor
-		intendedParentID := fmt.Sprintf("%s:%s:%s", node.Parent.ID.GroupID, node.Parent.ID.ArtifactID, node.Parent.ID.Version)
+		intendedParentID := node.Parent.ID.Coordinate()
 		return artifact.Relationship{
 			From: *auxPkg,
 			To:   *mainPkg,
@@ -1145,6 +1148,9 @@ func (j *archiveParser) createMainPkgRelationship(mainPkg *pkg.Package, parentPk
 	if j.dependencyGraph != nil && j.depth > 0 {
 		mainID := extractMavenIDFromPackage(mainPkg)
 		node := j.dependencyGraph.FindNode(mainID)
+		if node == nil {
+			node = j.dependencyGraph.FindNodeByGA(mainID.GroupID, mainID.ArtifactID)
+		}
 		if node != nil {
 			rel.Data = NewDependencyRelationshipData(node.Depth()-1, node.Scope)
 		}

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -57,14 +57,16 @@ var javaArchiveHashes = []crypto.Hash{
 }
 
 type archiveParser struct {
-	fileManifest intFile.ZipFileManifest
-	location     file.Location
-	archivePath  string
-	contentPath  string
-	fileInfo     archiveFilename
-	detectNested bool
-	cfg          ArchiveCatalogerConfig
-	maven        *maven.Resolver
+	fileManifest    intFile.ZipFileManifest
+	location        file.Location
+	archivePath     string
+	contentPath     string
+	fileInfo        archiveFilename
+	detectNested    bool
+	cfg             ArchiveCatalogerConfig
+	maven           *maven.Resolver
+	dependencyGraph *DependencyGraph
+	depth           int
 }
 
 type genericArchiveParserAdapter struct {
@@ -77,17 +79,19 @@ func newGenericArchiveParserAdapter(cfg ArchiveCatalogerConfig) genericArchivePa
 
 // parseJavaArchive is a parser function for java archive contents, returning all Java libraries and nested archives
 func (gap genericArchiveParserAdapter) parseJavaArchive(ctx context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
-	return gap.processJavaArchive(ctx, reader, nil)
+	return gap.processJavaArchive(ctx, reader, nil, 0, nil)
 }
 
 // processJavaArchive processes an archive for java contents, returning all Java libraries and nested archives
-func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
+func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package, depth int, rootGraph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	parser, cleanupFn, err := newJavaArchiveParser(ctx, reader, true, gap.cfg)
 	// note: even on error, we should always run cleanup functions
 	defer cleanupFn()
 	if err != nil {
 		return nil, nil, err
 	}
+	parser.depth = depth
+	parser.dependencyGraph = rootGraph
 	return parser.parse(ctx, parentPkg)
 }
 
@@ -151,18 +155,22 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		return nil, nil, err
 	}
 
+	// build dependency graph from embedded POMs (only at top-level)
+	if j.cfg.UseEmbeddedPOMDependencies && mainPkg != nil && j.depth == 0 {
+		j.buildDependencyGraphFromEmbeddedPOMs(ctx, mainPkg)
+	}
+
 	if mainPkg != nil {
 		finalizePackage(mainPkg)
 		pkgs = append(pkgs, *mainPkg)
 
 		if parentPkg != nil {
-			relationships = append(relationships, artifact.Relationship{
-				From: *mainPkg,
-				To:   *parentPkg,
-				Type: artifact.DependencyOfRelationship,
-			})
+			relationships = append(relationships, j.createMainPkgRelationship(mainPkg, parentPkg))
 		}
 	}
+
+	// build package index for parent resolution when graph is available
+	pkgIndex := j.buildPkgIndex(mainPkg, auxPkgs)
 
 	for i := range auxPkgs {
 		auxPkg := &auxPkgs[i]
@@ -171,11 +179,7 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 		pkgs = append(pkgs, *auxPkg)
 
 		if mainPkg != nil {
-			relationships = append(relationships, artifact.Relationship{
-				From: *auxPkg,
-				To:   *mainPkg,
-				Type: artifact.DependencyOfRelationship,
-			})
+			relationships = append(relationships, j.createAuxPkgRelationship(auxPkg, mainPkg, pkgIndex))
 		}
 	}
 
@@ -611,28 +615,28 @@ func (j *archiveParser) getLicenseFromFileInArchive(ctx context.Context) []pkg.L
 
 func (j *archiveParser) discoverPkgsFromNestedArchives(ctx context.Context, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
 	// we know that all java archives are zip formatted files, so we can use the shared zip helper
-	return discoverPkgsFromZip(ctx, j.location, j.archivePath, j.contentPath, j.fileManifest, parentPkg, j.cfg)
+	return discoverPkgsFromZip(ctx, j.location, j.archivePath, j.contentPath, j.fileManifest, parentPkg, j.cfg, j.depth+1, j.dependencyGraph)
 }
 
 // discoverPkgsFromZip finds Java archives within Java archives, returning all listed Java packages found and
 // associating each discovered package to the given parent package.
-func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	// search and parse pom.properties files & fetch the contents
 	openers, err := intFile.ExtractFromZipToUniqueTempFile(ctx, archivePath, contentPath, fileManifest.GlobMatch(false, archiveFormatGlobs...)...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to extract files from zip: %w", err)
 	}
 
-	return discoverPkgsFromOpeners(ctx, location, openers, parentPkg, cfg)
+	return discoverPkgsFromOpeners(ctx, location, openers, parentPkg, cfg, depth, graph)
 }
 
 // discoverPkgsFromOpeners finds Java archives within the given files and associates them with the given parent package.
-func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	var pkgs []pkg.Package
 	var relationships []artifact.Relationship
 
 	for pathWithinArchive, archiveOpener := range sortedIter(openers) {
-		nestedPkgs, nestedRelationships, err := discoverPkgsFromOpener(ctx, location, pathWithinArchive, archiveOpener, cfg, parentPkg)
+		nestedPkgs, nestedRelationships, err := discoverPkgsFromOpener(ctx, location, pathWithinArchive, archiveOpener, cfg, parentPkg, depth, graph)
 		if err != nil {
 			log.WithFields("location", location.Path(), "error", err).Debug("unable to discover java packages from opener")
 			continue
@@ -656,7 +660,7 @@ func discoverPkgsFromOpeners(ctx context.Context, location file.Location, opener
 }
 
 // discoverPkgsFromOpener finds Java archives within the given file.
-func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	archiveReadCloser, err := archiveOpener.Open()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to open archived file from tempdir: %w", err)
@@ -674,7 +678,7 @@ func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWit
 	nestedPkgs, nestedRelationships, err := gap.processJavaArchive(ctx, file.LocationReadCloser{
 		Location:   nestedLocation,
 		ReadCloser: archiveReadCloser,
-	}, parentPkg)
+	}, parentPkg, depth, graph)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to process nested java archive (%s): %w", pathWithinArchive, err)
 	}
@@ -880,4 +884,271 @@ func sortedIter[K cmp.Ordered, V any](values map[K]V) iter.Seq2[K, V] {
 			}
 		}
 	}
+}
+
+// buildDependencyGraphFromEmbeddedPOMs extracts all embedded POMs and builds a dependency graph.
+func (j *archiveParser) buildDependencyGraphFromEmbeddedPOMs(ctx context.Context, mainPkg *pkg.Package) {
+	poms := j.extractUnifiedPOMs(ctx)
+	if len(poms) == 0 {
+		return
+	}
+
+	rootID := extractMavenIDFromPackage(mainPkg)
+	if !rootID.Valid() {
+		return
+	}
+
+	j.dependencyGraph = NewDependencyGraph()
+	j.dependencyGraph.BuildFromPOMs(ctx, poms, j.maven, rootID, j.cfg.ResolveTransitiveDependencies, j.cfg.MaxParentRecursiveDepth)
+}
+
+// extractUnifiedPOMs collects all parsed POMs from the root archive and nested JARs.
+func (j *archiveParser) extractUnifiedPOMs(ctx context.Context) map[maven.ID]*maven.Project {
+	poms := j.extractAllPOMsByID(ctx)
+	nestedPoms := j.extractAllPOMsFromNestedJARs(ctx)
+	for id, pom := range nestedPoms {
+		if _, exists := poms[id]; !exists {
+			poms[id] = pom
+		}
+	}
+	return poms
+}
+
+// extractAllPOMsByID parses all pom.xml files in the root archive and indexes them by maven.ID.
+func (j *archiveParser) extractAllPOMsByID(ctx context.Context) map[maven.ID]*maven.Project {
+	result := make(map[maven.ID]*maven.Project)
+
+	extractPaths := j.fileManifest.GlobMatch(false, pomXMLGlob)
+	if len(extractPaths) == 0 {
+		return result
+	}
+
+	contents, err := intFile.ContentsFromZip(ctx, j.archivePath, extractPaths...)
+	if err != nil {
+		log.WithFields("location", j.location.Path(), "error", err).Debug("unable to extract POM files for graph building")
+		return result
+	}
+
+	for filePath, fileContents := range contents {
+		pom, err := maven.ParsePomXML(strings.NewReader(fileContents))
+		if err != nil {
+			log.WithFields("contents-path", filePath, "error", err).Debug("failed to parse pom.xml for graph building")
+			continue
+		}
+		if pom == nil {
+			continue
+		}
+
+		id := j.maven.ResolveID(ctx, pom)
+		if id.GroupID == "" || id.ArtifactID == "" {
+			continue
+		}
+		result[id] = pom
+	}
+
+	return result
+}
+
+// extractAllPOMsFromNestedJARs opens nested archives and extracts their embedded POMs.
+func (j *archiveParser) extractAllPOMsFromNestedJARs(ctx context.Context) map[maven.ID]*maven.Project {
+	result := make(map[maven.ID]*maven.Project)
+
+	nestedArchivePaths := j.fileManifest.GlobMatch(false, archiveFormatGlobs...)
+	if len(nestedArchivePaths) == 0 {
+		return result
+	}
+
+	openers, err := intFile.ExtractFromZipToUniqueTempFile(ctx, j.archivePath, j.contentPath, nestedArchivePaths...)
+	if err != nil {
+		log.WithFields("location", j.location.Path(), "error", err).Debug("unable to extract nested archives for POM discovery")
+		return result
+	}
+
+	for _, opener := range openers {
+		readCloser, err := opener.Open()
+		if err != nil {
+			continue
+		}
+
+		nestedPoms := extractPOMsFromArchiveReader(ctx, readCloser, j.maven)
+		_ = readCloser.Close()
+
+		for id, pom := range nestedPoms {
+			if _, exists := result[id]; !exists {
+				result[id] = pom
+			}
+		}
+	}
+
+	return result
+}
+
+// extractPOMsFromArchiveReader extracts and indexes all pom.xml files from an archive reader.
+func extractPOMsFromArchiveReader(ctx context.Context, reader io.ReadCloser, resolver *maven.Resolver) map[maven.ID]*maven.Project {
+	result := make(map[maven.ID]*maven.Project)
+
+	td := tmpdir.FromContext(ctx)
+	if td == nil {
+		return result
+	}
+
+	tmpFile, cleanupFn, err := td.NewFile("nested-*.jar")
+	if err != nil {
+		return result
+	}
+	defer cleanupFn()
+
+	if _, err := io.Copy(tmpFile, reader); err != nil {
+		return result
+	}
+	_ = tmpFile.Close()
+
+	fileManifest, err := intFile.NewZipFileManifest(ctx, tmpFile.Name())
+	if err != nil {
+		return result
+	}
+
+	pomPaths := fileManifest.GlobMatch(false, pomXMLGlob)
+	if len(pomPaths) == 0 {
+		return result
+	}
+
+	contents, err := intFile.ContentsFromZip(ctx, tmpFile.Name(), pomPaths...)
+	if err != nil {
+		return result
+	}
+
+	for _, fileContents := range contents {
+		pom, err := maven.ParsePomXML(strings.NewReader(fileContents))
+		if err != nil || pom == nil {
+			continue
+		}
+		id := resolver.ResolveID(ctx, pom)
+		if id.GroupID == "" || id.ArtifactID == "" {
+			continue
+		}
+		result[id] = pom
+	}
+
+	return result
+}
+
+// extractMavenIDFromPackage extracts a maven.ID from a package's Java metadata.
+func extractMavenIDFromPackage(p *pkg.Package) maven.ID {
+	if p == nil {
+		return maven.ID{}
+	}
+
+	metadata, ok := p.Metadata.(pkg.JavaArchive)
+	if !ok {
+		return maven.ID{}
+	}
+
+	if metadata.PomProperties != nil {
+		return maven.NewID(
+			metadata.PomProperties.GroupID,
+			metadata.PomProperties.ArtifactID,
+			metadata.PomProperties.Version,
+		)
+	}
+
+	if metadata.PomProject != nil {
+		return maven.NewID(
+			metadata.PomProject.GroupID,
+			metadata.PomProject.ArtifactID,
+			metadata.PomProject.Version,
+		)
+	}
+
+	return maven.ID{}
+}
+
+// buildPkgIndex creates a lookup from maven.ID to package for all known packages.
+func (j *archiveParser) buildPkgIndex(mainPkg *pkg.Package, auxPkgs []pkg.Package) map[maven.ID]*pkg.Package {
+	index := make(map[maven.ID]*pkg.Package)
+
+	if mainPkg != nil {
+		id := extractMavenIDFromPackage(mainPkg)
+		if id.Valid() {
+			index[id] = mainPkg
+		}
+	}
+
+	for i := range auxPkgs {
+		id := extractMavenIDFromPackage(&auxPkgs[i])
+		if id.Valid() {
+			index[id] = &auxPkgs[i]
+		}
+	}
+
+	return index
+}
+
+// createAuxPkgRelationship creates a dependency relationship for an auxiliary package,
+// wiring it to its actual Maven parent when the dependency graph is available.
+func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *pkg.Package, pkgIndex map[maven.ID]*pkg.Package) artifact.Relationship {
+	if j.dependencyGraph == nil {
+		return artifact.Relationship{
+			From: *auxPkg,
+			To:   *mainPkg,
+			Type: artifact.DependencyOfRelationship,
+		}
+	}
+
+	auxID := extractMavenIDFromPackage(auxPkg)
+	node := j.dependencyGraph.FindNode(auxID)
+	if node == nil {
+		return artifact.Relationship{
+			From: *auxPkg,
+			To:   *mainPkg,
+			Type: artifact.DependencyOfRelationship,
+		}
+	}
+
+	if node.Parent != nil {
+		if parentPkg, exists := pkgIndex[node.Parent.ID]; exists {
+			return artifact.Relationship{
+				From: *auxPkg,
+				To:   *parentPkg,
+				Type: artifact.DependencyOfRelationship,
+				Data: NewDependencyRelationshipData(node.Depth()-1, node.Scope),
+			}
+		}
+		// parent not in this archive's packages — defer for post-processor
+		intendedParentID := fmt.Sprintf("%s:%s:%s", node.Parent.ID.GroupID, node.Parent.ID.ArtifactID, node.Parent.ID.Version)
+		return artifact.Relationship{
+			From: *auxPkg,
+			To:   *mainPkg,
+			Type: artifact.DependencyOfRelationship,
+			Data: NewDependencyRelationshipDataWithParent(node.Depth()-1, node.Scope, intendedParentID),
+		}
+	}
+
+	// node is direct child of root
+	return artifact.Relationship{
+		From: *auxPkg,
+		To:   *mainPkg,
+		Type: artifact.DependencyOfRelationship,
+		Data: NewDependencyRelationshipData(node.Depth()-1, node.Scope),
+	}
+}
+
+// createMainPkgRelationship creates a dependency relationship for the main package to its parent,
+// enriching with graph data when available.
+func (j *archiveParser) createMainPkgRelationship(mainPkg *pkg.Package, parentPkg *pkg.Package) artifact.Relationship {
+	rel := artifact.Relationship{
+		From: *mainPkg,
+		To:   *parentPkg,
+		Type: artifact.DependencyOfRelationship,
+	}
+
+	if j.dependencyGraph != nil && j.depth > 0 {
+		mainID := extractMavenIDFromPackage(mainPkg)
+		node := j.dependencyGraph.FindNode(mainID)
+		if node != nil {
+			rel.Data = NewDependencyRelationshipData(node.Depth()-1, node.Scope)
+		}
+	}
+
+	return rel
 }

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -65,7 +65,7 @@ type archiveParser struct {
 	detectNested    bool
 	cfg             ArchiveCatalogerConfig
 	maven           *maven.Resolver
-	dependencyGraph *DependencyGraph
+	dependencyGraph *dependencyGraph
 	depth           int
 }
 
@@ -83,7 +83,7 @@ func (gap genericArchiveParserAdapter) parseJavaArchive(ctx context.Context, _ f
 }
 
 // processJavaArchive processes an archive for java contents, returning all Java libraries and nested archives
-func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package, depth int, rootGraph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
+func (gap genericArchiveParserAdapter) processJavaArchive(ctx context.Context, reader file.LocationReadCloser, parentPkg *pkg.Package, depth int, rootGraph *dependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	parser, cleanupFn, err := newJavaArchiveParser(ctx, reader, true, gap.cfg)
 	// note: even on error, we should always run cleanup functions
 	defer cleanupFn()
@@ -620,7 +620,7 @@ func (j *archiveParser) discoverPkgsFromNestedArchives(ctx context.Context, pare
 
 // discoverPkgsFromZip finds Java archives within Java archives, returning all listed Java packages found and
 // associating each discovered package to the given parent package.
-func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePath, contentPath string, fileManifest intFile.ZipFileManifest, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *dependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	// search and parse pom.properties files & fetch the contents
 	openers, err := intFile.ExtractFromZipToUniqueTempFile(ctx, archivePath, contentPath, fileManifest.GlobMatch(false, archiveFormatGlobs...)...)
 	if err != nil {
@@ -631,7 +631,7 @@ func discoverPkgsFromZip(ctx context.Context, location file.Location, archivePat
 }
 
 // discoverPkgsFromOpeners finds Java archives within the given files and associates them with the given parent package.
-func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpeners(ctx context.Context, location file.Location, openers map[string]intFile.Opener, parentPkg *pkg.Package, cfg ArchiveCatalogerConfig, depth int, graph *dependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	var pkgs []pkg.Package
 	var relationships []artifact.Relationship
 
@@ -660,7 +660,7 @@ func discoverPkgsFromOpeners(ctx context.Context, location file.Location, opener
 }
 
 // discoverPkgsFromOpener finds Java archives within the given file.
-func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package, depth int, graph *DependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
+func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWithinArchive string, archiveOpener intFile.Opener, cfg ArchiveCatalogerConfig, parentPkg *pkg.Package, depth int, graph *dependencyGraph) ([]pkg.Package, []artifact.Relationship, error) {
 	archiveReadCloser, err := archiveOpener.Open()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to open archived file from tempdir: %w", err)
@@ -898,8 +898,8 @@ func (j *archiveParser) buildDependencyGraphFromEmbeddedPOMs(ctx context.Context
 		return
 	}
 
-	j.dependencyGraph = NewDependencyGraph()
-	j.dependencyGraph.BuildFromPOMs(ctx, poms, j.maven, rootID, j.cfg.ResolveTransitiveDependencies, j.cfg.MaxParentRecursiveDepth)
+	j.dependencyGraph = newDependencyGraph()
+	j.dependencyGraph.buildFromPOMs(ctx, poms, j.maven, rootID, j.cfg.ResolveTransitiveDependencies, j.cfg.MaxParentRecursiveDepth)
 }
 
 // extractUnifiedPOMs collects all parsed POMs from the root archive and nested JARs.
@@ -1096,9 +1096,9 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 	}
 
 	auxID := extractMavenIDFromPackage(auxPkg)
-	node := j.dependencyGraph.FindNode(auxID)
+	node := j.dependencyGraph.findNode(auxID)
 	if node == nil {
-		node = j.dependencyGraph.FindNodeByGA(auxID.GroupID, auxID.ArtifactID)
+		node = j.dependencyGraph.findNodeByGA(auxID.GroupID, auxID.ArtifactID)
 	}
 	if node == nil {
 		return artifact.Relationship{
@@ -1114,7 +1114,7 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 				From: *auxPkg,
 				To:   *parentPkg,
 				Type: artifact.DependencyOfRelationship,
-				Data: NewDependencyRelationshipData(node.Depth()-1, node.Scope),
+				Data: newDependencyRelationshipData(node.depth()-1, node.Scope),
 			}
 		}
 		// parent not in this archive's packages — defer for post-processor
@@ -1123,7 +1123,7 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 			From: *auxPkg,
 			To:   *mainPkg,
 			Type: artifact.DependencyOfRelationship,
-			Data: NewDependencyRelationshipDataWithParent(node.Depth()-1, node.Scope, intendedParentID),
+			Data: newDependencyRelationshipDataWithParent(node.depth()-1, node.Scope, intendedParentID),
 		}
 	}
 
@@ -1132,7 +1132,7 @@ func (j *archiveParser) createAuxPkgRelationship(auxPkg *pkg.Package, mainPkg *p
 		From: *auxPkg,
 		To:   *mainPkg,
 		Type: artifact.DependencyOfRelationship,
-		Data: NewDependencyRelationshipData(node.Depth()-1, node.Scope),
+		Data: newDependencyRelationshipData(node.depth()-1, node.Scope),
 	}
 }
 
@@ -1147,12 +1147,12 @@ func (j *archiveParser) createMainPkgRelationship(mainPkg *pkg.Package, parentPk
 
 	if j.dependencyGraph != nil && j.depth > 0 {
 		mainID := extractMavenIDFromPackage(mainPkg)
-		node := j.dependencyGraph.FindNode(mainID)
+		node := j.dependencyGraph.findNode(mainID)
 		if node == nil {
-			node = j.dependencyGraph.FindNodeByGA(mainID.GroupID, mainID.ArtifactID)
+			node = j.dependencyGraph.findNodeByGA(mainID.GroupID, mainID.ArtifactID)
 		}
 		if node != nil {
-			rel.Data = NewDependencyRelationshipData(node.Depth()-1, node.Scope)
+			rel.Data = newDependencyRelationshipData(node.depth()-1, node.Scope)
 		}
 	}
 

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -322,3 +322,69 @@ func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
 		assert.Nil(t, rel.Data)
 	})
 }
+
+func TestMavenID_Coordinate(t *testing.T) {
+	id := maven.NewID("com.example", "my-lib", "1.0.0")
+	assert.Equal(t, "com.example:my-lib:1.0.0", id.Coordinate())
+
+	empty := maven.ID{}
+	assert.Equal(t, "::", empty.Coordinate())
+}
+
+func TestCreateAuxPkgRelationship_VersionMismatchFallback(t *testing.T) {
+	// Graph declares dep-a at version 2.0, but the actual embedded JAR has version 2.1
+	// (e.g. dependency management resolved a different version). FindNodeByGA should still match.
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAGraphID := maven.NewID("com.example", "dep-a", "2.0")
+
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(rootID)
+	graph.AddNode(depAGraphID, "compile", root)
+
+	rootPkg := &pkg.Package{
+		Name:    "root",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "root",
+				Version:    "1.0",
+			},
+		},
+	}
+	rootPkg.SetID()
+
+	// auxPkg has version 2.1 — different from graph's 2.0
+	auxPkg := &pkg.Package{
+		Name:    "dep-a",
+		Version: "2.1",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "dep-a",
+				Version:    "2.1",
+			},
+		},
+	}
+	auxPkg.SetID()
+
+	parser := &archiveParser{
+		dependencyGraph: graph,
+	}
+
+	pkgIndex := map[maven.ID]*pkg.Package{
+		rootID: rootPkg,
+	}
+
+	rel := parser.createAuxPkgRelationship(auxPkg, rootPkg, pkgIndex)
+	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+	assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
+
+	data, ok := rel.Data.(DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Equal(t, 0, data.Depth)
+	assert.True(t, data.IsDirectDependency)
+	assert.Equal(t, "compile", data.Scope)
+}

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -1,0 +1,324 @@
+package java
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+func TestBuildDependencyGraphFromEmbeddedPOMs_Integration(t *testing.T) {
+	// Simulate a scenario where we have a root POM with two direct dependencies,
+	// one of which has a transitive dependency
+	rootID := maven.NewID("com.example", "root-app", "1.0.0")
+	depAID := maven.NewID("com.example", "lib-a", "2.0.0")
+	depBID := maven.NewID("org.other", "lib-b", "3.0.0")
+	transitiveID := maven.NewID("org.transitive", "lib-c", "4.0.0")
+
+	compileScope := "compile"
+	runtimeScope := "runtime"
+
+	rootPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depAID.GroupID, ArtifactID: &depAID.ArtifactID, Version: &depAID.Version, Scope: &compileScope},
+			{GroupID: &depBID.GroupID, ArtifactID: &depBID.ArtifactID, Version: &depBID.Version, Scope: &runtimeScope},
+		},
+	}
+	depAPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &transitiveID.GroupID, ArtifactID: &transitiveID.ArtifactID, Version: &transitiveID.Version, Scope: &compileScope},
+		},
+	}
+
+	poms := map[maven.ID]*maven.Project{
+		rootID: rootPom,
+		depAID: depAPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	graph := NewDependencyGraph()
+	graph.BuildFromPOMs(context.Background(), poms, resolver, rootID, true, 10)
+
+	// Verify graph structure
+	require.Equal(t, 4, graph.Size())
+
+	nodeA := graph.FindNode(depAID)
+	require.NotNil(t, nodeA)
+	assert.Equal(t, "compile", nodeA.Scope)
+	assert.Equal(t, 1, nodeA.Depth())
+	assert.Equal(t, graph.Root, nodeA.Parent)
+
+	nodeB := graph.FindNode(depBID)
+	require.NotNil(t, nodeB)
+	assert.Equal(t, "runtime", nodeB.Scope)
+	assert.Equal(t, 1, nodeB.Depth())
+	assert.Equal(t, graph.Root, nodeB.Parent)
+
+	nodeC := graph.FindNode(transitiveID)
+	require.NotNil(t, nodeC)
+	assert.Equal(t, "compile", nodeC.Scope)
+	assert.Equal(t, 2, nodeC.Depth())
+	assert.Equal(t, nodeA, nodeC.Parent)
+}
+
+func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
+	// Setup: graph with root -> depA -> depB
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAID := maven.NewID("com.example", "dep-a", "2.0")
+	depBID := maven.NewID("com.example", "dep-b", "3.0")
+
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(rootID)
+	nodeA := graph.AddNode(depAID, "compile", root)
+	graph.AddNode(depBID, "runtime", nodeA)
+
+	rootPkg := &pkg.Package{
+		Name:    "root",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "root",
+				Version:    "1.0",
+			},
+		},
+	}
+	rootPkg.SetID()
+
+	depAPkg := &pkg.Package{
+		Name:    "dep-a",
+		Version: "2.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "dep-a",
+				Version:    "2.0",
+			},
+		},
+	}
+	depAPkg.SetID()
+
+	depBPkg := &pkg.Package{
+		Name:    "dep-b",
+		Version: "3.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "dep-b",
+				Version:    "3.0",
+			},
+		},
+	}
+	depBPkg.SetID()
+
+	parser := &archiveParser{
+		dependencyGraph: graph,
+	}
+
+	pkgIndex := map[maven.ID]*pkg.Package{
+		rootID: rootPkg,
+		depAID: depAPkg,
+	}
+
+	t.Run("direct dependency wired to root", func(t *testing.T) {
+		rel := parser.createAuxPkgRelationship(depAPkg, rootPkg, pkgIndex)
+		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+		// depA's parent is root, which is in pkgIndex
+		assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
+
+		data, ok := rel.Data.(DependencyRelationshipData)
+		require.True(t, ok)
+		assert.Equal(t, 0, data.Depth)
+		assert.True(t, data.IsDirectDependency)
+		assert.Equal(t, "compile", data.Scope)
+		assert.Empty(t, data.IntendedParentID)
+	})
+
+	t.Run("transitive dependency wired to parent in index", func(t *testing.T) {
+		rel := parser.createAuxPkgRelationship(depBPkg, rootPkg, pkgIndex)
+		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+		// depB's parent is depA, which IS in pkgIndex
+		assert.Equal(t, depAPkg.ID(), rel.To.(pkg.Package).ID())
+
+		data, ok := rel.Data.(DependencyRelationshipData)
+		require.True(t, ok)
+		assert.Equal(t, 1, data.Depth)
+		assert.False(t, data.IsDirectDependency)
+		assert.Equal(t, "runtime", data.Scope)
+		assert.Empty(t, data.IntendedParentID)
+	})
+
+	t.Run("transitive dependency deferred when parent not in index", func(t *testing.T) {
+		// Remove depA from index to simulate it being in a different archive
+		sparseIndex := map[maven.ID]*pkg.Package{
+			rootID: rootPkg,
+		}
+
+		rel := parser.createAuxPkgRelationship(depBPkg, rootPkg, sparseIndex)
+		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+		// falls back to rootPkg since depA isn't in the index
+		assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
+
+		data, ok := rel.Data.(DependencyRelationshipData)
+		require.True(t, ok)
+		assert.Equal(t, 1, data.Depth)
+		assert.Equal(t, "com.example:dep-a:2.0", data.IntendedParentID)
+	})
+}
+
+func TestCreateAuxPkgRelationship_WithoutGraph(t *testing.T) {
+	rootPkg := &pkg.Package{
+		Name:    "root",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "root",
+				Version:    "1.0",
+			},
+		},
+	}
+	rootPkg.SetID()
+
+	auxPkg := &pkg.Package{
+		Name:    "aux",
+		Version: "2.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "aux",
+				Version:    "2.0",
+			},
+		},
+	}
+	auxPkg.SetID()
+
+	parser := &archiveParser{
+		dependencyGraph: nil,
+	}
+
+	pkgIndex := map[maven.ID]*pkg.Package{}
+
+	rel := parser.createAuxPkgRelationship(auxPkg, rootPkg, pkgIndex)
+	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+	assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
+	assert.Nil(t, rel.Data)
+}
+
+func TestExtractMavenIDFromPackage(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      *pkg.Package
+		expected maven.ID
+	}{
+		{
+			name: "from pom properties",
+			pkg: &pkg.Package{
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "com.example",
+						ArtifactID: "my-lib",
+						Version:    "1.0",
+					},
+				},
+			},
+			expected: maven.NewID("com.example", "my-lib", "1.0"),
+		},
+		{
+			name: "from pom project when no properties",
+			pkg: &pkg.Package{
+				Metadata: pkg.JavaArchive{
+					PomProject: &pkg.JavaPomProject{
+						GroupID:    "org.other",
+						ArtifactID: "other-lib",
+						Version:    "2.0",
+					},
+				},
+			},
+			expected: maven.NewID("org.other", "other-lib", "2.0"),
+		},
+		{
+			name:     "nil package",
+			pkg:      nil,
+			expected: maven.ID{},
+		},
+		{
+			name: "non-java metadata",
+			pkg: &pkg.Package{
+				Metadata: nil,
+			},
+			expected: maven.ID{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractMavenIDFromPackage(tt.pkg))
+		})
+	}
+}
+
+func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
+	rootID := maven.NewID("com.example", "root", "1.0")
+	nestedID := maven.NewID("com.example", "nested", "2.0")
+
+	graph := NewDependencyGraph()
+	root := graph.SetRoot(rootID)
+	graph.AddNode(nestedID, "compile", root)
+
+	mainPkg := &pkg.Package{
+		Name:    "nested",
+		Version: "2.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "nested",
+				Version:    "2.0",
+			},
+		},
+	}
+	mainPkg.SetID()
+
+	parentPkg := &pkg.Package{
+		Name:    "root",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+	}
+	parentPkg.SetID()
+
+	t.Run("enriched at depth > 0", func(t *testing.T) {
+		parser := &archiveParser{
+			dependencyGraph: graph,
+			depth:           1,
+		}
+		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+
+		data, ok := rel.Data.(DependencyRelationshipData)
+		require.True(t, ok)
+		assert.Equal(t, 0, data.Depth)
+		assert.Equal(t, "compile", data.Scope)
+	})
+
+	t.Run("not enriched at depth 0", func(t *testing.T) {
+		parser := &archiveParser{
+			dependencyGraph: graph,
+			depth:           0,
+		}
+		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
+		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
+		assert.Nil(t, rel.Data)
+	})
+}

--- a/syft/pkg/cataloger/java/archive_parser_integration_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_integration_test.go
@@ -42,28 +42,28 @@ func TestBuildDependencyGraphFromEmbeddedPOMs_Integration(t *testing.T) {
 
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
-	graph := NewDependencyGraph()
-	graph.BuildFromPOMs(context.Background(), poms, resolver, rootID, true, 10)
+	graph := newDependencyGraph()
+	graph.buildFromPOMs(context.Background(), poms, resolver, rootID, true, 10)
 
 	// Verify graph structure
-	require.Equal(t, 4, graph.Size())
+	require.Equal(t, 4, graph.size())
 
-	nodeA := graph.FindNode(depAID)
+	nodeA := graph.findNode(depAID)
 	require.NotNil(t, nodeA)
 	assert.Equal(t, "compile", nodeA.Scope)
-	assert.Equal(t, 1, nodeA.Depth())
+	assert.Equal(t, 1, nodeA.depth())
 	assert.Equal(t, graph.Root, nodeA.Parent)
 
-	nodeB := graph.FindNode(depBID)
+	nodeB := graph.findNode(depBID)
 	require.NotNil(t, nodeB)
 	assert.Equal(t, "runtime", nodeB.Scope)
-	assert.Equal(t, 1, nodeB.Depth())
+	assert.Equal(t, 1, nodeB.depth())
 	assert.Equal(t, graph.Root, nodeB.Parent)
 
-	nodeC := graph.FindNode(transitiveID)
+	nodeC := graph.findNode(transitiveID)
 	require.NotNil(t, nodeC)
 	assert.Equal(t, "compile", nodeC.Scope)
-	assert.Equal(t, 2, nodeC.Depth())
+	assert.Equal(t, 2, nodeC.depth())
 	assert.Equal(t, nodeA, nodeC.Parent)
 }
 
@@ -73,10 +73,10 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 	depAID := maven.NewID("com.example", "dep-a", "2.0")
 	depBID := maven.NewID("com.example", "dep-b", "3.0")
 
-	graph := NewDependencyGraph()
-	root := graph.SetRoot(rootID)
-	nodeA := graph.AddNode(depAID, "compile", root)
-	graph.AddNode(depBID, "runtime", nodeA)
+	graph := newDependencyGraph()
+	root := graph.setRoot(rootID)
+	nodeA := graph.addNode(depAID, "compile", root)
+	graph.addNode(depBID, "runtime", nodeA)
 
 	rootPkg := &pkg.Package{
 		Name:    "root",
@@ -135,7 +135,7 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		// depA's parent is root, which is in pkgIndex
 		assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
 
-		data, ok := rel.Data.(DependencyRelationshipData)
+		data, ok := rel.Data.(dependencyRelationshipData)
 		require.True(t, ok)
 		assert.Equal(t, 0, data.Depth)
 		assert.True(t, data.IsDirectDependency)
@@ -149,7 +149,7 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		// depB's parent is depA, which IS in pkgIndex
 		assert.Equal(t, depAPkg.ID(), rel.To.(pkg.Package).ID())
 
-		data, ok := rel.Data.(DependencyRelationshipData)
+		data, ok := rel.Data.(dependencyRelationshipData)
 		require.True(t, ok)
 		assert.Equal(t, 1, data.Depth)
 		assert.False(t, data.IsDirectDependency)
@@ -168,7 +168,7 @@ func TestCreateAuxPkgRelationship_WithGraph(t *testing.T) {
 		// falls back to rootPkg since depA isn't in the index
 		assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
 
-		data, ok := rel.Data.(DependencyRelationshipData)
+		data, ok := rel.Data.(dependencyRelationshipData)
 		require.True(t, ok)
 		assert.Equal(t, 1, data.Depth)
 		assert.Equal(t, "com.example:dep-a:2.0", data.IntendedParentID)
@@ -273,9 +273,9 @@ func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
 	rootID := maven.NewID("com.example", "root", "1.0")
 	nestedID := maven.NewID("com.example", "nested", "2.0")
 
-	graph := NewDependencyGraph()
-	root := graph.SetRoot(rootID)
-	graph.AddNode(nestedID, "compile", root)
+	graph := newDependencyGraph()
+	root := graph.setRoot(rootID)
+	graph.addNode(nestedID, "compile", root)
 
 	mainPkg := &pkg.Package{
 		Name:    "nested",
@@ -306,7 +306,7 @@ func TestCreateMainPkgRelationship_WithGraph(t *testing.T) {
 		rel := parser.createMainPkgRelationship(mainPkg, parentPkg)
 		assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
 
-		data, ok := rel.Data.(DependencyRelationshipData)
+		data, ok := rel.Data.(dependencyRelationshipData)
 		require.True(t, ok)
 		assert.Equal(t, 0, data.Depth)
 		assert.Equal(t, "compile", data.Scope)
@@ -337,9 +337,9 @@ func TestCreateAuxPkgRelationship_VersionMismatchFallback(t *testing.T) {
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depAGraphID := maven.NewID("com.example", "dep-a", "2.0")
 
-	graph := NewDependencyGraph()
-	root := graph.SetRoot(rootID)
-	graph.AddNode(depAGraphID, "compile", root)
+	graph := newDependencyGraph()
+	root := graph.setRoot(rootID)
+	graph.addNode(depAGraphID, "compile", root)
 
 	rootPkg := &pkg.Package{
 		Name:    "root",
@@ -382,7 +382,7 @@ func TestCreateAuxPkgRelationship_VersionMismatchFallback(t *testing.T) {
 	assert.Equal(t, artifact.DependencyOfRelationship, rel.Type)
 	assert.Equal(t, rootPkg.ID(), rel.To.(pkg.Package).ID())
 
-	data, ok := rel.Data.(DependencyRelationshipData)
+	data, ok := rel.Data.(dependencyRelationshipData)
 	require.True(t, ok)
 	assert.Equal(t, 0, data.Depth)
 	assert.True(t, data.IsDirectDependency)

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -742,7 +742,7 @@ func TestParseNestedJar(t *testing.T) {
 			actual, _, err := gap.processJavaArchive(pkgtest.Context(t), file.LocationReadCloser{
 				Location:   file.NewLocation(fixture.Name()),
 				ReadCloser: fixture,
-			}, nil)
+			}, nil, 0, nil)
 			require.NoError(t, err)
 
 			expectedNameVersionPairSet := strset.New()

--- a/syft/pkg/cataloger/java/config.go
+++ b/syft/pkg/cataloger/java/config.go
@@ -33,6 +33,11 @@ type ArchiveCatalogerConfig struct {
 	// ResolveTransitiveDependencies enables resolving transitive dependencies for java packages found within archives.
 	// app-config: java.resolve-transitive-dependencies
 	ResolveTransitiveDependencies bool `yaml:"resolve-transitive-dependencies" json:"resolve-transitive-dependencies" mapstructure:"resolve-transitive-dependencies"`
+
+	// UseEmbeddedPOMDependencies enables building a hierarchical dependency graph from embedded pom.xml files within archives.
+	// When enabled, dependency relationships are wired to their actual Maven parent rather than all pointing to the root archive.
+	// app-config: java.use-embedded-pom-dependencies
+	UseEmbeddedPOMDependencies bool `yaml:"use-embedded-pom-dependencies" json:"use-embedded-pom-dependencies" mapstructure:"use-embedded-pom-dependencies"`
 }
 
 func DefaultArchiveCatalogerConfig() ArchiveCatalogerConfig {
@@ -45,6 +50,7 @@ func DefaultArchiveCatalogerConfig() ArchiveCatalogerConfig {
 		MavenBaseURL:                  strings.Join(mavenCfg.Repositories, ","),
 		MaxParentRecursiveDepth:       mavenCfg.MaxParentRecursiveDepth,
 		ResolveTransitiveDependencies: false,
+		UseEmbeddedPOMDependencies:    false,
 	}
 }
 
@@ -72,6 +78,11 @@ func (j ArchiveCatalogerConfig) WithMavenBaseURL(input string) ArchiveCatalogerC
 
 func (j ArchiveCatalogerConfig) WithResolveTransitiveDependencies(resolveTransitiveDependencies bool) ArchiveCatalogerConfig {
 	j.ResolveTransitiveDependencies = resolveTransitiveDependencies
+	return j
+}
+
+func (j ArchiveCatalogerConfig) WithUseEmbeddedPOMDependencies(input bool) ArchiveCatalogerConfig {
+	j.UseEmbeddedPOMDependencies = input
 	return j
 }
 

--- a/syft/pkg/cataloger/java/dependency_graph.go
+++ b/syft/pkg/cataloger/java/dependency_graph.go
@@ -1,0 +1,146 @@
+package java
+
+import (
+	"context"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+// DependencyNode represents a single node in the Maven dependency tree.
+type DependencyNode struct {
+	ID       maven.ID
+	Scope    string
+	Parent   *DependencyNode
+	Children []*DependencyNode
+}
+
+// Depth computes this node's depth by walking the parent chain.
+func (n *DependencyNode) Depth() int {
+	depth := 0
+	current := n.Parent
+	for current != nil {
+		depth++
+		current = current.Parent
+	}
+	return depth
+}
+
+// DependencyGraph holds the tree of Maven dependencies built from embedded POM files.
+type DependencyGraph struct {
+	Root    *DependencyNode
+	NodeMap map[maven.ID]*DependencyNode
+}
+
+// NewDependencyGraph creates an empty dependency graph.
+func NewDependencyGraph() *DependencyGraph {
+	return &DependencyGraph{
+		NodeMap: make(map[maven.ID]*DependencyNode),
+	}
+}
+
+// SetRoot creates and sets the root node of the graph.
+func (g *DependencyGraph) SetRoot(id maven.ID) *DependencyNode {
+	node := &DependencyNode{ID: id}
+	g.Root = node
+	g.NodeMap[id] = node
+	return node
+}
+
+// AddNode adds a dependency node with the given parent.
+func (g *DependencyGraph) AddNode(id maven.ID, scope string, parent *DependencyNode) *DependencyNode {
+	if _, exists := g.NodeMap[id]; exists {
+		return g.NodeMap[id]
+	}
+	node := &DependencyNode{
+		ID:     id,
+		Scope:  scope,
+		Parent: parent,
+	}
+	if parent != nil {
+		parent.Children = append(parent.Children, node)
+	}
+	g.NodeMap[id] = node
+	return node
+}
+
+// FindNode looks up a node by exact maven.ID match.
+func (g *DependencyGraph) FindNode(id maven.ID) *DependencyNode {
+	return g.NodeMap[id]
+}
+
+// Size returns the number of nodes in the graph.
+func (g *DependencyGraph) Size() int {
+	return len(g.NodeMap)
+}
+
+// BuildFromPOMs constructs the dependency graph by walking embedded POM dependency sections.
+func (g *DependencyGraph) BuildFromPOMs(
+	ctx context.Context,
+	poms map[maven.ID]*maven.Project,
+	resolver *maven.Resolver,
+	rootID maven.ID,
+	resolveTransitive bool,
+	maxDepth int,
+) {
+	rootPom, exists := poms[rootID]
+	if !exists {
+		log.WithFields("rootID", rootID).Debug("root POM not found in embedded POMs, skipping graph build")
+		return
+	}
+
+	rootNode := g.SetRoot(rootID)
+
+	visited := map[maven.ID]bool{rootID: true}
+	g.buildFromPOM(ctx, poms, resolver, rootPom, rootNode, visited, resolveTransitive, maxDepth)
+}
+
+func (g *DependencyGraph) buildFromPOM(
+	ctx context.Context,
+	poms map[maven.ID]*maven.Project,
+	resolver *maven.Resolver,
+	pom *maven.Project,
+	parentNode *DependencyNode,
+	visited map[maven.ID]bool,
+	resolveTransitive bool,
+	maxDepth int,
+) {
+	if parentNode.Depth() >= maxDepth {
+		return
+	}
+
+	deps := maven.DirectPomDependencies(pom)
+	for i := range deps {
+		dep := deps[i]
+
+		depID := resolver.ResolveDependencyID(ctx, pom, dep)
+		if depID.GroupID == "" || depID.ArtifactID == "" {
+			continue
+		}
+
+		if visited[depID] {
+			continue
+		}
+
+		scope := resolver.ResolveProperty(ctx, pom, dep.Scope)
+
+		node := g.AddNode(depID, scope, parentNode)
+
+		if resolveTransitive {
+			childPom, childExists := poms[depID]
+			if childExists {
+				branchVisited := copyVisited(visited)
+				branchVisited[depID] = true
+				g.buildFromPOM(ctx, poms, resolver, childPom, node, branchVisited, resolveTransitive, maxDepth)
+			}
+		}
+	}
+}
+
+func copyVisited(m map[maven.ID]bool) map[maven.ID]bool {
+	cp := make(map[maven.ID]bool, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}

--- a/syft/pkg/cataloger/java/dependency_graph.go
+++ b/syft/pkg/cataloger/java/dependency_graph.go
@@ -8,15 +8,15 @@ import (
 )
 
 // DependencyNode represents a single node in the Maven dependency tree.
-type DependencyNode struct {
+type dependencyNode struct {
 	ID       maven.ID
 	Scope    string
-	Parent   *DependencyNode
-	Children []*DependencyNode
+	Parent   *dependencyNode
+	Children []*dependencyNode
 }
 
 // Depth computes this node's depth by walking the parent chain.
-func (n *DependencyNode) Depth() int {
+func (n *dependencyNode) depth() int {
 	depth := 0
 	current := n.Parent
 	for current != nil {
@@ -27,32 +27,32 @@ func (n *DependencyNode) Depth() int {
 }
 
 // DependencyGraph holds the tree of Maven dependencies built from embedded POM files.
-type DependencyGraph struct {
-	Root    *DependencyNode
-	NodeMap map[maven.ID]*DependencyNode
+type dependencyGraph struct {
+	Root    *dependencyNode
+	NodeMap map[maven.ID]*dependencyNode
 }
 
 // NewDependencyGraph creates an empty dependency graph.
-func NewDependencyGraph() *DependencyGraph {
-	return &DependencyGraph{
-		NodeMap: make(map[maven.ID]*DependencyNode),
+func newDependencyGraph() *dependencyGraph {
+	return &dependencyGraph{
+		NodeMap: make(map[maven.ID]*dependencyNode),
 	}
 }
 
 // SetRoot creates and sets the root node of the graph.
-func (g *DependencyGraph) SetRoot(id maven.ID) *DependencyNode {
-	node := &DependencyNode{ID: id}
+func (g *dependencyGraph) setRoot(id maven.ID) *dependencyNode {
+	node := &dependencyNode{ID: id}
 	g.Root = node
 	g.NodeMap[id] = node
 	return node
 }
 
 // AddNode adds a dependency node with the given parent.
-func (g *DependencyGraph) AddNode(id maven.ID, scope string, parent *DependencyNode) *DependencyNode {
+func (g *dependencyGraph) addNode(id maven.ID, scope string, parent *dependencyNode) *dependencyNode {
 	if _, exists := g.NodeMap[id]; exists {
 		return g.NodeMap[id]
 	}
-	node := &DependencyNode{
+	node := &dependencyNode{
 		ID:     id,
 		Scope:  scope,
 		Parent: parent,
@@ -65,14 +65,14 @@ func (g *DependencyGraph) AddNode(id maven.ID, scope string, parent *DependencyN
 }
 
 // FindNode looks up a node by exact maven.ID match.
-func (g *DependencyGraph) FindNode(id maven.ID) *DependencyNode {
+func (g *dependencyGraph) findNode(id maven.ID) *dependencyNode {
 	return g.NodeMap[id]
 }
 
 // FindNodeByGA looks up a node by groupId and artifactId only, ignoring version.
 // This handles version-mismatch scenarios where Maven dependency management resolves
 // a different version than what the POM declares.
-func (g *DependencyGraph) FindNodeByGA(groupID, artifactID string) *DependencyNode {
+func (g *dependencyGraph) findNodeByGA(groupID, artifactID string) *dependencyNode {
 	for id, node := range g.NodeMap {
 		if id.GroupID == groupID && id.ArtifactID == artifactID {
 			return node
@@ -82,12 +82,12 @@ func (g *DependencyGraph) FindNodeByGA(groupID, artifactID string) *DependencyNo
 }
 
 // Size returns the number of nodes in the graph.
-func (g *DependencyGraph) Size() int {
+func (g *dependencyGraph) size() int {
 	return len(g.NodeMap)
 }
 
 // BuildFromPOMs constructs the dependency graph by walking embedded POM dependency sections.
-func (g *DependencyGraph) BuildFromPOMs(
+func (g *dependencyGraph) buildFromPOMs(
 	ctx context.Context,
 	poms map[maven.ID]*maven.Project,
 	resolver *maven.Resolver,
@@ -101,23 +101,23 @@ func (g *DependencyGraph) BuildFromPOMs(
 		return
 	}
 
-	rootNode := g.SetRoot(rootID)
+	rootNode := g.setRoot(rootID)
 
 	visited := map[maven.ID]bool{rootID: true}
 	g.buildFromPOM(ctx, poms, resolver, rootPom, rootNode, visited, resolveTransitive, maxDepth)
 }
 
-func (g *DependencyGraph) buildFromPOM(
+func (g *dependencyGraph) buildFromPOM(
 	ctx context.Context,
 	poms map[maven.ID]*maven.Project,
 	resolver *maven.Resolver,
 	pom *maven.Project,
-	parentNode *DependencyNode,
+	parentNode *dependencyNode,
 	visited map[maven.ID]bool,
 	resolveTransitive bool,
 	maxDepth int,
 ) {
-	if parentNode.Depth() >= maxDepth {
+	if parentNode.depth() >= maxDepth {
 		return
 	}
 
@@ -136,7 +136,7 @@ func (g *DependencyGraph) buildFromPOM(
 
 		scope := resolver.ResolveProperty(ctx, pom, dep.Scope)
 
-		node := g.AddNode(depID, scope, parentNode)
+		node := g.addNode(depID, scope, parentNode)
 
 		if resolveTransitive {
 			childPom, childExists := poms[depID]

--- a/syft/pkg/cataloger/java/dependency_graph.go
+++ b/syft/pkg/cataloger/java/dependency_graph.go
@@ -69,6 +69,18 @@ func (g *DependencyGraph) FindNode(id maven.ID) *DependencyNode {
 	return g.NodeMap[id]
 }
 
+// FindNodeByGA looks up a node by groupId and artifactId only, ignoring version.
+// This handles version-mismatch scenarios where Maven dependency management resolves
+// a different version than what the POM declares.
+func (g *DependencyGraph) FindNodeByGA(groupID, artifactID string) *DependencyNode {
+	for id, node := range g.NodeMap {
+		if id.GroupID == groupID && id.ArtifactID == artifactID {
+			return node
+		}
+	}
+	return nil
+}
+
 // Size returns the number of nodes in the graph.
 func (g *DependencyGraph) Size() int {
 	return len(g.NodeMap)

--- a/syft/pkg/cataloger/java/dependency_graph_test.go
+++ b/syft/pkg/cataloger/java/dependency_graph_test.go
@@ -1,0 +1,288 @@
+package java
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/pkg/cataloger/java/internal/maven"
+)
+
+func TestDependencyGraph_BasicConstruction(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depA := maven.NewID("com.example", "dep-a", "2.0")
+	depB := maven.NewID("com.example", "dep-b", "3.0")
+
+	root := g.SetRoot(rootID)
+	require.NotNil(t, root)
+	assert.Equal(t, rootID, root.ID)
+	assert.Nil(t, root.Parent)
+	assert.Equal(t, 0, root.Depth())
+
+	nodeA := g.AddNode(depA, "compile", root)
+	require.NotNil(t, nodeA)
+	assert.Equal(t, depA, nodeA.ID)
+	assert.Equal(t, "compile", nodeA.Scope)
+	assert.Equal(t, root, nodeA.Parent)
+	assert.Equal(t, 1, nodeA.Depth())
+
+	nodeB := g.AddNode(depB, "runtime", root)
+	require.NotNil(t, nodeB)
+	assert.Equal(t, "runtime", nodeB.Scope)
+	assert.Equal(t, root, nodeB.Parent)
+	assert.Equal(t, 1, nodeB.Depth())
+
+	assert.Equal(t, 3, g.Size())
+	assert.Len(t, root.Children, 2)
+}
+
+func TestDependencyGraph_DepthComputation(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	level1 := maven.NewID("com.example", "level1", "1.0")
+	level2 := maven.NewID("com.example", "level2", "1.0")
+	level3 := maven.NewID("com.example", "level3", "1.0")
+
+	root := g.SetRoot(rootID)
+	n1 := g.AddNode(level1, "", root)
+	n2 := g.AddNode(level2, "", n1)
+	n3 := g.AddNode(level3, "", n2)
+
+	assert.Equal(t, 0, root.Depth())
+	assert.Equal(t, 1, n1.Depth())
+	assert.Equal(t, 2, n2.Depth())
+	assert.Equal(t, 3, n3.Depth())
+}
+
+func TestDependencyGraph_FindNode(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depID := maven.NewID("com.example", "dep", "2.0")
+	missingID := maven.NewID("com.example", "missing", "1.0")
+
+	g.SetRoot(rootID)
+	g.AddNode(depID, "compile", g.Root)
+
+	assert.NotNil(t, g.FindNode(rootID))
+	assert.NotNil(t, g.FindNode(depID))
+	assert.Nil(t, g.FindNode(missingID))
+}
+
+func TestDependencyGraph_FindNode_ExactMatchOnly(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depID := maven.NewID("com.example", "dep", "2.0")
+
+	g.SetRoot(rootID)
+	g.AddNode(depID, "", g.Root)
+
+	// different version should not match
+	differentVersion := maven.NewID("com.example", "dep", "3.0")
+	assert.Nil(t, g.FindNode(differentVersion))
+
+	// different groupID should not match
+	differentGroup := maven.NewID("org.other", "dep", "2.0")
+	assert.Nil(t, g.FindNode(differentGroup))
+}
+
+func TestDependencyGraph_AddNode_DuplicatePrevented(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depID := maven.NewID("com.example", "dep", "1.0")
+
+	root := g.SetRoot(rootID)
+	first := g.AddNode(depID, "compile", root)
+	second := g.AddNode(depID, "runtime", root)
+
+	// should return existing node, not create duplicate
+	assert.Same(t, first, second)
+	assert.Equal(t, 2, g.Size())
+	// scope from first insertion is preserved
+	assert.Equal(t, "compile", first.Scope)
+}
+
+func TestDependencyGraph_BuildFromPOMs(t *testing.T) {
+	ctx := context.Background()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAID := maven.NewID("com.example", "dep-a", "2.0")
+	depBID := maven.NewID("com.example", "dep-b", "3.0")
+
+	scope := "compile"
+
+	rootPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depAID.GroupID, ArtifactID: &depAID.ArtifactID, Version: &depAID.Version, Scope: &scope},
+			{GroupID: &depBID.GroupID, ArtifactID: &depBID.ArtifactID, Version: &depBID.Version},
+		},
+	}
+
+	poms := map[maven.ID]*maven.Project{
+		rootID: rootPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, false, 10)
+
+	assert.Equal(t, 3, g.Size())
+	assert.NotNil(t, g.FindNode(rootID))
+	assert.NotNil(t, g.FindNode(depAID))
+	assert.NotNil(t, g.FindNode(depBID))
+
+	nodeA := g.FindNode(depAID)
+	assert.Equal(t, "compile", nodeA.Scope)
+	assert.Equal(t, g.Root, nodeA.Parent)
+}
+
+func TestDependencyGraph_BuildFromPOMs_Transitive(t *testing.T) {
+	ctx := context.Background()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAID := maven.NewID("com.example", "dep-a", "2.0")
+	depBID := maven.NewID("com.example", "dep-b", "3.0")
+
+	rootPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depAID.GroupID, ArtifactID: &depAID.ArtifactID, Version: &depAID.Version},
+		},
+	}
+	depAPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depBID.GroupID, ArtifactID: &depBID.ArtifactID, Version: &depBID.Version},
+		},
+	}
+
+	poms := map[maven.ID]*maven.Project{
+		rootID: rootPom,
+		depAID: depAPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+
+	assert.Equal(t, 3, g.Size())
+
+	nodeB := g.FindNode(depBID)
+	require.NotNil(t, nodeB)
+	assert.Equal(t, 2, nodeB.Depth())
+
+	nodeA := g.FindNode(depAID)
+	require.NotNil(t, nodeA)
+	assert.Equal(t, nodeA, nodeB.Parent)
+}
+
+func TestDependencyGraph_BuildFromPOMs_CyclePrevention(t *testing.T) {
+	ctx := context.Background()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAID := maven.NewID("com.example", "dep-a", "2.0")
+
+	// dep-a depends back on root (cycle)
+	rootPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depAID.GroupID, ArtifactID: &depAID.ArtifactID, Version: &depAID.Version},
+		},
+	}
+	depAPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &rootID.GroupID, ArtifactID: &rootID.ArtifactID, Version: &rootID.Version},
+		},
+	}
+
+	poms := map[maven.ID]*maven.Project{
+		rootID: rootPom,
+		depAID: depAPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+
+	// should not loop infinitely — root + dep-a only
+	assert.Equal(t, 2, g.Size())
+}
+
+func TestDependencyGraph_BuildFromPOMs_MaxDepth(t *testing.T) {
+	ctx := context.Background()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depAID := maven.NewID("com.example", "dep-a", "2.0")
+	depBID := maven.NewID("com.example", "dep-b", "3.0")
+	depCID := maven.NewID("com.example", "dep-c", "4.0")
+
+	rootPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depAID.GroupID, ArtifactID: &depAID.ArtifactID, Version: &depAID.Version},
+		},
+	}
+	depAPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depBID.GroupID, ArtifactID: &depBID.ArtifactID, Version: &depBID.Version},
+		},
+	}
+	depBPom := &maven.Project{
+		Dependencies: &[]maven.Dependency{
+			{GroupID: &depCID.GroupID, ArtifactID: &depCID.ArtifactID, Version: &depCID.Version},
+		},
+	}
+
+	poms := map[maven.ID]*maven.Project{
+		rootID: rootPom,
+		depAID: depAPom,
+		depBID: depBPom,
+	}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	// maxDepth=2 should stop at dep-b (depth 2), not include dep-c
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 2)
+
+	assert.NotNil(t, g.FindNode(rootID))
+	assert.NotNil(t, g.FindNode(depAID))
+	assert.NotNil(t, g.FindNode(depBID))
+	assert.Nil(t, g.FindNode(depCID))
+}
+
+func TestDependencyGraph_BuildFromPOMs_MissingRoot(t *testing.T) {
+	ctx := context.Background()
+
+	rootID := maven.NewID("com.example", "missing", "1.0")
+	poms := map[maven.ID]*maven.Project{}
+
+	resolver := maven.NewResolver(nil, maven.DefaultConfig())
+
+	g := NewDependencyGraph()
+	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+
+	// graph should remain empty
+	assert.Equal(t, 0, g.Size())
+	assert.Nil(t, g.Root)
+}
+
+func TestDependencyGraph_Size(t *testing.T) {
+	g := NewDependencyGraph()
+	assert.Equal(t, 0, g.Size())
+
+	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
+	assert.Equal(t, 1, g.Size())
+
+	g.AddNode(maven.NewID("com.example", "a", "1.0"), "", root)
+	assert.Equal(t, 2, g.Size())
+
+	g.AddNode(maven.NewID("com.example", "b", "1.0"), "", root)
+	assert.Equal(t, 3, g.Size())
+}

--- a/syft/pkg/cataloger/java/dependency_graph_test.go
+++ b/syft/pkg/cataloger/java/dependency_graph_test.go
@@ -11,100 +11,100 @@ import (
 )
 
 func TestDependencyGraph_BasicConstruction(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depA := maven.NewID("com.example", "dep-a", "2.0")
 	depB := maven.NewID("com.example", "dep-b", "3.0")
 
-	root := g.SetRoot(rootID)
+	root := g.setRoot(rootID)
 	require.NotNil(t, root)
 	assert.Equal(t, rootID, root.ID)
 	assert.Nil(t, root.Parent)
-	assert.Equal(t, 0, root.Depth())
+	assert.Equal(t, 0, root.depth())
 
-	nodeA := g.AddNode(depA, "compile", root)
+	nodeA := g.addNode(depA, "compile", root)
 	require.NotNil(t, nodeA)
 	assert.Equal(t, depA, nodeA.ID)
 	assert.Equal(t, "compile", nodeA.Scope)
 	assert.Equal(t, root, nodeA.Parent)
-	assert.Equal(t, 1, nodeA.Depth())
+	assert.Equal(t, 1, nodeA.depth())
 
-	nodeB := g.AddNode(depB, "runtime", root)
+	nodeB := g.addNode(depB, "runtime", root)
 	require.NotNil(t, nodeB)
 	assert.Equal(t, "runtime", nodeB.Scope)
 	assert.Equal(t, root, nodeB.Parent)
-	assert.Equal(t, 1, nodeB.Depth())
+	assert.Equal(t, 1, nodeB.depth())
 
-	assert.Equal(t, 3, g.Size())
+	assert.Equal(t, 3, g.size())
 	assert.Len(t, root.Children, 2)
 }
 
 func TestDependencyGraph_DepthComputation(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	level1 := maven.NewID("com.example", "level1", "1.0")
 	level2 := maven.NewID("com.example", "level2", "1.0")
 	level3 := maven.NewID("com.example", "level3", "1.0")
 
-	root := g.SetRoot(rootID)
-	n1 := g.AddNode(level1, "", root)
-	n2 := g.AddNode(level2, "", n1)
-	n3 := g.AddNode(level3, "", n2)
+	root := g.setRoot(rootID)
+	n1 := g.addNode(level1, "", root)
+	n2 := g.addNode(level2, "", n1)
+	n3 := g.addNode(level3, "", n2)
 
-	assert.Equal(t, 0, root.Depth())
-	assert.Equal(t, 1, n1.Depth())
-	assert.Equal(t, 2, n2.Depth())
-	assert.Equal(t, 3, n3.Depth())
+	assert.Equal(t, 0, root.depth())
+	assert.Equal(t, 1, n1.depth())
+	assert.Equal(t, 2, n2.depth())
+	assert.Equal(t, 3, n3.depth())
 }
 
 func TestDependencyGraph_FindNode(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depID := maven.NewID("com.example", "dep", "2.0")
 	missingID := maven.NewID("com.example", "missing", "1.0")
 
-	g.SetRoot(rootID)
-	g.AddNode(depID, "compile", g.Root)
+	g.setRoot(rootID)
+	g.addNode(depID, "compile", g.Root)
 
-	assert.NotNil(t, g.FindNode(rootID))
-	assert.NotNil(t, g.FindNode(depID))
-	assert.Nil(t, g.FindNode(missingID))
+	assert.NotNil(t, g.findNode(rootID))
+	assert.NotNil(t, g.findNode(depID))
+	assert.Nil(t, g.findNode(missingID))
 }
 
 func TestDependencyGraph_FindNode_ExactMatchOnly(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depID := maven.NewID("com.example", "dep", "2.0")
 
-	g.SetRoot(rootID)
-	g.AddNode(depID, "", g.Root)
+	g.setRoot(rootID)
+	g.addNode(depID, "", g.Root)
 
 	// different version should not match
 	differentVersion := maven.NewID("com.example", "dep", "3.0")
-	assert.Nil(t, g.FindNode(differentVersion))
+	assert.Nil(t, g.findNode(differentVersion))
 
 	// different groupID should not match
 	differentGroup := maven.NewID("org.other", "dep", "2.0")
-	assert.Nil(t, g.FindNode(differentGroup))
+	assert.Nil(t, g.findNode(differentGroup))
 }
 
 func TestDependencyGraph_AddNode_DuplicatePrevented(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depID := maven.NewID("com.example", "dep", "1.0")
 
-	root := g.SetRoot(rootID)
-	first := g.AddNode(depID, "compile", root)
-	second := g.AddNode(depID, "runtime", root)
+	root := g.setRoot(rootID)
+	first := g.addNode(depID, "compile", root)
+	second := g.addNode(depID, "runtime", root)
 
 	// should return existing node, not create duplicate
 	assert.Same(t, first, second)
-	assert.Equal(t, 2, g.Size())
+	assert.Equal(t, 2, g.size())
 	// scope from first insertion is preserved
 	assert.Equal(t, "compile", first.Scope)
 }
@@ -131,15 +131,15 @@ func TestDependencyGraph_BuildFromPOMs(t *testing.T) {
 
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
-	g := NewDependencyGraph()
-	g.BuildFromPOMs(ctx, poms, resolver, rootID, false, 10)
+	g := newDependencyGraph()
+	g.buildFromPOMs(ctx, poms, resolver, rootID, false, 10)
 
-	assert.Equal(t, 3, g.Size())
-	assert.NotNil(t, g.FindNode(rootID))
-	assert.NotNil(t, g.FindNode(depAID))
-	assert.NotNil(t, g.FindNode(depBID))
+	assert.Equal(t, 3, g.size())
+	assert.NotNil(t, g.findNode(rootID))
+	assert.NotNil(t, g.findNode(depAID))
+	assert.NotNil(t, g.findNode(depBID))
 
-	nodeA := g.FindNode(depAID)
+	nodeA := g.findNode(depAID)
 	assert.Equal(t, "compile", nodeA.Scope)
 	assert.Equal(t, g.Root, nodeA.Parent)
 }
@@ -169,16 +169,16 @@ func TestDependencyGraph_BuildFromPOMs_Transitive(t *testing.T) {
 
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
-	g := NewDependencyGraph()
-	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+	g := newDependencyGraph()
+	g.buildFromPOMs(ctx, poms, resolver, rootID, true, 10)
 
-	assert.Equal(t, 3, g.Size())
+	assert.Equal(t, 3, g.size())
 
-	nodeB := g.FindNode(depBID)
+	nodeB := g.findNode(depBID)
 	require.NotNil(t, nodeB)
-	assert.Equal(t, 2, nodeB.Depth())
+	assert.Equal(t, 2, nodeB.depth())
 
-	nodeA := g.FindNode(depAID)
+	nodeA := g.findNode(depAID)
 	require.NotNil(t, nodeA)
 	assert.Equal(t, nodeA, nodeB.Parent)
 }
@@ -208,11 +208,11 @@ func TestDependencyGraph_BuildFromPOMs_CyclePrevention(t *testing.T) {
 
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
-	g := NewDependencyGraph()
-	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+	g := newDependencyGraph()
+	g.buildFromPOMs(ctx, poms, resolver, rootID, true, 10)
 
 	// should not loop infinitely — root + dep-a only
-	assert.Equal(t, 2, g.Size())
+	assert.Equal(t, 2, g.size())
 }
 
 func TestDependencyGraph_BuildFromPOMs_MaxDepth(t *testing.T) {
@@ -248,13 +248,13 @@ func TestDependencyGraph_BuildFromPOMs_MaxDepth(t *testing.T) {
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
 	// maxDepth=2 should stop at dep-b (depth 2), not include dep-c
-	g := NewDependencyGraph()
-	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 2)
+	g := newDependencyGraph()
+	g.buildFromPOMs(ctx, poms, resolver, rootID, true, 2)
 
-	assert.NotNil(t, g.FindNode(rootID))
-	assert.NotNil(t, g.FindNode(depAID))
-	assert.NotNil(t, g.FindNode(depBID))
-	assert.Nil(t, g.FindNode(depCID))
+	assert.NotNil(t, g.findNode(rootID))
+	assert.NotNil(t, g.findNode(depAID))
+	assert.NotNil(t, g.findNode(depBID))
+	assert.Nil(t, g.findNode(depCID))
 }
 
 func TestDependencyGraph_BuildFromPOMs_MissingRoot(t *testing.T) {
@@ -265,54 +265,54 @@ func TestDependencyGraph_BuildFromPOMs_MissingRoot(t *testing.T) {
 
 	resolver := maven.NewResolver(nil, maven.DefaultConfig())
 
-	g := NewDependencyGraph()
-	g.BuildFromPOMs(ctx, poms, resolver, rootID, true, 10)
+	g := newDependencyGraph()
+	g.buildFromPOMs(ctx, poms, resolver, rootID, true, 10)
 
 	// graph should remain empty
-	assert.Equal(t, 0, g.Size())
+	assert.Equal(t, 0, g.size())
 	assert.Nil(t, g.Root)
 }
 
 func TestDependencyGraph_Size(t *testing.T) {
-	g := NewDependencyGraph()
-	assert.Equal(t, 0, g.Size())
+	g := newDependencyGraph()
+	assert.Equal(t, 0, g.size())
 
-	root := g.SetRoot(maven.NewID("com.example", "root", "1.0"))
-	assert.Equal(t, 1, g.Size())
+	root := g.setRoot(maven.NewID("com.example", "root", "1.0"))
+	assert.Equal(t, 1, g.size())
 
-	g.AddNode(maven.NewID("com.example", "a", "1.0"), "", root)
-	assert.Equal(t, 2, g.Size())
+	g.addNode(maven.NewID("com.example", "a", "1.0"), "", root)
+	assert.Equal(t, 2, g.size())
 
-	g.AddNode(maven.NewID("com.example", "b", "1.0"), "", root)
-	assert.Equal(t, 3, g.Size())
+	g.addNode(maven.NewID("com.example", "b", "1.0"), "", root)
+	assert.Equal(t, 3, g.size())
 }
 
 func TestDependencyGraph_FindNodeByGA(t *testing.T) {
-	g := NewDependencyGraph()
+	g := newDependencyGraph()
 
 	rootID := maven.NewID("com.example", "root", "1.0")
 	depID := maven.NewID("com.example", "dep", "2.0")
 
-	root := g.SetRoot(rootID)
-	g.AddNode(depID, "compile", root)
+	root := g.setRoot(rootID)
+	g.addNode(depID, "compile", root)
 
 	t.Run("matches regardless of version", func(t *testing.T) {
-		node := g.FindNodeByGA("com.example", "dep")
+		node := g.findNodeByGA("com.example", "dep")
 		require.NotNil(t, node)
 		assert.Equal(t, depID, node.ID)
 	})
 
 	t.Run("different version still matches", func(t *testing.T) {
-		node := g.FindNodeByGA("com.example", "dep")
+		node := g.findNodeByGA("com.example", "dep")
 		require.NotNil(t, node)
 		assert.Equal(t, "2.0", node.ID.Version)
 	})
 
 	t.Run("wrong groupID does not match", func(t *testing.T) {
-		assert.Nil(t, g.FindNodeByGA("org.other", "dep"))
+		assert.Nil(t, g.findNodeByGA("org.other", "dep"))
 	})
 
 	t.Run("wrong artifactID does not match", func(t *testing.T) {
-		assert.Nil(t, g.FindNodeByGA("com.example", "missing"))
+		assert.Nil(t, g.findNodeByGA("com.example", "missing"))
 	})
 }

--- a/syft/pkg/cataloger/java/dependency_graph_test.go
+++ b/syft/pkg/cataloger/java/dependency_graph_test.go
@@ -286,3 +286,33 @@ func TestDependencyGraph_Size(t *testing.T) {
 	g.AddNode(maven.NewID("com.example", "b", "1.0"), "", root)
 	assert.Equal(t, 3, g.Size())
 }
+
+func TestDependencyGraph_FindNodeByGA(t *testing.T) {
+	g := NewDependencyGraph()
+
+	rootID := maven.NewID("com.example", "root", "1.0")
+	depID := maven.NewID("com.example", "dep", "2.0")
+
+	root := g.SetRoot(rootID)
+	g.AddNode(depID, "compile", root)
+
+	t.Run("matches regardless of version", func(t *testing.T) {
+		node := g.FindNodeByGA("com.example", "dep")
+		require.NotNil(t, node)
+		assert.Equal(t, depID, node.ID)
+	})
+
+	t.Run("different version still matches", func(t *testing.T) {
+		node := g.FindNodeByGA("com.example", "dep")
+		require.NotNil(t, node)
+		assert.Equal(t, "2.0", node.ID.Version)
+	})
+
+	t.Run("wrong groupID does not match", func(t *testing.T) {
+		assert.Nil(t, g.FindNodeByGA("org.other", "dep"))
+	})
+
+	t.Run("wrong artifactID does not match", func(t *testing.T) {
+		assert.Nil(t, g.FindNodeByGA("com.example", "missing"))
+	})
+}

--- a/syft/pkg/cataloger/java/internal/maven/resolver.go
+++ b/syft/pkg/cataloger/java/internal/maven/resolver.go
@@ -43,6 +43,11 @@ func (m ID) String() string {
 	return fmt.Sprintf("(groupId: %s artifactId: %s version: %s)", m.GroupID, m.ArtifactID, m.Version)
 }
 
+// Coordinate returns the standard Maven coordinate format "groupId:artifactId:version".
+func (m ID) Coordinate() string {
+	return m.GroupID + ":" + m.ArtifactID + ":" + m.Version
+}
+
 // Valid indicates that the given maven ID has values for groupId, artifactId, and version
 func (m ID) Valid() bool {
 	return m.GroupID != "" && m.ArtifactID != "" && m.Version != ""

--- a/syft/pkg/cataloger/java/post_process.go
+++ b/syft/pkg/cataloger/java/post_process.go
@@ -41,7 +41,7 @@ func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg ArchiveCata
 			continue
 		}
 
-		data, ok := rel.Data.(DependencyRelationshipData)
+		data, ok := rel.Data.(dependencyRelationshipData)
 		if !ok || data.IntendedParentID == "" {
 			continue
 		}
@@ -55,16 +55,7 @@ func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg ArchiveCata
 			continue
 		}
 
-		// fallback: try to find nearest ancestor in SBOM
-		ancestor := findNearestAncestor(pkgIndex, data.IntendedParentID)
-		if ancestor != nil {
-			rel.To = *ancestor
-			data.IntendedParentID = ""
-			rel.Data = data
-			updated = true
-		} else {
-			log.WithFields("intendedParent", data.IntendedParentID).Debug("unable to resolve deferred parent relationship")
-		}
+		log.WithFields("intendedParent", data.IntendedParentID).Debug("unable to resolve deferred parent relationship")
 	}
 
 	if updated {
@@ -133,14 +124,6 @@ func findPackageByMavenID(pkgIndex map[string]*pkg.Package, mavenID string) *pkg
 		}
 	}
 
-	return nil
-}
-
-// findNearestAncestor attempts to locate a parent by progressively relaxing the match.
-// This handles the skip-to-ancestor case where an intermediate parent is not in the SBOM.
-func findNearestAncestor(pkgIndex map[string]*pkg.Package, intendedParentID string) *pkg.Package {
-	// the 3-tier lookup in findPackageByMavenID already handles relaxed matching
-	// this function exists as an extension point for future ancestor-walking logic
 	return nil
 }
 

--- a/syft/pkg/cataloger/java/post_process.go
+++ b/syft/pkg/cataloger/java/post_process.go
@@ -1,0 +1,191 @@
+package java
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/sbomsync"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+// ResolveHierarchicalDependencies resolves deferred parent relationships for Java packages.
+// When the dependency graph at cataloging time identifies an intended parent that wasn't
+// available in the same archive, this post-processor resolves those deferred relationships
+// by looking up parents across the full SBOM.
+func ResolveHierarchicalDependencies(accessor sbomsync.Accessor, cfg ArchiveCatalogerConfig) {
+	if !cfg.UseEmbeddedPOMDependencies {
+		return
+	}
+
+	var packages []pkg.Package
+	var relationships []artifact.Relationship
+
+	accessor.ReadFromSBOM(func(s *sbom.SBOM) {
+		packages = s.Artifacts.Packages.Sorted(pkg.JavaPkg)
+		relationships = s.Relationships
+	})
+
+	if len(relationships) == 0 {
+		return
+	}
+
+	pkgIndex := buildPackageIndex(packages)
+
+	var updated bool
+	for i := range relationships {
+		rel := &relationships[i]
+		if rel.Type != artifact.DependencyOfRelationship {
+			continue
+		}
+
+		data, ok := rel.Data.(DependencyRelationshipData)
+		if !ok || data.IntendedParentID == "" {
+			continue
+		}
+
+		resolvedParent := findPackageByMavenID(pkgIndex, data.IntendedParentID)
+		if resolvedParent != nil {
+			rel.To = *resolvedParent
+			data.IntendedParentID = ""
+			rel.Data = data
+			updated = true
+			continue
+		}
+
+		// fallback: try to find nearest ancestor in SBOM
+		ancestor := findNearestAncestor(pkgIndex, data.IntendedParentID)
+		if ancestor != nil {
+			rel.To = *ancestor
+			data.IntendedParentID = ""
+			rel.Data = data
+			updated = true
+		} else {
+			log.WithFields("intendedParent", data.IntendedParentID).Debug("unable to resolve deferred parent relationship")
+		}
+	}
+
+	if updated {
+		accessor.WriteToSBOM(func(s *sbom.SBOM) {
+			s.Relationships = relationships
+		})
+	}
+}
+
+// buildPackageIndex creates a 3-tier index of Java packages by their Maven coordinates.
+func buildPackageIndex(packages []pkg.Package) map[string]*pkg.Package {
+	index := make(map[string]*pkg.Package)
+
+	for i := range packages {
+		p := &packages[i]
+		mavenID := extractMavenIDString(p)
+		if mavenID == "" {
+			continue
+		}
+
+		// full ID: groupId:artifactId:version
+		if _, exists := index[mavenID]; !exists {
+			index[mavenID] = p
+		}
+
+		// partial: groupId:artifactId
+		ga := extractGroupArtifact(mavenID)
+		if ga != "" {
+			if _, exists := index[ga]; !exists {
+				index[ga] = p
+			}
+		}
+
+		// minimal: artifactId only
+		a := extractArtifactIDFromCoord(mavenID)
+		if a != "" {
+			if _, exists := index[a]; !exists {
+				index[a] = p
+			}
+		}
+	}
+
+	return index
+}
+
+// findPackageByMavenID looks up a package using 3-tier matching: full ID, groupId:artifactId, artifactId.
+func findPackageByMavenID(pkgIndex map[string]*pkg.Package, mavenID string) *pkg.Package {
+	// try exact match first
+	if p, exists := pkgIndex[mavenID]; exists {
+		return p
+	}
+
+	// try groupId:artifactId
+	ga := extractGroupArtifact(mavenID)
+	if ga != "" {
+		if p, exists := pkgIndex[ga]; exists {
+			return p
+		}
+	}
+
+	// try artifactId only
+	a := extractArtifactIDFromCoord(mavenID)
+	if a != "" {
+		if p, exists := pkgIndex[a]; exists {
+			return p
+		}
+	}
+
+	return nil
+}
+
+// findNearestAncestor attempts to locate a parent by progressively relaxing the match.
+// This handles the skip-to-ancestor case where an intermediate parent is not in the SBOM.
+func findNearestAncestor(pkgIndex map[string]*pkg.Package, intendedParentID string) *pkg.Package {
+	// the 3-tier lookup in findPackageByMavenID already handles relaxed matching
+	// this function exists as an extension point for future ancestor-walking logic
+	return nil
+}
+
+// extractMavenIDString returns "groupId:artifactId:version" from a package's Java metadata.
+func extractMavenIDString(p *pkg.Package) string {
+	if p == nil {
+		return ""
+	}
+
+	metadata, ok := p.Metadata.(pkg.JavaArchive)
+	if !ok {
+		return ""
+	}
+
+	if metadata.PomProperties != nil {
+		pp := metadata.PomProperties
+		if pp.GroupID != "" && pp.ArtifactID != "" {
+			return fmt.Sprintf("%s:%s:%s", pp.GroupID, pp.ArtifactID, pp.Version)
+		}
+	}
+
+	if metadata.PomProject != nil {
+		pj := metadata.PomProject
+		if pj.GroupID != "" && pj.ArtifactID != "" {
+			return fmt.Sprintf("%s:%s:%s", pj.GroupID, pj.ArtifactID, pj.Version)
+		}
+	}
+
+	return ""
+}
+
+// extractGroupArtifact returns "groupId:artifactId" from a full maven coordinate string.
+func extractGroupArtifact(mavenID string) string {
+	parts := strings.SplitN(mavenID, ":", 3)
+	if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0] + ":" + parts[1]
+	}
+	return ""
+}
+
+// extractArtifactIDFromCoord returns just the artifactId from a maven coordinate string.
+func extractArtifactIDFromCoord(mavenID string) string {
+	parts := strings.SplitN(mavenID, ":", 3)
+	if len(parts) >= 2 {
+		return parts[1]
+	}
+	return ""
+}

--- a/syft/pkg/cataloger/java/post_process_test.go
+++ b/syft/pkg/cataloger/java/post_process_test.go
@@ -191,7 +191,7 @@ func TestResolveHierarchicalDependencies_Disabled(t *testing.T) {
 				From: pkg.Package{Name: "child"},
 				To:   pkg.Package{Name: "wrong-parent"},
 				Type: artifact.DependencyOfRelationship,
-				Data: NewDependencyRelationshipDataWithParent(1, "", "com.example:real-parent:1.0"),
+				Data: newDependencyRelationshipDataWithParent(1, "", "com.example:real-parent:1.0"),
 			},
 		},
 	}
@@ -244,7 +244,7 @@ func TestResolveHierarchicalDependencies_ResolvesParent(t *testing.T) {
 				From: child,
 				To:   placeholder,
 				Type: artifact.DependencyOfRelationship,
-				Data: NewDependencyRelationshipDataWithParent(1, "compile", "com.example:real-parent:1.0"),
+				Data: newDependencyRelationshipDataWithParent(1, "compile", "com.example:real-parent:1.0"),
 			},
 		},
 	}
@@ -257,7 +257,7 @@ func TestResolveHierarchicalDependencies_ResolvesParent(t *testing.T) {
 	assert.Equal(t, "real-parent", resolvedTo.Name)
 
 	// IntendedParentID should be cleared
-	data, ok := accessor.relationships[0].Data.(DependencyRelationshipData)
+	data, ok := accessor.relationships[0].Data.(dependencyRelationshipData)
 	require.True(t, ok)
 	assert.Empty(t, data.IntendedParentID)
 	assert.Equal(t, "compile", data.Scope)

--- a/syft/pkg/cataloger/java/post_process_test.go
+++ b/syft/pkg/cataloger/java/post_process_test.go
@@ -1,0 +1,287 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
+)
+
+func TestBuildPackageIndex(t *testing.T) {
+	p1 := pkg.Package{
+		Name:    "dep-a",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "dep-a",
+				Version:    "1.0",
+			},
+		},
+	}
+
+	p2 := pkg.Package{
+		Name:    "dep-b",
+		Version: "2.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "org.other",
+				ArtifactID: "dep-b",
+				Version:    "2.0",
+			},
+		},
+	}
+
+	packages := []pkg.Package{p1, p2}
+	index := buildPackageIndex(packages)
+
+	// full ID lookup
+	assert.NotNil(t, index["com.example:dep-a:1.0"])
+	assert.NotNil(t, index["org.other:dep-b:2.0"])
+
+	// partial lookup
+	assert.NotNil(t, index["com.example:dep-a"])
+	assert.NotNil(t, index["org.other:dep-b"])
+
+	// artifact-only lookup
+	assert.NotNil(t, index["dep-a"])
+	assert.NotNil(t, index["dep-b"])
+}
+
+func TestFindPackageByMavenID(t *testing.T) {
+	p := pkg.Package{
+		Name:    "my-lib",
+		Version: "3.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "my-lib",
+				Version:    "3.0",
+			},
+		},
+	}
+
+	packages := []pkg.Package{p}
+	index := buildPackageIndex(packages)
+
+	tests := []struct {
+		name  string
+		id    string
+		found bool
+	}{
+		{name: "exact match", id: "com.example:my-lib:3.0", found: true},
+		{name: "group:artifact match", id: "com.example:my-lib:9.9", found: true},
+		{name: "artifact only match", id: "org.different:my-lib:1.0", found: true},
+		{name: "no match", id: "com.example:other-lib:1.0", found: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findPackageByMavenID(index, tt.id)
+			if tt.found {
+				require.NotNil(t, result)
+				assert.Equal(t, "my-lib", result.Name)
+			} else {
+				assert.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestExtractMavenIDString(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      *pkg.Package
+		expected string
+	}{
+		{
+			name: "from pom properties",
+			pkg: &pkg.Package{
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "com.example",
+						ArtifactID: "my-lib",
+						Version:    "1.0",
+					},
+				},
+			},
+			expected: "com.example:my-lib:1.0",
+		},
+		{
+			name: "from pom project",
+			pkg: &pkg.Package{
+				Metadata: pkg.JavaArchive{
+					PomProject: &pkg.JavaPomProject{
+						GroupID:    "org.other",
+						ArtifactID: "other-lib",
+						Version:    "2.0",
+					},
+				},
+			},
+			expected: "org.other:other-lib:2.0",
+		},
+		{
+			name: "pom properties preferred over pom project",
+			pkg: &pkg.Package{
+				Metadata: pkg.JavaArchive{
+					PomProperties: &pkg.JavaPomProperties{
+						GroupID:    "com.props",
+						ArtifactID: "props-lib",
+						Version:    "1.0",
+					},
+					PomProject: &pkg.JavaPomProject{
+						GroupID:    "com.project",
+						ArtifactID: "project-lib",
+						Version:    "2.0",
+					},
+				},
+			},
+			expected: "com.props:props-lib:1.0",
+		},
+		{
+			name:     "nil package",
+			pkg:      nil,
+			expected: "",
+		},
+		{
+			name: "no java metadata",
+			pkg: &pkg.Package{
+				Metadata: nil,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, extractMavenIDString(tt.pkg))
+		})
+	}
+}
+
+func TestExtractGroupArtifact(t *testing.T) {
+	assert.Equal(t, "com.example:my-lib", extractGroupArtifact("com.example:my-lib:1.0"))
+	assert.Equal(t, "com.example:my-lib", extractGroupArtifact("com.example:my-lib"))
+	assert.Equal(t, "", extractGroupArtifact(""))
+	assert.Equal(t, "", extractGroupArtifact("single"))
+}
+
+func TestExtractArtifactIDFromCoord(t *testing.T) {
+	assert.Equal(t, "my-lib", extractArtifactIDFromCoord("com.example:my-lib:1.0"))
+	assert.Equal(t, "my-lib", extractArtifactIDFromCoord("com.example:my-lib"))
+	assert.Equal(t, "", extractArtifactIDFromCoord("single"))
+	assert.Equal(t, "", extractArtifactIDFromCoord(""))
+}
+
+func TestResolveHierarchicalDependencies_Disabled(t *testing.T) {
+	// should be a no-op when feature is disabled
+	cfg := DefaultArchiveCatalogerConfig()
+	cfg.UseEmbeddedPOMDependencies = false
+
+	accessor := &mockAccessor{
+		relationships: []artifact.Relationship{
+			{
+				From: pkg.Package{Name: "child"},
+				To:   pkg.Package{Name: "wrong-parent"},
+				Type: artifact.DependencyOfRelationship,
+				Data: NewDependencyRelationshipDataWithParent(1, "", "com.example:real-parent:1.0"),
+			},
+		},
+	}
+
+	ResolveHierarchicalDependencies(accessor, cfg)
+
+	// relationship should be unchanged
+	assert.Equal(t, "wrong-parent", accessor.relationships[0].To.(pkg.Package).Name)
+}
+
+func TestResolveHierarchicalDependencies_ResolvesParent(t *testing.T) {
+	parent := pkg.Package{
+		Name:    "real-parent",
+		Version: "1.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "real-parent",
+				Version:    "1.0",
+			},
+		},
+	}
+	parent.SetID()
+
+	child := pkg.Package{
+		Name:    "child",
+		Version: "2.0",
+		Type:    pkg.JavaPkg,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.example",
+				ArtifactID: "child",
+				Version:    "2.0",
+			},
+		},
+	}
+	child.SetID()
+
+	placeholder := pkg.Package{Name: "placeholder"}
+	placeholder.SetID()
+
+	cfg := DefaultArchiveCatalogerConfig()
+	cfg.UseEmbeddedPOMDependencies = true
+
+	accessor := &mockAccessor{
+		packages: []pkg.Package{parent, child, placeholder},
+		relationships: []artifact.Relationship{
+			{
+				From: child,
+				To:   placeholder,
+				Type: artifact.DependencyOfRelationship,
+				Data: NewDependencyRelationshipDataWithParent(1, "compile", "com.example:real-parent:1.0"),
+			},
+		},
+	}
+
+	ResolveHierarchicalDependencies(accessor, cfg)
+
+	// relationship should now point to real-parent
+	resolvedTo, ok := accessor.relationships[0].To.(pkg.Package)
+	require.True(t, ok)
+	assert.Equal(t, "real-parent", resolvedTo.Name)
+
+	// IntendedParentID should be cleared
+	data, ok := accessor.relationships[0].Data.(DependencyRelationshipData)
+	require.True(t, ok)
+	assert.Empty(t, data.IntendedParentID)
+	assert.Equal(t, "compile", data.Scope)
+}
+
+// mockAccessor implements sbomsync.Accessor for testing
+type mockAccessor struct {
+	packages      []pkg.Package
+	relationships []artifact.Relationship
+}
+
+func (m *mockAccessor) ReadFromSBOM(fn func(*sbom.SBOM)) {
+	s := &sbom.SBOM{
+		Relationships: m.relationships,
+	}
+	s.Artifacts.Packages = pkg.NewCollection(m.packages...)
+	fn(s)
+}
+
+func (m *mockAccessor) WriteToSBOM(fn func(*sbom.SBOM)) {
+	s := &sbom.SBOM{
+		Relationships: m.relationships,
+	}
+	s.Artifacts.Packages = pkg.NewCollection(m.packages...)
+	fn(s)
+	m.relationships = s.Relationships
+}

--- a/syft/pkg/cataloger/java/relationship_metadata.go
+++ b/syft/pkg/cataloger/java/relationship_metadata.go
@@ -1,0 +1,40 @@
+package java
+
+import "fmt"
+
+// DependencyRelationshipData holds metadata about a dependency relationship that is
+// attached to artifact.Relationship.Data for enriched Syft JSON output.
+type DependencyRelationshipData struct {
+	Depth              int    `json:"depth"`
+	Scope              string `json:"scope,omitempty"`
+	IsDirectDependency bool   `json:"isDirectDependency"`
+	IntendedParentID   string `json:"intendedParentId,omitempty"`
+}
+
+// NewDependencyRelationshipData creates relationship metadata with depth and scope.
+func NewDependencyRelationshipData(depth int, scope string) DependencyRelationshipData {
+	return DependencyRelationshipData{
+		Depth:              depth,
+		Scope:              scope,
+		IsDirectDependency: depth == 0,
+	}
+}
+
+// NewDependencyRelationshipDataWithParent creates relationship metadata that includes
+// an intended parent ID for deferred resolution by the post-processor.
+func NewDependencyRelationshipDataWithParent(depth int, scope string, intendedParentID string) DependencyRelationshipData {
+	return DependencyRelationshipData{
+		Depth:              depth,
+		Scope:              scope,
+		IsDirectDependency: depth == 0,
+		IntendedParentID:   intendedParentID,
+	}
+}
+
+// IntendedParentMavenID returns the formatted intended parent ID string for display/logging.
+func (d DependencyRelationshipData) IntendedParentMavenID() string {
+	if d.IntendedParentID == "" {
+		return ""
+	}
+	return fmt.Sprintf("intendedParent=%s", d.IntendedParentID)
+}

--- a/syft/pkg/cataloger/java/relationship_metadata.go
+++ b/syft/pkg/cataloger/java/relationship_metadata.go
@@ -1,7 +1,5 @@
 package java
 
-import "fmt"
-
 // DependencyRelationshipData holds metadata about a dependency relationship that is
 // attached to artifact.Relationship.Data for enriched Syft JSON output.
 type DependencyRelationshipData struct {
@@ -29,12 +27,4 @@ func NewDependencyRelationshipDataWithParent(depth int, scope string, intendedPa
 		IsDirectDependency: depth == 0,
 		IntendedParentID:   intendedParentID,
 	}
-}
-
-// IntendedParentMavenID returns the formatted intended parent ID string for display/logging.
-func (d DependencyRelationshipData) IntendedParentMavenID() string {
-	if d.IntendedParentID == "" {
-		return ""
-	}
-	return fmt.Sprintf("intendedParent=%s", d.IntendedParentID)
 }

--- a/syft/pkg/cataloger/java/relationship_metadata.go
+++ b/syft/pkg/cataloger/java/relationship_metadata.go
@@ -2,7 +2,7 @@ package java
 
 // DependencyRelationshipData holds metadata about a dependency relationship that is
 // attached to artifact.Relationship.Data for enriched Syft JSON output.
-type DependencyRelationshipData struct {
+type dependencyRelationshipData struct {
 	Depth              int    `json:"depth"`
 	Scope              string `json:"scope,omitempty"`
 	IsDirectDependency bool   `json:"isDirectDependency"`
@@ -10,8 +10,8 @@ type DependencyRelationshipData struct {
 }
 
 // NewDependencyRelationshipData creates relationship metadata with depth and scope.
-func NewDependencyRelationshipData(depth int, scope string) DependencyRelationshipData {
-	return DependencyRelationshipData{
+func newDependencyRelationshipData(depth int, scope string) dependencyRelationshipData {
+	return dependencyRelationshipData{
 		Depth:              depth,
 		Scope:              scope,
 		IsDirectDependency: depth == 0,
@@ -20,8 +20,8 @@ func NewDependencyRelationshipData(depth int, scope string) DependencyRelationsh
 
 // NewDependencyRelationshipDataWithParent creates relationship metadata that includes
 // an intended parent ID for deferred resolution by the post-processor.
-func NewDependencyRelationshipDataWithParent(depth int, scope string, intendedParentID string) DependencyRelationshipData {
-	return DependencyRelationshipData{
+func newDependencyRelationshipDataWithParent(depth int, scope string, intendedParentID string) dependencyRelationshipData {
+	return dependencyRelationshipData{
 		Depth:              depth,
 		Scope:              scope,
 		IsDirectDependency: depth == 0,

--- a/syft/pkg/cataloger/java/relationship_metadata_test.go
+++ b/syft/pkg/cataloger/java/relationship_metadata_test.go
@@ -94,28 +94,3 @@ func TestNewDependencyRelationshipDataWithParent(t *testing.T) {
 		})
 	}
 }
-
-func TestDependencyRelationshipData_IntendedParentMavenID(t *testing.T) {
-	tests := []struct {
-		name     string
-		data     DependencyRelationshipData
-		expected string
-	}{
-		{
-			name:     "empty intended parent",
-			data:     NewDependencyRelationshipData(0, "compile"),
-			expected: "",
-		},
-		{
-			name:     "with intended parent",
-			data:     NewDependencyRelationshipDataWithParent(1, "runtime", "org.example:lib:1.0"),
-			expected: "intendedParent=org.example:lib:1.0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, tt.data.IntendedParentMavenID())
-		})
-	}
-}

--- a/syft/pkg/cataloger/java/relationship_metadata_test.go
+++ b/syft/pkg/cataloger/java/relationship_metadata_test.go
@@ -44,7 +44,7 @@ func TestNewDependencyRelationshipData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := NewDependencyRelationshipData(tt.depth, tt.scope)
+			data := newDependencyRelationshipData(tt.depth, tt.scope)
 			assert.Equal(t, tt.expectDepth, data.Depth)
 			assert.Equal(t, tt.expectScope, data.Scope)
 			assert.Equal(t, tt.expectDirect, data.IsDirectDependency)
@@ -86,7 +86,7 @@ func TestNewDependencyRelationshipDataWithParent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := NewDependencyRelationshipDataWithParent(tt.depth, tt.scope, tt.intendedParentID)
+			data := newDependencyRelationshipDataWithParent(tt.depth, tt.scope, tt.intendedParentID)
 			assert.Equal(t, tt.depth, data.Depth)
 			assert.Equal(t, tt.scope, data.Scope)
 			assert.Equal(t, tt.expectDirect, data.IsDirectDependency)

--- a/syft/pkg/cataloger/java/relationship_metadata_test.go
+++ b/syft/pkg/cataloger/java/relationship_metadata_test.go
@@ -1,0 +1,121 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDependencyRelationshipData(t *testing.T) {
+	tests := []struct {
+		name               string
+		depth              int
+		scope              string
+		expectDirect       bool
+		expectDepth        int
+		expectScope        string
+		expectIntendedPart string
+	}{
+		{
+			name:         "direct dependency (depth 0)",
+			depth:        0,
+			scope:        "compile",
+			expectDirect: true,
+			expectDepth:  0,
+			expectScope:  "compile",
+		},
+		{
+			name:         "transitive dependency (depth 1)",
+			depth:        1,
+			scope:        "runtime",
+			expectDirect: false,
+			expectDepth:  1,
+			expectScope:  "runtime",
+		},
+		{
+			name:         "deep transitive (depth 3)",
+			depth:        3,
+			scope:        "",
+			expectDirect: false,
+			expectDepth:  3,
+			expectScope:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := NewDependencyRelationshipData(tt.depth, tt.scope)
+			assert.Equal(t, tt.expectDepth, data.Depth)
+			assert.Equal(t, tt.expectScope, data.Scope)
+			assert.Equal(t, tt.expectDirect, data.IsDirectDependency)
+			assert.Empty(t, data.IntendedParentID)
+		})
+	}
+}
+
+func TestNewDependencyRelationshipDataWithParent(t *testing.T) {
+	tests := []struct {
+		name             string
+		depth            int
+		scope            string
+		intendedParentID string
+		expectDirect     bool
+	}{
+		{
+			name:             "direct with deferred parent",
+			depth:            0,
+			scope:            "compile",
+			intendedParentID: "org.example:parent:1.0",
+			expectDirect:     true,
+		},
+		{
+			name:             "transitive with deferred parent",
+			depth:            2,
+			scope:            "test",
+			intendedParentID: "org.example:lib-a:2.0",
+			expectDirect:     false,
+		},
+		{
+			name:             "empty parent ID",
+			depth:            1,
+			scope:            "",
+			intendedParentID: "",
+			expectDirect:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := NewDependencyRelationshipDataWithParent(tt.depth, tt.scope, tt.intendedParentID)
+			assert.Equal(t, tt.depth, data.Depth)
+			assert.Equal(t, tt.scope, data.Scope)
+			assert.Equal(t, tt.expectDirect, data.IsDirectDependency)
+			assert.Equal(t, tt.intendedParentID, data.IntendedParentID)
+		})
+	}
+}
+
+func TestDependencyRelationshipData_IntendedParentMavenID(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     DependencyRelationshipData
+		expected string
+	}{
+		{
+			name:     "empty intended parent",
+			data:     NewDependencyRelationshipData(0, "compile"),
+			expected: "",
+		},
+		{
+			name:     "with intended parent",
+			data:     NewDependencyRelationshipDataWithParent(1, "runtime", "org.example:lib:1.0"),
+			expected: "intendedParent=org.example:lib:1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.data.IntendedParentMavenID())
+		})
+	}
+}

--- a/syft/pkg/cataloger/java/tar_wrapped_archive_parser.go
+++ b/syft/pkg/cataloger/java/tar_wrapped_archive_parser.go
@@ -80,5 +80,5 @@ func discoverPkgsFromTar(ctx context.Context, location file.Location, archivePat
 		return nil, nil, fmt.Errorf("unable to extract files from tar: %w", err)
 	}
 
-	return discoverPkgsFromOpeners(ctx, location, openers, nil, cfg)
+	return discoverPkgsFromOpeners(ctx, location, openers, nil, cfg, 0, nil)
 }

--- a/syft/pkg/cataloger/java/zip_wrapped_archive_parser.go
+++ b/syft/pkg/cataloger/java/zip_wrapped_archive_parser.go
@@ -52,5 +52,5 @@ func (gzp genericZipWrappedJavaArchiveParser) parseZipWrappedJavaArchive(ctx con
 	}
 
 	// look for java archives within the zip archive
-	return discoverPkgsFromZip(ctx, reader.Location, archivePath, contentPath, fileManifest, nil, gzp.cfg)
+	return discoverPkgsFromZip(ctx, reader.Location, archivePath, contentPath, fileManifest, nil, gzp.cfg, 0, nil)
 }


### PR DESCRIPTION
## Description
- Adds a dependency graph built from embedded `pom.xml` files in Java archives, wiring auxiliary packages to their actual Maven parents rather than flat to the root archive
- Enriches dependency relationships with depth, scope, and direct/transitive metadata for Syft JSON output
- Deferred parent resolution via post-processor handles cross-archive dependencies
- Gated by `java.use-embedded-pom-dependencies` (default: false) — no behavior change unless opted in

### Design decisions
- `maven.ID` as map key
- `FindNodeByGA` fallback to handle version-mismatch scenarios where dependency management resolves a different version than what the POM declares
- `ID.Coordinate()`: explicit, round-trippable serialization (`groupId:artifactId:version`) used for `IntendedParentID` in JSON
- Branch-scoped cycle detection: visited map is copied per branch so diamond dependencies are still resolved
- Post-processor 3-tier index: `full coord → groupId:artifactId → artifactId` fallback for cross-archive parent resolution
- Feature flag default off: zero behavioral change for existing users

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references
This PR splits #4843 to focus on embedded POM graph only and incorporates all architectural feedback from @kzantow's review:

1. Relationship logic moved to `pkg/cataloger/java`
2. Java-specific config, `UseEmbeddedPOMDependencies`, moved from shared relationship options to `ArchiveCatalogerConfig`
3. Use `maven.ID` as map key with explicit serialization and `maven_id.go` wrapper removed
4. Version-agnostic graph lookup fallback by added `FindNodeByGA(groupID, artifactID string)` as a fallback when exact `maven.ID` match (including version) fails. This handles the scenario where Maven dependency management resolves a different version than what the POM declares and the graph still finds the correct node by `groupId:artifactId`.
5. Depth is computed, not stored. The depth value in `DependencyRelationshipData` is output enrichment for SBOM consumers, not structural redundancy on the graph.
6. Lookup maps extracted into helper where inline map construction in `archive_parser.go` was replaced with a `buildPkgIndex()` method. Relationship creation split into clearly named `createAuxPkgRelationship` and `createMainPkgRelationship` methods.