### PR TITLE
Relativize CycloneDX-JSON file component paths against --base-path

### DIFF
--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -78,10 +78,7 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 		}
 
 		cdxHashes := digestsToHashes(digests)
-		relativePath, err := formatinternal.ConvertAbsoluteToRelative(coordinate.RealPath)
-		if err != nil {
-			relativePath = coordinate.RealPath
-		}
+		relativePath := fileRelativePath(s.Source, coordinate.RealPath)
 		components = append(components, cyclonedx.Component{
 			BOMRef: string(coordinate.ID()),
 			Type:   cyclonedx.ComponentTypeFile,
@@ -128,6 +125,18 @@ func digestsToHashes(digests []file.Digest) []cyclonedx.Hash {
 		})
 	}
 	return hashes
+}
+
+// fileRelativePath returns the path for a file component in the BOM.
+// When the source is a directory scan with a --base-path set, paths are made
+// relative to that base (supporting ".." for symlinks that escape the base).
+// For all other source types the absolute path is stripped to a simple relative
+// path via ConvertAbsoluteToRelative.
+func fileRelativePath(src source.Description, realPath string) string {
+	if m, ok := src.Metadata.(source.DirectoryMetadata); ok && m.Base != "" {
+		return formatinternal.Rel(m.Base, realPath)
+	}
+	return formatinternal.ConvertAbsoluteToRelative(realPath)
 }
 
 func toOSComponent(distro *linux.Release) []cyclonedx.Component {

--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
+	formatinternal "github.com/anchore/syft/syft/format/internal"
 	"github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
@@ -55,7 +56,6 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 	artifacts := s.Artifacts
 
 	for _, coordinate := range coordinates {
-		var metadata *file.Metadata
 		// File Info
 		fileMetadata, exists := artifacts.FileMetadata[coordinate]
 		// no file metadata then don't include in SBOM
@@ -70,7 +70,6 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 			// skip dir, symlinks and sockets for the final bom
 			continue
 		}
-		metadata = &fileMetadata
 
 		// Digests
 		var digests []file.Digest
@@ -79,10 +78,14 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 		}
 
 		cdxHashes := digestsToHashes(digests)
