### PR TITLE
fix(cyclonedx): preserve metadata.component name and version on decode

### DIFF
--- a/syft/format/cyclonedxjson/decoder_test.go
+++ b/syft/format/cyclonedxjson/decoder_test.go
@@ -1,6 +1,7 @@
 package cyclonedxjson
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/syft/format/internal/testutil"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -84,6 +86,29 @@ func TestDecoder_Decode(t *testing.T) {
 			}
 
 			assert.ElementsMatch(t, test.packages, pkgs)
+		})
+	}
+}
+
+// the source name and version (as set by --source-name and --source-version) are only expressed as the
+// CycloneDX metadata.component name and version, so they must survive an encode-decode round trip.
+// see https://github.com/anchore/grype/issues/2418
+func TestDecoder_SourceNameAndVersionRoundTrip(t *testing.T) {
+	subject := testutil.DirectoryInput(t, t.TempDir())
+	subject.Source.Name = "my-app"
+	subject.Source.Version = "0.1.0"
+
+	for _, enc := range defaultFormatEncoders() {
+		t.Run(enc.Version(), func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, enc.Encode(&buf, subject))
+
+			s, _, _, err := NewFormatDecoder().Decode(bytes.NewReader(buf.Bytes()))
+			require.NoError(t, err)
+			require.NotNil(t, s)
+
+			assert.Equal(t, subject.Source.Name, s.Source.Name)
+			assert.Equal(t, subject.Source.Version, s.Source.Version)
 		})
 	}
 }

--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -221,6 +221,14 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 		supplier = meta.Supplier.Name
 	}
 
+	// Always preserve name/version so CycloneDX metadata.component round-trips
+	// (e.g. syft --source-version → grype → cyclonedx-json).
+	desc := source.Description{
+		Name:     c.Name,
+		Version:  c.Version,
+		Supplier: supplier,
+	}
+
 	switch c.Type {
 	case cyclonedx.ComponentTypeContainer:
 		var labels map[string]string
@@ -229,29 +237,19 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 			labels = decodeProperties(*meta.Properties, "syft:image:labels:")
 		}
 
-		return source.Description{
-			ID:       "",
-			Supplier: supplier,
-			// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
-
-			Metadata: source.ImageMetadata{
-				UserInput:      c.Name,
-				ID:             c.BOMRef,
-				ManifestDigest: c.Version,
-				Labels:         labels,
-			},
+		desc.Metadata = source.ImageMetadata{
+			UserInput:      c.Name,
+			ID:             c.BOMRef,
+			ManifestDigest: c.Version,
+			Labels:         labels,
 		}
+		return desc
 	case cyclonedx.ComponentTypeFile:
-		// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
-
 		// TODO: this is lossy... we can't know if this is a file or a directory
-		return source.Description{
-			ID:       "",
-			Supplier: supplier,
-			Metadata: source.FileMetadata{Path: c.Name},
-		}
+		desc.Metadata = source.FileMetadata{Path: c.Name}
+		return desc
 	}
-	return source.Description{}
+	return desc
 }
 
 // if there is more than one tool in meta.Tools' list the last item will be used

--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -221,8 +221,8 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 		supplier = meta.Supplier.Name
 	}
 
-	// Always preserve name/version so CycloneDX metadata.component round-trips
-	// (e.g. syft --source-version → grype → cyclonedx-json).
+	// the component name and version describe the source, so they are always preserved (regardless of
+	// component type) to survive a decode-then-encode round trip.
 	desc := source.Description{
 		Name:     c.Name,
 		Version:  c.Version,
@@ -243,12 +243,11 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 			ManifestDigest: c.Version,
 			Labels:         labels,
 		}
-		return desc
 	case cyclonedx.ComponentTypeFile:
 		// TODO: this is lossy... we can't know if this is a file or a directory
 		desc.Metadata = source.FileMetadata{Path: c.Name}
-		return desc
 	}
+
 	return desc
 }
 

