### PR TITLE
feat (npm): Handle npm-shrinkwrap in the same way as package-lock

### DIFF
--- a/cmd/syft/internal/test/integration/node_packages_test.go
+++ b/cmd/syft/internal/test/integration/node_packages_test.go
@@ -31,6 +31,27 @@ func TestNpmPackageLockDirectory(t *testing.T) {
 	}
 }
 
+func TestNpmShrinkwrapDirectory(t *testing.T) {
+	sbom, _ := catalogDirectory(t, "testdata/npm-shrinkwrap")
+
+	foundPackages := strset.New()
+
+	for actualPkg := range sbom.Artifacts.Packages.Enumerate(pkg.NpmPkg) {
+		for _, actualLocation := range actualPkg.Locations.ToSlice() {
+			if strings.Contains(actualLocation.RealPath, "node_modules") {
+				t.Errorf("found packages from npm-shrinkwrap.json in node_modules: %s", actualLocation)
+			}
+		}
+		foundPackages.Add(actualPkg.Name)
+	}
+
+	// ensure that integration test commonTestCases stay in sync with the available catalogers
+	const expectedPackageCount = 2
+	if foundPackages.Size() != expectedPackageCount {
+		t.Errorf("found the wrong set of npm-shrinkwrap.json packages (expected: %d, actual: %d)", expectedPackageCount, foundPackages.Size())
+	}
+}
+
 func TestYarnPackageLockDirectory(t *testing.T) {
 	sbom, _ := catalogDirectory(t, "testdata/yarn-lock")
 

--- a/cmd/syft/internal/test/integration/testdata/npm-shrinkwrap/npm-shrinkwrap.json
+++ b/cmd/syft/internal/test/integration/testdata/npm-shrinkwrap/npm-shrinkwrap.json
@@ -1,0 +1,18 @@
+{
+  "name": "npm-shrinkwrap",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "collapse-white-space": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.0.0.tgz",
+      "integrity": "sha512-eh9krktAIMDL0KHuN7WTBJ/0PMv8KUvfQRBkIlGmW61idRM2DJjgd1qXEPr4wyk2PimZZeNww3RVYo6CMvDGlg=="
+    },
+    "insert-css": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/insert-css/-/insert-css-2.0.0.tgz",
+      "integrity": "sha1-610Ql7dUL0x56jBg067gfQU4gPQ="
+    }
+  }
+}

--- a/cmd/syft/internal/test/integration/testdata/npm-shrinkwrap/package.json
+++ b/cmd/syft/internal/test/integration/testdata/npm-shrinkwrap/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "npm-shrinkwrap",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "collapse-white-space": "^2.0.0",
+    "insert-css": "^2.0.0"
+  }
+}

