### PR TITLE
fix: conanfile comments in [requires] no longer skip dependencies

### DIFF
--- a/syft/pkg/cataloger/cpp/parse_conanfile.go
+++ b/syft/pkg/cataloger/cpp/parse_conanfile.go
@@ -31,15 +31,20 @@ func parseConanfile(_ context.Context, _ file.Resolver, _ *generic.Environment, 
 			return nil, nil, fmt.Errorf("failed to parse conanfile.txt file: %w", err)
 		}
 
+		trimmed := strings.TrimSpace(line)
+
+		// skip blank lines and comments without affecting section state
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
 		switch {
 		case strings.Contains(line, "[requires]"):
 			inRequirements = true
-		case strings.ContainsAny(line, "[]") || strings.HasPrefix(strings.TrimSpace(line), "#"):
+			continue
+		case strings.ContainsAny(line, "[]"):
 			inRequirements = false
-		}
-
-		m := pkg.ConanfileEntry{
-			Ref: strings.TrimSpace(line),
+			continue
 		}
 
 		if !inRequirements {
@@ -47,7 +52,7 @@ func parseConanfile(_ context.Context, _ file.Resolver, _ *generic.Environment, 
 		}
 
 		p := newConanfilePackage(
-			m,
+			pkg.ConanfileEntry{Ref: trimmed},
 			reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 		)
 		if p == nil {

--- a/syft/pkg/cataloger/cpp/parse_conanfile_test.go
+++ b/syft/pkg/cataloger/cpp/parse_conanfile_test.go
@@ -86,3 +86,36 @@ func TestParseConanfile(t *testing.T) {
 
 	pkgtest.TestFileParser(t, fixture, parseConanfile, expected, expectedRelationships)
 }
+
+func TestParseConanfileCommentInRequires(t *testing.T) {
+	fixture := "testdata/conanfile-comment-in-requires.txt"
+	fixtureLocationSet := file.NewLocationSet(file.NewLocation(fixture))
+	expected := []pkg.Package{
+		{
+			Name:      "catch2",
+			Version:   "2.13.8",
+			PURL:      "pkg:conan/catch2@2.13.8",
+			Locations: fixtureLocationSet,
+			Language:  pkg.CPP,
+			Type:      pkg.ConanPkg,
+			Metadata: pkg.ConanfileEntry{
+				Ref: "catch2/2.13.8",
+			},
+		},
+		{
+			Name:      "docopt.cpp",
+			Version:   "0.6.3",
+			PURL:      "pkg:conan/docopt.cpp@0.6.3",
+			Locations: fixtureLocationSet,
+			Language:  pkg.CPP,
+			Type:      pkg.ConanPkg,
+			Metadata: pkg.ConanfileEntry{
+				Ref: "docopt.cpp/0.6.3",
+			},
+		},
+	}
+
+	var expectedRelationships []artifact.Relationship
+
+	pkgtest.TestFileParser(t, fixture, parseConanfile, expected, expectedRelationships)
+}

--- a/syft/pkg/cataloger/cpp/testdata/conanfile-comment-in-requires.txt
+++ b/syft/pkg/cataloger/cpp/testdata/conanfile-comment-in-requires.txt
@@ -1,0 +1,9 @@
+# Docs at https://docs.conan.io/en/latest/reference/conanfile_txt.html
+
+[requires]
+# this is a comment inside requires
+catch2/2.13.8
+docopt.cpp/0.6.3
+
+[generators]
+cmake_find_package_multi


### PR DESCRIPTION
## Problem

Comments inside the `[requires]` section of `conanfile.txt` silently stopped dependency detection. Any package listed after a comment line was skipped.

From #5017: dependencies after a comment line in `[requires]` are not detected.

## Root Cause

The section-state switch OR'd the comment check (`strings.HasPrefix(..., "#")`) with the new-section check (`strings.ContainsAny(line, "[]")`). Both set `inRequirements = false`, so a comment inside `[requires]` acted like a section boundary.

## Fix

Skip blank lines and comments *before* evaluating section state, so they never toggle `inRequirements`. Section headers (`[generators]`, etc.) still end the requires section as before.

```
[requires]
# this comment used to break parsing
fmt/8.1.1    ← previously skipped
```

Fixes #5017