### PR TITLE
fix: add curated CPE vendor candidates for common Conan C/C++ packages

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -508,6 +508,26 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "poco"},
 			candidateAddition{AdditionalVendors: []string{"pocoproject"}},
 		},
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "libcurl"},
+			candidateAddition{AdditionalVendors: []string{"haxx"}, AdditionalProducts: []string{"curl"}},
+		},
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "protobuf"},
+			candidateAddition{AdditionalVendors: []string{"google"}},
+		},
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "mbedtls"},
+			candidateAddition{AdditionalVendors: []string{"arm"}, AdditionalProducts: []string{"mbed_tls"}},
+		},
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "lwip"},
+			candidateAddition{AdditionalVendors: []string{"lwip_project"}},
+		},
 	})
 
 var defaultCandidateRemovals = buildCandidateRemovalLookup(

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -855,6 +855,66 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "conan libcurl has curated haxx vendor and curl product",
+			p: pkg.Package{
+				Name:    "libcurl",
+				Version: "7.87.0",
+				Type:    pkg.ConanPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:curl:curl:7.87.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:curl:libcurl:7.87.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:haxx:curl:7.87.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:haxx:libcurl:7.87.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libcurl:curl:7.87.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libcurl:libcurl:7.87.0:*:*:*:*:*:*:*",
+			},
+		},
+		{
+			name: "conan protobuf has curated google vendor",
+			p: pkg.Package{
+				Name:    "protobuf",
+				Version: "3.21.9",
+				Type:    pkg.ConanPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:google:protobuf:3.21.9:*:*:*:*:*:*:*",
+				"cpe:2.3:a:protobuf:protobuf:3.21.9:*:*:*:*:*:*:*",
+			},
+		},
+		{
+			name: "conan mbedtls has curated arm vendor and mbed_tls product",
+			p: pkg.Package{
+				Name:    "mbedtls",
+				Version: "2.28.0",
+				Type:    pkg.ConanPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:arm:mbed_tls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:arm:mbedtls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed-tls:mbed_tls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed-tls:mbedtls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed:mbed_tls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed:mbedtls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed_tls:mbed_tls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbed_tls:mbedtls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbedtls:mbed_tls:2.28.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:mbedtls:mbedtls:2.28.0:*:*:*:*:*:*:*",
+			},
+		},
+		{
+			name: "conan lwip has curated lwip_project vendor",
+			p: pkg.Package{
+				Name:    "lwip",
+				Version: "2.1.3",
+				Type:    pkg.ConanPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:lwip:lwip:2.1.3:*:*:*:*:*:*:*",
+				"cpe:2.3:a:lwip_project:lwip:2.1.3:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Problem

CPE generation for Conan packages falls back to `vendor := package name`, because Conan manifests (`conanfile.txt` / `conan.lock`) carry no vendor-bearing field and the CPE dictionary does not cover the Conan ecosystem. For packages whose NVD vendor differs from the Conan package name, the generated CPE matches no NVD records, and downstream scanners (grype, Anchore Enterprise) silently report zero CVEs.

Concrete example: a `conanfile.txt` declaring `libcurl/7.87.0` produces

```
cpe:2.3:a:libcurl:libcurl:7.87.0:*:*:*:*:*:*:*
```

while NVD registers curl CVEs under `haxx`/`curl` vendors (e.g. [CVE-2023-23914](https://nvd.nist.gov/vuln/detail/CVE-2023-23914), [CVE-2023-27533](https://nvd.nist.gov/vuln/detail/CVE-2023-27533)). Result: zero CVEs reported for a version with dozens of published vulnerabilities. Correcting the CPE vendor recovers the full expected match set. Packages whose name equals their NVD vendor (openssl, zlib, boost) are unaffected, which makes this failure mode easy to miss.

This is the same class of issue previously fixed for poco in #2740 (grype anchore/grype#1737), and currently proposed for expat in #4788.

## Change

Data-only: extends the curated additions table in `candidate_by_package_type.go` with vendor/product candidates for widely used C/C++ packages whose NVD identity differs from their Conan name, following the existing `poco -> pocoproject` entry:

| Conan name | Added vendor | Added product | NVD reference |
|---|---|---|---|
| `libcurl` | `haxx` | `curl` | `cpe:2.3:a:haxx:libcurl`, `cpe:2.3:a:haxx:curl` |
| `protobuf` | `google` | – | `cpe:2.3:a:google:protobuf` |
| `mbedtls` | `arm` | `mbed_tls` | `cpe:2.3:a:arm:mbed_tls` |
| `lwip` | `lwip_project` | – | `cpe:2.3:a:lwip_project:lwip` |

These are additions, not replacements — the name-derived candidates are retained, so no existing matches are removed.

## Testing

Added table-driven cases to `TestGeneratePackageCPEs` in `generate_test.go` asserting the complete generated CPE set for each of the four packages. `go test ./syft/pkg/cataloger/internal/cpegenerate/` passes.

Verified end-to-end that a directory scan of a `conanfile.txt` declaring `libcurl/7.87.0` previously matched 0 NVD CVEs, and matches the expected CVE set once the `haxx` vendor candidate is present.
