### PR TITLE
Limit how deep the java cataloger descends into nested archives

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -56,6 +56,25 @@ var javaArchiveHashes = []crypto.Hash{
 	crypto.SHA1,
 }
 
+// maxNestedArchiveDepth is how many archives deep the cataloger will descend before it stops. Real archives nest a
+// few levels at most (a war holding jars, a spring boot fat jar), so this is well above anything legitimate. Without
+// a limit an archive that only contains a slightly smaller copy of itself makes syft copy and hash the remaining
+// bytes to temp space once per level, and a long enough chain overflows the stack, which is not recoverable.
+const maxNestedArchiveDepth = 32
+
+type nestedArchiveDepthCtxKey struct{}
+
+// nestedArchiveDepth returns how many archives the cataloger descended into to reach the current one.
+func nestedArchiveDepth(ctx context.Context) int {
+	depth, _ := ctx.Value(nestedArchiveDepthCtxKey{}).(int)
+	return depth
+}
+
+// incrementNestedArchiveDepth returns a context marking that the cataloger is descending one archive deeper.
+func incrementNestedArchiveDepth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, nestedArchiveDepthCtxKey{}, nestedArchiveDepth(ctx)+1)
+}
+
 type archiveParser struct {
 	fileManifest intFile.ZipFileManifest
 	location     file.Location
@@ -181,13 +200,17 @@ func (j *archiveParser) parse(ctx context.Context, parentPkg *pkg.Package) ([]pk
 
 	var errs error
 	if j.detectNested {
-		// find nested java archive packages
-		nestedPkgs, nestedRelationships, err := j.discoverPkgsFromNestedArchives(ctx, mainPkg)
-		if err != nil {
-			errs = unknown.Append(errs, j.location, err)
+		if nestedArchiveDepth(ctx) >= maxNestedArchiveDepth {
+			errs = unknown.Appendf(errs, j.location, "nested archives not cataloged: maximum nested archive depth (%v) reached", maxNestedArchiveDepth)
+		} else {
+			// find nested java archive packages
+			nestedPkgs, nestedRelationships, err := j.discoverPkgsFromNestedArchives(ctx, mainPkg)
+			if err != nil {
+				errs = unknown.Append(errs, j.location, err)
+			}
+			pkgs = append(pkgs, nestedPkgs...)
+			relationships = append(relationships, nestedRelationships...)
 		}
-		pkgs = append(pkgs, nestedPkgs...)
-		relationships = append(relationships, nestedRelationships...)
 	} else {
 		// .jar and .war files are present in archives, are others? or generally just consider them top-level?
 		nestedArchives := j.fileManifest.GlobMatch(true, "**/*.jar", "**/*.war")
@@ -671,7 +694,7 @@ func discoverPkgsFromOpener(ctx context.Context, location file.Location, pathWit
 	nestedLocation := file.NewLocationFromCoordinates(location.Coordinates)
 	nestedLocation.AccessPath = nestedPath
 	gap := newGenericArchiveParserAdapter(cfg)
-	nestedPkgs, nestedRelationships, err := gap.processJavaArchive(ctx, file.LocationReadCloser{
+	nestedPkgs, nestedRelationships, err := gap.processJavaArchive(incrementNestedArchiveDepth(ctx), file.LocationReadCloser{
 		Location:   nestedLocation,
 		ReadCloser: archiveReadCloser,
 	}, parentPkg)

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1,7 +1,10 @@
 package java
 
 import (
+	"archive/zip"
 	"bufio"
+	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -1724,4 +1727,76 @@ func Test_jarPomPropertyResolutionDoesNotPanic(t *testing.T) {
 
 	_, _, err = ap.parse(ctx, nil)
 	require.NoError(t, err)
+}
+
+// buildDeeplyNestedJar returns the path to a jar containing a jar containing a jar... to the given depth. Every level
+// is a valid archive with a manifest, so every level yields exactly one package, which makes the number of packages
+// found equal to the number of levels descended into.
+func buildDeeplyNestedJar(t *testing.T, depth int) string {
+	t.Helper()
+
+	var payload []byte
+	for level := depth; level >= 1; level-- {
+		buf := &bytes.Buffer{}
+		zw := zip.NewWriter(buf)
+
+		manifest, err := zw.Create("META-INF/MANIFEST.MF")
+		require.NoError(t, err)
+		_, err = manifest.Write([]byte(fmt.Sprintf("Manifest-Version: 1.0\nImplementation-Title: level-%d\nImplementation-Version: 1.0.%d\n\n", level, level)))
+		require.NoError(t, err)
+
+		if payload != nil {
+			// stored, not deflated, so the fixture stays cheap to build and does not rely on compression
+			nested, err := zw.CreateHeader(&zip.FileHeader{Name: fmt.Sprintf("nested-%d.jar", level+1), Method: zip.Store})
+			require.NoError(t, err)
+			_, err = nested.Write(payload)
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, zw.Close())
+		payload = buf.Bytes()
+	}
+
+	jarPath := filepath.Join(t.TempDir(), "deeply-nested.jar")
+	require.NoError(t, os.WriteFile(jarPath, payload, 0600))
+	return jarPath
+}
+
+func Test_maxNestedArchiveDepth(t *testing.T) {
+	jarPath := buildDeeplyNestedJar(t, maxNestedArchiveDepth+10)
+
+	fixture, err := os.Open(jarPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fixture.Close()) })
+
+	gap := newGenericArchiveParserAdapter(ArchiveCatalogerConfig{})
+	pkgs, _, err := gap.processJavaArchive(pkgtest.Context(t), file.LocationReadCloser{
+		Location:   file.NewLocation(fixture.Name()),
+		ReadCloser: fixture,
+	}, nil)
+	require.NoError(t, err)
+
+	// the deepest archive we descend into reports an unknown rather than cataloging its own contents, so its package
+	// is dropped along with everything below it
+	assert.Len(t, pkgs, maxNestedArchiveDepth)
+}
+
+func Test_maxNestedArchiveDepth_reportsUnknown(t *testing.T) {
+	jarPath := buildDeeplyNestedJar(t, 2)
+
+	fixture, err := os.Open(jarPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, fixture.Close()) })
+
+	ctx := context.WithValue(pkgtest.Context(t), nestedArchiveDepthCtxKey{}, maxNestedArchiveDepth)
+
+	gap := newGenericArchiveParserAdapter(ArchiveCatalogerConfig{})
+	pkgs, _, err := gap.processJavaArchive(ctx, file.LocationReadCloser{
+		Location:   file.NewLocation(fixture.Name()),
+		ReadCloser: fixture,
+	}, nil)
+
+	require.ErrorContains(t, err, "maximum nested archive depth (32) reached")
+	// the archive at the limit is still cataloged, we just don't open what's inside it
+	assert.Len(t, pkgs, 1)
 }


### PR DESCRIPTION
## Description

The Java cataloger will follow a chain of nested archives as far as it goes. There's no depth limit on the `processJavaArchive` -> `parse` -> `discoverPkgsFromNestedArchives` -> `discoverPkgsFromOpener` -> `processJavaArchive` cycle, and every level copies the remaining bytes out to temp space and SHA1s them, so the work grows faster than the input does. Scanning a jar that's nothing but jars stored inside each other, on my laptop:

- 200 levels, 67KB input, 0.25s
- 1000 levels, 339KB input, 1.37s
- 4000 levels, 1.36MB input, 11.6s

So 4x the input costs about 8.5x the time, and the temp writes scale the same way. A longer chain eventually overflows the goroutine stack, and that's a runtime fatal error rather than a panic, so a caller can't recover from it. Not a big deal if you're scanning your own build output, but syft gets embedded in services that scan whatever gets uploaded to them.

So: cap the descent at 32 archives. The depth rides on the context and gets bumped in `discoverPkgsFromOpener`, which is the one place we descend. At the limit `parse` reports the same "nested archives not cataloged" unknown it already reports when nesting is turned off, rather than recursing. Anything real nests two or three levels (a war of jars, a spring boot fat jar), so 32 leaves plenty of headroom. Same shape as the `MaxParentRecursiveDepth` guard the maven resolver already uses for parent poms.

I made it a const instead of a config field because I couldn't think of a reason anyone would tune it, but if you'd rather have it on `ArchiveCatalogerConfig` that's an easy change.

This is the always-on Java path, which is separate from the opt-in recursive cataloging subsystem in #4761 and #4044. Those have their own MaxDepth and are off by default, so they don't cover this.

No output change for real archives.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have added comments to my code, particularly in hard-to-understand sections

On testing, so you know exactly what I ran: `go test ./syft/pkg/cataloger/java/ -run Test_maxNestedArchiveDepth` (both new tests pass) and `go test ./syft/pkg/cataloger/java/internal/...` (ok). I couldn't get a full `./syft/pkg/cataloger/java/...` run to finish locally since the maven fixture builds download at about 22 kB/s on my connection, so I'm leaning on CI for the rest of the package.

The tests build the nested jar in-process, so there's no binary fixture to add. `Test_maxNestedArchiveDepth` scans a 42 level chain and expects 32 packages back; on main it returns 42 with no error, which is the runaway. `Test_maxNestedArchiveDepth_reportsUnknown` starts a small archive at the limit and checks the unknown comes back. Both fail on main and pass with the change.
