### PR TITLE
fix: detect source archives by content, not filename substring (#4582)

### DIFF
--- a/syft/source/filesource/file_source.go
+++ b/syft/source/filesource/file_source.go
@@ -212,7 +212,19 @@ func fileAnalysisPath(path string, skipExtractArchive bool) (string, func() erro
 		return analysisPath, cleanupFn, nil
 	}
 
-	envelopedUnarchiver, _, err := intFile.IdentifyArchive(context.Background(), path, nil)
+	// Pass the file contents to archive identification rather than relying on the
+	// filename alone. mholt/archives matches filenames with strings.Contains, so a
+	// regular file whose name merely contains an archive extension as a substring
+	// (e.g. "sample.tar.gz_hashed.json") is otherwise misidentified as an archive
+	// and fails to "unarchive". With the reader, content-based detection runs and
+	// non-archives fall through to regular file analysis. See issue #4582.
+	f, err := os.Open(path)
+	if err != nil {
+		return "", cleanupFn, fmt.Errorf("unable to open source file: %w", err)
+	}
+	defer f.Close()
+
+	envelopedUnarchiver, _, err := intFile.IdentifyArchive(context.Background(), path, f)
 	if unarchiver, ok := envelopedUnarchiver.(archives.Extractor); err == nil && ok {
 		analysisPath, cleanupFn, err = unarchiveToTmp(path, unarchiver)
 		if err != nil {

--- a/syft/source/filesource/file_source_test.go
+++ b/syft/source/filesource/file_source_test.go
@@ -1,6 +1,8 @@
 package filesource
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"io"
 	"os"
 	"os/exec"
@@ -167,6 +169,48 @@ func TestNewFromFile_WithArchive(t *testing.T) {
 
 		})
 	}
+}
+
+func Test_fileAnalysisPath(t *testing.T) {
+	t.Run("regular file with archive extension in its name is not unarchived", func(t *testing.T) {
+		// a regular JSON file whose name contains ".tar.gz" as a substring should be
+		// analyzed as-is, not misidentified as an archive. See issue #4582.
+		dir := t.TempDir()
+		p := filepath.Join(dir, "sample.tar.gz_hashed.json")
+		require.NoError(t, os.WriteFile(p, []byte(`{"hello":"world"}`), 0o600))
+
+		analysisPath, cleanupFn, err := fileAnalysisPath(p, false)
+		t.Cleanup(func() { assert.NoError(t, cleanupFn()) })
+
+		require.NoError(t, err)
+		// the file is not an archive, so analysis happens on the original path
+		assert.Equal(t, p, analysisPath)
+	})
+
+	t.Run("real gzipped tar is still extracted", func(t *testing.T) {
+		dir := t.TempDir()
+		p := filepath.Join(dir, "real.tar.gz")
+
+		f, err := os.Create(p)
+		require.NoError(t, err)
+		gw := gzip.NewWriter(f)
+		tw := tar.NewWriter(gw)
+		contents := []byte("hi")
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: "a.txt", Mode: 0o600, Size: int64(len(contents))}))
+		_, err = tw.Write(contents)
+		require.NoError(t, err)
+		require.NoError(t, tw.Close())
+		require.NoError(t, gw.Close())
+		require.NoError(t, f.Close())
+
+		analysisPath, cleanupFn, err := fileAnalysisPath(p, false)
+		t.Cleanup(func() { assert.NoError(t, cleanupFn()) })
+
+		require.NoError(t, err)
+		// a genuine archive is extracted to a temp dir, so the analysis path differs
+		assert.NotEqual(t, p, analysisPath)
+		assert.FileExists(t, filepath.Join(analysisPath, "a.txt"))
+	})
 }
 
 // setupArchiveTest encapsulates common test setup work for tar file tests. It returns a cleanup function,


### PR DESCRIPTION
## Description

fileAnalysisPath calls IdentifyArchive with a nil reader, so mholt/archives can only match on the filename, and it does that with a substring check (strings.Contains lowercased for ".gz", ".tar", etc). That means any ordinary file whose name happens to contain an archive extension gets treated as an archive and the scan fails. The reported case is a JSON file named sample.tar.gz_hashed.json, but as @kzantow pointed out on #4582 even a real binary named syft.tar.gz.bin trips it. This worked fine in 1.36.0 and regressed sometime after.

The fix opens the file and hands the reader to IdentifyArchive so detection runs on content. Non-archives fail the header check, get no extractor, and fall through to normal file analysis; genuine archives still match on their header and extract as before.

One thing worth flagging: with content-based detection, a file named like an archive but not actually valid (including a genuinely corrupt .tar.gz) now falls through to plain file analysis instead of erroring. That matches pre-1.36 behavior and seems like the better default for a tool you point at arbitrary files, but it does mean a truly broken archive gets analyzed as a regular file rather than surfacing the corruption. If you'd rather keep an explicit error for that, or tighten the alias handling in internal/file/archive_aliases.go instead, happy to rework it - just say which way you'd prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4582
