### PR TITLE
fix: PE case-insensitive extensions (Win32/ISO 9660 compatibility)

### DIFF
--- a/syft/pkg/cataloger/binary/capabilities.yaml
+++ b/syft/pkg/cataloger/binary/capabilities.yaml
@@ -1055,6 +1055,8 @@ catalogers:
         detector: # AUTO-GENERATED
           method: glob # AUTO-GENERATED
           criteria: # AUTO-GENERATED
+            - '**/*.DLL'
+            - '**/*.EXE'
             - '**/*.dll'
             - '**/*.exe'
             - '**/*.bpl'

--- a/syft/pkg/cataloger/binary/capabilities.yaml
+++ b/syft/pkg/cataloger/binary/capabilities.yaml
@@ -1057,6 +1057,7 @@ catalogers:
           criteria: # AUTO-GENERATED
             - '**/*.DLL'
             - '**/*.EXE'
+            - '**/*.BPL'
             - '**/*.dll'
             - '**/*.exe'
             - '**/*.bpl'

--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -16,7 +16,7 @@ import (
 // BPL (Borland Package Library) files are PE-format binaries used by Delphi and C++Builder.
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.DLL", "**/*.EXE", "**/*.dll", "**/*.exe", "**/*.bpl")
+		WithParserByGlobs(parsePE, "**/*.DLL", "**/*.EXE", "**/*.BPL", "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {

--- a/syft/pkg/cataloger/binary/pe_package_cataloger.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger.go
@@ -16,7 +16,7 @@ import (
 // BPL (Borland Package Library) files are PE-format binaries used by Delphi and C++Builder.
 func NewPEPackageCataloger() pkg.Cataloger {
 	return generic.NewCataloger("pe-binary-package-cataloger").
-		WithParserByGlobs(parsePE, "**/*.dll", "**/*.exe", "**/*.bpl")
+		WithParserByGlobs(parsePE, "**/*.DLL", "**/*.EXE", "**/*.dll", "**/*.exe", "**/*.bpl")
 }
 
 func parsePE(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {

--- a/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
@@ -79,6 +79,7 @@ func Test_PEPackageCataloger_Globs(t *testing.T) {
 				// uppercase extensions appear on Windows/ISO 9660 filesystems and must also match
 				"src/winlibrary.DLL",
 				"src/winprogram.EXE",
+				"src/winarchive.BPL",
 			},
 		},
 	}

--- a/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
+++ b/syft/pkg/cataloger/binary/pe_package_cataloger_test.go
@@ -70,12 +70,15 @@ func Test_PEPackageCataloger_Globs(t *testing.T) {
 		expected []string
 	}{
 		{
-			name:    "obtain PE binary files (dll, exe, bpl)",
+			name:    "obtain PE binary files (dll, exe, bpl), including uppercase extensions",
 			fixture: "testdata/glob-paths",
 			expected: []string{
 				"src/library.dll",
 				"src/program.exe",
 				"src/archive.bpl",
+				// uppercase extensions appear on Windows/ISO 9660 filesystems and must also match
+				"src/winlibrary.DLL",
+				"src/winprogram.EXE",
 			},
 		},
 	}

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/winarchive.BPL
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/winarchive.BPL
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/winlibrary.DLL
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/winlibrary.DLL
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/binary/testdata/glob-paths/src/winprogram.EXE
+++ b/syft/pkg/cataloger/binary/testdata/glob-paths/src/winprogram.EXE
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/dotnet/capabilities.yaml
+++ b/syft/pkg/cataloger/dotnet/capabilities.yaml
@@ -39,6 +39,10 @@ catalogers:
           - '**/*.deps.json'
           - '**/*.dll'
           - '**/*.exe'
+          - '**/*.bpl'
+          - '**/*.DLL'
+          - '**/*.EXE'
+          - '**/*.BPL'
     metadata_types: # AUTO-GENERATED
       - pkg.DotnetDepsEntry
       - pkg.DotnetPortableExecutableEntry
@@ -173,6 +177,10 @@ catalogers:
         criteria:
           - '**/*.dll'
           - '**/*.exe'
+          - '**/*.bpl'
+          - '**/*.DLL'
+          - '**/*.EXE'
+          - '**/*.BPL'
     metadata_types: # AUTO-GENERATED
       - pkg.DotnetPortableExecutableEntry
     package_types: # AUTO-GENERATED

--- a/syft/pkg/cataloger/dotnet/cataloger_test.go
+++ b/syft/pkg/cataloger/dotnet/cataloger_test.go
@@ -36,6 +36,10 @@ func TestCataloger_Globs(t *testing.T) {
 				"src/something.bpl",
 				"src/something.dll",
 				"src/something.exe",
+				// uppercase extensions appear on Windows/ISO 9660 filesystems and must also match
+				"src/winsomething.DLL",
+				"src/winsomething.EXE",
+				"src/winsomething.BPL",
 			},
 		},
 		{
@@ -47,6 +51,10 @@ func TestCataloger_Globs(t *testing.T) {
 				"src/something.deps.json",
 				"src/something.dll",
 				"src/something.exe",
+				// uppercase extensions appear on Windows/ISO 9660 filesystems and must also match
+				"src/winsomething.DLL",
+				"src/winsomething.EXE",
+				"src/winsomething.BPL",
 			},
 			// the binary cataloger probes executables by MIME type to find embedded bundles,
 			// but the glob fixtures aren't real binaries so those queries go unfulfilled

--- a/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
+++ b/syft/pkg/cataloger/dotnet/deps_binary_cataloger.go
@@ -27,6 +27,10 @@ const (
 	dllGlob      = "**/*.dll"
 	exeGlob      = "**/*.exe"
 	bplGlob      = "**/*.bpl"
+	// uppercase variants match PE files on case-preserving Windows/ISO 9660 filesystems (doublestar globs are case-sensitive)
+	dllGlobUpper = "**/*.DLL"
+	exeGlobUpper = "**/*.EXE"
+	bplGlobUpper = "**/*.BPL"
 )
 
 var elfMagic = []byte{0x7f, 'E', 'L', 'F'}
@@ -483,7 +487,7 @@ func readDepsJSON(resolver file.Resolver, loc file.Location) (*depsJSON, error) 
 
 // findPEFiles locates and parses all PE files (dll/exe).
 func findPEFiles(resolver file.Resolver) ([]logicalPE, error, error) {
-	peLocs, err := resolver.FilesByGlob(dllGlob, exeGlob, bplGlob)
+	peLocs, err := resolver.FilesByGlob(dllGlob, exeGlob, bplGlob, dllGlobUpper, exeGlobUpper, bplGlobUpper)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to find PE files: %w", err)
 	}

--- a/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.BPL
+++ b/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.BPL
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.DLL
+++ b/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.DLL
@@ -1,0 +1,1 @@
+bogus PE contents

--- a/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.EXE
+++ b/syft/pkg/cataloger/dotnet/testdata/glob-paths/src/winsomething.EXE
@@ -1,0 +1,1 @@
+bogus PE contents


### PR DESCRIPTION
## Description
pe-binary-package-cataloger skips valid PE files with upper-case extensions owing to the way FiletreeResolver glob pattern match works: while .EXE and .DLL are perfectly valid from Win32 standpoint, syft skips scanning them entirely. The problem is particularly noticeable when scanning regular ISO 9660 images of dependency installers, where file names/extensions are uppercase.

The PR adds only new extensions (.EXE and .DLL) to the search criteria without reducing the existing coverage.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
## Checklist
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
## Issue references
