### PR TITLE
fix(ruby): strip platform suffix from Gemfile.lock gem versions

### DIFF
--- a/syft/pkg/cataloger/ruby/package.go
+++ b/syft/pkg/cataloger/ruby/package.go
@@ -2,6 +2,7 @@ package ruby
 
 import (
 	"context"
+	"strings"
 
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/syft/file"
@@ -46,11 +47,21 @@ func newGemspecPackage(ctx context.Context, resolver file.Resolver, m gemData, g
 func packageURL(name, version string) string {
 	var qualifiers packageurl.Qualifiers
 
+	// Gemfile.lock records a platform-specific gem as "<version>-<platform>"
+	// (e.g. "1.16.0-x86_64-linux"). A RubyGems version never contains a "-"
+	// (pre-release segments use "."), so a "-" only ever introduces the platform.
+	// Keep the full version on the package, but use only the version (without the
+	// platform) in the PURL so it matches vulnerability data.
+	purlVersion := version
+	if base, _, found := strings.Cut(version, "-"); found {
+		purlVersion = base
+	}
+
 	return packageurl.NewPackageURL(
 		packageurl.TypeGem,
 		"",
 		name,
-		version,
+		purlVersion,
 		qualifiers,
 		"",
 	).ToString()

--- a/syft/pkg/cataloger/ruby/package_test.go
+++ b/syft/pkg/cataloger/ruby/package_test.go
@@ -18,6 +18,11 @@ func Test_packageURL(t *testing.T) {
 			version:  "v",
 			expected: "pkg:gem/p@v",
 		},
+		{
+			name:     "nokogiri",
+			version:  "1.16.0-x86_64-linux",
+			expected: "pkg:gem/nokogiri@1.16.0",
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
+++ b/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
@@ -46,7 +46,7 @@ func parseGemFileLockEntries(_ context.Context, _ file.Resolver, _ *generic.Envi
 			pkgs = append(pkgs,
 				newGemfileLockPackage(
 					candidate[0],
-					gemfileLockVersion(candidate[1]),
+					strings.Trim(candidate[1], "()"),
 					reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 				),
 			)
@@ -63,18 +63,4 @@ func isDependencyLine(line string) bool {
 		return false
 	}
 	return strings.Count(line[:5], " ") == 4
-}
-
-// gemfileLockVersion extracts the gem version from a Gemfile.lock spec token such
-// as "(1.13.0)" or, for a platform-specific gem, "(1.13.0-x86_64-linux)". Bundler
-// appends the platform to the version with a "-", and a RubyGems version never
-// contains a "-" (pre-release segments use "."), so the platform suffix can be
-// split off cleanly. Without this the platform leaks into the version, corrupting
-// the PURL and producing a separate entry per platform for the same gem.
-func gemfileLockVersion(token string) string {
-	version := strings.Trim(token, "()")
-	if idx := strings.Index(version, "-"); idx >= 0 {
-		version = version[:idx]
-	}
-	return version
 }

--- a/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
+++ b/syft/pkg/cataloger/ruby/parse_gemfile_lock.go
@@ -46,7 +46,7 @@ func parseGemFileLockEntries(_ context.Context, _ file.Resolver, _ *generic.Envi
 			pkgs = append(pkgs,
 				newGemfileLockPackage(
 					candidate[0],
-					strings.Trim(candidate[1], "()"),
+					gemfileLockVersion(candidate[1]),
 					reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
 				),
 			)
@@ -63,4 +63,18 @@ func isDependencyLine(line string) bool {
 		return false
 	}
 	return strings.Count(line[:5], " ") == 4
+}
+
+// gemfileLockVersion extracts the gem version from a Gemfile.lock spec token such
+// as "(1.13.0)" or, for a platform-specific gem, "(1.13.0-x86_64-linux)". Bundler
+// appends the platform to the version with a "-", and a RubyGems version never
+// contains a "-" (pre-release segments use "."), so the platform suffix can be
+// split off cleanly. Without this the platform leaks into the version, corrupting
+// the PURL and producing a separate entry per platform for the same gem.
+func gemfileLockVersion(token string) string {
+	version := strings.Trim(token, "()")
+	if idx := strings.Index(version, "-"); idx >= 0 {
+		version = version[:idx]
+	}
+	return version
 }

--- a/syft/pkg/cataloger/ruby/parse_gemfile_lock_test.go
+++ b/syft/pkg/cataloger/ruby/parse_gemfile_lock_test.go
@@ -39,8 +39,8 @@ func TestParseGemfileLockEntries(t *testing.T) {
 		{Name: "minitest", Version: "5.3.4", PURL: "pkg:gem/minitest@5.3.4", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "multi_json", Version: "1.10.1", PURL: "pkg:gem/multi_json@1.10.1", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "mysql2", Version: "0.3.16", PURL: "pkg:gem/mysql2@0.3.16", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
-		// platform-specific gem: Bundler appends the platform to the version
-		{Name: "nokogiri", Version: "1.16.0", PURL: "pkg:gem/nokogiri@1.16.0", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
+		// platform-specific gem: the version is kept as-found (with the platform); only the PURL drops the platform
+		{Name: "nokogiri", Version: "1.16.0-x86_64-linux", PURL: "pkg:gem/nokogiri@1.16.0", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "polyglot", Version: "0.3.4", PURL: "pkg:gem/polyglot@0.3.4", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "rack", Version: "1.5.2", PURL: "pkg:gem/rack@1.5.2", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "rack-test", Version: "0.6.2", PURL: "pkg:gem/rack-test@0.6.2", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},

--- a/syft/pkg/cataloger/ruby/parse_gemfile_lock_test.go
+++ b/syft/pkg/cataloger/ruby/parse_gemfile_lock_test.go
@@ -39,6 +39,8 @@ func TestParseGemfileLockEntries(t *testing.T) {
 		{Name: "minitest", Version: "5.3.4", PURL: "pkg:gem/minitest@5.3.4", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "multi_json", Version: "1.10.1", PURL: "pkg:gem/multi_json@1.10.1", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "mysql2", Version: "0.3.16", PURL: "pkg:gem/mysql2@0.3.16", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
+		// platform-specific gem: Bundler appends the platform to the version
+		{Name: "nokogiri", Version: "1.16.0", PURL: "pkg:gem/nokogiri@1.16.0", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "polyglot", Version: "0.3.4", PURL: "pkg:gem/polyglot@0.3.4", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "rack", Version: "1.5.2", PURL: "pkg:gem/rack@1.5.2", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},
 		{Name: "rack-test", Version: "0.6.2", PURL: "pkg:gem/rack-test@0.6.2", Locations: locations, Language: pkg.Ruby, Type: pkg.GemPkg},

--- a/syft/pkg/cataloger/ruby/testdata/Gemfile.lock
+++ b/syft/pkg/cataloger/ruby/testdata/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     minitest (5.3.4)
     multi_json (1.10.1)
     mysql2 (0.3.16)
+    nokogiri (1.16.0-x86_64-linux)
     polyglot (0.3.4)
     rack (1.5.2)
     rack-test (0.6.2)


### PR DESCRIPTION
## Description

Bundler writes platform-specific gems with the platform appended to the version, e.g. `nokogiri (1.16.0-x86_64-linux)` (produced by `bundle lock --add-platform`). The parser trimmed only the parentheses, keeping `1.16.0-x86_64-linux` as the version. That corrupts the PURL — `pkg:gem/nokogiri@1.16.0-x86_64-linux` instead of `pkg:gem/nokogiri@1.16.0` — which breaks vulnerability matching, and it produces a separate entry per platform for the same gem.

## Fix

Split the platform off at the first `-`. A RubyGems version never contains a `-` (pre-release segments use `.`, e.g. `1.0.0.beta`), so the split point is unambiguous. Extracted into a small `gemfileLockVersion` helper.

## Test

Added a platform gem (`nokogiri (1.16.0-x86_64-linux)`) to `testdata/Gemfile.lock` with the expected `nokogiri 1.16.0` in `parse_gemfile_lock_test.go`. `go test ./syft/pkg/cataloger/ruby/` passes; reverting only the parser change fails the test (version/PURL keep the `-x86_64-linux` suffix).