--- a/internal/packagemetadata/generated.go
+++ b/internal/packagemetadata/generated.go
@@ -44,6 +44,7 @@ func AllTypes() []any {
 		pkg.NixStoreEntry{},
 		pkg.NpmPackage{},
 		pkg.NpmPackageLockEntry{},
+		pkg.NpmShrinkwrapEntry{},
 		pkg.OpamPackage{},
 		pkg.PEBinary{},
 		pkg.PhpComposerInstalledEntry{},

--- a/internal/packagemetadata/names.go
+++ b/internal/packagemetadata/names.go
@@ -94,6 +94,7 @@ var jsonTypes = makeJSONTypes(
 	jsonNames(pkg.NixStoreEntry{}, "nix-store-entry", "NixStoreMetadata"),
 	jsonNames(pkg.NpmPackage{}, "javascript-npm-package", "NpmPackageJsonMetadata"),
 	jsonNames(pkg.NpmPackageLockEntry{}, "javascript-npm-package-lock-entry", "NpmPackageLockJsonMetadata"),
+	jsonNames(pkg.NpmShrinkwrapEntry{}, "javascript-npm-shrinkwrap-entry"),
 	jsonNames(pkg.YarnLockEntry{}, "javascript-yarn-lock-entry", "YarnLockJsonMetadata"),
 	jsonNames(pkg.PnpmLockEntry{}, "javascript-pnpm-lock-entry"),
 	jsonNames(pkg.PEBinary{}, "pe-binary"),

--- a/internal/packagemetadata/names_test.go
+++ b/internal/packagemetadata/names_test.go
@@ -181,6 +181,11 @@ func TestReflectTypeFromJSONName_LegacyValues(t *testing.T) {
 			expected: reflect.TypeFor[pkg.NpmPackageLockEntry](),
 		},
 		{
+			name:     "map pkg.NpmShrinkwrapEntry struct type",
+			input:    "javascript-npm-shrinkwrap-entry",
+			expected: reflect.TypeFor[pkg.NpmShrinkwrapEntry](),
+		},
+		{
 			name:     "map pkg.PortageEntry struct type",
 			input:    "PortageMetadata",
 			expected: reflect.TypeFor[pkg.PortageEntry](),
@@ -412,6 +417,13 @@ func Test_JSONName_JSONLegacyName(t *testing.T) {
 			metadata:           pkg.NpmPackageLockEntry{},
 			expectedJSONName:   "javascript-npm-package-lock-entry",
 			expectedLegacyName: "NpmPackageLockJsonMetadata",
+		},
+		{
+			name:             "NpmShrinkwrapMetadata",
+			metadata:         pkg.NpmShrinkwrapEntry{},
+			expectedJSONName: "javascript-npm-shrinkwrap-entry",
+			// note: the legacy name should never be blank if it didn't exist pre v11.x
+			expectedLegacyName: "javascript-npm-shrinkwrap-entry",
 		},
 		{
 			name:               "PhpComposerLockMetadata",

--- a/syft/format/internal/spdxutil/helpers/download_location.go
+++ b/syft/format/internal/spdxutil/helpers/download_location.go
@@ -31,6 +31,8 @@ func DownloadLocation(p pkg.Package) string {
 			location = metadata.URL
 		case pkg.NpmPackageLockEntry:
 			location = metadata.Resolved
+		case pkg.NpmShrinkwrapEntry:
+			location = metadata.Resolved
 		case pkg.PhpComposerLockEntry:
 			location = metadata.Dist.URL
 		case pkg.PhpComposerInstalledEntry:

--- a/syft/format/internal/spdxutil/helpers/download_location_test.go
+++ b/syft/format/internal/spdxutil/helpers/download_location_test.go
@@ -65,6 +65,24 @@ func Test_DownloadLocation(t *testing.T) {
 			expected: NOASSERTION,
 		},
 		{
+			name: "from npm-shrinkwrap should include resolved",
+			input: pkg.Package{
+				Metadata: pkg.NpmShrinkwrapEntry{
+					Resolved: "http://npm-shrinkwrap.test",
+				},
+			},
+			expected: "http://npm-shrinkwrap.test",
+		},
+		{
+			name: "from npm-shrinkwrap empty should be NONE",
+			input: pkg.Package{
+				Metadata: pkg.NpmShrinkwrapEntry{
+					Resolved: "",
+				},
+			},
+			expected: NOASSERTION,
+		},
+		{
 			name: "from php installed.json",
 			input: pkg.Package{
 				Metadata: pkg.PhpComposerInstalledEntry{

--- a/syft/format/internal/spdxutil/helpers/originator_supplier_test.go
+++ b/syft/format/internal/spdxutil/helpers/originator_supplier_test.go
@@ -37,6 +37,7 @@ func Test_OriginatorSupplier(t *testing.T) {
 		pkg.MicrosoftKbPatch{},
 		pkg.NixStoreEntry{},
 		pkg.NpmPackageLockEntry{},
+		pkg.NpmShrinkwrapEntry{},
 		pkg.PhpComposerInstalledEntry{},
 		pkg.PhpPearEntry{},
 		pkg.PhpPeclEntry{},

--- a/syft/pkg/cataloger/javascript/capabilities.yaml
+++ b/syft/pkg/cataloger/javascript/capabilities.yaml
@@ -122,6 +122,38 @@ catalogers:
             default: true
             evidence:
               - NpmPackageLockEntry.Integrity
+      - function: parseNpmShrinkwrap
+        detector: # AUTO-GENERATED
+          method: glob # AUTO-GENERATED
+          criteria: # AUTO-GENERATED
+            - '**/npm-shrinkwrap.json'
+        metadata_types: # AUTO-GENERATED
+          - pkg.NpmShrinkwrapEntry
+        package_types: # AUTO-GENERATED
+          - npm
+        json_schema_types: # AUTO-GENERATED
+          - JavascriptNpmShrinkwrapEntry
+        capabilities: # MANUAL - preserved across regeneration
+          - name: license
+            default: true
+          - name: dependency.depth
+            default:
+              - direct
+              - indirect
+          - name: dependency.edges
+            default: ""
+          - name: dependency.kinds
+            default:
+              - runtime
+              - dev
+          - name: package_manager.files.listing
+            default: false
+          - name: package_manager.files.digests
+            default: false
+          - name: package_manager.package_integrity_hash
+            default: true
+            evidence:
+              - NpmShrinkwrapEntry.Integrity
   - ecosystem: javascript # MANUAL
     name: javascript-package-cataloger # AUTO-GENERATED
     type: generic # AUTO-GENERATED

--- a/syft/pkg/cataloger/javascript/cataloger.go
+++ b/syft/pkg/cataloger/javascript/cataloger.go
@@ -18,9 +18,11 @@ func NewPackageCataloger() pkg.Cataloger {
 func NewLockCataloger(cfg CatalogerConfig) pkg.Cataloger {
 	yarnLockAdapter := newGenericYarnLockAdapter(cfg)
 	packageLockAdapter := newGenericPackageLockAdapter(cfg)
+	shrinkwrapAdapter := newGenericNpmShrinkwrapAdapter(cfg)
 	pnpmLockAdapter := newGenericPnpmLockAdapter(cfg)
 	return generic.NewCataloger("javascript-lock-cataloger").
 		WithParserByGlobs(packageLockAdapter.parsePackageLock, "**/package-lock.json").
+		WithParserByGlobs(shrinkwrapAdapter.parseNpmShrinkwrap, "**/npm-shrinkwrap.json").
 		WithParserByGlobs(yarnLockAdapter.parseYarnLock, "**/yarn.lock").
 		WithParserByGlobs(pnpmLockAdapter.parsePnpmLock, "**/pnpm-lock.yaml")
 }

--- a/syft/pkg/cataloger/javascript/cataloger_test.go
+++ b/syft/pkg/cataloger/javascript/cataloger_test.go
@@ -173,6 +173,7 @@ func Test_LockCataloger_Globs(t *testing.T) {
 			name:    "obtain package files",
 			fixture: "testdata/glob-paths",
 			expected: []string{
+				"src/npm-shrinkwrap.json",
 				"src/package-lock.json",
 				"src/pnpm-lock.yaml",
 				"src/yarn.lock",

--- a/syft/pkg/cataloger/javascript/dependency.go
+++ b/syft/pkg/cataloger/javascript/dependency.go
@@ -40,6 +40,36 @@ func packageLockDependencySpecifier(p pkg.Package) dependency.Specification {
 	}
 }
 
+func npmShrinkwrapDependencySpecifier(p pkg.Package) dependency.Specification {
+	meta, ok := p.Metadata.(pkg.NpmShrinkwrapEntry)
+	if !ok {
+		log.Tracef("cataloger failed to extract npm shrinkwrap metadata for package %+v", p.Name)
+		return dependency.Specification{}
+	}
+
+	provides := []string{p.Name}
+
+	var requires []string
+
+	for name, dependencySpecifier := range meta.Dependencies {
+		purl, err := packageurl.FromString(strings.ReplaceAll(dependencySpecifier, "npm:", "pkg:npm/"))
+		if err == nil {
+			// if the package url is valid, include the name from the package url since this is likely an alias
+			var fullName = fmt.Sprintf("%s/%s", purl.Namespace, purl.Name)
+			requires = append(requires, fullName)
+		}
+
+		requires = append(requires, name)
+	}
+
+	return dependency.Specification{
+		ProvidesRequires: dependency.ProvidesRequires{
+			Provides: provides,
+			Requires: requires,
+		},
+	}
+}
+
 func pnpmLockDependencySpecifier(p pkg.Package) dependency.Specification {
 	meta, ok := p.Metadata.(pkg.PnpmLockEntry)
 	if !ok {

--- a/syft/pkg/cataloger/javascript/parse_npm_shrinkwrap.go
+++ b/syft/pkg/cataloger/javascript/parse_npm_shrinkwrap.go
@@ -1,0 +1,169 @@
+package javascript
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/unknown"
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/dependency"
+)
+
+type genericNpmShrinkwrapAdapter struct {
+	cfg CatalogerConfig
+}
+
+func newGenericNpmShrinkwrapAdapter(cfg CatalogerConfig) genericNpmShrinkwrapAdapter {
+	return genericNpmShrinkwrapAdapter{
+		cfg: cfg,
+	}
+}
+
+// parseNpmShrinkwrap parses an npm-shrinkwrap.json and returns the discovered JavaScript packages.
+// npm-shrinkwrap.json is structurally identical to package-lock.json; it is used by npm to lock
+// dependency trees for installed tools and is published with the package (unlike package-lock.json).
+func (a genericNpmShrinkwrapAdapter) parseNpmShrinkwrap(ctx context.Context, resolver file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+	// in the case we find npm-shrinkwrap.json files in the node_modules directories, skip those
+	// as the whole purpose of the lock file is for the specific dependencies of the root project
+	if pathContainsNodeModulesDirectory(reader.Path()) {
+		return nil, nil, nil
+	}
+
+	var pkgs []pkg.Package
+	dec := json.NewDecoder(reader)
+
+	var lock packageLock
+	for {
+		if err := dec.Decode(&lock); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse npm-shrinkwrap.json file: %w", err)
+		}
+	}
+
+	if lock.LockfileVersion == 1 {
+		for name, pkgMeta := range lock.Dependencies {
+			// skip packages that are only present as a dev dependency
+			if !a.cfg.IncludeDevDependencies && pkgMeta.Dev {
+				continue
+			}
+
+			pkgs = append(pkgs, newShrinkwrapV1Package(ctx, a.cfg, resolver, reader.Location, name, pkgMeta))
+		}
+	}
+
+	if lock.LockfileVersion == 2 || lock.LockfileVersion == 3 {
+		for name, pkgMeta := range lock.Packages {
+			if name == "" {
+				if pkgMeta.Name == "" {
+					continue
+				}
+				name = pkgMeta.Name
+			}
+
+			// skip packages that are only present as a dev dependency
+			if !a.cfg.IncludeDevDependencies && pkgMeta.Dev {
+				continue
+			}
+
+			// handles alias names
+			if pkgMeta.Name != "" {
+				name = pkgMeta.Name
+			}
+
+			newPkg := newShrinkwrapV2Package(ctx, a.cfg, resolver, reader.Location, getNameFromPath(name), pkgMeta)
+			pkgs = append(pkgs, newPkg)
+		}
+	}
+
+	pkg.Sort(pkgs)
+
+	return pkgs, dependency.Resolve(npmShrinkwrapDependencySpecifier, pkgs), unknown.IfEmptyf(pkgs, "unable to determine packages")
+}
+
+func newShrinkwrapV1Package(ctx context.Context, cfg CatalogerConfig, resolver file.Resolver, location file.Location, name string, u lockDependency) pkg.Package {
+	version := u.Version
+
+	const aliasPrefixShrinkwrapV1 = "npm:"
+
+	// Handles type aliases https://github.com/npm/rfcs/blob/main/implemented/0001-package-aliases.md
+	if strings.HasPrefix(version, aliasPrefixShrinkwrapV1) {
+		// this is an alias.
+		// `"version": "npm:canonical-name@X.Y.Z"`
+		canonicalPackageAndVersion := version[len(aliasPrefixShrinkwrapV1):]
+		versionSeparator := strings.LastIndex(canonicalPackageAndVersion, "@")
+
+		name = canonicalPackageAndVersion[:versionSeparator]
+		version = canonicalPackageAndVersion[versionSeparator+1:]
+	}
+
+	var licenseSet pkg.LicenseSet
+
+	if cfg.SearchRemoteLicenses {
+		license, err := getLicenseFromNpmRegistry(cfg.NPMBaseURL, name, version)
+		if err == nil && license != "" {
+			licenseSet = pkg.NewLicenseSet(pkg.NewLicensesFromValuesWithContext(ctx, license)...)
+		}
+		if err != nil {
+			log.Debugf("unable to extract licenses from javascript npm-shrinkwrap.json for package %s:%s: %+v", name, version, err)
+		}
+	}
+
+	return finalizeLockPkg(
+		ctx,
+		resolver,
+		location,
+		pkg.Package{
+			Name:      name,
+			Version:   version,
+			Licenses:  licenseSet,
+			Locations: file.NewLocationSet(location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+			PURL:      packageURL(name, version),
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata:  pkg.NpmShrinkwrapEntry{Resolved: u.Resolved, Integrity: u.Integrity},
+		},
+	)
+}
+
+func newShrinkwrapV2Package(ctx context.Context, cfg CatalogerConfig, resolver file.Resolver, location file.Location, name string, u lockPackage) pkg.Package {
+	var licenseSet pkg.LicenseSet
+
+	if u.License != nil {
+		licenseSet = pkg.NewLicenseSet(pkg.NewLicensesFromLocationWithContext(ctx, location, u.License...)...)
+	} else if cfg.SearchRemoteLicenses {
+		license, err := getLicenseFromNpmRegistry(cfg.NPMBaseURL, name, u.Version)
+		if err == nil && license != "" {
+			licenseSet = pkg.NewLicenseSet(pkg.NewLicensesFromValuesWithContext(ctx, license)...)
+		}
+		if err != nil {
+			log.Debugf("unable to extract licenses from javascript npm-shrinkwrap.json for package %s:%s: %+v", name, u.Version, err)
+		}
+	}
+
+	return finalizeLockPkg(
+		ctx,
+		resolver,
+		location,
+		pkg.Package{
+			Name:      name,
+			Version:   u.Version,
+			Locations: file.NewLocationSet(location.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
+			Licenses:  licenseSet,
+			PURL:      packageURL(name, u.Version),
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata:  pkg.NpmShrinkwrapEntry{Resolved: u.Resolved, Integrity: u.Integrity, Dependencies: u.Dependencies},
+		},
+	)
+}
+
+

--- a/syft/pkg/cataloger/javascript/parse_npm_shrinkwrap_test.go
+++ b/syft/pkg/cataloger/javascript/parse_npm_shrinkwrap_test.go
@@ -1,0 +1,281 @@
+package javascript
+
+import (
+	"context"
+	"testing"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
+)
+
+func TestParseNpmShrinkwrap(t *testing.T) {
+	var expectedRelationships []artifact.Relationship
+	expectedPkgs := []pkg.Package{
+		{
+			Name:     "@actions/core",
+			Version:  "1.6.0",
+			PURL:     "pkg:npm/%40actions/core@1.6.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz", Integrity: "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw=="},
+		},
+		{
+			Name:     "ansi-regex",
+			Version:  "3.0.0",
+			PURL:     "pkg:npm/ansi-regex@3.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz", Integrity: "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="},
+		},
+		{
+			Name:     "cowsay",
+			Version:  "1.4.0",
+			PURL:     "pkg:npm/cowsay@1.4.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/cowsay/-/cowsay-1.4.0.tgz", Integrity: "sha512-rdg5k5PsHFVJheO/pmE3aDg2rUDDTfPJau6yYkZYlHFktUz+UxbE+IgnUAEyyCyv4noL5ltxXD0gZzmHPCy/9g=="},
+		},
+		{
+			Name:     "get-stdin",
+			Version:  "5.0.1",
+			PURL:     "pkg:npm/get-stdin@5.0.1",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz", Integrity: "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="},
+		},
+		{
+			Name:     "is-fullwidth-code-point",
+			Version:  "2.0.0",
+			PURL:     "pkg:npm/is-fullwidth-code-point@2.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz", Integrity: "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="},
+		},
+		{
+			Name:     "minimist",
+			Version:  "0.0.10",
+			PURL:     "pkg:npm/minimist@0.0.10",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz", Integrity: "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="},
+		},
+		{
+			Name:     "optimist",
+			Version:  "0.6.1",
+			PURL:     "pkg:npm/optimist@0.6.1",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz", Integrity: "sha1-2j6nRob6IaGaERwybpDrFaAZZoY="},
+		},
+		{
+			Name:     "string-width",
+			Version:  "2.1.1",
+			PURL:     "pkg:npm/string-width@2.1.1",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz", Integrity: "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw=="},
+		},
+		{
+			Name:     "strip-ansi",
+			Version:  "4.0.0",
+			PURL:     "pkg:npm/strip-ansi@4.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz", Integrity: "sha1-qEeQIusaw2iocTibY1JixQXuNo8="},
+		},
+		{
+			Name:     "strip-eof",
+			Version:  "1.0.0",
+			PURL:     "pkg:npm/strip-eof@1.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz", Integrity: "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="},
+		},
+		{
+			Name:     "wordwrap",
+			Version:  "0.0.3",
+			PURL:     "pkg:npm/wordwrap@0.0.3",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz", Integrity: "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="},
+		},
+	}
+	fixture := "testdata/npm-shrinkwrap/npm-shrinkwrap.json"
+	for i := range expectedPkgs {
+		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
+	}
+
+	adapter := newGenericNpmShrinkwrapAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parseNpmShrinkwrap, expectedPkgs, expectedRelationships)
+}
+
+func TestParseNpmShrinkwrapV2(t *testing.T) {
+	ctx := context.TODO()
+	fixture := "testdata/npm-shrinkwrap/npm-shrinkwrap-v2.json"
+	var expectedRelationships []artifact.Relationship
+	expectedPkgs := []pkg.Package{
+		{
+			Name:     "npm",
+			Version:  "6.14.6",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/npm@6.14.6",
+			Metadata: pkg.NpmShrinkwrapEntry{Dependencies: map[string]string{"@types/react": "^18.0.9"}},
+		},
+		{
+			Name:     "@types/prop-types",
+			Version:  "15.7.5",
+			PURL:     "pkg:npm/%40types/prop-types@15.7.5",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicenseFromLocationsWithContext(ctx, "MIT", file.NewLocation(fixture)),
+			),
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz", Integrity: "sha1-XxnSuFqY6VWANvajysyIGUIPBc8="},
+		},
+		{
+			Name:     "@types/react",
+			Version:  "18.0.17",
+			PURL:     "pkg:npm/%40types/react@18.0.17",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicenseFromLocationsWithContext(ctx, "MIT", file.NewLocation(fixture)),
+			),
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz", Integrity: "sha1-RYPZwyLWfv5LOak10iPtzHBQzPQ=", Dependencies: map[string]string{"@types/prop-types": "*", "@types/scheduler": "*", "csstype": "^3.0.2"}},
+		},
+		{
+			Name:     "@types/scheduler",
+			Version:  "0.16.2",
+			PURL:     "pkg:npm/%40types/scheduler@0.16.2",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicenseFromLocationsWithContext(ctx, "MIT", file.NewLocation(fixture)),
+			),
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz", Integrity: "sha1-GmL4lSVyPd4kuhsBsJK/XfitTTk="},
+		},
+		{
+			Name:     "csstype",
+			Version:  "3.1.0",
+			PURL:     "pkg:npm/csstype@3.1.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			Licenses: pkg.NewLicenseSet(
+				pkg.NewLicenseFromLocationsWithContext(ctx, "MIT", file.NewLocation(fixture)),
+			),
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz", Integrity: "sha1-TdysNxjXh8+d8NG30VAzklyPKfI="},
+		},
+	}
+	for i := range expectedPkgs {
+		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
+	}
+	expectedRelationships = []artifact.Relationship{
+		{
+			From: expectedPkgs[1],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[3],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[4],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[2],
+			To:   expectedPkgs[0],
+			Type: artifact.DependencyOfRelationship,
+		},
+	}
+	adapter := newGenericNpmShrinkwrapAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parseNpmShrinkwrap, expectedPkgs, expectedRelationships)
+}
+
+func TestParseNpmShrinkwrapV3(t *testing.T) {
+	fixture := "testdata/npm-shrinkwrap/npm-shrinkwrap-v3.json"
+	var expectedRelationships []artifact.Relationship
+	expectedPkgs := []pkg.Package{
+		{
+			Name:     "lock-v3-fixture",
+			Version:  "1.0.0",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/lock-v3-fixture@1.0.0",
+			Metadata: pkg.NpmShrinkwrapEntry{Dependencies: map[string]string{"@types/react": "^18.0.9"}},
+		},
+		{
+			Name:     "@types/prop-types",
+			Version:  "15.7.5",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/prop-types@15.7.5",
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz", Integrity: "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="},
+		},
+		{
+			Name:     "@types/react",
+			Version:  "18.0.20",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/react@18.0.20",
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/react/-/react-18.0.20.tgz", Integrity: "sha512-MWul1teSPxujEHVwZl4a5HxQ9vVNsjTchVA+xRqv/VYGCuKGAU6UhfrTdF5aBefwD1BHUD8i/zq+O/vyCm/FrA==", Dependencies: map[string]string{"@types/prop-types": "*", "@types/scheduler": "*", "csstype": "^3.0.2"}},
+		},
+		{
+			Name:     "@types/scheduler",
+			Version:  "0.16.2",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/%40types/scheduler@0.16.2",
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz", Integrity: "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="},
+		},
+		{
+			Name:     "csstype",
+			Version:  "3.1.1",
+			Language: pkg.JavaScript,
+			Type:     pkg.NpmPkg,
+			PURL:     "pkg:npm/csstype@3.1.1",
+			Metadata: pkg.NpmShrinkwrapEntry{Resolved: "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz", Integrity: "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="},
+		},
+	}
+	for i := range expectedPkgs {
+		expectedPkgs[i].Locations.Add(file.NewLocation(fixture))
+	}
+	expectedRelationships = []artifact.Relationship{
+		{
+			From: expectedPkgs[1],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[3],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[4],
+			To:   expectedPkgs[2],
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: expectedPkgs[2],
+			To:   expectedPkgs[0],
+			Type: artifact.DependencyOfRelationship,
+		},
+	}
+	adapter := newGenericNpmShrinkwrapAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parseNpmShrinkwrap, expectedPkgs, expectedRelationships)
+}
+
+func Test_corruptNpmShrinkwrap(t *testing.T) {
+	gap := newGenericNpmShrinkwrapAdapter(DefaultCatalogerConfig())
+	pkgtest.NewCatalogTester().
+		FromFile(t, "testdata/corrupt/npm-shrinkwrap.json").
+		WithError().
+		TestParser(t, gap.parseNpmShrinkwrap)
+}

