### PR TITLE
Add pkg.Architecture interface

### DIFF
--- a/syft/pkg/alpm.go
+++ b/syft/pkg/alpm.go
@@ -11,6 +11,11 @@ import (
 
 var _ FileOwner = (*AlpmDBEntry)(nil)
 
+var _ Architecture = (*AlpmDBEntry)(nil)
+
+// TargetArchitecture returns the pacman target architecture (e.g. "x86_64", "aarch64").
+func (m AlpmDBEntry) TargetArchitecture() string { return m.Architecture }
+
 const AlpmDBGlob = "**/var/lib/pacman/local/**/desc"
 
 // AlpmDBEntry is a struct that represents the package data stored in the pacman flat-file stores for arch linux.

--- a/syft/pkg/apk.go
+++ b/syft/pkg/apk.go
@@ -17,6 +17,11 @@ const ApkDBGlob = "**/lib/apk/db/installed"
 
 var _ FileOwner = (*ApkDBEntry)(nil)
 
+var _ Architecture = (*ApkDBEntry)(nil)
+
+// TargetArchitecture returns the Alpine target architecture (e.g. "x86_64", "aarch64").
+func (m ApkDBEntry) TargetArchitecture() string { return m.Architecture }
+
 // ApkDBEntry represents all captured data for the alpine linux package manager flat-file store.
 // See the following sources for more information:
 // - https://wiki.alpinelinux.org/wiki/Apk_spec

--- a/syft/pkg/architecture.go
+++ b/syft/pkg/architecture.go
@@ -1,0 +1,16 @@
+package pkg
+
+// Architecture is the interface that wraps the TargetArchitecture method.
+//
+// TargetArchitecture returns the target CPU architecture a piece of package Metadata records,
+// in its ecosystem's native spelling: rpm and apk use the GNU/kernel form ("x86_64",
+// "aarch64", "noarch"), while dpkg uses the Debian form ("amd64", "arm64", "all"). It lets
+// consumers read a package's architecture directly from metadata rather than parsing the
+// PURL "arch" qualifier.
+//
+// The method is named TargetArchitecture rather than Architecture (or Arch) because the dpkg
+// and apk metadata already expose an Architecture field, and rpm an Arch field; Go does not
+// permit a method to share a name with a field on the same type.
+type Architecture interface {
+	TargetArchitecture() string
+}

--- a/syft/pkg/architecture_test.go
+++ b/syft/pkg/architecture_test.go
@@ -1,0 +1,52 @@
+package pkg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchitecture_TargetArchitecture(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata any
+		want     string
+	}{
+		{name: "rpm db entry", metadata: RpmDBEntry{Arch: "x86_64"}, want: "x86_64"},
+		{name: "rpm archive", metadata: RpmArchive{Arch: "aarch64"}, want: "aarch64"},
+		{name: "rpm noarch passes through", metadata: RpmDBEntry{Arch: "noarch"}, want: "noarch"},
+		{name: "dpkg db entry", metadata: DpkgDBEntry{Architecture: "amd64"}, want: "amd64"},
+		{name: "dpkg archive entry", metadata: DpkgArchiveEntry{Architecture: "arm64"}, want: "arm64"},
+		{name: "apk db entry", metadata: ApkDBEntry{Architecture: "x86_64"}, want: "x86_64"},
+		{name: "alpm db entry", metadata: AlpmDBEntry{Architecture: "x86_64"}, want: "x86_64"},
+		{name: "bitnami sbom entry", metadata: BitnamiSBOMEntry{Architecture: "arm64"}, want: "arm64"},
+		{name: "golang binary buildinfo", metadata: GolangBinaryBuildinfoEntry{Architecture: "amd64"}, want: "amd64"},
+		{name: "golang source entry", metadata: GolangSourceEntry{Architecture: "arm64"}, want: "arm64"},
+		{name: "elf binary note", metadata: ELFBinaryPackageNoteJSONPayload{Architecture: "x86_64"}, want: "x86_64"},
+		{name: "linux kernel", metadata: LinuxKernel{Architecture: "aarch64"}, want: "aarch64"},
+		{name: "snap entry", metadata: SnapEntry{Architecture: "amd64"}, want: "amd64"},
+		{name: "conda meta package", metadata: CondaMetaPackage{Arch: "x86_64"}, want: "x86_64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, ok := tt.metadata.(Architecture)
+			require.True(t, ok, "%T must implement Architecture", tt.metadata)
+			assert.Equal(t, tt.want, a.TargetArchitecture())
+		})
+	}
+}
+
+// TestArchitecture_excludesNonCPUArchitecture locks in that metadata whose "architecture"
+// is not a CPU architecture does NOT implement the interface — most importantly GGUF, whose
+// Architecture field is the AI model architecture ("llama"), not a CPU arch.
+func TestArchitecture_excludesNonCPUArchitecture(t *testing.T) {
+	excluded := []any{
+		GGUFFileHeader{Architecture: "llama"},
+	}
+	for _, m := range excluded {
+		_, ok := m.(Architecture)
+		assert.Falsef(t, ok, "%T must NOT implement Architecture", m)
+	}
+}

