### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,4 @@
 # Dependabot configuration
-#
-# Grouping behavior (see inline comments for details):
-#   - Minor + patch updates: grouped into a single PR per ecosystem
-#   - Major version bumps: individual PR per dependency
-#   - Security updates: individual PR per dependency
-#
-# Note: "patch" refers to semver version bumps (1.2.3 -> 1.2.4), not security fixes.
-# Security updates are identified separately via GitHub's Advisory Database and
-# can be any version bump (patch, minor, or major) that fixes a known CVE.
 
 version: 2
 
@@ -30,14 +21,6 @@ updates:
       - dependency-name: "github.com/aquasecurity/go-version"
       - dependency-name: "github.com/knqyf263/go-apk-version"
       - dependency-name: "github.com/knqyf263/go-deb-version"
-    groups:
-      go-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directories:
@@ -51,11 +34,3 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-    groups:
-      actions-minor-patch:
-        applies-to: version-updates  # security updates get individual PRs
-        patterns:
-          - "*"
-        update-types:  # major omitted, gets individual PRs
-          - "minor"
-          - "patch"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,11 @@ on:
         options:
           - "all"
           - "install-script-only"
+      skip-checks:
+        description: skip the check-gate (release even if checks haven't passed on main)
+        type: boolean
+        default: false
+        required: false
 
 jobs:
   version-available:
@@ -32,7 +37,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
-    if: ${{ github.event.inputs.phase == 'all' }}
+    if: ${{ github.event.inputs.phase == 'all' && !inputs.skip-checks }}
     permissions:
       contents: read
       checks: read # required for getting the status of specific check names
@@ -45,7 +50,14 @@ jobs:
 
   release:
     needs: [check-gate, version-available]
-    if: ${{ github.event.inputs.phase == 'all' }}
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     environment: release
     # runs-on.com: compute instances for parallel builds
     #   spot disabled: reliability for build workflows (used for releases too)
@@ -82,8 +94,8 @@ jobs:
       - name: Build & publish release artifacts
         run: make ci-release
         env:
-          # used for pushing tags
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          # for pushing tags (does not inherit workflow permissions)
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           # for mac signing and notarization...
           QUILL_SIGN_P12: ${{ secrets.ANCHORE_APPLE_DEVELOPER_ID_CERT_CHAIN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,4 @@
 rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore/workflows is an internal repository; using @main is acceptable
-        anchore/*: any
   dangerous-triggers:
     ignore:
       # Safe use of pull_request_target - only runs trusted scripts from base repo,


### PR DESCRIPTION
quick pass refactoring syft's release pipeline:

- release.yaml: swapped DEPLOY_KEY for TAG_TOKEN in the ci-release step (for pushing tags; doesn't inherit workflow permissions)
- release.yaml: added a skip-checks workflow_dispatch boolean input and wired check-gate to be skippable (`!inputs.skip-checks` alongside the existing phase gate)
- release.yaml: reworked the release job's `if` so it runs even when check-gate is skipped, but still requires version-available to succeed and never runs if check-gate failed/was cancelled
- dependabot: dropped the go-minor-patch + actions-minor-patch grouping (and the stale grouping comment) so updates come as individual PRs
- zizmor: removed the unpinned-uses config

note: a few items from the usual pass were already in place on main, so no-ops here — go-make is already at v0.7.0 in .make, golangci already uses the native gci/gofmt formatters, and /.make is already listed in dependabot's gomod directories. there's no separate manual tag/push step (ci-release/go-make does the tagging), so nothing to remove there.