### PR TITLE
feat: add .bpl extension to PE cataloger

### DIFF
--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -161,7 +161,7 @@ func DefaultPackageTaskFactories() Factories {
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary",
 		),
 		newSimplePackageTaskFactory(binary.NewELFPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "elf-package", "elf"),
-		newSimplePackageTaskFactory(binary.NewPEPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "pe-package", "pe", "dll", "exe"),
+		newSimplePackageTaskFactory(binary.NewPEPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "pe-package", "pe", "dll", "exe", "bpl"),
 		newSimplePackageTaskFactory(githubactions.NewActionUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
 		newSimplePackageTaskFactory(githubactions.NewWorkflowUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
 		newSimplePackageTaskFactory(java.NewJvmDistributionCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "java", "jvm", "jdk", "jre"),

--- a/syft/pkg/cataloger/binary/capabilities.yaml
+++ b/syft/pkg/cataloger/binary/capabilities.yaml
@@ -957,6 +957,7 @@ catalogers:
       function: NewPEPackageCataloger
     selectors: # AUTO-GENERATED
       - binary
+      - bpl
       - declared
       - directory
       - dll
@@ -971,6 +972,7 @@ catalogers:
         detector: # AUTO-GENERATED
           method: glob # AUTO-GENERATED
           criteria: # AUTO-GENERATED
+            - '**/*.bpl'
             - '**/*.dll'
             - '**/*.exe'
         metadata_types: # AUTO-GENERATED

--- a/syft/pkg/cataloger/binary/capabilities.yaml
+++ b/syft/pkg/cataloger/binary/capabilities.yaml
@@ -972,9 +972,9 @@ catalogers:
         detector: # AUTO-GENERATED
           method: glob # AUTO-GENERATED
           criteria: # AUTO-GENERATED
-            - '**/*.bpl'
             - '**/*.dll'
             - '**/*.exe'
+            - '**/*.bpl'
         metadata_types: # AUTO-GENERATED
           - pkg.PEBinary
         package_types: # AUTO-GENERATED

--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -12,10 +12,11 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/internal/pe"
 )
 
-// NewPEPackageCataloger returns a cataloger that interprets packages from DLL and EXE files.
+// NewPEPackageCataloger returns a cataloger that interprets packages from DLL, EXE, and BPL files.
+// BPL (Borland Package Library) files are PE-format binaries used by Delphi and C++Builder.
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe")
+		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {

--- a/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
@@ -62,3 +62,30 @@ func Test_PEPackageCataloger(t *testing.T) {
 	}
 
 }
+
+func Test_PEPackageCataloger_Globs(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		expected []string
+	}{
+		{
+			name:    "obtain PE binary files (dll, exe, bpl)",
+			fixture: "testdata/glob-paths",
+			expected: []string{
+				"src/library.dll",
+				"src/program.exe",
+				"src/archive.bpl",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pkgtest.NewCatalogTester().
+				FromDirectory(t, test.fixture).
+				ExpectsResolverContentQueries(test.expected).
+				TestCataloger(t, NewPEPackageCataloger())
+		})
+	}
+}

--- a/syft/pkg/cataloger/binary/testdata/.gitignore
+++ b/syft/pkg/cataloger/binary/testdata/.gitignore
@@ -9,3 +9,4 @@ classifiers/bin
 !VERSION*
 !classifiers/snippets/**/bin/
 !*.exe
+!*.dll

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/archive.bpl
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/archive.bpl
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/library.dll
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/library.dll
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/notes.txt
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/notes.txt
@@ -1,0 +1,1 @@
+not a binary

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/program.exe
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/program.exe
@@ -1,0 +1,1 @@
+bogus PE contents


### PR DESCRIPTION
Adds `**/*.bpl` to the PE binary package cataloger globs so Borland Package Library files are picked up during scans.

BPL files are standard PE/DLL format used by Delphi and C++Builder. Confirmed by the issue reporter: renaming `.bpl` → `.dll` already works with the existing cataloger.

Closes #4664