--- a/syft/pkg/cataloger/javascript/testdata/corrupt/npm-shrinkwrap.json
+++ b/syft/pkg/cataloger/javascript/testdata/corrupt/npm-shrinkwrap.json
@@ -1,0 +1,4 @@
+{
+  "requires": true,
+  "lockfi
+}

--- a/syft/pkg/cataloger/javascript/testdata/glob-paths/src/npm-shrinkwrap.json
+++ b/syft/pkg/cataloger/javascript/testdata/glob-paths/src/npm-shrinkwrap.json
@@ -1,0 +1,1 @@
+bogus npm-shrinkwrap.json

--- a/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap-v2.json
+++ b/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap-v2.json
@@ -1,0 +1,86 @@
+{
+    "name": "npm",
+    "version": "6.14.6",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "npm",
+            "version": "6.14.6",
+            "dependencies": {
+                "@types/react": "^18.0.9"
+            },
+            "devDependencies": {
+                "async": "^3.2.4"
+            }
+        },
+        "node_modules/@types/prop-types": {
+            "version": "15.7.5",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+            "integrity": "sha1-XxnSuFqY6VWANvajysyIGUIPBc8=",
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "18.0.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+            "integrity": "sha1-RYPZwyLWfv5LOak10iPtzHBQzPQ=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+            "integrity": "sha1-GmL4lSVyPd4kuhsBsJK/XfitTTk=",
+            "license": "MIT"
+        },
+        "node_modules/csstype": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+            "integrity": "sha1-TdysNxjXh8+d8NG30VAzklyPKfI=",
+            "license": "MIT"
+        },
+        "node_modules/async": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "dev": true
+        }
+    },
+    "dependencies": {
+        "@types/prop-types": {
+            "version": "15.7.5",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+            "integrity": "sha1-XxnSuFqY6VWANvajysyIGUIPBc8="
+        },
+        "@types/react": {
+            "version": "18.0.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+            "integrity": "sha1-RYPZwyLWfv5LOak10iPtzHBQzPQ=",
+            "requires": {
+                "@types/prop-types": "*",
+                "@types/scheduler": "*",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@types/scheduler": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+            "integrity": "sha1-GmL4lSVyPd4kuhsBsJK/XfitTTk="
+        },
+        "csstype": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+            "integrity": "sha1-TdysNxjXh8+d8NG30VAzklyPKfI="
+        },
+        "async": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+            "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+            "dev": true
+        }
+    }
+}

