### PR TITLE
fix(java): preserve Eclipse Classpath license expressions

### DIFF
--- a/internal/spdxlicense/license.go
+++ b/internal/spdxlicense/license.go
@@ -16,6 +16,12 @@ const (
 	LicenseRefPrefix = "LicenseRef-" // prefix for non-standard licenses
 )
 
+var licenseExpressionsByURL = map[string]string{
+	"projects.eclipse.org/license/secondary-gpl-2.0-cp": "GPL-2.0-only WITH Classpath-exception-2.0",
+	"www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt": "EPL-2.0",
+	"www.gnu.org/software/classpath/license.html":       "GPL-2.0-only WITH Classpath-exception-2.0",
+}
+
 //go:generate go run ./generate
 
 // ID returns the canonical license ID for the given license ID
@@ -50,6 +56,11 @@ func LicenseByURL(url string) (LicenseInfo, bool) {
 	if id, exists := urlToLicense[url]; exists {
 		return LicenseInfo{
 			ID: id,
+		}, true
+	}
+	if expression, exists := licenseExpressionsByURL[url]; exists {
+		return LicenseInfo{
+			ID: expression,
 		}, true
 	}
 	return LicenseInfo{}, false

--- a/internal/spdxlicense/license_url_test.go
+++ b/internal/spdxlicense/license_url_test.go
@@ -42,6 +42,24 @@ func TestLicenseByURL(t *testing.T) {
 			wantFound: true,
 		},
 		{
+			name:      "GNU Classpath Exception URL",
+			url:       "https://www.gnu.org/software/classpath/license.html",
+			wantID:    "GPL-2.0-only WITH Classpath-exception-2.0",
+			wantFound: true,
+		},
+		{
+			name:      "Eclipse secondary GPL Classpath URL",
+			url:       "https://projects.eclipse.org/license/secondary-gpl-2.0-cp",
+			wantID:    "GPL-2.0-only WITH Classpath-exception-2.0",
+			wantFound: true,
+		},
+		{
+			name:      "Eclipse Public License legacy URL",
+			url:       "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt",
+			wantID:    "EPL-2.0",
+			wantFound: true,
+		},
+		{
 			name:      "URL with trailing whitespace",
 			url:       "  http://opensource.org/licenses/MIT  ",
 			wantID:    "MIT",

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anchore/syft/internal"
 	intFile "github.com/anchore/syft/internal/file"
 	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/spdxlicense"
 	"github.com/anchore/syft/internal/tmpdir"
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"
@@ -50,6 +51,8 @@ var archiveFormatGlobs = []string{
 	"**/*.rar", // Java Resource Adapter Archive
 	"**/*.zap", // ZAP add-ons https://github.com/zaproxy/zaproxy/wiki/ZapAddOns
 }
+
+const eclipseClasspathDualLicense = "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
 
 // javaArchiveHashes are all the current hash algorithms used to calculate archive digests
 var javaArchiveHashes = []crypto.Hash{
@@ -286,7 +289,7 @@ func (j *archiveParser) discoverMainPackage(ctx context.Context) (*pkg.Package, 
 func (j *archiveParser) discoverNameVersionLicense(ctx context.Context, manifest *pkg.JavaManifest) (string, string, []pkg.License, *parsedPomProject) {
 	// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
 	// TODO: when we support locations of paths within archives we should start passing the specific manifest location object instead of the top jar
-	lics := pkg.NewLicensesFromLocationWithContext(ctx, j.location, selectLicenses(manifest)...)
+	lics := combineEclipseClasspathAlternatives(pkg.NewLicensesFromLocationWithContext(ctx, j.location, selectLicenses(manifest)...))
 	/*
 		We should name and version from, in this order:
 		1. pom.properties if we find exactly 1
@@ -375,9 +378,90 @@ func toPkgLicenses(ctx context.Context, location *file.Location, licenses []mave
 		if name == "" && url == "" {
 			continue
 		}
-		out = append(out, pkg.NewLicenseFromFieldsWithContext(ctx, name, url, location))
+		candidate := pkg.NewLicenseFromFieldsWithContext(ctx, name, url, location)
+		out = append(out, candidate)
 	}
-	return out
+	return combineMavenLicenseAlternatives(out)
+}
+
+func combineMavenLicenseAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) < 2 {
+		return licenses
+	}
+
+	enriched := slices.Clone(licenses)
+	for i := range enriched {
+		if enriched[i].SPDXExpression == "" && len(enriched[i].URLs) > 0 {
+			if info, found := spdxlicense.LicenseByURL(enriched[i].URLs[0]); found {
+				enriched[i].SPDXExpression = info.ID
+			}
+		}
+	}
+
+	return combineLicenseAlternatives(enriched)
+}
+
+func combineEclipseClasspathAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) != 2 {
+		return licenses
+	}
+
+	hasEPL := false
+	hasGPLClasspath := false
+	for _, candidate := range licenses {
+		switch candidate.SPDXExpression {
+		case "EPL-2.0":
+			hasEPL = true
+		case "GPL-2.0-only WITH Classpath-exception-2.0":
+			hasGPLClasspath = true
+		}
+	}
+	if !hasEPL || !hasGPLClasspath {
+		return licenses
+	}
+
+	return combineLicenseAlternatives(licenses)
+}
+
+func combineLicenseAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) < 2 {
+		return licenses
+	}
+
+	var values []string
+	var expressions []string
+	var locations []file.Location
+	urls := strset.New()
+	seenExpressions := strset.New()
+
+	for _, candidate := range licenses {
+		if candidate.SPDXExpression == "" {
+			return licenses
+		}
+
+		if candidate.Value != "" {
+			values = append(values, candidate.Value)
+		}
+		if !seenExpressions.Has(candidate.SPDXExpression) {
+			expressions = append(expressions, candidate.SPDXExpression)
+			seenExpressions.Add(candidate.SPDXExpression)
+		}
+		urls.Add(candidate.URLs...)
+		locations = append(locations, candidate.Locations.ToSlice()...)
+	}
+
+	combinedURLs := urls.List()
+	slices.Sort(combinedURLs)
+
+	return []pkg.License{
+		{
+			Value:          strings.Join(values, " OR "),
+			SPDXExpression: strings.Join(expressions, " OR "),
+			Type:           licenses[0].Type,
+			URLs:           combinedURLs,
+			Locations:      file.NewLocationSet(locations...),
+		},
+	}
 }
 
 type parsedPomProject struct {
@@ -586,6 +670,7 @@ func (j *archiveParser) getLicenseFromFileInArchive(ctx context.Context) []pkg.L
 				licenseContents := contents[licenseMatch]
 				r := strings.NewReader(licenseContents)
 				foundLicenses := pkg.NewLicensesFromReadCloserWithContext(ctx, file.NewLocationReadCloser(j.location, io.NopCloser(r)))
+				foundLicenses = normalizeClasspathExceptionLicenses(foundLicenses, licenseContents)
 				for _, l := range foundLicenses {
 					if l.SPDXExpression != "" {
 						identified = append(identified, l)
@@ -607,6 +692,35 @@ func (j *archiveParser) getLicenseFromFileInArchive(ctx context.Context) []pkg.L
 	}
 
 	return identified
+}
+
+func normalizeClasspathExceptionLicenses(found []pkg.License, contents string) []pkg.License {
+	if len(found) != 2 || !strings.Contains(strings.ToLower(contents), "classpath exception") {
+		return found
+	}
+
+	var epl *pkg.License
+	var gpl *pkg.License
+	for i := range found {
+		switch found[i].SPDXExpression {
+		case "EPL-2.0":
+			epl = &found[i]
+		case "GPL-2.0-only":
+			gpl = &found[i]
+		}
+	}
+	if epl == nil || gpl == nil {
+		return found
+	}
+
+	return []pkg.License{
+		{
+			Value:          eclipseClasspathDualLicense,
+			SPDXExpression: eclipseClasspathDualLicense,
+			Type:           epl.Type,
+			Locations:      file.NewLocationSet(append(epl.Locations.ToSlice(), gpl.Locations.ToSlice()...)...),
+		},
+	}
 }
 
 func (j *archiveParser) discoverPkgsFromNestedArchives(ctx context.Context, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {

--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -19,6 +19,7 @@ import (
 	"github.com/anchore/syft/internal"
 	intFile "github.com/anchore/syft/internal/file"
 	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/spdxlicense"
 	"github.com/anchore/syft/internal/tmpdir"
 	"github.com/anchore/syft/internal/unknown"
 	"github.com/anchore/syft/syft/artifact"
@@ -51,6 +52,8 @@ var archiveFormatGlobs = []string{
 	"**/*.rar", // Java Resource Adapter Archive
 	"**/*.zap", // ZAP add-ons https://github.com/zaproxy/zaproxy/wiki/ZapAddOns
 }
+
+const eclipseClasspathDualLicense = "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0"
 
 // javaArchiveHashes are all the current hash algorithms used to calculate archive digests
 var javaArchiveHashes = []crypto.Hash{
@@ -287,7 +290,7 @@ func (j *archiveParser) discoverMainPackage(ctx context.Context) (*pkg.Package, 
 func (j *archiveParser) discoverNameVersionLicense(ctx context.Context, manifest *pkg.JavaManifest) (string, string, []pkg.License, *parsedPomProject) {
 	// we use j.location because we want to associate the license declaration with where we discovered the contents in the manifest
 	// TODO: when we support locations of paths within archives we should start passing the specific manifest location object instead of the top jar
-	lics := pkg.NewLicensesFromLocationWithContext(ctx, j.location, selectLicenses(manifest)...)
+	lics := combineEclipseClasspathAlternatives(pkg.NewLicensesFromLocationWithContext(ctx, j.location, selectLicenses(manifest)...))
 	/*
 		We should name and version from, in this order:
 		1. pom.properties if we find exactly 1
@@ -379,9 +382,90 @@ func toPkgLicenses(ctx context.Context, location *file.Location, licenses []mave
 		if name == "" && url == "" {
 			continue
 		}
-		out = append(out, pkg.NewLicenseFromFieldsWithContext(ctx, name, url, location))
+		candidate := pkg.NewLicenseFromFieldsWithContext(ctx, name, url, location)
+		out = append(out, candidate)
 	}
-	return out
+	return combineMavenLicenseAlternatives(out)
+}
+
+func combineMavenLicenseAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) < 2 {
+		return licenses
+	}
+
+	enriched := slices.Clone(licenses)
+	for i := range enriched {
+		if enriched[i].SPDXExpression == "" && len(enriched[i].URLs) > 0 {
+			if info, found := spdxlicense.LicenseByURL(enriched[i].URLs[0]); found {
+				enriched[i].SPDXExpression = info.ID
+			}
+		}
+	}
+
+	return combineLicenseAlternatives(enriched)
+}
+
+func combineEclipseClasspathAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) != 2 {
+		return licenses
+	}
+
+	hasEPL := false
+	hasGPLClasspath := false
+	for _, candidate := range licenses {
+		switch candidate.SPDXExpression {
+		case "EPL-2.0":
+			hasEPL = true
+		case "GPL-2.0-only WITH Classpath-exception-2.0":
+			hasGPLClasspath = true
+		}
+	}
+	if !hasEPL || !hasGPLClasspath {
+		return licenses
+	}
+
+	return combineLicenseAlternatives(licenses)
+}
+
+func combineLicenseAlternatives(licenses []pkg.License) []pkg.License {
+	if len(licenses) < 2 {
+		return licenses
+	}
+
+	var values []string
+	var expressions []string
+	var locations []file.Location
+	urls := strset.New()
+	seenExpressions := strset.New()
+
+	for _, candidate := range licenses {
+		if candidate.SPDXExpression == "" {
+			return licenses
+		}
+
+		if candidate.Value != "" {
+			values = append(values, candidate.Value)
+		}
+		if !seenExpressions.Has(candidate.SPDXExpression) {
+			expressions = append(expressions, candidate.SPDXExpression)
+			seenExpressions.Add(candidate.SPDXExpression)
+		}
+		urls.Add(candidate.URLs...)
+		locations = append(locations, candidate.Locations.ToSlice()...)
+	}
+
+	combinedURLs := urls.List()
+	slices.Sort(combinedURLs)
+
+	return []pkg.License{
+		{
+			Value:          strings.Join(values, " OR "),
+			SPDXExpression: strings.Join(expressions, " OR "),
+			Type:           licenses[0].Type,
+			URLs:           combinedURLs,
+			Locations:      file.NewLocationSet(locations...),
+		},
+	}
 }
 
 type parsedPomProject struct {
@@ -590,6 +674,7 @@ func (j *archiveParser) getLicenseFromFileInArchive(ctx context.Context) []pkg.L
 				licenseContents := contents[licenseMatch]
 				r := strings.NewReader(licenseContents)
 				foundLicenses := pkg.NewLicensesFromReadCloserWithContext(ctx, file.NewLocationReadCloser(j.location, io.NopCloser(r)))
+				foundLicenses = normalizeClasspathExceptionLicenses(foundLicenses, licenseContents)
 				for _, l := range foundLicenses {
 					if l.SPDXExpression != "" {
 						identified = append(identified, l)
@@ -649,6 +734,35 @@ func (j *archiveParser) versionFromPropertiesFile(ctx context.Context, manifest 
 	}
 
 	return ""
+}
+
+func normalizeClasspathExceptionLicenses(found []pkg.License, contents string) []pkg.License {
+	if len(found) != 2 || !strings.Contains(strings.ToLower(contents), "classpath exception") {
+		return found
+	}
+
+	var epl *pkg.License
+	var gpl *pkg.License
+	for i := range found {
+		switch found[i].SPDXExpression {
+		case "EPL-2.0":
+			epl = &found[i]
+		case "GPL-2.0-only":
+			gpl = &found[i]
+		}
+	}
+	if epl == nil || gpl == nil {
+		return found
+	}
+
+	return []pkg.License{
+		{
+			Value:          eclipseClasspathDualLicense,
+			SPDXExpression: eclipseClasspathDualLicense,
+			Type:           epl.Type,
+			Locations:      file.NewLocationSet(append(epl.Locations.ToSlice(), gpl.Locations.ToSlice()...)...),
+		},
+	}
 }
 
 func (j *archiveParser) discoverPkgsFromNestedArchives(ctx context.Context, parentPkg *pkg.Package) ([]pkg.Package, []artifact.Relationship, error) {

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -89,6 +89,83 @@ func TestSearchMavenForLicenses(t *testing.T) {
 	}
 }
 
+func TestToPkgLicensesCombinesMavenAlternatives(t *testing.T) {
+	const eplName = "Eclipse Public License 2.0"
+	const eplURL = "https://projects.eclipse.org/license/epl-2.0"
+	const gplName = "GNU General Public License, version 2 with the GNU Classpath Exception"
+	const gplURL = "https://projects.eclipse.org/license/secondary-gpl-2.0-cp"
+
+	actual := toPkgLicenses(pkgtest.Context(t), nil, []maven.License{
+		{Name: ptr(eplName), URL: ptr(eplURL)},
+		{Name: ptr(gplName), URL: ptr(gplURL)},
+	})
+
+	expected := []pkg.License{
+		{
+			Value:          eplName + " OR " + gplName,
+			SPDXExpression: "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+			Type:           license.Declared,
+			URLs:           []string{eplURL, gplURL},
+		},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCombineEclipseClasspathAlternatives(t *testing.T) {
+	alternatives := []pkg.License{
+		{Value: "EPL", SPDXExpression: "EPL-2.0", Type: license.Declared},
+		{Value: "GPL plus exception", SPDXExpression: "GPL-2.0-only WITH Classpath-exception-2.0", Type: license.Declared},
+	}
+
+	actual := combineEclipseClasspathAlternatives(alternatives)
+	require.Len(t, actual, 1)
+	assert.Equal(t, eclipseClasspathDualLicense, actual[0].SPDXExpression)
+
+	unrelated := []pkg.License{
+		{SPDXExpression: "Apache-2.0"},
+		{SPDXExpression: "MIT"},
+	}
+	assert.Equal(t, unrelated, combineEclipseClasspathAlternatives(unrelated))
+}
+
+func TestNormalizeClasspathExceptionLicenses(t *testing.T) {
+	location := file.NewLocation("META-INF/LICENSE.md")
+	actual := normalizeClasspathExceptionLicenses([]pkg.License{
+		{
+			Value:          "EPL-2.0",
+			SPDXExpression: "EPL-2.0",
+			Type:           license.Concluded,
+			Locations:      file.NewLocationSet(location),
+		},
+		{
+			Value:          "GPL-2.0-only",
+			SPDXExpression: "GPL-2.0-only",
+			Type:           license.Concluded,
+			Locations:      file.NewLocationSet(location),
+		},
+	}, "## CLASSPATH EXCEPTION\n\nAs a special exception...")
+
+	expected := []pkg.License{
+		{
+			Value:          eclipseClasspathDualLicense,
+			SPDXExpression: eclipseClasspathDualLicense,
+			Type:           license.Concluded,
+			Locations:      file.NewLocationSet(location),
+		},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestNormalizeClasspathExceptionLicensesPreservesOtherLicenses(t *testing.T) {
+	found := []pkg.License{
+		{SPDXExpression: "EPL-2.0"},
+		{SPDXExpression: "GPL-2.0-only"},
+		{SPDXExpression: "MIT"},
+	}
+
+	assert.Equal(t, found, normalizeClasspathExceptionLicenses(found, "## CLASSPATH EXCEPTION"))
+}
+
 func TestParseJar(t *testing.T) {
 	ctx := pkgtest.Context(t)
 	tests := []struct {

--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -261,11 +261,58 @@ func selectLicenses(manifest *pkg.JavaManifest) []string {
 
 	for _, fieldName := range fieldNames {
 		if v := fieldValueFromManifest(*manifest, fieldName); v != "" {
-			result = append(result, v)
+			if fieldName != "Bundle-License" {
+				result = append(result, v)
+				continue
+			}
+
+			for _, clause := range splitUnquoted(v, ',') {
+				identifier := strings.TrimSpace(splitUnquoted(clause, ';')[0])
+				if identifier != "" {
+					result = append(result, identifier)
+				}
+			}
 		}
 	}
 
 	return result
+}
+
+func splitUnquoted(value string, delimiter rune) []string {
+	var parts []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+
+	for _, r := range value {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if quote != 0 && r == '\\' {
+			current.WriteRune(r)
+			escaped = true
+			continue
+		}
+		if r == '\'' || r == '"' {
+			if quote == 0 {
+				quote = r
+			} else if quote == r {
+				quote = 0
+			}
+			current.WriteRune(r)
+			continue
+		}
+		if quote == 0 && r == delimiter {
+			parts = append(parts, current.String())
+			current.Reset()
+			continue
+		}
+		current.WriteRune(r)
+	}
+
+	return append(parts, current.String())
 }
 
 func fieldValueFromManifest(manifest pkg.JavaManifest, fieldName string) string {

--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -296,9 +296,10 @@ func splitUnquoted(value string, delimiter rune) []string {
 			continue
 		}
 		if r == '\'' || r == '"' {
-			if quote == 0 {
+			switch quote {
+			case 0:
 				quote = r
-			} else if quote == r {
+			case r:
 				quote = 0
 			}
 			current.WriteRune(r)

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -194,6 +194,23 @@ func TestParseJavaManifest(t *testing.T) {
 	}
 }
 
+func TestSelectLicensesSplitsBundleLicenseClauses(t *testing.T) {
+	manifest := &pkg.JavaManifest{
+		Main: pkg.KeyValues{
+			{
+				Key: "Bundle-License",
+				Value: "https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt;description=\"EPL, version 2\", " +
+					"https://www.gnu.org/software/classpath/license.html",
+			},
+		},
+	}
+
+	assert.Equal(t, []string{
+		"https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt",
+		"https://www.gnu.org/software/classpath/license.html",
+	}, selectLicenses(manifest))
+}
+
 func TestSelectName(t *testing.T) {
 	tests := []struct {
 		desc     string


### PR DESCRIPTION
## Description

Fixes Java license normalization for Eclipse/GlassFish artifacts that are dual-licensed under EPL-2.0 or GPL-2.0 with the Classpath Exception.

Before this change, Syft either emitted an opaque `LicenseRef` for the license URLs or concluded `EPL-2.0 AND GPL-2.0-only`. The latter both changed the dual-license semantics and dropped `Classpath-exception-2.0`.

This change:

- normalizes the Eclipse and GNU Classpath Exception URLs to valid SPDX expressions
- parses individual OSGi `Bundle-License` clauses while preserving quoted attributes
- combines Maven license alternatives with `OR` when every alternative resolves to SPDX
- preserves the Classpath Exception when Java license text contains the EPL/GPL pair and an explicit Classpath Exception section
- leaves unknown and unrelated license combinations unchanged

After the change, all six artifacts from the issue reproducer report:

```text
(EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0)
```

Validation performed:

- `go test ./internal/spdxlicense -count=1`
- targeted Java cataloger regression tests for Maven alternatives, OSGi manifest parsing, POM parsing, and license-file normalization
- end-to-end SPDX JSON scan of all six pinned JARs from the reproducer
- `git diff --check`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #5009