### PR TITLE
fix(go-module-cataloger): use correct error variable in package load 

### DIFF
--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -134,7 +134,7 @@ func (c *goModCataloger) loadPackages(modDir string, loc file.Location) (pkgs ma
 			// Log errors but continue processing
 			for _, e := range p.Errors {
 				log.Debugf("package load error for %s: %v", p.PkgPath, e)
-				unknownErr = unknown.Append(unknownErr, loc, err)
+				unknownErr = unknown.Append(unknownErr, loc, e)
 			}
 		}
 	}

--- a/syft/pkg/cataloger/golang/parse_go_mod.go
+++ b/syft/pkg/cataloger/golang/parse_go_mod.go
@@ -132,9 +132,9 @@ func (c *goModCataloger) loadPackages(modDir string, loc file.Location) (pkgs ma
 	for _, p := range rootPkgs {
 		if len(p.Errors) > 0 {
 			// Log errors but continue processing
-			for _, e := range p.Errors {
-				log.Debugf("package load error for %s: %v", p.PkgPath, e)
-				unknownErr = unknown.Append(unknownErr, loc, e)
+			for _, pe := range p.Errors {
+				log.Debugf("package load error for %s: %v", p.PkgPath, pe)
+				unknownErr = unknown.Append(unknownErr, loc, pe)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

In the loop over `rootPkgs`, the error appended to `unknownErr` was incorrectly using the outer `err` (from `packages.Load`) instead of the individual package error `e`. This could cause:
- nil or stale error values to be recorded when package-specific errors existed.
- Loss of detailed per-package error information in the final error report.

Changed `unknown.Append(..., err)` to `unknown.Append(..., e)` to properly capture each package's load error.

## Type of change

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