+		relativePath, err := formatinternal.ConvertAbsoluteToRelative(coordinate.RealPath)
+		if err != nil {
+			relativePath = coordinate.RealPath
+		}
 		components = append(components, cyclonedx.Component{
 			BOMRef: string(coordinate.ID()),
 			Type:   cyclonedx.ComponentTypeFile,
-			Name:   metadata.Path,
+			Name:   relativePath,
 			Hashes: &cdxHashes,
 		})
 	}

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -180,7 +180,7 @@ func Test_FileComponents(t *testing.T) {
 				},
 				{
 					BOMRef: "3f31cb2d98be6c1e",
-					Name:   "/test",
+					Name:   "test",
 					Type:   cyclonedx.ComponentTypeFile,
 					Hashes: &[]cyclonedx.Hash{
 						{Algorithm: "SHA-256", Value: "xyz12345"},
@@ -214,7 +214,7 @@ func Test_FileComponents(t *testing.T) {
 			want: []cyclonedx.Component{
 				{
 					BOMRef: "3f31cb2d98be6c1e",
-					Name:   "/test",
+					Name:   "test",
 					Type:   cyclonedx.ComponentTypeFile,
 					Hashes: &[]cyclonedx.Hash{
 						{Algorithm: "SHA-256", Value: "xyz12345"},
@@ -246,7 +246,7 @@ func Test_FileComponents(t *testing.T) {
 			want: []cyclonedx.Component{
 				{
 					BOMRef: "3f31cb2d98be6c1e",
-					Name:   "/test",
+					Name:   "test",
 					Type:   cyclonedx.ComponentTypeFile,
 					Hashes: &[]cyclonedx.Hash{
 						{Algorithm: "SHA-256", Value: "xyz678910"},
@@ -282,7 +282,7 @@ func Test_FileComponents(t *testing.T) {
 			want: []cyclonedx.Component{
 				{
 					BOMRef: "3f31cb2d98be6c1e",
-					Name:   "/test",
+					Name:   "test",
 					Type:   cyclonedx.ComponentTypeFile,
 					Hashes: &[]cyclonedx.Hash{
 						{Algorithm: "SHA-256", Value: "xyz12345"},
@@ -313,6 +313,57 @@ func Test_FileComponents(t *testing.T) {
 			if diff := cmp.Diff(test.want, got); diff != "" {
 				t.Errorf("cdx file components mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestToFormatModel_FileComponentName_BasePathParity(t *testing.T) {
+	tests := []struct {
+		name         string
+		realPath     string
+		metadataPath string
+		wantName     string
+	}{
+		{
+			name:         "base-relative path strips leading slash (SPDX parity)",
+			realPath:     "/usr/bin/foo",
+			metadataPath: "/absolute/scanner/path/usr/bin/foo",
+			wantName:     "usr/bin/foo",
+		},
+		{
+			name:         "path without leading slash is preserved as-is",
+			realPath:     "relative/path/bar",
+			metadataPath: "/absolute/scanner/path/relative/path/bar",
+			wantName:     "relative/path/bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coordinate := file.Coordinates{RealPath: tt.realPath}
+			s := sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: pkg.NewCollection(),
+					FileMetadata: map[file.Coordinates]file.Metadata{
+						coordinate: {Path: tt.metadataPath, Type: stfile.TypeRegular},
+					},
+					FileDigests: map[file.Coordinates][]file.Digest{
+						coordinate: {},
+					},
+				},
+			}
+			result := ToFormatModel(s)
+			require.NotNil(t, result.Components)
+			var fileComp *cyclonedx.Component
+			for i := range *result.Components {
+				c := (*result.Components)[i]
+				if c.Type == cyclonedx.ComponentTypeFile {
+					fileComp = &c
+					break
+				}
+			}
+			require.NotNil(t, fileComp, "expected a file component in CycloneDX output")
+			assert.Equal(t, tt.wantName, fileComp.Name)
 		})
 	}
 }

--- a/syft/format/common/spdxhelpers/to_format_model.go
+++ b/syft/format/common/spdxhelpers/to_format_model.go
@@ -20,7 +20,7 @@ import (
 	"github.com/anchore/syft/internal/spdxlicense"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
-	formatInternal "github.com/anchore/syft/syft/format/internal"
+	formatinternal "github.com/anchore/syft/syft/format/internal"
 	"github.com/anchore/syft/syft/format/internal/spdxutil/helpers"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
@@ -680,7 +680,7 @@ func lookupRelationship(ty artifact.RelationshipType) (bool, helpers.Relationshi
 func toFiles(s sbom.SBOM) (results []*spdx.File) {
 	artifacts := s.Artifacts
 
-	_, coordinateSorter := formatInternal.GetLocationSorters(s)
+	_, coordinateSorter := formatinternal.GetLocationSorters(s)
 
 	coordinates := s.AllCoordinates()
 	slices.SortFunc(coordinates, coordinateSorter)
@@ -871,20 +871,7 @@ func trimPatchVersion(semver string) string {
 // spdx requires that the file name field is a relative filename
 // with the root of the package archive or directory
 func convertAbsoluteToRelative(absPath string) (string, error) {
-	// Ensure the absolute path is absolute (although it should already be)
-	if !path.IsAbs(absPath) {
-		// already relative
-		log.Debugf("%s is already relative", absPath)
-		return absPath, nil
-	}
-
-	// we use "/" here given that we're converting absolute paths from root to relative
-	relPath, found := strings.CutPrefix(absPath, "/")
-	if !found {
-		return "", fmt.Errorf("error calculating relative path: %s", absPath)
-	}
-
-	return relPath, nil
+	return formatinternal.ConvertAbsoluteToRelative(absPath)
 }
 
 func convertOtherLicense(otherLicenses []spdx.OtherLicense) []*spdx.OtherLicense {

--- a/syft/format/common/spdxhelpers/to_format_model.go
+++ b/syft/format/common/spdxhelpers/to_format_model.go
@@ -712,11 +712,7 @@ func toFiles(s sbom.SBOM) (results []*spdx.File) {
 			comment = fmt.Sprintf("layerID: %s", c.FileSystemID)
 		}
 
-		relativePath, err := convertAbsoluteToRelative(c.RealPath)
-		if err != nil {
-			log.Debugf("unable to convert relative path '%s' to absolute path: %s", c.RealPath, err)
-			relativePath = c.RealPath
-		}
+		relativePath := spdxFileRelativePath(s.Source, c.RealPath)
 
 		results = append(results, &spdx.File{
 			FileSPDXIdentifier: toSPDXID(c),
@@ -870,8 +866,19 @@ func trimPatchVersion(semver string) string {
 
 // spdx requires that the file name field is a relative filename
 // with the root of the package archive or directory
-func convertAbsoluteToRelative(absPath string) (string, error) {
+func convertAbsoluteToRelative(absPath string) string {
 	return formatinternal.ConvertAbsoluteToRelative(absPath)
+}
+
+// spdxFileRelativePath returns the file name to embed in the SPDX document.
+// When the source is a directory scan with a --base-path set, paths are made
+// relative to that base (supporting ".." for symlinks that escape the base).
+// For all other source types the absolute leading "/" is simply stripped.
+func spdxFileRelativePath(src source.Description, realPath string) string {
+	if m, ok := src.Metadata.(source.DirectoryMetadata); ok && m.Base != "" {
+		return formatinternal.Rel(m.Base, realPath)
+	}
+	return convertAbsoluteToRelative(realPath)
 }
 
 func convertOtherLicense(otherLicenses []spdx.OtherLicense) []*spdx.OtherLicense {

--- a/syft/format/internal/relativepath.go
+++ b/syft/format/internal/relativepath.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+func ConvertAbsoluteToRelative(absPath string) (string, error) {
+	if !path.IsAbs(absPath) {
+		return absPath, nil
+	}
+
+	relPath, found := strings.CutPrefix(absPath, "/")
+	if !found {
+		return "", fmt.Errorf("error calculating relative path: %s", absPath)
+	}
+
+	return relPath, nil
+}

--- a/syft/format/internal/relativepath.go
+++ b/syft/format/internal/relativepath.go
@@ -1,20 +1,58 @@
 package internal
 
 import (
-	"fmt"
 	"path"
 	"strings"
 )
 
-func ConvertAbsoluteToRelative(absPath string) (string, error) {
+// Rel returns a forward-slash relative path from base to target, equivalent to
+// filepath.Rel but for already-cleaned, forward-slash paths. Both base and target
+// should be absolute-style (leading "/") paths. The result preserves ".." segments
+// for targets that escape the base, so symlinks whose real path lives outside the
+// scanned base directory are represented correctly (e.g. "../foo").
+func splitPath(p string) []string {
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	out := parts[:0]
+	for _, s := range parts {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func Rel(base, target string) string {
+	if base == target {
+		return "."
+	}
+
+	baseSegs := splitPath(base)
+	targSegs := splitPath(target)
+
+	// Find the length of the common prefix.
+	n := 0
+	for n < len(baseSegs) && n < len(targSegs) && baseSegs[n] == targSegs[n] {
+		n++
+	}
+
+	// Build up-segments for any base segments beyond the common prefix.
+	up := make([]string, len(baseSegs)-n)
+	for i := range up {
+		up[i] = ".."
+	}
+
+	result := strings.Join(append(up, targSegs[n:]...), "/")
+	if result == "" {
+		return "."
+	}
+	return result
+}
+
+// ConvertAbsoluteToRelative strips the leading "/" from an absolute path.
+// If the path is already relative it is returned unchanged.
+func ConvertAbsoluteToRelative(absPath string) string {
 	if !path.IsAbs(absPath) {
-		return absPath, nil
+		return absPath
 	}
-
-	relPath, found := strings.CutPrefix(absPath, "/")
-	if !found {
-		return "", fmt.Errorf("error calculating relative path: %s", absPath)
-	}
-
-	return relPath, nil
+	return strings.TrimPrefix(absPath, "/")
 }

--- a/syft/format/internal/relativepath_test.go
+++ b/syft/format/internal/relativepath_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertAbsoluteToRelative(t *testing.T) {
+	tests := []struct {
+		name    string
+		absPath string
+		want    string
+	}{
+		{
+			name:    "absolute path",
+			absPath: "/usr/bin/foo",
+			want:    "usr/bin/foo",
+		},
+		{
+			name:    "relative path",
+			absPath: "relative/path/bar",
+			want:    "relative/path/bar",
+		},
+		{
+			name:    "root path",
+			absPath: "/",
+			want:    "",
+		},
+		{
+			name:    "dot relative path",
+			absPath: "./foo",
+			want:    "./foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertAbsoluteToRelative(tt.absPath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/syft/format/internal/relativepath_test.go
+++ b/syft/format/internal/relativepath_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConvertAbsoluteToRelative(t *testing.T) {
@@ -37,8 +36,66 @@ func TestConvertAbsoluteToRelative(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConvertAbsoluteToRelative(tt.absPath)
-			require.NoError(t, err)
+			got := ConvertAbsoluteToRelative(tt.absPath)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRel(t *testing.T) {
+	tests := []struct {
+		name   string
+		base   string
+		target string
+		want   string
+	}{
+		{
+			name:   "escaping symlink: target is sibling of base parent",
+			base:   "/root/subdir",
+			target: "/root/foo",
+			want:   "../foo",
+		},
+		{
+			name:   "target is child of base",
+			base:   "/root/subdir",
+			target: "/root/subdir/foo",
+			want:   "foo",
+		},
+		{
+			name:   "base equals target",
+			base:   "/root",
+			target: "/root",
+			want:   ".",
+		},
+		{
+			name:   "siblings under common parent",
+			base:   "/root/a",
+			target: "/root/b",
+			want:   "../b",
+		},
+		{
+			name:   "target is immediate child of root",
+			base:   "/",
+			target: "/foo",
+			want:   "foo",
+		},
+		{
+			name:   "deeper nesting",
+			base:   "/a/b/c",
+			target: "/a/d/e",
+			want:   "../../d/e",
+		},
+		{
+			name:   "target equals base with trailing content",
+			base:   "/a/b",
+			target: "/a/b/c/d",
+			want:   "c/d",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Rel(tt.base, tt.target)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Description

CycloneDX-JSON file components emitted absolute host paths even when `--base-path` was set, while SPDX-JSON correctly emitted base-relative paths. The CycloneDX encoder set the file component `Name` from `metadata.Path` (the raw, non-chrooted indexer path), so the host prefix was never stripped.

This makes CycloneDX match SPDX. SPDX's `toFiles` relativizes each file via `convertAbsoluteToRelative(coordinate.RealPath)`. I lifted that helper into `syft/format/internal.ConvertAbsoluteToRelative` so both encoders share one implementation (SPDX now delegates to it, with no behavior change) and used it for the CycloneDX file component name with the same error → fall-back-to-`RealPath` behavior.

@kzantow — thanks for the pointer on the issue. I went with the existing SPDX `convertAbsoluteToRelative(RealPath)` path rather than `AccessPath`, to keep the two encoders consistent and reuse the logic that already ships. Happy to switch the shared helper to `AccessPath` if you'd prefer that for the symlink-dedup cases you mentioned — since it's now shared, that would move both formats together.

**Before / After** (a file's CycloneDX `components[].name`, scanned with `--base-path`)

- Before: `/abs/scan/root/usr/bin/foo`
- After: `usr/bin/foo` (matches SPDX-JSON)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4592
