### PR TITLE
Fix panic on `cabal.project.freeze` `installed` constraints dropping all Haskell packages

### DIFF
--- a/syft/pkg/cataloger/haskell/parse_cabal_freeze.go
+++ b/syft/pkg/cataloger/haskell/parse_cabal_freeze.go
@@ -45,6 +45,10 @@ func parseCabalFreeze(_ context.Context, _ file.Resolver, _ *generic.Environment
 
 		line = line[startPkgEncoding:endPkgEncoding]
 		fields := strings.Split(line, " ==")
+		// skip constraints without a version (e.g. GHC boot libs: "any.base installed")
+		if len(fields) < 2 {
+			continue
+		}
 
 		pkgName, pkgVersion := fields[0], fields[1]
 		pkgs = append(

--- a/syft/pkg/cataloger/haskell/testdata/cabal.project.freeze
+++ b/syft/pkg/cataloger/haskell/testdata/cabal.project.freeze
@@ -1,5 +1,7 @@
 active-repositories: hackage.haskell.org:merge
 constraints: any.Cabal ==3.2.1.0,
+             any.array installed,
+             any.base installed,
              any.Diff ==0.4.1,
              any.HTTP ==4000.3.16,
              any.HUnit ==1.6.2.0,


### PR DESCRIPTION
## Description

`syft` panics on real `cabal.project.freeze` files and drops **all** Haskell packages from the scan.

Every `cabal freeze` emits `any.<pkg> installed,` constraints for GHC boot libraries (`base`, `array`, `ghc-prim`, ...). `parseCabalFreeze` splits each constraint on `" =="` and unconditionally reads `fields[1]`; an `installed` line has no `" =="`, so `fields` has length 1 and `fields[1]` panics with `index out of range [1]`. The per-cataloger `recover` then swallows the panic and yields **zero** Haskell packages for the entire scan.

Reproducible on any real freeze file (e.g. `cabal init -n && cabal freeze`), which is the same repro from the previously-closed #1362 — that fix guarded a different index and the panic simply moved to `fields[1]`.

## Fix

Skip constraint lines without a version (`len(fields) < 2`) so `installed` boot-lib lines are ignored and the remaining `== version` packages parse normally.

## Test

Extended `testdata/cabal.project.freeze` with `any.array installed,` / `any.base installed,`. The existing exact-set assertion in `parse_cabal_freeze_test.go` is now a regression guard: it passes only if the `installed` lines are skipped and every real package still parses. Before the fix the fixture panicked.