--- a/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
 )
 
 func Test_decode(t *testing.T) {
@@ -480,4 +481,72 @@ func Test_useBomRefOverDerivedSyftArtifactID(t *testing.T) {
 	assert.Len(t, pkgsWithoutID, 1)
 	assert.NotEqual(t, "", pkgsWithoutID[0].ID())
 
+}
+
+func Test_extractComponents_preservesNameAndVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		component       *cyclonedx.Component
+		wantName        string
+		wantVersion     string
+		wantMetaType    string
+		wantImageDigest string
+	}{
+		{
+			name: "application component (directory / --source-version)",
+			component: &cyclonedx.Component{
+				Type:    cyclonedx.ComponentTypeApplication,
+				Name:    "my-app",
+				Version: "0.1.0",
+			},
+			wantName:    "my-app",
+			wantVersion: "0.1.0",
+		},
+		{
+			name: "file component preserves version",
+			component: &cyclonedx.Component{
+				Type:    cyclonedx.ComponentTypeFile,
+				Name:    "/path/to/project",
+				Version: "1.2.3",
+			},
+			wantName:     "/path/to/project",
+			wantVersion:  "1.2.3",
+			wantMetaType: "file",
+		},
+		{
+			name: "container component preserves version and image digest",
+			component: &cyclonedx.Component{
+				Type:    cyclonedx.ComponentTypeContainer,
+				BOMRef:  "img-ref",
+				Name:    "alpine:latest",
+				Version: "sha256:abc123",
+			},
+			wantName:        "alpine:latest",
+			wantVersion:     "sha256:abc123",
+			wantMetaType:    "image",
+			wantImageDigest: "sha256:abc123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractComponents(&cyclonedx.Metadata{Component: tt.component})
+			assert.Equal(t, tt.wantName, got.Name)
+			assert.Equal(t, tt.wantVersion, got.Version)
+
+			switch tt.wantMetaType {
+			case "file":
+				meta, ok := got.Metadata.(source.FileMetadata)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantName, meta.Path)
+			case "image":
+				meta, ok := got.Metadata.(source.ImageMetadata)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantName, meta.UserInput)
+				assert.Equal(t, tt.wantImageDigest, meta.ManifestDigest)
+			default:
+				assert.Nil(t, got.Metadata)
+			}
+		})
+	}
 }

--- a/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
@@ -483,70 +483,109 @@ func Test_useBomRefOverDerivedSyftArtifactID(t *testing.T) {
 
 }
 
