### PR TITLE
fix: local version identifiers in python requirements parsing

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -29,8 +29,8 @@ const (
 	// namePattern matches: requests[security]
 	namePattern = `(?P<name>\w[\w\[\],\s-_\.]+)`
 
-	// versionConstraintPattern matches: == 2.8.*
-	versionConstraintPattern = `(?P<versionConstraint>([^\S\r\n]*[~=>!<]+\s*[0-9a-zA-Z.*]+[^\S\r\n]*,?)+)?(@[^\S\r\n]*(?P<url>[^;]*))?`
+	// versionConstraintPattern matches: == 2.8.* (including local version identifiers, e.g. == 1.2.3+gcr.2)
+	versionConstraintPattern = `(?P<versionConstraint>([^\S\r\n]*[~=>!<]+\s*[0-9a-zA-Z.*+]+[^\S\r\n]*,?)+)?(@[^\S\r\n]*(?P<url>[^;]*))?`
 
 	// markersPattern matches: python_version < "2.7" and sys_platform == "linux"
 	markersPattern = `(;(?P<markers>.*))?`

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -140,6 +140,18 @@ func TestParseRequirementsTxt(t *testing.T) {
 				VersionConstraint: "== 1.0.0",
 			},
 		},
+		{
+			Name:      "local-version",
+			Version:   "1.2.3+gcr.2",
+			PURL:      "pkg:pypi/local-version@1.2.3%2Bgcr.2",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "local-version",
+				VersionConstraint: "== 1.2.3+gcr.2",
+			},
+		},
 	}
 
 	var testCases = []struct {
@@ -357,6 +369,23 @@ func Test_newRequirement(t *testing.T) {
 				Markers:           "sys_platform == 'win32'",
 			},
 		},
+		{
+			name: "local version identifier",
+			raw:  "local-version == 1.2.3+gcr.2",
+			want: &unprocessedRequirement{
+				Name:              "local-version",
+				VersionConstraint: "== 1.2.3+gcr.2",
+			},
+		},
+		{
+			name: "local version identifier with markers",
+			raw:  "local-version == 1.2.3+ubuntu1 ; sys_platform == 'linux'",
+			want: &unprocessedRequirement{
+				Name:              "local-version",
+				VersionConstraint: "== 1.2.3+ubuntu1",
+				Markers:           "sys_platform == 'linux'",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -387,6 +416,16 @@ func Test_parseVersion(t *testing.T) {
 			name:    "arbitrary equality constraint",
 			version: " === 1.26.20 ",
 			want:    "1.26.20",
+		},
+		{
+			name:    "local version identifier",
+			version: " == 1.2.3+gcr.2 ",
+			want:    "1.2.3+gcr.2",
+		},
+		{
+			name:    "arbitrary equality with local version identifier",
+			version: " === 1.2.3+ubuntu1 ",
+			want:    "1.2.3+ubuntu1",
 		},
 		{
 			name:    "resolve lowest, simple constraint",

--- a/syft/pkg/cataloger/python/testdata/requires/requirements.txt
+++ b/syft/pkg/cataloger/python/testdata/requires/requirements.txt
@@ -25,3 +25,4 @@ celery[redis, pytest] == 4.4.7 # should remove [redis, pytest]
 requests[security] == 2.8.* ; python_version < "2.7" and sys_platform == "linux"
 GithubSampleProject == 3.7.1 @ git+https://github.com/owner/repo@releases/tag/v3.7.1
 FrIeNdLy-_-bArD == 1.0.0
+local-version == 1.2.3+gcr.2


### PR DESCRIPTION
## Description

This PR adds support for [_local version segments_](https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-segments) in Python requirements.txt, such as `1.2.3+ubuntu.1`.

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes: #4958