### PR TITLE
exclude npm devOptional dependencies by default

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_package_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock.go
@@ -27,10 +27,11 @@ type packageLock struct {
 
 // lockDependency represents a single package dependency listed in the package.lock json file
 type lockDependency struct {
-	Version   string `json:"version"`
-	Resolved  string `json:"resolved"`
-	Integrity string `json:"integrity"`
-	Dev       bool   `json:"dev"`
+	Version     string `json:"version"`
+	Resolved    string `json:"resolved"`
+	Integrity   string `json:"integrity"`
+	Dev         bool   `json:"dev"`
+	DevOptional bool   `json:"devOptional"`
 }
 
 type lockPackage struct {
@@ -40,6 +41,7 @@ type lockPackage struct {
 	Integrity    string             `json:"integrity"`
 	License      packageLockLicense `json:"license"`
 	Dev          bool               `json:"dev"`
+	DevOptional  bool               `json:"devOptional"`
 	Dependencies map[string]string  `json:"dependencies"`
 }
 
@@ -78,8 +80,8 @@ func (a genericPackageLockAdapter) parsePackageLock(ctx context.Context, resolve
 
 	if lock.LockfileVersion == 1 {
 		for name, pkgMeta := range lock.Dependencies {
-			// skip packages that are only present as a dev dependency
-			if !a.cfg.IncludeDevDependencies && pkgMeta.Dev {
+			// skip packages that are only present as a dev dependency (including devOptional)
+			if !a.cfg.IncludeDevDependencies && (pkgMeta.Dev || pkgMeta.DevOptional) {
 				continue
 			}
 
@@ -96,8 +98,8 @@ func (a genericPackageLockAdapter) parsePackageLock(ctx context.Context, resolve
 				name = pkgMeta.Name
 			}
 
-			// skip packages that are only present as a dev dependency
-			if !a.cfg.IncludeDevDependencies && pkgMeta.Dev {
+			// skip packages that are only present as a dev dependency (including devOptional)
+			if !a.cfg.IncludeDevDependencies && (pkgMeta.Dev || pkgMeta.DevOptional) {
 				continue
 			}
 

--- a/syft/pkg/cataloger/javascript/parse_package_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_package_lock_test.go
@@ -422,3 +422,42 @@ func Test_corruptPackageLock(t *testing.T) {
 		WithError().
 		TestParser(t, gap.parsePackageLock)
 }
+
+func TestParsePackageLockDevOptional(t *testing.T) {
+	fixture := "testdata/pkg-lock/package-lock-dev-optional.json"
+
+	regularDep := pkg.Package{
+		Name:     "regular-dep",
+		Version:  "1.0.0",
+		PURL:     "pkg:npm/regular-dep@1.0.0",
+		Language: pkg.JavaScript,
+		Type:     pkg.NpmPkg,
+		Metadata: pkg.NpmPackageLockEntry{Resolved: "https://registry.npmjs.org/regular-dep/-/regular-dep-1.0.0.tgz", Integrity: "sha512-regular"},
+	}
+	devOptionalDep := pkg.Package{
+		Name:     "dev-optional-dep",
+		Version:  "2.0.0",
+		PURL:     "pkg:npm/dev-optional-dep@2.0.0",
+		Language: pkg.JavaScript,
+		Type:     pkg.NpmPkg,
+		Metadata: pkg.NpmPackageLockEntry{Resolved: "https://registry.npmjs.org/dev-optional-dep/-/dev-optional-dep-2.0.0.tgz", Integrity: "sha512-devoptional"},
+	}
+
+	t.Run("devOptional excluded by default", func(t *testing.T) {
+		expected := []pkg.Package{regularDep}
+		for i := range expected {
+			expected[i].Locations.Add(file.NewLocation(fixture))
+		}
+		adapter := newGenericPackageLockAdapter(CatalogerConfig{})
+		pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expected, nil)
+	})
+
+	t.Run("devOptional included when dev dependencies are included", func(t *testing.T) {
+		expected := []pkg.Package{devOptionalDep, regularDep}
+		for i := range expected {
+			expected[i].Locations.Add(file.NewLocation(fixture))
+		}
+		adapter := newGenericPackageLockAdapter(CatalogerConfig{}.WithIncludeDevDependencies(true))
+		pkgtest.TestFileParser(t, fixture, adapter.parsePackageLock, expected, nil)
+	})
+}

--- a/syft/pkg/cataloger/javascript/testdata/pkg-lock/package-lock-dev-optional.json
+++ b/syft/pkg/cataloger/javascript/testdata/pkg-lock/package-lock-dev-optional.json
@@ -1,0 +1,22 @@
+{
+  "name": "test-dev-optional",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0"
+    },
+    "node_modules/regular-dep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regular-dep/-/regular-dep-1.0.0.tgz",
+      "integrity": "sha512-regular"
+    },
+    "node_modules/dev-optional-dep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dev-optional-dep/-/dev-optional-dep-2.0.0.tgz",
+      "integrity": "sha512-devoptional",
+      "devOptional": true
+    }
+  }
+}


### PR DESCRIPTION
## Description

npm records packages that are only reachable through dev dependencies (or that are simultaneously `dev` and `optional`) with `"devOptional": true` in `package-lock.json`. Syft already skips `"dev": true` packages when dev dependencies are excluded, but `devOptional` ones slipped through and ended up in the catalog.

This treats `devOptional` the same as `dev`: such packages are skipped unless `IncludeDevDependencies` is enabled, for both the v1 (`dependencies`) and v2/v3 (`packages`) lockfile layouts.

Per @kzantow's request on the issue, the change is exercised by a small `package-lock.json` fixture (`testdata/pkg-lock/package-lock-dev-optional.json`) that contains a `devOptional` entry, with tests asserting it is excluded by default and included when `IncludeDevDependencies` is set.

Closes #4982