-func Test_extractComponents_preservesNameAndVersion(t *testing.T) {
+func Test_extractComponents(t *testing.T) {
 	tests := []struct {
-		name            string
-		component       *cyclonedx.Component
-		wantName        string
-		wantVersion     string
-		wantMetaType    string
-		wantImageDigest string
+		name     string
+		input    *cyclonedx.Metadata
+		expected source.Description
 	}{
 		{
-			name: "application component (directory / --source-version)",
-			component: &cyclonedx.Component{
-				Type:    cyclonedx.ComponentTypeApplication,
+			name:     "no metadata",
+			input:    nil,
+			expected: source.Description{},
+		},
+		{
+			name:     "no component",
+			input:    &cyclonedx.Metadata{},
+			expected: source.Description{},
+		},
+		{
+			name: "application component keeps name and version",
+			input: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeApplication,
+					Name:    "my-app",
+					Version: "0.1.0",
+				},
+			},
+			expected: source.Description{
 				Name:    "my-app",
 				Version: "0.1.0",
 			},
-			wantName:    "my-app",
-			wantVersion: "0.1.0",
 		},
 		{
-			name: "file component preserves version",
-			component: &cyclonedx.Component{
-				Type:    cyclonedx.ComponentTypeFile,
-				Name:    "/path/to/project",
-				Version: "1.2.3",
+			name: "file component keeps name and version",
+			input: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeFile,
+					Name:    "/path/to/project",
+					Version: "1.2.3",
+				},
 			},
-			wantName:     "/path/to/project",
-			wantVersion:  "1.2.3",
-			wantMetaType: "file",
+			expected: source.Description{
+				Name:     "/path/to/project",
+				Version:  "1.2.3",
+				Metadata: source.FileMetadata{Path: "/path/to/project"},
+			},
 		},
 		{
-			name: "container component preserves version and image digest",
-			component: &cyclonedx.Component{
-				Type:    cyclonedx.ComponentTypeContainer,
-				BOMRef:  "img-ref",
+			name: "container component keeps name and version",
+			input: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeContainer,
+					BOMRef:  "img-ref",
+					Name:    "alpine:latest",
+					Version: "sha256:abc123",
+				},
+				Properties: &[]cyclonedx.Property{
+					{Name: "syft:image:labels:maintainer", Value: "someone"},
+				},
+			},
+			expected: source.Description{
 				Name:    "alpine:latest",
 				Version: "sha256:abc123",
+				Metadata: source.ImageMetadata{
+					UserInput:      "alpine:latest",
+					ID:             "img-ref",
+					ManifestDigest: "sha256:abc123",
+					Labels:         map[string]string{"maintainer": "someone"},
+				},
 			},
-			wantName:        "alpine:latest",
-			wantVersion:     "sha256:abc123",
-			wantMetaType:    "image",
-			wantImageDigest: "sha256:abc123",
+		},
+		{
+			name: "component supplier is preferred over metadata supplier",
+			input: &cyclonedx.Metadata{
+				Supplier: &cyclonedx.OrganizationalEntity{Name: "metadata-supplier"},
+				Component: &cyclonedx.Component{
+					Type:     cyclonedx.ComponentTypeApplication,
+					Name:     "my-app",
+					Supplier: &cyclonedx.OrganizationalEntity{Name: "component-supplier"},
+				},
+			},
+			expected: source.Description{
+				Name:     "my-app",
+				Supplier: "component-supplier",
+			},
+		},
+		{
+			name: "metadata supplier is used when the component has none",
+			input: &cyclonedx.Metadata{
+				Supplier: &cyclonedx.OrganizationalEntity{Name: "metadata-supplier"},
+				Component: &cyclonedx.Component{
+					Type: cyclonedx.ComponentTypeApplication,
+					Name: "my-app",
+				},
+			},
+			expected: source.Description{
+				Name:     "my-app",
+				Supplier: "metadata-supplier",
+			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractComponents(&cyclonedx.Metadata{Component: tt.component})
-			assert.Equal(t, tt.wantName, got.Name)
-			assert.Equal(t, tt.wantVersion, got.Version)
-
-			switch tt.wantMetaType {
-			case "file":
-				meta, ok := got.Metadata.(source.FileMetadata)
-				require.True(t, ok)
-				assert.Equal(t, tt.wantName, meta.Path)
-			case "image":
-				meta, ok := got.Metadata.(source.ImageMetadata)
-				require.True(t, ok)
-				assert.Equal(t, tt.wantName, meta.UserInput)
-				assert.Equal(t, tt.wantImageDigest, meta.ManifestDigest)
-			default:
-				assert.Nil(t, got.Metadata)
-			}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, extractComponents(test.input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- `extractComponents` now always copies `metadata.component` `name`/`version` into `source.Description`
- Container and file metadata paths still populate typed `Metadata`, and containers keep `ManifestDigest` from the component version
- Adds unit coverage for application/file/container round-trip preservation

Fixes https://github.com/anchore/grype/issues/2418

Previously, decoding a CycloneDX SBOM (e.g. from `syft . --source-version=0.1.0`) dropped `metadata.component.version`, so `grype sbom:... --output cyclonedx-json` emitted an SBOM without that field.

## Test plan
- [x] `go test ./syft/format/internal/cyclonedxutil/helpers/ -run Test_extractComponents_preservesNameAndVersion`
- [ ] Manual: `syft . --output cyclonedx-json=bom.cdx.json --source-version=0.1.0` then scan with Grype cyclonedx-json output and confirm `metadata.component.version` is retained (once Grype picks up this Syft fix)