--- a/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap-v3.json
+++ b/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap-v3.json
@@ -1,0 +1,49 @@
+{
+  "name": "lock-v3-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lock-v3-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/react": "^18.0.9"
+      },
+      "devDependencies": {
+        "async": "^3.2.4"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.0.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.20.tgz",
+      "integrity": "sha512-MWul1teSPxujEHVwZl4a5HxQ9vVNsjTchVA+xRqv/VYGCuKGAU6UhfrTdF5aBefwD1BHUD8i/zq+O/vyCm/FrA==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    }
+  }
+}

--- a/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap.json
+++ b/syft/pkg/cataloger/javascript/testdata/npm-shrinkwrap/npm-shrinkwrap.json
@@ -1,0 +1,81 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "cowsay": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cowsay/-/cowsay-1.4.0.tgz",
+      "integrity": "sha512-rdg5k5PsHFVJheO/pmE3aDg2rUDDTfPJau6yYkZYlHFktUz+UxbE+IgnUAEyyCyv4noL5ltxXD0gZzmHPCy/9g==",
+      "requires": {
+        "get-stdin": "^5.0.1",
+        "optimist": "~0.6.1",
+        "string-width": "~2.1.1",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g="
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    }
+  }
+}

--- a/syft/pkg/npm.go
+++ b/syft/pkg/npm.go
@@ -36,6 +36,21 @@ type NpmPackageLockEntry struct {
 	Dependencies map[string]string `mapstructure:"dependencies" json:"dependencies"`
 }
 
