### PR TITLE
chore: pin php apache fixture to debian snapshot

### DIFF
--- a/syft/pkg/cataloger/php/testdata/image-apache/Dockerfile
+++ b/syft/pkg/cataloger/php/testdata/image-apache/Dockerfile
@@ -1,5 +1,19 @@
 FROM --platform=linux/amd64 httpd:2.4.63-bookworm AS builder
 
+# pin apt to a debian snapshot so the exact php8.2 point release stays installable.
+# a plain version pin drifts out from under us: debian's mirrors only keep the latest
+# point release, so 8.2.31 disappears once 8.2.32 ships. snapshot.debian.org archives
+# every version forever, which is what actually keeps the fixture (and its test
+# expectations) reproducible. timestamp is any point where 8.2.31 was current
+# (8.2.31: 2026-05-08, 8.2.32: 2026-07-04).
+ARG SNAPSHOT=20260701T000000Z
+RUN rm -f /etc/apt/sources.list /etc/apt/sources.list.d/debian.sources && \
+    printf '%s\n' \
+      "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${SNAPSHOT}/ bookworm main" \
+      "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${SNAPSHOT}/ bookworm-updates main" \
+      "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${SNAPSHOT}/ bookworm-security main" \
+      > /etc/apt/sources.list
+
 # pin php8.2 packages to avoid version drift when debian publishes security updates
 ARG PHP_VERSION=8.2.31-1~deb12u1
 RUN apt update -y && apt install -y \


### PR DESCRIPTION
This fixes the PHP pins in test fixtures. The plain version pin drifted out from under us: Debian mirrors only keep the latest point release, so 8.2.31 became uninstallable once 8.2.32 shipped and apt pulled the unpinned transitive php8.2-cli at 8.2.32. Pointing apt at snapshot.debian.org keeps the exact point release installable so the fixture (and its test expectations) stay reproducible.
