### PR TITLE
Add multi-platform OCI image support

### DIFF
--- a/cmd/syft/internal/test/integration/multiplatform_oci_test.go
+++ b/cmd/syft/internal/test/integration/multiplatform_oci_test.go
@@ -1,0 +1,144 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/stereoscope/pkg/image"
+	"github.com/anchore/stereoscope/pkg/imagetest"
+	"github.com/anchore/syft/syft"
+	"github.com/anchore/syft/syft/source"
+)
+
+// TestMultiPlatformOCIImageSelection verifies that syft can load a single platform out of a
+// multi-platform OCI image on disk (both --from oci-dir and --from oci-archive) by selecting the
+// image that matches the requested platform.
+func TestMultiPlatformOCIImageSelection(t *testing.T) {
+	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+
+	// Per-platform image config digests within the multi-platform index, obtained from the OCI layout
+	// (see anchore/stereoscope integration tests: TestPlatformSelectionWithOciLocalSources).
+	expectedDigest := map[string]string{
+		"arm64":   "sha256:59de7b16fa64a0a21873c02622c45259e89dbbe29e33afd77821f6106d537c95",
+		"s390x":   "sha256:121427690da1f522eb73d58432b070a96c1b6be6b2aa0603dc76f029febdf2b1",
+		"amd64":   "sha256:a8951deb17b620ff20ca25c0bfa82eca93560711def5bf096ee1e38a11742658",
+		"ppc64le": "sha256:642fb8a0ef786227bb12ad0da6326b97809c162b86329f5e39ad990672cee5da",
+	}
+
+	// syft --from source tag -> stereoscope OCI source used to prepare the local fixture
+	sources := map[string]image.Source{
+		"oci-dir":     image.OciDirectorySource,
+		"oci-archive": image.OciTarballSource,
+	}
+
+	for from, imageSource := range sources {
+		for _, arch := range []string{"amd64", "arm64", "s390x", "ppc64le"} {
+			t.Run(fmt.Sprintf("%s/linux/%s", from, arch), func(t *testing.T) {
+				localPath := imagetest.PrepareMultiplatformFixtureImage(t, imageSource, remoteImage)
+
+				platform, err := image.NewPlatform("linux/" + arch)
+				require.NoError(t, err)
+
+				src, err := syft.GetSource(
+					context.Background(),
+					localPath,
+					syft.DefaultGetSourceConfig().WithSources(from).WithPlatform(platform),
+				)
+				require.NoError(t, err)
+				t.Cleanup(func() {
+					require.NoError(t, src.Close())
+				})
+
+				meta, ok := src.Describe().Metadata.(source.ImageMetadata)
+				require.True(t, ok, "expected image metadata, got %T", src.Describe().Metadata)
+
+				// The raw config of the selected image must match the requested platform...
+				assertConfigPlatform(t, meta.RawConfig, "linux", arch)
+				// ...and it must be the exact per-platform image from the multi-platform index.
+				assert.Equal(t, expectedDigest[arch], meta.ID)
+			})
+		}
+	}
+}
+
+// TestMultiPlatformOCIImageSelection_UnavailablePlatform verifies that requesting a platform not present
+// in the multi-platform OCI image results in an error rather than silently selecting the wrong image.
+func TestMultiPlatformOCIImageSelection_UnavailablePlatform(t *testing.T) {
+	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+
+	// windows/amd64 is not present in this linux-only multi-platform image
+	platform, err := image.NewPlatform("windows/amd64")
+	require.NoError(t, err)
+
+	sources := map[string]image.Source{
+		"oci-dir":     image.OciDirectorySource,
+		"oci-archive": image.OciTarballSource,
+	}
+
+	for from, imageSource := range sources {
+		t.Run(from, func(t *testing.T) {
+			localPath := imagetest.PrepareMultiplatformFixtureImage(t, imageSource, remoteImage)
+
+			_, err := syft.GetSource(
+				context.Background(),
+				localPath,
+				syft.DefaultGetSourceConfig().WithSources(from).WithPlatform(platform),
+			)
+			require.ErrorContains(t, err, "windows/amd64")
+		})
+	}
+}
+
+// TestMultiPlatformOCIImageSelection_DefaultPlatform verifies that not specifying a platform results
+// in the current platform being selected.
+func TestMultiPlatformOCIImageSelection_DefaultPlatform(t *testing.T) {
+	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+
+	sources := map[string]image.Source{
+		"oci-dir":     image.OciDirectorySource,
+		"oci-archive": image.OciTarballSource,
+	}
+
+	for from, imageSource := range sources {
+		t.Run(from, func(t *testing.T) {
+			localPath := imagetest.PrepareMultiplatformFixtureImage(t, imageSource, remoteImage)
+
+			src, err := syft.GetSource(
+				context.Background(),
+				localPath,
+				syft.DefaultGetSourceConfig().WithSources(from),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, src.Close())
+			})
+
+			meta, ok := src.Describe().Metadata.(source.ImageMetadata)
+			require.True(t, ok, "expected image metadata, got %T", src.Describe().Metadata)
+
+			// The raw config of the selected image must match the current platform
+			assertConfigPlatform(t, meta.RawConfig, "linux", runtime.GOARCH)
+		})
+	}
+}
+
+// assertConfigPlatform asserts the os/architecture recorded in a raw OCI image config document.
+func assertConfigPlatform(t *testing.T, rawConfig []byte, os, architecture string) {
+	t.Helper()
+	require.NotEmpty(t, rawConfig)
+
+	var cfg struct {
+		OS           string `json:"os"`
+		Architecture string `json:"architecture"`
+	}
+	require.NoError(t, json.Unmarshal(rawConfig, &cfg))
+
+	assert.Equal(t, os, cfg.OS)
+	assert.Equal(t, architecture, cfg.Architecture)
+}