+// NpmShrinkwrapEntry represents a single entry within the "packages" section of an npm-shrinkwrap.json file.
+// npm-shrinkwrap.json is structurally identical to package-lock.json; the only difference is that
+// npm-shrinkwrap.json is committed to source control and published with the package, allowing it to
+// lock dependency trees for installed tools. package-lock.json is not published by default.
+type NpmShrinkwrapEntry struct {
+	// Resolved is URL where this package was downloaded from (registry source)
+	Resolved string `mapstructure:"resolved" json:"resolved"`
+
+	// Integrity is Subresource Integrity hash for verification using standard SRI format (sha512-... or sha1-...). npm changed from SHA-1 to SHA-512 in newer versions. For registry sources this is the integrity from registry, for remote tarballs it's SHA-512 of the file. npm verifies tarball matches this hash before unpacking, throwing EINTEGRITY error if mismatch detected.
+	Integrity string `mapstructure:"integrity" json:"integrity"`
+
+	// Dependencies is a map of dependencies and their version markers, i.e. "lodash": "^1.0.0"
+	Dependencies map[string]string `mapstructure:"dependencies" json:"dependencies"`
+}
+
 // YarnLockEntry represents a single entry section of a yarn.lock file.
 type YarnLockEntry struct {
 	// Resolved is URL where this package was downloaded from


### PR DESCRIPTION
## Description

Add support for `npm-shrinkwrap.json` files.
https://docs.npmjs.com/cli/v11/configuring-npm/package-lock-json#package-lockjson-vs-npm-shrinkwrapjson

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

Have not been able to get `make test` pass even on `main` branch...