--- a/syft/pkg/binary.go
+++ b/syft/pkg/binary.go
@@ -13,6 +13,11 @@ type ClassifierMatch struct {
 	Location   file.Location `mapstructure:"Location" json:"location"`
 }
 
+var _ Architecture = (*ELFBinaryPackageNoteJSONPayload)(nil)
+
+// TargetArchitecture returns the ELF binary target architecture (e.g. "x86_64", "aarch64").
+func (m ELFBinaryPackageNoteJSONPayload) TargetArchitecture() string { return m.Architecture }
+
 // ELFBinaryPackageNoteJSONPayload Represents metadata captured from the .note.package section of an ELF-formatted binary
 type ELFBinaryPackageNoteJSONPayload struct {
 	// (these are well-known fields as defined by systemd ELF package metadata "spec" https://systemd.io/ELF_PACKAGE_METADATA/)

--- a/syft/pkg/bitnami.go
+++ b/syft/pkg/bitnami.go
@@ -1,5 +1,10 @@
 package pkg
 
+var _ Architecture = (*BitnamiSBOMEntry)(nil)
+
+// TargetArchitecture returns the Bitnami package target architecture (e.g. "amd64", "arm64").
+func (b BitnamiSBOMEntry) TargetArchitecture() string { return b.Architecture }
+
 // BitnamiSBOMEntry represents all captured data from Bitnami packages
 // described in Bitnami' SPDX files.
 type BitnamiSBOMEntry struct {

--- a/syft/pkg/conda.go
+++ b/syft/pkg/conda.go
@@ -42,6 +42,11 @@ type CondaLink struct {
 	Type int `json:"type"`
 }
 
+var _ Architecture = (*CondaMetaPackage)(nil)
+
+// TargetArchitecture returns the Conda package target architecture (e.g. "x86_64", "aarch64").
+func (m CondaMetaPackage) TargetArchitecture() string { return m.Arch }
+
 // CondaMetaPackage represents metadata for a Conda package extracted from the conda-meta/*.json files.
 type CondaMetaPackage struct {
 	// Arch is the target CPU architecture for the package (e.g., "arm64", "x86_64").

--- a/syft/pkg/dpkg.go
+++ b/syft/pkg/dpkg.go
@@ -12,6 +12,17 @@ const DpkgDBGlob = "**/var/lib/dpkg/{status,status.d/**}"
 
 var _ FileOwner = (*DpkgDBEntry)(nil)
 
+var (
+	_ Architecture = (*DpkgDBEntry)(nil)
+	_ Architecture = (*DpkgArchiveEntry)(nil)
+)
+
+// TargetArchitecture returns the Debian target architecture (e.g. "amd64", "arm64", "all").
+func (m DpkgDBEntry) TargetArchitecture() string { return m.Architecture }
+
+// TargetArchitecture returns the Debian target architecture (e.g. "amd64", "arm64", "all").
+func (m DpkgArchiveEntry) TargetArchitecture() string { return m.Architecture }
+
 // DpkgArchiveEntry represents package metadata extracted from a .deb archive file.
 type DpkgArchiveEntry DpkgDBEntry
 

--- a/syft/pkg/golang.go
+++ b/syft/pkg/golang.go
@@ -1,5 +1,16 @@
 package pkg
 
+var (
+	_ Architecture = (*GolangBinaryBuildinfoEntry)(nil)
+	_ Architecture = (*GolangSourceEntry)(nil)
+)
+
+// TargetArchitecture returns the Go build target architecture (GOARCH, e.g. "amd64", "arm64").
+func (m GolangBinaryBuildinfoEntry) TargetArchitecture() string { return m.Architecture }
+
+// TargetArchitecture returns the Go build target architecture (GOARCH, e.g. "amd64", "arm64").
+func (m GolangSourceEntry) TargetArchitecture() string { return m.Architecture }
+
 // GolangBinaryBuildinfoEntry represents all captured data for a Golang binary
 type GolangBinaryBuildinfoEntry struct {
 	// BuildSettings contains the Go build settings and flags used to compile the binary (e.g., GOARCH, GOOS, CGO_ENABLED).

--- a/syft/pkg/linux_kernel.go
+++ b/syft/pkg/linux_kernel.go
@@ -1,5 +1,10 @@
 package pkg
 
+var _ Architecture = (*LinuxKernel)(nil)
+
+// TargetArchitecture returns the kernel target architecture (e.g. "x86_64", "aarch64").
+func (m LinuxKernel) TargetArchitecture() string { return m.Architecture }
+
 // LinuxKernel represents all captured data for a Linux kernel
 type LinuxKernel struct {
 	// Name is kernel name (typically "Linux")

--- a/syft/pkg/rpm.go
+++ b/syft/pkg/rpm.go
@@ -22,6 +22,17 @@ const RpmManifestGlob = "**/var/lib/rpmmanifest/container-manifest-2"
 
 var _ FileOwner = (*RpmDBEntry)(nil)
 
+var (
+	_ Architecture = (*RpmDBEntry)(nil)
+	_ Architecture = (*RpmArchive)(nil)
+)
+
+// TargetArchitecture returns the rpm target architecture (e.g. "x86_64", "aarch64", "noarch").
+func (m RpmDBEntry) TargetArchitecture() string { return m.Arch }
+
+// TargetArchitecture returns the rpm target architecture (e.g. "x86_64", "aarch64", "noarch").
+func (m RpmArchive) TargetArchitecture() string { return m.Arch }
+
 // RpmArchive represents package metadata extracted directly from a .rpm archive file, containing the same information as an RPM database entry.
 type RpmArchive RpmDBEntry
 

--- a/syft/pkg/snap.go
+++ b/syft/pkg/snap.go
@@ -8,6 +8,11 @@ const (
 	SnapTypeSnapd  = "snapd"
 )
 
+var _ Architecture = (*SnapEntry)(nil)
+
+// TargetArchitecture returns the Snap target architecture (e.g. "amd64", "arm64").
+func (m SnapEntry) TargetArchitecture() string { return m.Architecture }
+
 // SnapEntry represents metadata for a Snap package extracted from snap.yaml or snapcraft.yaml files.
 type SnapEntry struct {
 	// SnapType indicates the snap type (base, kernel, app, gadget, or snapd).


### PR DESCRIPTION
Add a pkg.Architecture interface that exposes a TargetArchitecture method. (The method cannot be called Architecture because package metadata types already use that name.) Modeled on the FileOwner interface, this gives clients of Syft a simple way to ask, "is this package one that can specify CPU architecture and if so what architecture does it target?".

## Description

<!-- Please include a summary of the changes along with any relevant motivation and context -->

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
