### PR TITLE
fix(apk): allow large installed db fields

### DIFF
--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -32,12 +32,15 @@ type parsedData struct {
 	pkg.ApkDBEntry
 }
 
+const maxApkDBFieldSize = 10 * 1024 * 1024
+
 // parseApkDB parses packages from a given APK "installed" flat-file DB. For more
 // information on specific fields, see https://wiki.alpinelinux.org/wiki/Apk_spec.
 //
 //nolint:funlen
 func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(nil, maxApkDBFieldSize)
 
 	var errs error
 	var apks []parsedData

--- a/syft/pkg/cataloger/alpine/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db_test.go
@@ -719,6 +719,25 @@ func Test_processChecksum(t *testing.T) {
 	}
 }
 
+func TestParseApkDBAllowsLargeFieldValues(t *testing.T) {
+	contents := strings.Join([]string{
+		"P:large-description",
+		"V:1.0-r0",
+		"A:x86_64",
+		"S:1",
+		"I:1",
+		"T:" + strings.Repeat("a", 70*1024),
+		"",
+	}, "\n")
+	reader := file.NewLocationReadCloser(file.NewLocation("large-installed-db"), io.NopCloser(strings.NewReader(contents)))
+
+	pkgs, _, err := parseApkDB(context.Background(), nil, new(generic.Environment), reader)
+
+	require.NoError(t, err)
+	require.Len(t, pkgs, 1)
+	assert.Equal(t, "large-description", pkgs[0].Name)
+}
+
 func Test_parseApkDB_expectedPkgNames(t *testing.T) {
 	tests := []struct {
 		fixture      string


### PR DESCRIPTION
## Description

Fixes #5094.

The Alpine installed DB parser now raises the scanner token limit to 10 MiB so oversized-but-valid field values do not cause the whole cataloger to fail with `bufio.Scanner: token too long`.

## Testing

- `go test ./syft/pkg/cataloger/alpine -run TestParseApkDBAllowsLargeFieldValues -count=1`
- `go test ./syft/pkg/cataloger/alpine -count=1`
- `git diff --check`
