### PR TITLE
Add support for programmatically listing catalogers

### DIFF
--- a/cmd/syft/internal/test/integration/package_catalogers_represented_test.go
+++ b/cmd/syft/internal/test/integration/package_catalogers_represented_test.go
@@ -31,17 +31,11 @@ func TestAllPackageCatalogersReachableInTasks(t *testing.T) {
 	taskFactories := task.DefaultPackageTaskFactories()
 	taskTagsByName := make(map[string][]string)
 	for _, factory := range taskFactories {
-		tsk := factory(task.DefaultCatalogingFactoryConfig())
-		if taskTagsByName[tsk.Name()] != nil {
-			t.Fatalf("duplicate task name: %q", tsk.Name())
+		if taskTagsByName[factory.Name()] != nil {
+			t.Fatalf("duplicate task name: %q", factory.Name())
 		}
 
-		require.NotNil(t, tsk)
-		if sel, ok := tsk.(task.Selector); ok {
-			taskTagsByName[tsk.Name()] = sel.Selectors()
-		} else {
-			taskTagsByName[tsk.Name()] = []string{}
-		}
+		taskTagsByName[factory.Name()] = factory.Selectors()
 	}
 
 	var constructorCount int

--- a/internal/task/factory.go
+++ b/internal/task/factory.go
@@ -8,9 +8,42 @@ import (
 	"github.com/scylladb/go-set/strset"
 )
 
-type factory func(cfg CatalogingFactoryConfig) Task
+type Factory interface {
+	Name() string
+	Selectors() []string
+	Task(CatalogingFactoryConfig) Task
+}
 
-type Factories []factory
+type factory struct {
+	name        string
+	tags        []string
+	taskFactory func(CatalogingFactoryConfig) Task
+}
+
+type Factories []Factory
+
+func newTaskFactory(name string, taskFactory func(CatalogingFactoryConfig) Task, tags ...string) factory {
+	return factory{
+		name:        name,
+		tags:        tags,
+		taskFactory: taskFactory,
+	}
+}
+
+func (f factory) Name() string {
+	return f.name
+}
+
+func (f factory) Selectors() []string {
+	return selectors(f.name, f.tags...)
+}
+
+func (f factory) Task(cfg CatalogingFactoryConfig) Task {
+	if f.taskFactory == nil {
+		return nil
+	}
+	return f.taskFactory(cfg)
+}
 
 func (f Factories) Tasks(cfg CatalogingFactoryConfig) ([]Task, error) {
 	var allTasks []Task
@@ -18,7 +51,7 @@ func (f Factories) Tasks(cfg CatalogingFactoryConfig) ([]Task, error) {
 	duplicateTaskNames := strset.New()
 	var err error
 	for _, fact := range f {
-		tsk := fact(cfg)
+		tsk := fact.Task(cfg)
 		if tsk == nil {
 			continue
 		}
@@ -37,4 +70,12 @@ func (f Factories) Tasks(cfg CatalogingFactoryConfig) ([]Task, error) {
 	}
 
 	return allTasks, err
+}
+
+func selectors(name string, tags ...string) []string {
+	set := strset.New(tags...)
+	set.Add(name)
+	list := set.List()
+	sort.Strings(list)
+	return list
 }

--- a/internal/task/file_tasks.go
+++ b/internal/task/file_tasks.go
@@ -25,10 +25,10 @@ func DefaultFileTaskFactories() Factories {
 	}
 }
 
-func newFileDigestCatalogerTaskFactory(tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
+func newFileDigestCatalogerTaskFactory(tags ...string) Factory {
+	return newTaskFactory("file-digest-cataloger", func(cfg CatalogingFactoryConfig) Task {
 		return newFileDigestCatalogerTask(cfg.FilesConfig.Selection, cfg.FilesConfig.Hashers, tags...)
-	}
+	}, commonFileTags(tags)...)
 }
 
 func newFileDigestCatalogerTask(selection file.Selection, hashers []crypto.Hash, tags ...string) Task {
@@ -56,10 +56,10 @@ func newFileDigestCatalogerTask(selection file.Selection, hashers []crypto.Hash,
 	return NewTask("file-digest-cataloger", fn, commonFileTags(tags)...)
 }
 
-func newFileMetadataCatalogerTaskFactory(tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
+func newFileMetadataCatalogerTaskFactory(tags ...string) Factory {
+	return newTaskFactory("file-metadata-cataloger", func(cfg CatalogingFactoryConfig) Task {
 		return newFileMetadataCatalogerTask(cfg.FilesConfig.Selection, tags...)
-	}
+	}, commonFileTags(tags)...)
 }
 
 func newFileMetadataCatalogerTask(selection file.Selection, tags ...string) Task {
@@ -87,10 +87,10 @@ func newFileMetadataCatalogerTask(selection file.Selection, tags ...string) Task
 	return NewTask("file-metadata-cataloger", fn, commonFileTags(tags)...)
 }
 
-func newFileContentCatalogerTaskFactory(tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
+func newFileContentCatalogerTaskFactory(tags ...string) Factory {
+	return newTaskFactory("file-content-cataloger", func(cfg CatalogingFactoryConfig) Task {
 		return newFileContentCatalogerTask(cfg.FilesConfig.Content, tags...)
-	}
+	}, commonFileTags(tags)...)
 }
 
 func newFileContentCatalogerTask(cfg filecontent.Config, tags ...string) Task {
@@ -113,10 +113,10 @@ func newFileContentCatalogerTask(cfg filecontent.Config, tags ...string) Task {
 	return NewTask("file-content-cataloger", fn, commonFileTags(tags)...)
 }
 
-func newExecutableCatalogerTaskFactory(tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
+func newExecutableCatalogerTaskFactory(tags ...string) Factory {
+	return newTaskFactory("file-executable-cataloger", func(cfg CatalogingFactoryConfig) Task {
 		return newExecutableCatalogerTask(cfg.FilesConfig.Selection, cfg.FilesConfig.Executable, tags...)
-	}
+	}, commonFileTags(tags)...)
 }
 
 func newExecutableCatalogerTask(selection file.Selection, cfg executable.Config, tags ...string) Task {

--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -20,21 +20,67 @@ import (
 	cpeutils "github.com/anchore/syft/syft/pkg/cataloger/common/cpe"
 )
 
-func newPackageTaskFactory(catalogerFactory func(CatalogingFactoryConfig) pkg.Cataloger, tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
-		return NewPackageTask(cfg, catalogerFactory(cfg), tags...)
+type PackageFactory interface {
+	Factory
+	Cataloger(CatalogingFactoryConfig) pkg.Cataloger
+}
+
+type packageFactory struct {
+	name             string
+	tags             []string
+	catalogerFactory func(CatalogingFactoryConfig) pkg.Cataloger
+}
+
+func newPackageTaskFactory(name string, catalogerFactory func(CatalogingFactoryConfig) pkg.Cataloger, tags ...string) packageFactory {
+	return packageFactory{
+		name:             name,
+		tags:             tags,
+		catalogerFactory: catalogerFactory,
 	}
 }
 
-func newSimplePackageTaskFactory(catalogerFactory func() pkg.Cataloger, tags ...string) factory {
-	return func(cfg CatalogingFactoryConfig) Task {
-		return NewPackageTask(cfg, catalogerFactory(), tags...)
+func newSimplePackageTaskFactory(name string, catalogerFactory func() pkg.Cataloger, tags ...string) packageFactory {
+	return newPackageTaskFactory(name, func(CatalogingFactoryConfig) pkg.Cataloger {
+		return catalogerFactory()
+	}, tags...)
+}
+
+func (f packageFactory) Name() string {
+	return f.name
+}
+
+func (f packageFactory) Selectors() []string {
+	return selectors(f.name, append(f.tags, pkgcataloging.PackageTag)...)
+}
+
+func (f packageFactory) Cataloger(cfg CatalogingFactoryConfig) pkg.Cataloger {
+	if f.catalogerFactory == nil {
+		return nil
 	}
+	return f.catalogerFactory(cfg)
+}
+
+func (f packageFactory) Task(cfg CatalogingFactoryConfig) Task {
+	return NewPackageTaskFromFactory(cfg, f.name, f.catalogerFactory, f.tags...)
 }
 
 // NewPackageTask creates a Task function for a generic pkg.Cataloger, honoring the common configuration options.
 func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string) Task {
+	if c == nil {
+		return nil
+	}
+	return NewPackageTaskFromFactory(cfg, c.Name(), func(CatalogingFactoryConfig) pkg.Cataloger {
+		return c
+	}, tags...)
+}
+
+// NewPackageTaskFromFactory creates a package task that constructs its cataloger only when the task is executed.
+func NewPackageTaskFromFactory(cfg CatalogingFactoryConfig, name string, catalogerFactory func(CatalogingFactoryConfig) pkg.Cataloger, tags ...string) Task {
 	fn := func(ctx context.Context, resolver file.Resolver, sbom sbomsync.Builder) error {
+		c := catalogerFactory(cfg)
+		if c == nil {
+			return nil
+		}
 		catalogerName := c.Name()
 		log.WithFields("name", catalogerName).Trace("starting package cataloger")
 
@@ -69,7 +115,7 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 	}
 	tags = append(tags, pkgcataloging.PackageTag)
 
-	return NewTask(c.Name(), fn, tags...)
+	return NewTask(name, fn, tags...)
 }
 
 func finalizePkgCatalogerResults(cfg CatalogingFactoryConfig, resolver file.PathResolver, catalogerName string, pkgs []pkg.Package, relationships []artifact.Relationship) ([]pkg.Package, []artifact.Relationship) {

--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -65,138 +65,149 @@ const (
 
 //nolint:funlen
 func DefaultPackageTaskFactories() Factories {
-	return []factory{
+	return Factories{
 		// OS package installed catalogers ///////////////////////////////////////////////////////////////////////////
-		newSimplePackageTaskFactory(arch.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "alpm", "archlinux", "pacman"),
-		newSimplePackageTaskFactory(alpine.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "apk", "alpine"),
-		newSimplePackageTaskFactory(debian.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "dpkg", "debian"),
-		newSimplePackageTaskFactory(gentoo.NewPortageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "portage", "gentoo"),
-		newSimplePackageTaskFactory(redhat.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "rpm", "redhat"),
+		newSimplePackageTaskFactory("alpm-db-cataloger", arch.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "alpm", "archlinux", "pacman"),
+		newSimplePackageTaskFactory("apk-db-cataloger", alpine.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "apk", "alpine"),
+		newSimplePackageTaskFactory("dpkg-db-cataloger", debian.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "dpkg", "debian"),
+		newSimplePackageTaskFactory("portage-cataloger", gentoo.NewPortageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "portage", "gentoo"),
+		newSimplePackageTaskFactory("rpm-db-cataloger", redhat.NewDBCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.OSTag, "linux", "rpm", "redhat"),
 
 		// OS package declared catalogers ///////////////////////////////////////////////////////////////////////////
-		newSimplePackageTaskFactory(redhat.NewArchiveCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.OSTag, "linux", "rpm", "redhat"),
-		newSimplePackageTaskFactory(debian.NewArchiveCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.OSTag, "linux", "deb", "debian"),
+		newSimplePackageTaskFactory("rpm-archive-cataloger", redhat.NewArchiveCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.OSTag, "linux", "rpm", "redhat"),
+		newSimplePackageTaskFactory("deb-archive-cataloger", debian.NewArchiveCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.OSTag, "linux", "deb", "debian"),
 
 		// language-specific package installed catalogers ///////////////////////////////////////////////////////////////////////////
-		newSimplePackageTaskFactory(cpp.NewConanInfoCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "cpp", "conan"),
-		newSimplePackageTaskFactory(javascript.NewPackageCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, JavaScript, Node),
-		newSimplePackageTaskFactory(php.NewComposerInstalledCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "php", "composer"),
-		newSimplePackageTaskFactory(r.NewPackageCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, pkgcataloging.DirectoryTag, "r"),
-		newSimplePackageTaskFactory(ruby.NewInstalledGemSpecCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "ruby", "gem", "gemspec"),
-		newSimplePackageTaskFactory(rust.NewAuditBinaryCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "rust", "binary"),
+		newSimplePackageTaskFactory("conan-info-cataloger", cpp.NewConanInfoCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "cpp", "conan"),
+		newSimplePackageTaskFactory("javascript-package-cataloger", javascript.NewPackageCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, JavaScript, Node),
+		newSimplePackageTaskFactory("php-composer-installed-cataloger", php.NewComposerInstalledCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "php", "composer"),
+		newSimplePackageTaskFactory("r-package-cataloger", r.NewPackageCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, pkgcataloging.DirectoryTag, "r"),
+		newSimplePackageTaskFactory("ruby-installed-gemspec-cataloger", ruby.NewInstalledGemSpecCataloger, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "ruby", "gem", "gemspec"),
+		newSimplePackageTaskFactory("cargo-auditable-binary-cataloger", rust.NewAuditBinaryCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "rust", "binary"),
 
 		// language-specific package declared catalogers ///////////////////////////////////////////////////////////////////////////
-		newSimplePackageTaskFactory(cpp.NewConanCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "cpp", "conan"),
+		newSimplePackageTaskFactory("conan-cataloger", cpp.NewConanCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "cpp", "conan"),
 		newPackageTaskFactory(
+			"vcpkg-manifest-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return cpp.NewVcpkgManifestCataloger(cfg.PackagesConfig.Cpp)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Cpp, Vcpkg),
-		newSimplePackageTaskFactory(dart.NewPubspecLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dart"),
-		newSimplePackageTaskFactory(dart.NewPubspecCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dart"),
-		newSimplePackageTaskFactory(elixir.NewMixLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "elixir"),
-		newSimplePackageTaskFactory(erlang.NewRebarLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "erlang"),
-		newSimplePackageTaskFactory(erlang.NewOTPCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "erlang", "otp"),
-		newSimplePackageTaskFactory(haskell.NewHackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "haskell", "hackage", "cabal"),
+		newSimplePackageTaskFactory("dart-pubspec-lock-cataloger", dart.NewPubspecLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dart"),
+		newSimplePackageTaskFactory("dart-pubspec-cataloger", dart.NewPubspecCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dart"),
+		newSimplePackageTaskFactory("elixir-mix-lock-cataloger", elixir.NewMixLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "elixir"),
+		newSimplePackageTaskFactory("erlang-rebar-lock-cataloger", erlang.NewRebarLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "erlang"),
+		newSimplePackageTaskFactory("erlang-otp-application-cataloger", erlang.NewOTPCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "erlang", "otp"),
+		newSimplePackageTaskFactory("haskell-cataloger", haskell.NewHackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "haskell", "hackage", "cabal"),
 		newPackageTaskFactory(
+			"go-module-file-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return golang.NewGoModuleFileCataloger(cfg.PackagesConfig.Golang)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Go, Golang, "gomod",
 		),
-		newSimplePackageTaskFactory(java.NewGradleLockfileCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Java, "gradle"),
+		newSimplePackageTaskFactory("java-gradle-lockfile-cataloger", java.NewGradleLockfileCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Java, "gradle"),
 		newPackageTaskFactory(
+			"java-pom-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return java.NewPomCataloger(cfg.PackagesConfig.JavaArchive)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Java, Maven,
 		),
 		newPackageTaskFactory(
+			"javascript-lock-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return javascript.NewLockCataloger(cfg.PackagesConfig.JavaScript)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, JavaScript, Node, NPM, "deno",
 		),
-		newSimplePackageTaskFactory(php.NewComposerLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "php", "composer"),
-		newSimplePackageTaskFactory(php.NewPearCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, pkgcataloging.ImageTag, "php", "pear"),
+		newSimplePackageTaskFactory("php-composer-lock-cataloger", php.NewComposerLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "php", "composer"),
+		newSimplePackageTaskFactory("php-pear-serialized-cataloger", php.NewPearCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, pkgcataloging.ImageTag, "php", "pear"),
 		newPackageTaskFactory(
+			"python-package-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return python.NewPackageCataloger(cfg.PackagesConfig.Python)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, Python,
 		),
-		newSimplePackageTaskFactory(ruby.NewGemFileLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ruby", "gem"),
-		newSimplePackageTaskFactory(ruby.NewGemSpecCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ruby", "gem", "gemspec"),
-		newSimplePackageTaskFactory(rust.NewCargoLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "rust", "cargo"),
-		newSimplePackageTaskFactory(swift.NewCocoapodsCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swift", "cocoapods"),
-		newSimplePackageTaskFactory(swift.NewSwiftPackageManagerCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swift", "spm"),
-		newSimplePackageTaskFactory(swipl.NewSwiplPackCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swipl", "pack"),
-		newSimplePackageTaskFactory(ocaml.NewOpamPackageManagerCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ocaml", "opam"),
+		newSimplePackageTaskFactory("ruby-gemfile-cataloger", ruby.NewGemFileLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ruby", "gem"),
+		newSimplePackageTaskFactory("ruby-gemspec-cataloger", ruby.NewGemSpecCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ruby", "gem", "gemspec"),
+		newSimplePackageTaskFactory("rust-cargo-lock-cataloger", rust.NewCargoLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "rust", "cargo"),
+		newSimplePackageTaskFactory("cocoapods-cataloger", swift.NewCocoapodsCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swift", "cocoapods"),
+		newSimplePackageTaskFactory("swift-package-manager-cataloger", swift.NewSwiftPackageManagerCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swift", "spm"),
+		newSimplePackageTaskFactory("swipl-pack-cataloger", swipl.NewSwiplPackCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "swipl", "pack"),
+		newSimplePackageTaskFactory("opam-cataloger", ocaml.NewOpamPackageManagerCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "ocaml", "opam"),
 
 		// language-specific package for both image and directory scans (but not necessarily declared) ////////////////////////////////////////
 		newPackageTaskFactory(
+			"dotnet-deps-binary-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return dotnet.NewDotnetDepsBinaryCataloger(cfg.PackagesConfig.Dotnet)
 			},
 			pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dotnet", "c#",
 		),
-		newSimplePackageTaskFactory(dotnet.NewDotnetPackagesLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.ImageTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dotnet", "c#"),
-		newSimplePackageTaskFactory(python.NewInstalledPackageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Python),
+		newSimplePackageTaskFactory("dotnet-packages-lock-cataloger", dotnet.NewDotnetPackagesLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.ImageTag, pkgcataloging.DirectoryTag, pkgcataloging.LanguageTag, "dotnet", "c#"),
+		newSimplePackageTaskFactory("python-installed-package-cataloger", python.NewInstalledPackageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Python),
 		newPackageTaskFactory(
+			"go-module-binary-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return golang.NewGoModuleBinaryCataloger(cfg.PackagesConfig.Golang)
 			},
 			pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Go, Golang, "gomod", "binary",
 		),
 		newPackageTaskFactory(
+			"java-archive-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return java.NewArchiveCataloger(cfg.PackagesConfig.JavaArchive)
 			},
 			pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Java, Maven,
 		),
-		newSimplePackageTaskFactory(java.NewNativeImageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Java),
+		newSimplePackageTaskFactory("graalvm-native-image-cataloger", java.NewNativeImageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, Java),
 		newPackageTaskFactory(
+			"nix-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return nix.NewCataloger(cfg.PackagesConfig.Nix)
 			},
 			pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "nix",
 		),
-		newSimplePackageTaskFactory(lua.NewPackageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "lua"),
+		newSimplePackageTaskFactory("lua-rock-cataloger", lua.NewPackageCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, pkgcataloging.LanguageTag, "lua"),
 
 		// other package catalogers ///////////////////////////////////////////////////////////////////////////
 		newPackageTaskFactory(
+			"binary-classifier-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return binary.NewClassifierCataloger(cfg.PackagesConfig.Binary)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary",
 		),
-		newSimplePackageTaskFactory(binary.NewELFPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "elf-package", "elf"),
-		newSimplePackageTaskFactory(binary.NewPEPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "pe-package", "pe", "dll", "exe", "bpl"),
-		newSimplePackageTaskFactory(githubactions.NewActionUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
-		newSimplePackageTaskFactory(githubactions.NewWorkflowUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
-		newSimplePackageTaskFactory(java.NewJvmDistributionCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "java", "jvm", "jdk", "jre"),
+		newSimplePackageTaskFactory("elf-binary-package-cataloger", binary.NewELFPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "elf-package", "elf"),
+		newSimplePackageTaskFactory("pe-binary-package-cataloger", binary.NewPEPackageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "pe-package", "pe", "dll", "exe", "bpl"),
+		newSimplePackageTaskFactory("github-actions-usage-cataloger", githubactions.NewActionUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
+		newSimplePackageTaskFactory("github-action-workflow-usage-cataloger", githubactions.NewWorkflowUsageCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "github", "github-actions"),
+		newSimplePackageTaskFactory("java-jvm-cataloger", java.NewJvmDistributionCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "java", "jvm", "jdk", "jre"),
 		newPackageTaskFactory(
+			"linux-kernel-cataloger",
 			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
 				return kernel.NewLinuxKernelCataloger(cfg.PackagesConfig.LinuxKernel)
 			},
 			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "linux", "kernel",
 		),
-		newSimplePackageTaskFactory(php.NewInterpreterCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "php"),
-		newSimplePackageTaskFactory(sbomCataloger.NewCataloger, "sbom"), // note: not evidence of installed packages
-		newSimplePackageTaskFactory(bitnamiSbomCataloger.NewCataloger, "bitnami", pkgcataloging.InstalledTag, pkgcataloging.ImageTag),
-		newSimplePackageTaskFactory(wordpress.NewWordpressPluginCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "wordpress"),
-		newSimplePackageTaskFactory(terraform.NewLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "terraform"),
-		newSimplePackageTaskFactory(homebrew.NewCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "homebrew"),
-		newSimplePackageTaskFactory(apple.NewAppBundleCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "apple"),
-		newSimplePackageTaskFactory(conda.NewCondaMetaCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.PackageTag, "conda"),
-		newSimplePackageTaskFactory(snap.NewCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "snap"),
-		newSimplePackageTaskFactory(ai.NewGGUFCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "ai", "model", "gguf", "ml"),
+		newSimplePackageTaskFactory("php-interpreter-cataloger", php.NewInterpreterCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "binary", "php"),
+		newSimplePackageTaskFactory("sbom-cataloger", sbomCataloger.NewCataloger, "sbom"), // note: not evidence of installed packages
+		newSimplePackageTaskFactory("bitnami-cataloger", bitnamiSbomCataloger.NewCataloger, "bitnami", pkgcataloging.InstalledTag, pkgcataloging.ImageTag),
+		newSimplePackageTaskFactory("wordpress-plugins-cataloger", wordpress.NewWordpressPluginCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "wordpress"),
+		newSimplePackageTaskFactory("terraform-lock-cataloger", terraform.NewLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "terraform"),
+		newSimplePackageTaskFactory("homebrew-cataloger", homebrew.NewCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "homebrew"),
+		newSimplePackageTaskFactory("apple-app-bundle-cataloger", apple.NewAppBundleCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "apple"),
+		newSimplePackageTaskFactory("conda-meta-cataloger", conda.NewCondaMetaCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.PackageTag, "conda"),
+		newSimplePackageTaskFactory("snap-cataloger", snap.NewCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "snap"),
+		newSimplePackageTaskFactory("gguf-cataloger", ai.NewGGUFCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "ai", "model", "gguf", "ml"),
 
 		// deprecated catalogers ////////////////////////////////////////
 		// these are catalogers that should not be selectable other than specific inclusion via name or "deprecated" tag (to remain backwards compatible)
-		newSimplePackageTaskFactory(dotnet.NewDotnetDepsCataloger, pkgcataloging.DeprecatedTag),               //nolint:staticcheck // TODO: remove in syft v2.0
-		newSimplePackageTaskFactory(dotnet.NewDotnetPortableExecutableCataloger, pkgcataloging.DeprecatedTag), //nolint:staticcheck // TODO: remove in syft v2.0
-		newSimplePackageTaskFactory(php.NewPeclCataloger, pkgcataloging.DeprecatedTag),                        //nolint:staticcheck // TODO: remove in syft v2.0
-		newSimplePackageTaskFactory(nix.NewStoreCataloger, pkgcataloging.DeprecatedTag),                       //nolint:staticcheck // TODO: remove in syft v2.0
+		newSimplePackageTaskFactory("dotnet-deps-cataloger", dotnet.NewDotnetDepsCataloger, pkgcataloging.DeprecatedTag),                              //nolint:staticcheck // TODO: remove in syft v2.0
+		newSimplePackageTaskFactory("dotnet-portable-executable-cataloger", dotnet.NewDotnetPortableExecutableCataloger, pkgcataloging.DeprecatedTag), //nolint:staticcheck // TODO: remove in syft v2.0
+		newSimplePackageTaskFactory("php-pecl-serialized-cataloger", php.NewPeclCataloger, pkgcataloging.DeprecatedTag),                               //nolint:staticcheck // TODO: remove in syft v2.0
+		newSimplePackageTaskFactory("nix-store-cataloger", nix.NewStoreCataloger, pkgcataloging.DeprecatedTag),                                        //nolint:staticcheck // TODO: remove in syft v2.0
 	}
 }

--- a/syft/create_sbom_config.go
+++ b/syft/create_sbom_config.go
@@ -2,9 +2,9 @@ package syft
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime/debug"
+	"sort"
 	"strings"
 
 	"github.com/anchore/syft/internal/log"
@@ -12,7 +12,9 @@ import (
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/exp"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
 	"github.com/anchore/syft/syft/source"
 )
@@ -38,6 +40,7 @@ type CreateSBOMConfig struct {
 
 	packageTaskFactories       task.Factories
 	packageCatalogerReferences []pkgcataloging.CatalogerReference
+	packageCatalogerTasks      []exp.Task
 }
 
 func DefaultCreateSBOMConfig() *CreateSBOMConfig {
@@ -164,6 +167,7 @@ func (c *CreateSBOMConfig) WithCatalogerSelection(selection cataloging.Selection
 func (c *CreateSBOMConfig) WithoutCatalogers() *CreateSBOMConfig {
 	c.packageTaskFactories = nil
 	c.packageCatalogerReferences = nil
+	c.packageCatalogerTasks = nil
 	return c
 }
 
@@ -177,6 +181,22 @@ func (c *CreateSBOMConfig) WithCatalogers(catalogerRefs ...pkgcataloging.Catalog
 	c.packageCatalogerReferences = append(c.packageCatalogerReferences, catalogerRefs...)
 
 	return c
+}
+
+// WithCatalogerTasks allows adding experimental package cataloger tasks with selection metadata and capabilities.
+func (c *CreateSBOMConfig) WithCatalogerTasks(tasks ...exp.Task) *CreateSBOMConfig {
+	c.packageCatalogerTasks = append(c.packageCatalogerTasks, tasks...)
+	return c
+}
+
+// CatalogerSelectionRequest returns the requested cataloger selection for experimental cataloger APIs.
+func (c *CreateSBOMConfig) CatalogerSelectionRequest() cataloging.SelectionRequest {
+	return c.CatalogerSelection
+}
+
+// CatalogerTasks returns all package cataloger tasks available to this configuration.
+func (c *CreateSBOMConfig) CatalogerTasks() ([]exp.Task, error) {
+	return c.catalogerTasks(c.catalogingFactoryConfig())
 }
 
 // makeTaskGroups considers the entire configuration and finalizes the set of tasks to be run. Tasks are run in
@@ -256,15 +276,7 @@ func (c *CreateSBOMConfig) fileTasks(cfg task.CatalogingFactoryConfig) ([]task.T
 
 // selectTasks returns the set of tasks that should be run to catalog packages and files.
 func (c *CreateSBOMConfig) selectTasks(src source.Description) ([]task.Task, []task.Task, *task.Selection, error) {
-	cfg := task.CatalogingFactoryConfig{
-		SearchConfig:         c.Search,
-		RelationshipsConfig:  c.Relationships,
-		DataGenerationConfig: c.DataGeneration,
-		PackagesConfig:       c.Packages,
-		LicenseConfig:        c.Licenses,
-		ComplianceConfig:     c.Compliance,
-		FilesConfig:          c.Files,
-	}
+	cfg := c.catalogingFactoryConfig()
 
 	persistentPkgTasks, selectablePkgTasks, err := c.allPackageTasks(cfg)
 	if err != nil {
@@ -368,40 +380,143 @@ func finalTaskSelectionRequest(req cataloging.SelectionRequest, src source.Descr
 }
 
 func (c *CreateSBOMConfig) allPackageTasks(cfg task.CatalogingFactoryConfig) ([]task.Task, []task.Task, error) {
-	persistentPackageTasks, selectablePackageTasks, err := c.userPackageTasks(cfg)
+	catalogerTasks, err := c.catalogerTasks(cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tsks, err := c.packageTaskFactories.Tasks(cfg)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to create package cataloger tasks: %w", err)
+	var persistentPackageTasks []exp.Task
+	var selectablePackageTasks []exp.Task
+	for _, catalogerTask := range catalogerTasks {
+		if catalogerTask.AlwaysEnabled() {
+			persistentPackageTasks = append(persistentPackageTasks, catalogerTask)
+			continue
+		}
+		selectablePackageTasks = append(selectablePackageTasks, catalogerTask)
 	}
 
-	return persistentPackageTasks, append(tsks, selectablePackageTasks...), nil
+	return packageTasks(persistentPackageTasks, cfg), packageTasks(selectablePackageTasks, cfg), nil
 }
 
-func (c *CreateSBOMConfig) userPackageTasks(cfg task.CatalogingFactoryConfig) ([]task.Task, []task.Task, error) {
-	var (
-		persistentPackageTasks []task.Task
-		selectablePackageTasks []task.Task
-	)
+func (c *CreateSBOMConfig) catalogingFactoryConfig() task.CatalogingFactoryConfig {
+	return task.CatalogingFactoryConfig{
+		SearchConfig:         c.Search,
+		RelationshipsConfig:  c.Relationships,
+		DataGenerationConfig: c.DataGeneration,
+		PackagesConfig:       c.Packages,
+		LicenseConfig:        c.Licenses,
+		ComplianceConfig:     c.Compliance,
+		FilesConfig:          c.Files,
+	}
+}
+
+func (c *CreateSBOMConfig) catalogerTasks(cfg task.CatalogingFactoryConfig) ([]exp.Task, error) {
+	capabilitiesByName, err := packageCatalogerCapabilitiesByName()
+	if err != nil {
+		return nil, fmt.Errorf("unable to load package cataloger capabilities: %w", err)
+	}
+
+	var catalogerTasks []exp.Task
+	for _, factory := range c.packageTaskFactories {
+		packageFactory, ok := factory.(task.PackageFactory)
+		if !ok {
+			continue
+		}
+
+		name := packageFactory.Name()
+		pf := packageFactory
+		options := []exp.TaskOption{exp.WithTags(catalogerTaskTags(name, packageFactory.Selectors())...)}
+		if capabilities, ok := capabilitiesByName[name]; ok {
+			options = append(options, exp.WithCapabilities(capabilities))
+		}
+		catalogerTasks = append(catalogerTasks, exp.NewCatalogerTaskFactory(name, func() pkg.Cataloger {
+			return pf.Cataloger(cfg)
+		}, options...))
+	}
 
 	for _, catalogerRef := range c.packageCatalogerReferences {
 		if catalogerRef.Cataloger == nil {
-			return nil, nil, errors.New("provided cataloger reference without a cataloger")
+			return nil, fmt.Errorf("provided cataloger reference without a cataloger")
 		}
+		options := []exp.TaskOption{exp.WithTags(catalogerRef.Tags...)}
 		if catalogerRef.AlwaysEnabled {
-			persistentPackageTasks = append(persistentPackageTasks, task.NewPackageTask(cfg, catalogerRef.Cataloger, catalogerRef.Tags...))
-			continue
+			options = append(options, exp.AlwaysEnabled())
 		}
-		if len(catalogerRef.Tags) == 0 {
-			return nil, nil, errors.New("provided cataloger reference without tags")
-		}
-		selectablePackageTasks = append(selectablePackageTasks, task.NewPackageTask(cfg, catalogerRef.Cataloger, catalogerRef.Tags...))
+		catalogerTasks = append(catalogerTasks, exp.NewCatalogerTask(catalogerRef.Cataloger, options...))
 	}
 
-	return persistentPackageTasks, selectablePackageTasks, nil
+	catalogerTasks = append(catalogerTasks, c.packageCatalogerTasks...)
+	if err := validateCatalogerTaskNames(catalogerTasks); err != nil {
+		return nil, err
+	}
+	return catalogerTasks, nil
+}
+
+func packageCatalogerCapabilitiesByName() (map[string]exp.Capabilities, error) {
+	allCapabilities, err := exp.PackageCatalogerCapabilities()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]exp.Capabilities, len(allCapabilities))
+	for _, capabilities := range allCapabilities {
+		result[capabilities.Name] = capabilities
+	}
+	return result, nil
+}
+
+func catalogerTaskTags(name string, selectors []string) []string {
+	tagSet := make(map[string]struct{}, len(selectors))
+	for _, selector := range selectors {
+		if selector == "" || selector == name {
+			continue
+		}
+		tagSet[selector] = struct{}{}
+	}
+
+	tags := make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+func validateCatalogerTaskNames(tasks []exp.Task) error {
+	seen := make(map[string]struct{}, len(tasks))
+	duplicates := make(map[string]struct{})
+	for _, catalogerTask := range tasks {
+		name := catalogerTask.Name()
+		if name == "" {
+			return fmt.Errorf("cataloger task without a name")
+		}
+		if _, ok := seen[name]; ok {
+			duplicates[name] = struct{}{}
+		}
+		seen[name] = struct{}{}
+	}
+
+	if len(duplicates) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(duplicates))
+	for name := range duplicates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return fmt.Errorf("duplicate cataloger task names: %s", strings.Join(names, ", "))
+}
+
+func packageTasks(catalogerTasks []exp.Task, cfg task.CatalogingFactoryConfig) []task.Task {
+	result := make([]task.Task, 0, len(catalogerTasks))
+	for _, catalogerTask := range catalogerTasks {
+		ct := catalogerTask
+		result = append(result, task.NewPackageTaskFromFactory(cfg, ct.Name(), func(task.CatalogingFactoryConfig) pkg.Cataloger {
+			return ct.Cataloger()
+		}, ct.Tags()...))
+	}
+	return result
 }
 
 // scopeTasks returns the set of tasks that should be run to generate additional scope information

--- a/syft/create_sbom_config_test.go
+++ b/syft/create_sbom_config_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/exp"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/source"
@@ -37,6 +38,33 @@ func (d dummyCataloger) Name() string {
 
 func (d dummyCataloger) Catalog(_ context.Context, _ file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
 	return nil, nil, nil
+}
+
+func TestCreateSBOMConfig_expCatalogerAPI(t *testing.T) {
+	cfg := DefaultCreateSBOMConfig().WithCatalogerSelection(
+		cataloging.NewSelectionRequest().WithDefaults("all").WithSubSelections("python"),
+	)
+
+	names, err := exp.ListCatalogers(cfg)
+	require.NoError(t, err)
+	assert.Contains(t, names, "python-package-cataloger")
+	assert.Contains(t, names, "python-installed-package-cataloger")
+	assert.NotContains(t, names, "ruby-gemfile-cataloger")
+
+	info, err := exp.CatalogerInfo(cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, info)
+
+	var foundPythonPackageCataloger bool
+	for _, catalogerInfo := range info {
+		if catalogerInfo.Name != "python-package-cataloger" {
+			continue
+		}
+		foundPythonPackageCataloger = true
+		assert.Contains(t, catalogerInfo.Selectors, "python")
+		assert.NotEmpty(t, catalogerInfo.Parsers)
+	}
+	assert.True(t, foundPythonPackageCataloger)
 }
 
 func TestCreateSBOMConfig_makeTaskGroups(t *testing.T) {
@@ -357,17 +385,12 @@ func TestCreateSBOMConfig_makeTaskGroups(t *testing.T) {
 
 func pkgCatalogerNamesWithTagOrName(t *testing.T, token string) []string {
 	var names []string
-	cfg := task.DefaultCatalogingFactoryConfig()
 	for _, factory := range task.DefaultPackageTaskFactories() {
-		cat := factory(cfg)
+		name := factory.Name()
 
-		name := cat.Name()
-
-		if selector, ok := cat.(task.Selector); ok {
-			if selector.HasAllSelectors(token) {
-				names = append(names, name)
-				continue
-			}
+		if strset.New(factory.Selectors()...).Has(token) {
+			names = append(names, name)
+			continue
 		}
 		if name == token {
 			names = append(names, name)
@@ -390,16 +413,9 @@ func pkgCatalogerNamesWithTagOrName(t *testing.T, token string) []string {
 
 func fileCatalogerNames(tokens ...string) []string {
 	var names []string
-	cfg := task.DefaultCatalogingFactoryConfig()
 topLoop:
 	for _, factory := range task.DefaultFileTaskFactories() {
-		cat := factory(cfg)
-
-		if cat == nil {
-			continue
-		}
-
-		name := cat.Name()
+		name := factory.Name()
 
 		if len(tokens) == 0 {
 			names = append(names, name)
@@ -407,12 +423,9 @@ topLoop:
 		}
 
 		for _, token := range tokens {
-			if selector, ok := cat.(task.Selector); ok {
-				if selector.HasAllSelectors(token) {
-					names = append(names, name)
-					continue topLoop
-				}
-
+			if strset.New(factory.Selectors()...).Has(token) {
+				names = append(names, name)
+				continue topLoop
 			}
 			if name == token {
 				names = append(names, name)

--- a/syft/exp/cataloger.go
+++ b/syft/exp/cataloger.go
@@ -1,0 +1,106 @@
+package exp
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/anchore/syft/internal/capabilities"
+	"github.com/anchore/syft/internal/task"
+	"github.com/anchore/syft/syft/cataloging"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+)
+
+// Cataloger describes an available cataloger and its selection metadata.
+type Cataloger struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// AllCatalogers returns information about all registered catalogers
+// (both package and file catalogers), sorted by name. Any additional
+// user-provided cataloger references are included in the result.
+func AllCatalogers(additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
+	return SelectCatalogers(cataloging.SelectionRequest{
+		DefaultNamesOrTags: []string{"all"},
+	}, additional...)
+}
+
+// SelectCatalogers returns information about catalogers matching the given
+// selection request. It applies the same selection logic used by CreateSBOM
+// and the "syft cataloger list" CLI command.
+//
+// Any additional user-provided cataloger references are merged into the
+// selectable set before selection is applied. References with AlwaysEnabled
+// set to true are always included in the result regardless of the selection.
+//
+// If the selection request is empty (zero value), no catalogers are returned;
+// use AllCatalogers() or pass a selection with DefaultNamesOrTags: []string{"all"}.
+func SelectCatalogers(selection cataloging.SelectionRequest, additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
+	cfg := task.DefaultCatalogingFactoryConfig()
+
+	pkgTasks, err := task.DefaultPackageTaskFactories().Tasks(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create package cataloger tasks: %w", err)
+	}
+
+	fileTasks, err := task.DefaultFileTaskFactories().Tasks(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create file cataloger tasks: %w", err)
+	}
+
+	var persistentTasks []task.Task
+	for _, ref := range additional {
+		if ref.Cataloger == nil {
+			continue
+		}
+		t := task.NewPackageTask(cfg, ref.Cataloger, ref.Tags...)
+		if ref.AlwaysEnabled {
+			persistentTasks = append(persistentTasks, t)
+		} else {
+			pkgTasks = append(pkgTasks, t)
+		}
+	}
+
+	if selection.IsEmpty() {
+		if len(persistentTasks) > 0 {
+			return extractCatalogers(persistentTasks), nil
+		}
+		return nil, nil
+	}
+
+	taskGroups := [][]task.Task{pkgTasks, fileTasks}
+	selectedGroups, _, err := task.SelectInGroups(taskGroups, selection)
+	if err != nil {
+		return nil, fmt.Errorf("unable to select catalogers: %w", err)
+	}
+
+	var selected []task.Task
+	for _, group := range selectedGroups {
+		selected = append(selected, group...)
+	}
+	selected = append(selected, persistentTasks...)
+
+	return extractCatalogers(selected), nil
+}
+
+func extractCatalogers(tasks []task.Task) []Cataloger {
+	infos := capabilities.ExtractCatalogerInfo(tasks)
+
+	catalogers := make([]Cataloger, 0, len(infos))
+	for _, info := range infos {
+		tags := info.Selectors
+		if tags == nil {
+			tags = []string{}
+		}
+		catalogers = append(catalogers, Cataloger{
+			Name: info.Name,
+			Tags: tags,
+		})
+	}
+
+	sort.Slice(catalogers, func(i, j int) bool {
+		return catalogers[i].Name < catalogers[j].Name
+	})
+
+	return catalogers
+}

--- a/syft/exp/cataloger.go
+++ b/syft/exp/cataloger.go
@@ -1,100 +1,318 @@
 package exp
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 
+	"github.com/scylladb/go-set/strset"
+
 	"github.com/anchore/syft/internal/capabilities"
+	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/internal/task"
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	_ "github.com/anchore/syft/syft/pkg/cataloger"
 )
 
-// Cataloger describes an available cataloger and its selection metadata.
+// Cataloger describes an available package cataloger and its selection metadata.
 type Cataloger struct {
 	Name string   `json:"name"`
 	Tags []string `json:"tags"`
 }
 
-// AllCatalogers returns information about all registered catalogers
-// (both package and file catalogers), sorted by name. Any additional
-// user-provided cataloger references are included in the result.
-func AllCatalogers(additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
-	return SelectCatalogers(cataloging.SelectionRequest{
-		DefaultNamesOrTags: []string{"all"},
-	}, additional...)
+// Task describes a package cataloger that can be selected and inspected before the cataloger is constructed.
+type Task struct {
+	name             string
+	tags             []string
+	capabilities     *Capabilities
+	catalogerFactory func() pkg.Cataloger
+	alwaysEnabled    bool
 }
 
-// SelectCatalogers returns information about catalogers matching the given
-// selection request. It applies the same selection logic used by CreateSBOM
-// and the "syft cataloger list" CLI command.
-//
-// Any additional user-provided cataloger references are merged into the
-// selectable set before selection is applied. References with AlwaysEnabled
-// set to true are always included in the result regardless of the selection.
-//
-// If the selection request is empty (zero value), no catalogers are returned;
-// use AllCatalogers() or pass a selection with DefaultNamesOrTags: []string{"all"}.
-func SelectCatalogers(selection cataloging.SelectionRequest, additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
-	cfg := task.DefaultCatalogingFactoryConfig()
+type TaskOption func(*Task)
 
-	pkgTasks, err := task.DefaultPackageTaskFactories().Tasks(cfg)
+// CatalogerTaskProvider is implemented by configuration types that can provide experimental cataloger tasks.
+type CatalogerTaskProvider interface {
+	CatalogerTasks() ([]Task, error)
+	CatalogerSelectionRequest() cataloging.SelectionRequest
+}
+
+// NewCatalogerTask creates a task from an already-constructed package cataloger.
+func NewCatalogerTask(cataloger pkg.Cataloger, options ...TaskOption) Task {
+	if cataloger == nil {
+		return Task{}
+	}
+	return NewCatalogerTaskFactory(cataloger.Name(), func() pkg.Cataloger {
+		return cataloger
+	}, options...)
+}
+
+// NewCatalogerTaskFactory creates a task that constructs its package cataloger only when needed.
+func NewCatalogerTaskFactory(name string, catalogerFactory func() pkg.Cataloger, options ...TaskOption) Task {
+	t := Task{
+		name:             name,
+		catalogerFactory: catalogerFactory,
+	}
+	WithTags(pkgcataloging.PackageTag)(&t)
+	for _, opt := range options {
+		opt(&t)
+	}
+	return t
+}
+
+func WithTags(tags ...string) TaskOption {
+	return func(t *Task) {
+		t.tags = append(t.tags, tags...)
+		t.tags = cleanTags(t.name, t.tags)
+	}
+}
+
+func WithCapabilities(c Capabilities) TaskOption {
+	return func(t *Task) {
+		if c.Name == "" {
+			c.Name = t.name
+		}
+		c.Selectors = cleanTags(t.name, append(c.Selectors, t.tags...))
+		t.capabilities = &c
+	}
+}
+
+func AlwaysEnabled() TaskOption {
+	return func(t *Task) {
+		t.alwaysEnabled = true
+	}
+}
+
+func (t Task) Name() string {
+	return t.name
+}
+
+func (t Task) Tags() []string {
+	return append([]string(nil), t.tags...)
+}
+
+func (t Task) Capabilities() (Capabilities, bool) {
+	if t.capabilities == nil {
+		return Capabilities{}, false
+	}
+	c := *t.capabilities
+	c.Name = t.name
+	c.Selectors = cleanTags(t.name, append(c.Selectors, t.tags...))
+	return c, true
+}
+
+func (t Task) Cataloger() pkg.Cataloger {
+	if t.catalogerFactory == nil {
+		return nil
+	}
+	return t.catalogerFactory()
+}
+
+func (t Task) Catalog(ctx context.Context, resolver file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
+	cataloger := t.Cataloger()
+	if cataloger == nil {
+		return nil, nil, fmt.Errorf("cataloger task %q has no cataloger factory", t.name)
+	}
+	return cataloger.Catalog(ctx, resolver)
+}
+
+func (t Task) AlwaysEnabled() bool {
+	return t.alwaysEnabled
+}
+
+func newCatalogerTasks(factories task.Factories, cfg task.CatalogingFactoryConfig, refs ...pkgcataloging.CatalogerReference) ([]Task, error) {
+	capabilitiesByName, err := catalogerCapabilitiesByName()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create package cataloger tasks: %w", err)
+		return nil, err
 	}
 
-	fileTasks, err := task.DefaultFileTaskFactories().Tasks(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create file cataloger tasks: %w", err)
-	}
-
-	var persistentTasks []task.Task
-	for _, ref := range additional {
-		if ref.Cataloger == nil {
+	var tasks []Task
+	for _, factory := range factories {
+		packageFactory, ok := factory.(task.PackageFactory)
+		if !ok {
 			continue
 		}
-		t := task.NewPackageTask(cfg, ref.Cataloger, ref.Tags...)
+
+		name := packageFactory.Name()
+		pf := packageFactory
+		catalogerTask := NewCatalogerTaskFactory(name, func() pkg.Cataloger {
+			return pf.Cataloger(cfg)
+		}, WithTags(tagsWithoutName(name, packageFactory.Selectors())...))
+
+		if c, ok := capabilitiesByName[name]; ok {
+			catalogerTask.capabilities = &c
+		}
+		tasks = append(tasks, catalogerTask)
+	}
+
+	for _, ref := range refs {
+		if ref.Cataloger == nil {
+			return nil, fmt.Errorf("provided cataloger reference without a cataloger")
+		}
+
+		options := []TaskOption{WithTags(ref.Tags...)}
 		if ref.AlwaysEnabled {
-			persistentTasks = append(persistentTasks, t)
-		} else {
-			pkgTasks = append(pkgTasks, t)
+			options = append(options, AlwaysEnabled())
 		}
+		tasks = append(tasks, NewCatalogerTask(ref.Cataloger, options...))
 	}
 
+	if err := validateTaskNames(tasks); err != nil {
+		return nil, err
+	}
+
+	return tasks, nil
+}
+
+// ListCatalogers returns the names of package catalogers selected by the provider's selection request.
+func ListCatalogers(provider CatalogerTaskProvider) ([]string, error) {
+	tasks, err := selectedProviderTasks(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(tasks))
+	for _, t := range tasks {
+		names = append(names, t.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// CatalogerInfo returns package cataloger capabilities selected by the provider's selection request.
+func CatalogerInfo(provider CatalogerTaskProvider) ([]Capabilities, error) {
+	tasks, err := selectedProviderTasks(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Capabilities, 0, len(tasks))
+	for _, t := range tasks {
+		if c, ok := t.Capabilities(); ok {
+			result = append(result, c)
+			continue
+		}
+		result = append(result, Capabilities{
+			Name:      t.Name(),
+			Type:      "custom",
+			Selectors: t.Tags(),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result, nil
+}
+
+// PackageCatalogerCapabilities returns all embedded package cataloger capabilities.
+func PackageCatalogerCapabilities() ([]Capabilities, error) {
+	entries, err := capabilities.Packages()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]Capabilities, 0, len(entries))
+	for _, entry := range entries {
+		converted, err := convertCapabilities(entry)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, converted)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result, nil
+}
+
+// SelectCatalogerTasks returns tasks matching a selection request without constructing catalogers.
+func SelectCatalogerTasks(tasks []Task, selection cataloging.SelectionRequest) ([]Task, error) {
 	if selection.IsEmpty() {
-		if len(persistentTasks) > 0 {
-			return extractCatalogers(persistentTasks), nil
-		}
-		return nil, nil
+		return append([]Task(nil), tasks...), nil
 	}
 
-	taskGroups := [][]task.Task{pkgTasks, fileTasks}
-	selectedGroups, _, err := task.SelectInGroups(taskGroups, selection)
+	var selectable []Task
+	var persistent []Task
+	for _, t := range tasks {
+		if t.AlwaysEnabled() {
+			persistent = append(persistent, t)
+			continue
+		}
+		selectable = append(selectable, t)
+	}
+
+	selectionTasks := make([]task.Task, 0, len(selectable))
+	for _, t := range selectable {
+		selectionTasks = append(selectionTasks, selectionTask(t))
+	}
+
+	selectedSelectionTasks, _, err := task.Select(selectionTasks, selection)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select catalogers: %w", err)
 	}
 
-	var selected []task.Task
-	for _, group := range selectedGroups {
-		selected = append(selected, group...)
+	selectedNames := strset.New()
+	for _, selected := range selectedSelectionTasks {
+		selectedNames.Add(selected.Name())
 	}
-	selected = append(selected, persistentTasks...)
 
+	var selected []Task
+	for _, t := range selectable {
+		if selectedNames.Has(t.Name()) {
+			selected = append(selected, t)
+		}
+	}
+	selected = append(selected, persistent...)
+
+	return selected, nil
+}
+
+// AllCatalogers returns information about all registered package catalogers, sorted by name.
+func AllCatalogers(additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
+	return SelectCatalogers(cataloging.NewSelectionRequest().WithDefaults("all"), additional...)
+}
+
+// SelectCatalogers returns information about package catalogers matching the given selection request.
+func SelectCatalogers(selection cataloging.SelectionRequest, additional ...pkgcataloging.CatalogerReference) ([]Cataloger, error) {
+	tasks, err := newCatalogerTasks(task.DefaultPackageTaskFactories(), task.DefaultCatalogingFactoryConfig(), additional...)
+	if err != nil {
+		return nil, err
+	}
+	selected, err := SelectCatalogerTasks(tasks, selection)
+	if err != nil {
+		return nil, err
+	}
 	return extractCatalogers(selected), nil
 }
 
-func extractCatalogers(tasks []task.Task) []Cataloger {
-	infos := capabilities.ExtractCatalogerInfo(tasks)
+func selectedProviderTasks(provider CatalogerTaskProvider) ([]Task, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("cataloger task provider is nil")
+	}
+	tasks, err := provider.CatalogerTasks()
+	if err != nil {
+		return nil, err
+	}
+	return SelectCatalogerTasks(tasks, provider.CatalogerSelectionRequest())
+}
 
-	catalogers := make([]Cataloger, 0, len(infos))
-	for _, info := range infos {
-		tags := info.Selectors
-		if tags == nil {
-			tags = []string{}
-		}
+func selectionTask(t Task) task.Task {
+	return task.NewTask(t.Name(), func(context.Context, file.Resolver, sbomsync.Builder) error {
+		return nil
+	}, t.Tags()...)
+}
+
+func extractCatalogers(tasks []Task) []Cataloger {
+	catalogers := make([]Cataloger, 0, len(tasks))
+	for _, t := range tasks {
 		catalogers = append(catalogers, Cataloger{
-			Name: info.Name,
-			Tags: tags,
+			Name: t.Name(),
+			Tags: t.Tags(),
 		})
 	}
 
@@ -103,4 +321,69 @@ func extractCatalogers(tasks []task.Task) []Cataloger {
 	})
 
 	return catalogers
+}
+
+func tagsWithoutName(name string, selectors []string) []string {
+	var tags []string
+	for _, selector := range selectors {
+		if selector == name {
+			continue
+		}
+		tags = append(tags, selector)
+	}
+	return cleanTags(name, tags)
+}
+
+func cleanTags(name string, tags []string) []string {
+	set := strset.New(tags...)
+	set.Remove("")
+	set.Remove(name)
+	result := set.List()
+	sort.Strings(result)
+	return result
+}
+
+func validateTaskNames(tasks []Task) error {
+	seen := strset.New()
+	duplicates := strset.New()
+	for _, t := range tasks {
+		if t.Name() == "" {
+			return fmt.Errorf("cataloger task without a name")
+		}
+		if seen.Has(t.Name()) {
+			duplicates.Add(t.Name())
+		}
+		seen.Add(t.Name())
+	}
+	if duplicates.Size() == 0 {
+		return nil
+	}
+	names := duplicates.List()
+	sort.Strings(names)
+	return fmt.Errorf("duplicate cataloger task names: %v", names)
+}
+
+func catalogerCapabilitiesByName() (map[string]Capabilities, error) {
+	entries, err := PackageCatalogerCapabilities()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]Capabilities, len(entries))
+	for _, entry := range entries {
+		result[entry.Name] = entry
+	}
+	return result, nil
+}
+
+func convertCapabilities(value any) (Capabilities, error) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return Capabilities{}, fmt.Errorf("unable to marshal cataloger capabilities: %w", err)
+	}
+	var result Capabilities
+	if err := json.Unmarshal(data, &result); err != nil {
+		return Capabilities{}, fmt.Errorf("unable to unmarshal cataloger capabilities: %w", err)
+	}
+	return result, nil
 }

--- a/syft/exp/cataloger_test.go
+++ b/syft/exp/cataloger_test.go
@@ -1,0 +1,151 @@
+package exp
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/cataloging"
+	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+type dummyCataloger struct {
+	name string
+}
+
+func (d dummyCataloger) Name() string { return d.name }
+func (d dummyCataloger) Catalog(_ context.Context, _ file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
+	return nil, nil, nil
+}
+
+func TestAllCatalogers(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		catalogers, err := AllCatalogers()
+		require.NoError(t, err)
+		assert.Greater(t, len(catalogers), 10)
+
+		for i := 1; i < len(catalogers); i++ {
+			assert.LessOrEqual(t, catalogers[i-1].Name, catalogers[i].Name, "results should be sorted by name")
+		}
+
+		names := make(map[string]bool)
+		for _, c := range catalogers {
+			assert.NotEmpty(t, c.Name)
+			names[c.Name] = true
+		}
+
+		assert.True(t, names["python-installed-package-cataloger"], "should contain python-installed-package-cataloger")
+		assert.True(t, names["go-module-binary-cataloger"], "should contain go-module-binary-cataloger")
+	})
+
+	t.Run("contains file catalogers", func(t *testing.T) {
+		catalogers, err := AllCatalogers()
+		require.NoError(t, err)
+
+		hasFileCataloger := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
+			return slices.Contains(c.Tags, "file")
+		})
+		assert.True(t, hasFileCataloger, "should include file catalogers")
+	})
+}
+
+func TestSelectCatalogers(t *testing.T) {
+	t.Run("with filter", func(t *testing.T) {
+		selection := cataloging.NewSelectionRequest().
+			WithDefaults("all").
+			WithSubSelections("python")
+
+		catalogers, err := SelectCatalogers(selection)
+		require.NoError(t, err)
+		assert.Greater(t, len(catalogers), 0)
+
+		for _, c := range catalogers {
+			// file catalogers are always included by the selection logic; skip them
+			if slices.Contains(c.Tags, "file") {
+				continue
+			}
+			assert.True(t, slices.Contains(c.Tags, "python"), "cataloger %q should have python tag", c.Name)
+		}
+	})
+
+	t.Run("empty selection", func(t *testing.T) {
+		catalogers, err := SelectCatalogers(cataloging.SelectionRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, catalogers)
+	})
+
+	t.Run("with additional always-enabled cataloger", func(t *testing.T) {
+		ref := pkgcataloging.CatalogerReference{
+			Cataloger:     dummyCataloger{name: "my-custom-cataloger"},
+			AlwaysEnabled: true,
+			Tags:          []string{"custom"},
+		}
+
+		catalogers, err := SelectCatalogers(
+			cataloging.NewSelectionRequest().WithDefaults("all"),
+			ref,
+		)
+		require.NoError(t, err)
+
+		found := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
+			return c.Name == "my-custom-cataloger"
+		})
+		assert.True(t, found, "should include the always-enabled custom cataloger")
+	})
+
+	t.Run("with additional selectable cataloger matching selection", func(t *testing.T) {
+		ref := pkgcataloging.CatalogerReference{
+			Cataloger: dummyCataloger{name: "my-python-cataloger"},
+			Tags:      []string{"python", "custom"},
+		}
+
+		catalogers, err := SelectCatalogers(
+			cataloging.NewSelectionRequest().WithDefaults("all").WithSubSelections("custom"),
+			ref,
+		)
+		require.NoError(t, err)
+
+		found := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
+			return c.Name == "my-python-cataloger"
+		})
+		assert.True(t, found, "should include custom cataloger that matches selection")
+	})
+
+	t.Run("with additional selectable cataloger not matching selection", func(t *testing.T) {
+		ref := pkgcataloging.CatalogerReference{
+			Cataloger: dummyCataloger{name: "my-ruby-cataloger"},
+			Tags:      []string{"ruby", "custom"},
+		}
+
+		catalogers, err := SelectCatalogers(
+			cataloging.NewSelectionRequest().WithDefaults("all").WithSubSelections("python"),
+			ref,
+		)
+		require.NoError(t, err)
+
+		found := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
+			return c.Name == "my-ruby-cataloger"
+		})
+		assert.False(t, found, "should not include custom cataloger that does not match selection")
+	})
+
+	t.Run("always-enabled cataloger included even with empty selection", func(t *testing.T) {
+		ref := pkgcataloging.CatalogerReference{
+			Cataloger:     dummyCataloger{name: "my-persistent-cataloger"},
+			AlwaysEnabled: true,
+			Tags:          []string{"custom"},
+		}
+
+		catalogers, err := SelectCatalogers(cataloging.SelectionRequest{}, ref)
+		require.NoError(t, err)
+
+		require.Len(t, catalogers, 1)
+		assert.Equal(t, "my-persistent-cataloger", catalogers[0].Name)
+	})
+}

--- a/syft/exp/cataloger_test.go
+++ b/syft/exp/cataloger_test.go
@@ -24,35 +24,37 @@ func (d dummyCataloger) Catalog(_ context.Context, _ file.Resolver) ([]pkg.Packa
 	return nil, nil, nil
 }
 
+type staticProvider struct {
+	tasks     []Task
+	selection cataloging.SelectionRequest
+}
+
+func (p staticProvider) CatalogerTasks() ([]Task, error) {
+	return p.tasks, nil
+}
+
+func (p staticProvider) CatalogerSelectionRequest() cataloging.SelectionRequest {
+	return p.selection
+}
+
 func TestAllCatalogers(t *testing.T) {
-	t.Run("happy path", func(t *testing.T) {
-		catalogers, err := AllCatalogers()
-		require.NoError(t, err)
-		assert.Greater(t, len(catalogers), 10)
+	catalogers, err := AllCatalogers()
+	require.NoError(t, err)
+	assert.Greater(t, len(catalogers), 10)
 
-		for i := 1; i < len(catalogers); i++ {
-			assert.LessOrEqual(t, catalogers[i-1].Name, catalogers[i].Name, "results should be sorted by name")
-		}
+	for i := 1; i < len(catalogers); i++ {
+		assert.LessOrEqual(t, catalogers[i-1].Name, catalogers[i].Name, "results should be sorted by name")
+	}
 
-		names := make(map[string]bool)
-		for _, c := range catalogers {
-			assert.NotEmpty(t, c.Name)
-			names[c.Name] = true
-		}
+	names := make(map[string]bool)
+	for _, c := range catalogers {
+		assert.NotEmpty(t, c.Name)
+		assert.Contains(t, c.Tags, pkgcataloging.PackageTag)
+		names[c.Name] = true
+	}
 
-		assert.True(t, names["python-installed-package-cataloger"], "should contain python-installed-package-cataloger")
-		assert.True(t, names["go-module-binary-cataloger"], "should contain go-module-binary-cataloger")
-	})
-
-	t.Run("contains file catalogers", func(t *testing.T) {
-		catalogers, err := AllCatalogers()
-		require.NoError(t, err)
-
-		hasFileCataloger := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
-			return slices.Contains(c.Tags, "file")
-		})
-		assert.True(t, hasFileCataloger, "should include file catalogers")
-	})
+	assert.True(t, names["python-installed-package-cataloger"], "should contain python-installed-package-cataloger")
+	assert.True(t, names["go-module-binary-cataloger"], "should contain go-module-binary-cataloger")
 }
 
 func TestSelectCatalogers(t *testing.T) {
@@ -66,18 +68,14 @@ func TestSelectCatalogers(t *testing.T) {
 		assert.Greater(t, len(catalogers), 0)
 
 		for _, c := range catalogers {
-			// file catalogers are always included by the selection logic; skip them
-			if slices.Contains(c.Tags, "file") {
-				continue
-			}
 			assert.True(t, slices.Contains(c.Tags, "python"), "cataloger %q should have python tag", c.Name)
 		}
 	})
 
-	t.Run("empty selection", func(t *testing.T) {
+	t.Run("empty selection returns all package catalogers", func(t *testing.T) {
 		catalogers, err := SelectCatalogers(cataloging.SelectionRequest{})
 		require.NoError(t, err)
-		assert.Empty(t, catalogers)
+		assert.Greater(t, len(catalogers), 10)
 	})
 
 	t.Run("with additional always-enabled cataloger", func(t *testing.T) {
@@ -135,7 +133,7 @@ func TestSelectCatalogers(t *testing.T) {
 		assert.False(t, found, "should not include custom cataloger that does not match selection")
 	})
 
-	t.Run("always-enabled cataloger included even with empty selection", func(t *testing.T) {
+	t.Run("always-enabled cataloger included with empty selection", func(t *testing.T) {
 		ref := pkgcataloging.CatalogerReference{
 			Cataloger:     dummyCataloger{name: "my-persistent-cataloger"},
 			AlwaysEnabled: true,
@@ -145,7 +143,66 @@ func TestSelectCatalogers(t *testing.T) {
 		catalogers, err := SelectCatalogers(cataloging.SelectionRequest{}, ref)
 		require.NoError(t, err)
 
-		require.Len(t, catalogers, 1)
-		assert.Equal(t, "my-persistent-cataloger", catalogers[0].Name)
+		found := slices.ContainsFunc(catalogers, func(c Cataloger) bool {
+			return c.Name == "my-persistent-cataloger"
+		})
+		assert.True(t, found)
 	})
+}
+
+func TestSelectCatalogerTasksDoesNotConstructCatalogers(t *testing.T) {
+	constructed := 0
+	task := NewCatalogerTaskFactory("custom-cataloger", func() pkg.Cataloger {
+		constructed++
+		return dummyCataloger{name: "custom-cataloger"}
+	}, WithTags("custom"))
+
+	selected, err := SelectCatalogerTasks([]Task{task}, cataloging.NewSelectionRequest().WithDefaults("custom"))
+	require.NoError(t, err)
+	require.Len(t, selected, 1)
+	assert.Zero(t, constructed)
+
+	assert.NotNil(t, selected[0].Cataloger())
+	assert.Equal(t, 1, constructed)
+}
+
+func TestCatalogerInfo(t *testing.T) {
+	capabilities := Capabilities{
+		Name: "custom-cataloger",
+		Type: "custom",
+		Detectors: []Detector{
+			{
+				Method:   GlobDetection,
+				Criteria: []string{"**/custom.lock"},
+			},
+		},
+	}
+	task := NewCatalogerTaskFactory(
+		"custom-cataloger",
+		func() pkg.Cataloger { return dummyCataloger{name: "custom-cataloger"} },
+		WithTags("custom"),
+		WithCapabilities(capabilities),
+	)
+
+	info, err := CatalogerInfo(staticProvider{tasks: []Task{task}})
+	require.NoError(t, err)
+	require.Len(t, info, 1)
+	assert.Equal(t, "custom-cataloger", info[0].Name)
+	assert.Contains(t, info[0].Selectors, "custom")
+	require.Len(t, info[0].Detectors, 1)
+	assert.Equal(t, GlobDetection, info[0].Detectors[0].Method)
+}
+
+func TestListCatalogers(t *testing.T) {
+	tasks := []Task{
+		NewCatalogerTaskFactory("custom-a", func() pkg.Cataloger { return dummyCataloger{name: "custom-a"} }, WithTags("custom")),
+		NewCatalogerTaskFactory("custom-b", func() pkg.Cataloger { return dummyCataloger{name: "custom-b"} }, WithTags("other")),
+	}
+
+	names, err := ListCatalogers(staticProvider{
+		tasks:     tasks,
+		selection: cataloging.NewSelectionRequest().WithDefaults("custom"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"custom-a"}, names)
 }

--- a/syft/exp/doc.go
+++ b/syft/exp/doc.go
@@ -1,0 +1,9 @@
+// Package exp provides experimental APIs for the syft library.
+//
+// APIs in this package have NO stability guarantees. They may change or be
+// removed in any release without notice. Do not depend on their behavior
+// in production systems.
+//
+// Once an API has proven stable and useful, it may be promoted to the main
+// syft package with proper stability guarantees.
+package exp

--- a/syft/exp/model.go
+++ b/syft/exp/model.go
@@ -1,0 +1,102 @@
+package exp
+
+// ArtifactDetectionMethod specifies the type of artifact detection mechanism.
+type ArtifactDetectionMethod string
+
+const (
+	GlobDetection     ArtifactDetectionMethod = "glob"
+	PathDetection     ArtifactDetectionMethod = "path"
+	MIMETypeDetection ArtifactDetectionMethod = "mimetype"
+)
+
+// Document represents the root structure of the capabilities data.
+type Document struct {
+	Configs           map[string]CatalogerConfigEntry `yaml:"configs,omitempty" json:"configs,omitempty"`
+	ApplicationConfig []ApplicationConfigField        `yaml:"application,omitempty" json:"application,omitempty"`
+	Catalogers        []Capabilities                  `yaml:"catalogers" json:"catalogers"`
+}
+
+type CatalogerConfigFieldEntry struct {
+	Key         string `yaml:"key" json:"key"`
+	Description string `yaml:"description" json:"description"`
+	AppKey      string `yaml:"app_key,omitempty" json:"app_key,omitempty"`
+}
+
+type CatalogerConfigEntry struct {
+	Fields []CatalogerConfigFieldEntry `yaml:"fields" json:"fields"`
+}
+
+type ApplicationConfigField struct {
+	Key          string `yaml:"key" json:"key"`
+	Description  string `yaml:"description" json:"description"`
+	DefaultValue any    `yaml:"default,omitempty" json:"default,omitempty"`
+}
+
+type Source struct {
+	File     string `yaml:"file" json:"file"`
+	Function string `yaml:"function" json:"function"`
+}
+
+type Detector struct {
+	Method     ArtifactDetectionMethod `yaml:"method" json:"method"`
+	Criteria   []string                `yaml:"criteria" json:"criteria"`
+	Conditions []DetectorCondition     `yaml:"conditions,omitempty" json:"conditions,omitempty"`
+	Packages   []DetectorPackageInfo   `yaml:"packages,omitempty" json:"packages,omitempty"`
+	Comment    string                  `yaml:"comment,omitempty" json:"comment,omitempty"`
+}
+
+type DetectorPackageInfo struct {
+	Class string   `yaml:"class" json:"class"`
+	Name  string   `yaml:"name" json:"name"`
+	PURL  string   `yaml:"purl" json:"purl"`
+	CPEs  []string `yaml:"cpes" json:"cpes"`
+	Type  string   `yaml:"type" json:"type"`
+}
+
+type DetectorCondition struct {
+	When    map[string]any `yaml:"when" json:"when"`
+	Comment string         `yaml:"comment,omitempty" json:"comment,omitempty"`
+}
+
+// Capabilities describes one package cataloger's capability metadata.
+type Capabilities struct {
+	Ecosystem       string        `yaml:"ecosystem" json:"ecosystem"`
+	Name            string        `yaml:"name" json:"name"`
+	Type            string        `yaml:"type" json:"type"`
+	Source          Source        `yaml:"source" json:"source"`
+	Config          string        `yaml:"config,omitempty" json:"config,omitempty"`
+	Selectors       []string      `yaml:"selectors,omitempty" json:"selectors,omitempty"`
+	Parsers         []Parser      `yaml:"parsers,omitempty" json:"parsers,omitempty"`
+	Detectors       []Detector    `yaml:"detectors,omitempty" json:"detectors,omitempty"`
+	MetadataTypes   []string      `yaml:"metadata_types,omitempty" json:"metadata_types,omitempty"`
+	PackageTypes    []string      `yaml:"package_types,omitempty" json:"package_types,omitempty"`
+	PURLTypes       []string      `yaml:"purl_types,omitempty" json:"purl_types,omitempty"`
+	JSONSchemaTypes []string      `yaml:"json_schema_types,omitempty" json:"json_schema_types,omitempty"`
+	Capabilities    CapabilitySet `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
+}
+
+type Parser struct {
+	ParserFunction  string        `yaml:"function" json:"function"`
+	Detector        Detector      `yaml:"detector" json:"detector"`
+	MetadataTypes   []string      `yaml:"metadata_types,omitempty" json:"metadata_types,omitempty"`
+	PackageTypes    []string      `yaml:"package_types,omitempty" json:"package_types,omitempty"`
+	PURLTypes       []string      `yaml:"purl_types,omitempty" json:"purl_types,omitempty"`
+	JSONSchemaTypes []string      `yaml:"json_schema_types,omitempty" json:"json_schema_types,omitempty"`
+	Capabilities    CapabilitySet `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
+}
+
+type CapabilityField struct {
+	Name       string                `yaml:"name" json:"name"`
+	Default    any                   `yaml:"default" json:"default"`
+	Conditions []CapabilityCondition `yaml:"conditions,omitempty" json:"conditions,omitempty"`
+	Evidence   []string              `yaml:"evidence,omitempty" json:"evidence,omitempty"`
+	Comment    string                `yaml:"comment,omitempty" json:"comment,omitempty"`
+}
+
+type CapabilityCondition struct {
+	When    map[string]any `yaml:"when" json:"when"`
+	Value   any            `yaml:"value" json:"value"`
+	Comment string         `yaml:"comment,omitempty" json:"comment,omitempty"`
+}
+
+type CapabilitySet []CapabilityField


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes along with any relevant motivation and context -->

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

This change adds a public interface to list all configured catalogers. This is a first pass at implementing https://github.com/anchore/syft/issues/4992 and as of now does not handle the pieces about `cataloger info` and config-based hydration.

## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (updates the documentation)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->

Fixes #4992 