### PR TITLE
fix(swift): guard slice access when pod entry has no version in Podfile.lock parser

### DIFF
--- a/syft/pkg/cataloger/swift/parse_podfile_lock.go
+++ b/syft/pkg/cataloger/swift/parse_podfile_lock.go
@@ -46,8 +46,14 @@ func parsePodfileLock(_ context.Context, _ file.Resolver, _ *generic.Environment
 			return nil, nil, fmt.Errorf("malformed podfile.lock")
 		}
 		splits := strings.Split(podBlob, " ")
+		if len(splits) < 1 {
+			continue
+		}
 		podName := splits[0]
-		podVersion := strings.TrimSuffix(strings.TrimPrefix(splits[1], "("), ")")
+		var podVersion string
+		if len(splits) > 1 {
+			podVersion = strings.TrimSuffix(strings.TrimPrefix(splits[1], "("), ")")
+		}
 		podRootPkg := strings.Split(podName, "/")[0]
 
 		var pkgHash string


### PR DESCRIPTION
When parsing Podfile.lock entries, the pod string is split by spaces to extract name and version. A pod specified without a version caused an index-out-of-bounds panic on splits[1]. Added bounds check before accessing the version field.

Used AI to help identify and draft this fix — reviewed and tested before submitting.