### PR TITLE
fix: use printf instead of echo to fix ANSI color output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,8 @@ is_command() (
 )
 
 echo_stderr() (
-  echo "$@" 1>&2
+  IFS=" "
+  printf "%b\n" "$*" 1>&2
 )
 
 _logp=2
@@ -75,12 +76,12 @@ init_colors
 
 log_tag() (
   case $1 in
-    0) echo "${RED}${BOLD}[error]${RESET}" ;;
-    1) echo "${RED}[warn]${RESET}" ;;
-    2) echo "[info]${RESET}" ;;
-    3) echo "${BLUE}[debug]${RESET}" ;;
-    4) echo "${PURPLE}[trace]${RESET}" ;;
-    *) echo "[$1]" ;;
+    0) printf "%b" "${RED}${BOLD}[error]${RESET}" ;;
+    1) printf "%b" "${RED}[warn]${RESET}" ;;
+    2) printf "%b" "[info]${RESET}" ;;
+    3) printf "%b" "${BLUE}[debug]${RESET}" ;;
+    4) printf "%b" "${PURPLE}[trace]${RESET}" ;;
+    *) printf "[%s]" "$1" ;;
   esac
 )
 


### PR DESCRIPTION
## Description

This PR fixes an issue where the `install.sh` script leaks raw ANSI escape codes (e.g., `\033[0;31m`) into the terminal output when executed via strict POSIX `sh` (such as `dash`). 

The `echo` command does not natively evaluate ANSI color codes in these environments. This update refactors the `echo_stderr` and `log_tag` functions to use `printf "%b"` instead of `echo`. This ensures cross-shell compatibility and renders the terminal colors correctly regardless of the shell being used.

**CLI Output Changes:**

**Before:**
<img width="1066" height="306" alt="Screenshot 2026-06-12 201015" src="https://github.com/user-attachments/assets/a1d777a1-1fea-4010-94a7-866f263dd911" />


**After:**
<img width="886" height="125" alt="Screenshot 2026-06-12 201842" src="https://github.com/user-attachments/assets/be8d4edb-edb7-4fc7-9cdd-27ab64574909" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections