### PR TITLE
feat(release): attach a vendored-source archive to releases

### DIFF
--- a/.github/scripts/create-vendored-source-archive.sh
+++ b/.github/scripts/create-vendored-source-archive.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Create a vendored-source archive for downstream (offline) packaging.
+#
+# Produces dist/syft_<version>_vendored-source.tar.gz containing the full syft
+# source tree plus a vendor/ directory of all Go module dependencies, so
+# downstream packagers can build syft without network access:
+#
+#     tar -xzf syft_<version>_vendored-source.tar.gz
+#     cd syft-<version>
+#     go build -mod=vendor ./cmd/syft
+#
+# This is invoked as a goreleaser global "before" hook (see .goreleaser.yaml) and
+# the resulting archive is attached to the GitHub release via release.extra_files.
+#
+# Vendoring is skipped for snapshot builds to keep the frequent snapshot CI fast.
+# The vendor/ directory is removed again once the archive is written so the actual
+# goreleaser build runs in module mode exactly as it does today (no behavior change
+# to the produced binaries).
+set -euo pipefail
+
+VERSION="${1:?usage: create-vendored-source-archive.sh <version> <is-snapshot>}"
+IS_SNAPSHOT="${2:-false}"
+
+if [ "${IS_SNAPSHOT}" = "true" ]; then
+  echo "skipping vendored-source archive for snapshot build"
+  exit 0
+fi
+
+DIST_DIR="${DIST_DIR:-dist}"
+PREFIX="syft-${VERSION}"
+ARCHIVE="${DIST_DIR}/syft_${VERSION}_vendored-source.tar.gz"
+
+mkdir -p "${DIST_DIR}"
+
+echo "vendoring Go module dependencies..."
+go mod vendor
+
+# pin the archive mtime to the release commit for a reproducible artifact, mirroring
+# the mod_timestamp={{ .CommitTimestamp }} approach used by the goreleaser builds.
+SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
+
+# Archive the git-tracked source files plus the (untracked) vendor/ tree, remapped
+# under a single top-level ${PREFIX}/ directory so extraction is self-contained.
+# Requires GNU tar (the release runs on a Linux runner); --sort/--mtime/--owner keep
+# the output byte-for-byte reproducible.
+FILE_LIST="$(mktemp)"
+trap 'rm -f "${FILE_LIST}"' EXIT
+{ git ls-files; find vendor -type f; } | LC_ALL=C sort -u >"${FILE_LIST}"
+
+echo "creating ${ARCHIVE}..."
+tar \
+  --owner=0 --group=0 --numeric-owner \
+  --mtime="@${SOURCE_DATE_EPOCH}" \
+  --sort=name \
+  --transform "s,^,${PREFIX}/," \
+  -czf "${ARCHIVE}" \
+  -T "${FILE_LIST}"
+
+# restore the working tree to module mode so goreleaser builds exactly as before
+rm -rf vendor
+
+echo "created ${ARCHIVE} ($(du -h "${ARCHIVE}" | cut -f1))"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,17 @@ project_name: syft
 release:
   prerelease: auto
   draft: false
+  # attach a vendored-source archive (source tree + vendor/) so downstream
+  # packagers can build syft offline. produced by the before-hook below.
+  extra_files:
+    - glob: ./dist/syft_*_vendored-source.tar.gz
+
+# produce a vendored-source archive at release time. the hook vendors deps, tars
+# the source + vendor/ tree into dist/, then removes vendor/ so the goreleaser
+# build itself is unchanged. skipped for snapshot builds to keep snapshot CI fast.
+before:
+  hooks:
+    - ./.github/scripts/create-vendored-source-archive.sh {{ .Version }} {{ .IsSnapshot }}
 
 env:
   - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
## What

Attaches a vendored-source archive to each syft release so downstream packagers can build offline (#5048).

## Approach

goreleaser-native, since syft's whole release is goreleaser-driven:

- A global `before` hook (`.github/scripts/create-vendored-source-archive.sh`) runs `go mod vendor` and tars the source tree (`git ls-files`) plus `vendor/` into `dist/syft_<version>_vendored-source.tar.gz` under a `syft-<version>/` prefix, then removes `vendor/` so the goreleaser build itself is unchanged.
- `release.extra_files` attaches that archive to the GitHub release.
- The hook is skipped for snapshot builds (`{{ .IsSnapshot }}`) so the frequent snapshot CI isn't slowed.

No workflow changes and no existing artifact altered — it all lives in `.goreleaser.yaml`, syft's single release source of truth.

## Verification

- `go mod vendor` + `go build -mod=vendor ./...` (CGO_ENABLED=0, matching the release) both pass.
- The hook end-to-end: snapshot mode skips; release mode produces the archive in **~7s** (49 MB) — negligible against syft's multi-arch/multi-image release, well within the "not very poor performance" bar you mentioned.
- **Offline build proof**: extracted the archive to a fresh dir and ran `GOPROXY=off GOMODCACHE=<empty> go build -mod=vendor ./cmd/syft` — it built with zero network (the module cache was never even created), which is exactly the downstream offline-packaging use case.
- The archive is reproducible (`--sort=name --mtime --owner=0 --group=0`), excludes `.git`, and targets GNU tar (the Linux release runner).

`goreleaser check` couldn't be run here (goreleaser isn't installed) and the real release path can't be exercised in a sandbox, but `.goreleaser.yaml` parses cleanly and the archive/build steps are verified as above. I kept it surgical (didn't add the archive to `checksums.txt`) — happy to also checksum/sign it alongside the binaries if you'd prefer.

Closes #5048.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). Verified with `go mod vendor` plus an offline `-mod=vendor` build from the extracted archive. DCO sign-off included.*
