### PR TITLE
Require tmpdir to exist for fingerprints

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -137,6 +137,7 @@ tasks:
   fingerprints:
     desc: Generate fingerprints for all non-docker test fixtures
     silent: true
+    deps: [tmpdir]
     # this will look for `testdata/Makefile` and invoke the `fingerprint` target to calculate all cache input fingerprint files
     generates:
       - '**/testdata/**/*.fingerprint'


### PR DESCRIPTION
The `fingerprints` task writes `cache_paths.json` into `.tmp/` (via `find_cache_paths.py`), but it never depended on the `tmpdir` task that actually creates `.tmp/`. Locally this is fine since `.tmp/` is usually left over from earlier runs, but on a clean CI runner the directory doesn't exist yet, so `upload-test-fixture-cache` blew up with:

```
FileNotFoundError: [Errno 2] No such file or directory: '.tmp/cache_paths.json'
```

This PR addresses this.