--- a/cmd/syft/internal/test/integration/multiplatform_oci_test.go
+++ b/cmd/syft/internal/test/integration/multiplatform_oci_test.go
@@ -38,32 +38,33 @@ func TestMultiPlatformOCIImageSelection(t *testing.T) {
 	}
 
 	for from, imageSource := range sources {
-		for _, arch := range []string{"amd64", "arm64", "s390x", "ppc64le"} {
-			t.Run(fmt.Sprintf("%s/linux/%s", from, arch), func(t *testing.T) {
-				localPath := imagetest.PrepareMultiplatformFixtureImage(t, imageSource, remoteImage)
+		t.Run(from, func(t *testing.T) {
+			localPath := imagetest.PrepareMultiplatformFixtureImage(t, imageSource, remoteImage)
+			for _, arch := range []string{"amd64", "arm64", "s390x", "ppc64le"} {
+				t.Run(fmt.Sprintf("linux/%s", arch), func(t *testing.T) {
+					platform, err := image.NewPlatform("linux/" + arch)
+					require.NoError(t, err)
 
-				platform, err := image.NewPlatform("linux/" + arch)
-				require.NoError(t, err)
+					src, err := syft.GetSource(
+						context.Background(),
+						localPath,
+						syft.DefaultGetSourceConfig().WithSources(from).WithPlatform(platform),
+					)
+					require.NoError(t, err)
+					t.Cleanup(func() {
+						require.NoError(t, src.Close())
+					})
 
-				src, err := syft.GetSource(
-					context.Background(),
-					localPath,
-					syft.DefaultGetSourceConfig().WithSources(from).WithPlatform(platform),
-				)
-				require.NoError(t, err)
-				t.Cleanup(func() {
-					require.NoError(t, src.Close())
+					meta, ok := src.Describe().Metadata.(source.ImageMetadata)
+					require.True(t, ok, "expected image metadata, got %T", src.Describe().Metadata)
+
+					// The raw config of the selected image must match the requested platform...
+					assertConfigPlatform(t, meta.RawConfig, "linux", arch)
+					// ...and it must be the exact per-platform image from the multi-platform index.
+					assert.Equal(t, expectedDigest[arch], meta.ID)
 				})
-
-				meta, ok := src.Describe().Metadata.(source.ImageMetadata)
-				require.True(t, ok, "expected image metadata, got %T", src.Describe().Metadata)
-
-				// The raw config of the selected image must match the requested platform...
-				assertConfigPlatform(t, meta.RawConfig, "linux", arch)
-				// ...and it must be the exact per-platform image from the multi-platform index.
-				assert.Equal(t, expectedDigest[arch], meta.ID)
-			})
-		}
+			}
+		})
 	}
 }
 

--- a/cmd/syft/internal/test/integration/multiplatform_oci_test.go
+++ b/cmd/syft/internal/test/integration/multiplatform_oci_test.go
@@ -20,15 +20,15 @@ import (
 // multi-platform OCI image on disk (both --from oci-dir and --from oci-archive) by selecting the
 // image that matches the requested platform.
 func TestMultiPlatformOCIImageSelection(t *testing.T) {
-	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+	remoteImage := "docker.io/library/busybox:1.38.0"
 
 	// Per-platform image config digests within the multi-platform index, obtained from the OCI layout
 	// (see anchore/stereoscope integration tests: TestPlatformSelectionWithOciLocalSources).
 	expectedDigest := map[string]string{
-		"arm64":   "sha256:59de7b16fa64a0a21873c02622c45259e89dbbe29e33afd77821f6106d537c95",
-		"s390x":   "sha256:121427690da1f522eb73d58432b070a96c1b6be6b2aa0603dc76f029febdf2b1",
-		"amd64":   "sha256:a8951deb17b620ff20ca25c0bfa82eca93560711def5bf096ee1e38a11742658",
-		"ppc64le": "sha256:642fb8a0ef786227bb12ad0da6326b97809c162b86329f5e39ad990672cee5da",
+		"arm64":   "sha256:e0e8b3cbfed68a90084781e2962f9c0deead51c5a3f11a488eef0283a4284bc2",
+		"s390x":   "sha256:0cf160e720a8e4f20883b72276a6eaded83b79539f3f1d39e35a3336154b9960",
+		"amd64":   "sha256:c6348fa86ba0fb2108c9334f5fe913ddc6d853313e655891f133a0127c30099f",
+		"ppc64le": "sha256:b144fc0e06537d07956cde340b878a81a717e394edb736d3110858a12a6635cb",
 	}
 
 	// syft --from source tag -> stereoscope OCI source used to prepare the local fixture
@@ -71,7 +71,7 @@ func TestMultiPlatformOCIImageSelection(t *testing.T) {
 // TestMultiPlatformOCIImageSelection_UnavailablePlatform verifies that requesting a platform not present
 // in the multi-platform OCI image results in an error rather than silently selecting the wrong image.
 func TestMultiPlatformOCIImageSelection_UnavailablePlatform(t *testing.T) {
-	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+	remoteImage := "docker.io/library/busybox:1.38.0"
 
 	// windows/amd64 is not present in this linux-only multi-platform image
 	platform, err := image.NewPlatform("windows/amd64")
@@ -99,7 +99,7 @@ func TestMultiPlatformOCIImageSelection_UnavailablePlatform(t *testing.T) {
 // TestMultiPlatformOCIImageSelection_DefaultPlatform verifies that not specifying a platform results
 // in the current platform being selected.
 func TestMultiPlatformOCIImageSelection_DefaultPlatform(t *testing.T) {
-	remoteImage := "quay.io/skopeo/stable:v1.20.0-immutable"
+	remoteImage := "docker.io/library/busybox:1.38.0"
 
 	sources := map[string]image.Source{
 		"oci-dir":     image.OciDirectorySource,

--- a/cmd/syft/internal/test/integration/testdata/.gitignore
+++ b/cmd/syft/internal/test/integration/testdata/.gitignore
@@ -8,3 +8,5 @@
 
 **/go.sum
 !image-go-bin-arch-coverage/go.sum
+
+cache/

--- a/go.mod
+++ b/go.mod
@@ -335,4 +335,4 @@ retract (
 	v0.53.1 // published accidentally with incorrect license in depdencies
 )
 
-replace github.com/anchore/stereoscope => github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf
+replace github.com/anchore/stereoscope => github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d

--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/cli v29.5.3+incompatible // indirect
+	github.com/docker/cli v29.6.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -238,8 +238,8 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/moby/api v1.54.2 // indirect
-	github.com/moby/moby/client v0.4.1 // indirect
+	github.com/moby/moby/api v1.55.0 // indirect
+	github.com/moby/moby/client v0.5.0 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/signal v0.7.1 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect
@@ -257,7 +257,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pborman/indent v1.2.1 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/piprate/json-gold v0.7.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
@@ -334,3 +334,5 @@ retract (
 	v0.53.2
 	v0.53.1 // published accidentally with incorrect license in depdencies
 )
+
+replace github.com/anchore/stereoscope => github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/anchore/go-sync v0.1.1
 	github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b
 	github.com/anchore/packageurl-go v0.2.0
-	github.com/anchore/stereoscope v0.2.2
+	github.com/anchore/stereoscope v0.2.3-0.20260720144826-e46db957a567
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/aquasecurity/go-pep440-version v0.0.1
 	github.com/bitnami/go-version v0.0.0-20250131085805-b1f57a8634ef
@@ -40,7 +40,7 @@ require (
 	github.com/elliotchance/phpserialize v1.4.0
 	github.com/facebookincubator/nvdtools v0.1.5
 	github.com/github/go-spdx/v2 v2.7.0
-	github.com/gkampitakis/go-snaps v0.5.22
+	github.com/gkampitakis/go-snaps v0.5.23
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/go-test/deep v1.1.1
@@ -171,7 +171,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/containerd/cgroups/v3 v3.1.3 // indirect
 	github.com/containerd/containerd/api v1.11.1 // indirect
-	github.com/containerd/containerd/v2 v2.3.2 // indirect
+	github.com/containerd/containerd/v2 v2.3.3 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -257,7 +257,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pborman/indent v1.2.1 // indirect
-	github.com/pelletier/go-toml/v2 v2.4.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
 	github.com/piprate/json-gold v0.7.0 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
@@ -334,5 +334,3 @@ retract (
 	v0.53.2
 	v0.53.1 // published accidentally with incorrect license in depdencies
 )
-
-replace github.com/anchore/stereoscope => github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.2.0 h1:CkrM4RMUwrEGAiE1OVlxaZNzWj0TuHRey7o4T/EAErk=
 github.com/anchore/packageurl-go v0.2.0/go.mod h1:2JCgOQMIsqZ7TmliXG4PnUthPJAKE3mWQbsW2XHjAOE=
+github.com/anchore/stereoscope v0.2.3-0.20260720144826-e46db957a567 h1:ZklP3dHyXFUKPrZaQcqP6M86KzlbpayiEvUUeQRT/BI=
+github.com/anchore/stereoscope v0.2.3-0.20260720144826-e46db957a567/go.mod h1:QIBWxa5WCrjtBqXH0+RIuECATrffcbaNdMWquZ83+OI=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
@@ -294,8 +296,8 @@ github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=
 github.com/containerd/containerd/api v1.11.1/go.mod h1:CaQFRu+N1MtbgL6JDOJLUB1hCKESU1lD6MuTJhgtdlw=
-github.com/containerd/containerd/v2 v2.3.2 h1:eLven1YxRMkeiKu7IcMrPKE+gn8sGR1DqHbbshMEvWM=
-github.com/containerd/containerd/v2 v2.3.2/go.mod h1:rHKGm3VW6wNrINb3x8mNT+w7qYXFVElTt/8HTuxVhD4=
+github.com/containerd/containerd/v2 v2.3.3 h1:MUNBVVBTBpPll7KPh5GTvkC3cfG03PQLAHVdsUoue9k=
+github.com/containerd/containerd/v2 v2.3.3/go.mod h1:rHKGm3VW6wNrINb3x8mNT+w7qYXFVElTt/8HTuxVhD4=
 github.com/containerd/continuity v0.5.0 h1:7a85HZpCSs+1Zps0Ee3DPSuAWY+0SJM1JNM51nlEVDg=
 github.com/containerd/continuity v0.5.0/go.mod h1:/lNJvtJKUQStBzpVQ1+rasXO1LAWtUQssk28EZvJ3nE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -408,8 +410,8 @@ github.com/github/go-spdx/v2 v2.7.0 h1:GzfXx4wFdlilARxmFRXW/mgUy3A4vSqZocCMFV6XF
 github.com/github/go-spdx/v2 v2.7.0/go.mod h1:Ftc45YYG1WzpzwEPKRVm9Jv8vDqOrN4gWoCkK+bHer0=
 github.com/gkampitakis/ciinfo v0.3.4 h1:5eBSibVuSMbb/H6Elc0IIEFbkzCJi3lm94n0+U7Z0KY=
 github.com/gkampitakis/ciinfo v0.3.4/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
-github.com/gkampitakis/go-snaps v0.5.22 h1:xg9omphRnbDnimMCl1KqznC4krlxOGpkB0vDSfX2P7M=
-github.com/gkampitakis/go-snaps v0.5.22/go.mod h1:uy3lVzCCRRsAwYqSocyw5fY8xRLCYEfqoOJNxr8HonM=
+github.com/gkampitakis/go-snaps v0.5.23 h1:okh5QR48zpUjpWtu65AtqxdCY8huJq+dEDuUzd1PuKg=
+github.com/gkampitakis/go-snaps v0.5.23/go.mod h1:uy3lVzCCRRsAwYqSocyw5fY8xRLCYEfqoOJNxr8HonM=
 github.com/glebarez/go-sqlite v1.20.3 h1:89BkqGOXR9oRmG58ZrzgoY/Fhy5x0M+/WV48U5zVrZ4=
 github.com/glebarez/go-sqlite v1.20.3/go.mod h1:u3N6D/wftiAzIOJtZl6BmedqxmmkDfH3q+ihjqxC9u0=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -620,8 +622,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
-github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d h1:cj6ooG1mjn0lTlsYETaHh/lZX4WlSMCCrcNok7wXAmA=
-github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d/go.mod h1:QlplQu2t4Oq+8WUlObBFRwM81mDKhnLoPTWOPteF48A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.8.1 h1:0fkCNhjrX0zPpwkWaDYU5VMrygg41Tu197mWILIJoqQ=
@@ -786,8 +786,8 @@ github.com/pborman/indent v1.2.1/go.mod h1:FitS+t35kIYtB5xWTZAPhnmrxcciEEOdbyrrp
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
-github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/piprate/json-gold v0.7.0 h1:bEMirgA5y8Z2loTQfxyIFfY+EflxH1CTP6r/KIlcJNw=

--- a/go.sum
+++ b/go.sum
@@ -620,8 +620,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
-github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf h1:X4r27XMdqLx1StBPCDnv8JfmBGx2oEwoDL7XXwpWxB0=
-github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf/go.mod h1:QlplQu2t4Oq+8WUlObBFRwM81mDKhnLoPTWOPteF48A=
+github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d h1:cj6ooG1mjn0lTlsYETaHh/lZX4WlSMCCrcNok7wXAmA=
+github.com/jasonpaulos/stereoscope v0.0.0-20260717145207-e197ddfc615d/go.mod h1:QlplQu2t4Oq+8WUlObBFRwM81mDKhnLoPTWOPteF48A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.8.1 h1:0fkCNhjrX0zPpwkWaDYU5VMrygg41Tu197mWILIJoqQ=

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,6 @@ github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b h1:e1bmaoJfZV
 github.com/anchore/go-version v1.2.2-0.20200701162849-18adb9c92b9b/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
 github.com/anchore/packageurl-go v0.2.0 h1:CkrM4RMUwrEGAiE1OVlxaZNzWj0TuHRey7o4T/EAErk=
 github.com/anchore/packageurl-go v0.2.0/go.mod h1:2JCgOQMIsqZ7TmliXG4PnUthPJAKE3mWQbsW2XHjAOE=
-github.com/anchore/stereoscope v0.2.2 h1:SGTLGoF6GHmKEn9Bb6LYpzzgz9nhvMZgN/c4fTSQjYY=
-github.com/anchore/stereoscope v0.2.2/go.mod h1:ylJXJKebLctP7u9ewguB1d0zUETJxvAA7r2DiuljDTM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
@@ -339,8 +337,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
 github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
-github.com/docker/cli v29.5.3+incompatible h1:nbEFfz774vBwQ5KRYv7c/AghjReqnGISvrRhzjV0evs=
-github.com/docker/cli v29.5.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v29.6.1+incompatible h1:oO7F4nn3Ovr/5TlfTUWFbMwBSS/B7Xs6Epv26gBrUP8=
+github.com/docker/cli v29.6.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
 github.com/docker/docker-credential-helpers v0.9.5/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
@@ -622,6 +620,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.14.0 h1:MHQqLhvpNUZfw+hM3AZDYK7jxO8FZoQeQM77g8iyZjg=
 github.com/invopop/jsonschema v0.14.0/go.mod h1:ygm6C2EaVNMBDPpaPlnOA2pFAxBnxGjFlMZABxm9n2I=
+github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf h1:X4r27XMdqLx1StBPCDnv8JfmBGx2oEwoDL7XXwpWxB0=
+github.com/jasonpaulos/stereoscope v0.0.0-20260716213708-1243139a6baf/go.mod h1:QlplQu2t4Oq+8WUlObBFRwM81mDKhnLoPTWOPteF48A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty/v6 v6.8.1 h1:0fkCNhjrX0zPpwkWaDYU5VMrygg41Tu197mWILIJoqQ=
@@ -723,10 +723,10 @@ github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3N
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
-github.com/moby/moby/api v1.54.2 h1:wiat9QAhnDQjA7wk1kh/TqHz2I1uUA7M7t9SAl/JNXg=
-github.com/moby/moby/api v1.54.2/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/wY=
-github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
+github.com/moby/moby/api v1.55.0 h1:2/sexvQyqIWS8pRSCFddBfpW2qE7vR7FCL+vN8pxwMc=
+github.com/moby/moby/api v1.55.0/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
+github.com/moby/moby/client v0.5.0 h1:5XhyPk2fuOWf6RlSFa3MkIIgDZkF25xToXW8Q/BH7cc=
+github.com/moby/moby/client v0.5.0/go.mod h1:rcVpF8ncl9vo5gaIBdol6CnbEtSj1uxMvEV/UrykF/s=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
@@ -786,8 +786,8 @@ github.com/pborman/indent v1.2.1/go.mod h1:FitS+t35kIYtB5xWTZAPhnmrxcciEEOdbyrrp
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
-github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.2 h1:M2fKKbmyvI+hGId/D0W64qDBMVhJnNR10O5gIbMc//Q=
+github.com/pelletier/go-toml/v2 v2.4.2/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pierrec/lz4/v4 v4.1.26 h1:GrpZw1gZttORinvzBdXPUXATeqlJjqUG/D87TKMnhjY=
 github.com/pierrec/lz4/v4 v4.1.26/go.mod h1:EoQMVJgeeEOMsCqCzqFm2O0cJvljX2nGZjcRIPL34O4=
 github.com/piprate/json-gold v0.7.0 h1:bEMirgA5y8Z2loTQfxyIFfY+EflxH1CTP6r/KIlcJNw=


### PR DESCRIPTION
## Description

Update stereoscope to include changes from https://github.com/anchore/stereoscope/pull/548, which add multi-platform OCI support.

To be clear, this doesn't add support for scanning multiple platforms simultaneously, but it does allow syft to operate on a single image within a multi-platform OCI image, which is currently not possible.

Also added an integration test to confirm this support is available in syft.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #1545 and part of #1683.
