### PR TITLE
Ensure we have a snapshot build for CLI tests when building a fresh cache

### DIFF
--- a/.make/main.go
+++ b/.make/main.go
@@ -56,11 +56,14 @@ func main() {
 			},
 		},
 
-		// cli tests: native go-make Task. Requires SYFT_BINARY_LOCATION pointing at
-		// an *absolute* path to the snapshot binary. Intentionally does NOT depend
-		// on snapshot: in CI we download a pre-built snapshot artifact and re-running
-		// goreleaser here would both burn ~10m and clobber the downloaded binary.
-		// Locally, the failure message tells you to run `make snapshot` first.
+		// cli tests: native go-make Task. Runs SYFT_BINARY_LOCATION at an *absolute*
+		// path to the snapshot binary. Builds the snapshot only when the binary is
+		// missing rather than depending on the snapshot task unconditionally: in
+		// validations.yaml CI we download a pre-built snapshot artifact, so the binary
+		// already exists and rebuilding would both burn ~10m and clobber it. When
+		// `make test` runs cold (e.g. the release pipeline) or locally with no
+		// snapshot, we build a single-target snapshot (current OS/arch only) since
+		// that's all the CLI tests need.
 		Task{
 			Name:        "cli",
 			Description: "Run CLI tests",
@@ -68,7 +71,8 @@ func main() {
 			Run: func() {
 				bin := snapshotBinPath()
 				if !file.Exists(bin) {
-					panic(fmt.Sprintf("snapshot binary not found at %s; run `make snapshot` first", bin))
+					Log("snapshot binary not found at %s; building single-target snapshot", bin)
+					Run("make snapshot:single-target")
 				}
 				Log("testing binary: %s", bin)
 				Run(


### PR DESCRIPTION
This fixes issues we're seeing in the cache publish job:

```
2026-06-15T06:34:12.1600406Z --- PASS: TestSqliteRpm (15.01s)
2026-06-15T06:34:12.1601034Z PASS
2026-06-15T06:34:13.2864257Z ok  	github.com/anchore/syft/cmd/syft/internal/test/integration	581.629s
2026-06-15T06:34:14.8319283Z [32m[integration] [0mDone running integration tests in 9m49.035547346s
2026-06-15T06:34:14.8320451Z [41m[37m
2026-06-15T06:34:14.8320732Z 
2026-06-15T06:34:14.8322073Z  ERROR: snapshot binary not found at /home/runner/_work/oss-release/oss-release/snapshot/linux-build_linux_amd64_v1/syft; run `make snapshot` first 
2026-06-15T06:34:14.8323898Z  [0m[0m[90m
2026-06-15T06:34:14.8324324Z main.main.func2()
2026-06-15T06:34:14.8325051Z /home/runner/_work/oss-release/oss-release/.make/main.go:71 +0x179
```