### PR TITLE
fix(apkdb): Increase buffer size if an overly long field occurs in an ApkDB record

### DIFF
--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -43,50 +43,50 @@ const maxAPKDBTokenSize = 512 * 1024
 //
 // nolint:funlen
 func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
-        // Attempt to parse with the default scanner.
-        // If it encounters a field which exceeds the 64KB buffer size, rewind
-        // and rescan with a larger buffer
-        apks, errs, scanErr := scanApkDBEntries(reader, 0)
-        if errors.Is(scanErr, bufio.ErrTooLong) {
-                if seeker, ok := reader.ReadCloser.(io.Seeker); ok {
-                        if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr == nil {
-                                apks, errs, scanErr = scanApkDBEntries(reader, maxAPKDBTokenSize)
-                        } else {
-                                log.Debugf("unable to rewind APK installed DB to re-parse with a larger buffer: %+v", seekErr)
-                        }
-                } else {
-                        log.Debug("APK installed DB contains an oversized field but the reader is not seekable; cannot re-parse with a larger buffer")
-                }
-        }
+	// Attempt to parse with the default scanner.
+	// If it encounters a field which exceeds the 64KB buffer size, rewind
+	// and rescan with a larger buffer
+	apks, errs, scanErr := scanApkDBEntries(reader, 0)
+	if errors.Is(scanErr, bufio.ErrTooLong) {
+		if seeker, ok := reader.ReadCloser.(io.Seeker); ok {
+			if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr == nil {
+				apks, errs, scanErr = scanApkDBEntries(reader, maxAPKDBTokenSize)
+			} else {
+				log.Debugf("unable to rewind APK installed DB to re-parse with a larger buffer: %+v", seekErr)
+			}
+		} else {
+			log.Debug("APK installed DB contains an oversized field but the reader is not seekable; cannot re-parse with a larger buffer")
+		}
+	}
 
-        if scanErr != nil {
-                return nil, nil, fmt.Errorf("failed to parse APK installed DB file: %w", scanErr)
-        }
+	if scanErr != nil {
+		return nil, nil, fmt.Errorf("failed to parse APK installed DB file: %w", scanErr)
+	}
 
-        var r *linux.Release
-        if env != nil {
-                r = env.LinuxRelease
-        }
-        // this is somewhat ugly, but better than completely failing when we can't find the release,
-        // e.g. embedded deeper in the tree, like containers or chroots.
-        // but we now have no way of handling different repository sources. On the other hand,
-        // we never could before this. At least now, we can handle some.
-        // This should get fixed with https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10875
-        if r == nil {
-                // find the repositories file from the relative directory of the DB file
-                releases := findReleases(resolver, reader.RealPath)
+	var r *linux.Release
+	if env != nil {
+		r = env.LinuxRelease
+	}
+	// this is somewhat ugly, but better than completely failing when we can't find the release,
+	// e.g. embedded deeper in the tree, like containers or chroots.
+	// but we now have no way of handling different repository sources. On the other hand,
+	// we never could before this. At least now, we can handle some.
+	// This should get fixed with https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10875
+	if r == nil {
+		// find the repositories file from the relative directory of the DB file
+		releases := findReleases(resolver, reader.RealPath)
 
-                if len(releases) > 0 {
-                        r = &releases[0]
-				}
-        }
+		if len(releases) > 0 {
+			r = &releases[0]
+		}
+	}
 
-        pkgs := make([]pkg.Package, 0, len(apks))
-        for _, apk := range apks {
-                pkgs = append(pkgs, newPackage(ctx, apk, r, reader.Location))
-        }
+	pkgs := make([]pkg.Package, 0, len(apks))
+	for _, apk := range apks {
+		pkgs = append(pkgs, newPackage(ctx, apk, r, reader.Location))
+	}
 
-        return pkgs, nil, errs
+	return pkgs, nil, errs
 }
 
 // scanApkDBEntries parses packages from a given APK "installed" flat-file DB.
@@ -99,7 +99,7 @@ func scanApkDBEntries(reader file.LocationReadCloser, maxTokenSize int) (apks []
 	if maxTokenSize > 0 {
 		scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxTokenSize)
 	}
-	
+
 	var currentEntry parsedData
 	entryParsingInProgress := false
 	fileParsingCtx := newApkFileParsingContext()

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -36,11 +36,12 @@ type parsedData struct {
 // information on specific fields, see https://wiki.alpinelinux.org/wiki/Apk_spec.
 //
 //nolint:funlen
-func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+func scanApkDBEntries(reader file.LocationReadCloser, maxTokenSize int) (apks []parsedData, errs error, scanErr error) {
 	scanner := bufio.NewScanner(reader)
-
-	var errs error
-	var apks []parsedData
+	if maxTokenSize > 0 {
+		scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxTokenSize)
+	}
+	
 	var currentEntry parsedData
 	entryParsingInProgress := false
 	fileParsingCtx := newApkFileParsingContext()
@@ -108,34 +109,7 @@ func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Enviro
 		appendApk(currentEntry)
 	}
 
-	if err := scanner.Err(); err != nil {
-		return nil, nil, fmt.Errorf("failed to parse APK installed DB file: %w", err)
-	}
-
-	var r *linux.Release
-	if env != nil {
-		r = env.LinuxRelease
-	}
-	// this is somewhat ugly, but better than completely failing when we can't find the release,
-	// e.g. embedded deeper in the tree, like containers or chroots.
-	// but we now have no way of handling different repository sources. On the other hand,
-	// we never could before this. At least now, we can handle some.
-	// This should get fixed with https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10875
-	if r == nil {
-		// find the repositories file from the relative directory of the DB file
-		releases := findReleases(resolver, reader.RealPath)
-
-		if len(releases) > 0 {
-			r = &releases[0]
-		}
-	}
-
-	pkgs := make([]pkg.Package, 0, len(apks))
-	for _, apk := range apks {
-		pkgs = append(pkgs, newPackage(ctx, apk, r, reader.Location))
-	}
-
-	return pkgs, nil, errs
+	return apks, errs, scanner.Err()
 }
 
 func findReleases(resolver file.Resolver, dbPath string) []linux.Release {

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -3,6 +3,7 @@ package alpine
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -32,10 +33,62 @@ type parsedData struct {
 	pkg.ApkDBEntry
 }
 
+// Maximum size of an APKDB line
+// 64KB is allocated by default, if that's too big then a buffer of maxAPKDBTokenSize
+// is used
+const maxAPKDBTokenSize = 512 * 1024
+
 // parseApkDB parses packages from a given APK "installed" flat-file DB. For more
 // information on specific fields, see https://wiki.alpinelinux.org/wiki/Apk_spec.
 //
-//nolint:funlen
+// nolint:funlen
+func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+        // Attempt to parse with the default scanner.
+        // If it encounters a field which exceeds the 64KB buffer size, rewind
+        // and rescan with a larger buffer
+        apks, errs, scanErr := scanApkDBEntries(reader, 0)
+        if errors.Is(scanErr, bufio.ErrTooLong) {
+                if seeker, ok := reader.ReadCloser.(io.Seeker); ok {
+                        if _, seekErr := seeker.Seek(0, io.SeekStart); seekErr == nil {
+                                apks, errs, scanErr = scanApkDBEntries(reader, maxAPKDBTokenSize)
+                        } else {
+                                log.Debugf("unable to rewind APK installed DB to re-parse with a larger buffer: %+v", seekErr)
+                        }
+                } else {
+                        log.Debug("APK installed DB contains an oversized field but the reader is not seekable; cannot re-parse with a larger buffer")
+                }
+        }
+
+        if scanErr != nil {
+                return nil, nil, fmt.Errorf("failed to parse APK installed DB file: %w", scanErr)
+        }
+
+        var r *linux.Release
+        if env != nil {
+                r = env.LinuxRelease
+        }
+        // this is somewhat ugly, but better than completely failing when we can't find the release,
+        // e.g. embedded deeper in the tree, like containers or chroots.
+        // but we now have no way of handling different repository sources. On the other hand,
+        // we never could before this. At least now, we can handle some.
+        // This should get fixed with https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10875
+        if r == nil {
+                // find the repositories file from the relative directory of the DB file
+                releases := findReleases(resolver, reader.RealPath)
+
+                if len(releases) > 0 {
+                        r = &releases[0]
+        }
+
+        pkgs := make([]pkg.Package, 0, len(apks))
+        for _, apk := range apks {
+                pkgs = append(pkgs, newPackage(ctx, apk, r, reader.Location))
+        }
+
+        return pkgs, nil, errs
+}
+
+
 func scanApkDBEntries(reader file.LocationReadCloser, maxTokenSize int) (apks []parsedData, errs error, scanErr error) {
 	scanner := bufio.NewScanner(reader)
 	if maxTokenSize > 0 {

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -40,8 +40,6 @@ const maxAPKDBTokenSize = 512 * 1024
 
 // parseApkDB parses packages from a given APK "installed" flat-file DB. For more
 // information on specific fields, see https://wiki.alpinelinux.org/wiki/Apk_spec.
-//
-// nolint:funlen
 func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	// Attempt to parse with the default scanner.
 	// If it encounters a field which exceeds the 64KB buffer size, rewind

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -88,7 +88,11 @@ func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Enviro
         return pkgs, nil, errs
 }
 
-
+// scanApkDBEntries parses packages from a given APK "installed" flat-file DB.
+// If maxTokenSize is > 0 it's passed to the scanner as a maximum token size
+//
+// Any scanner errors are returned so that caller has opportunity to recall with
+// a larger buffer
 func scanApkDBEntries(reader file.LocationReadCloser, maxTokenSize int) (apks []parsedData, errs error, scanErr error) {
 	scanner := bufio.NewScanner(reader)
 	if maxTokenSize > 0 {

--- a/syft/pkg/cataloger/alpine/parse_apk_db.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db.go
@@ -78,6 +78,7 @@ func parseApkDB(ctx context.Context, resolver file.Resolver, env *generic.Enviro
 
                 if len(releases) > 0 {
                         r = &releases[0]
+				}
         }
 
         pkgs := make([]pkg.Package, 0, len(apks))

--- a/syft/pkg/cataloger/alpine/parse_apk_db_test.go
+++ b/syft/pkg/cataloger/alpine/parse_apk_db_test.go
@@ -1,7 +1,9 @@
 package alpine
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -786,6 +788,53 @@ func Test_parseApkDB_expectedPkgNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Call parseApkDB against a DB which includes a field greater that bufio's
+// default 64KB token size - the reader should silently expand the buffer
+// size and successfully return the records
+func Test_parseApkDB_recoversFromOversizedField(t *testing.T) {
+	record := func(name, provides string) string {
+		return strings.Join([]string{
+			"C:Q1" + name + "0000000000000000000000000=",
+			"P:" + name,
+			"V:1.0.0-r0",
+			"A:x86_64",
+			"L:MIT",
+			"T:test package " + name,
+			"o:" + name,
+			"m:test",
+			"t:1700000000",
+			"S:100",
+			"I:200",
+			"p:" + provides,
+			"F:usr",
+			"R:" + name,
+			"Z:Q10000000000000000000000000000=",
+		}, "\n")
+	}
+
+	// create a provides line beyond the 64 KB default scanner token size
+	var big strings.Builder
+	big.WriteString("cmd:beta=1.0.0-r0")
+	for i := 0; i < 3000; i++ {
+		fmt.Fprintf(&big, " so-ver:lib%d.so=1.0.0-r0", i)
+	}
+	require.Greater(t, big.Len(), bufio.MaxScanTokenSize, "provides line must exceed the default token size to exercise the fix")
+
+	content := record("alpha", "cmd:alpha=1.0.0-r0") + "\n\n" + record("beta", big.String()) + "\n"
+
+	dbPath := filepath.Join(t.TempDir(), "installed")
+	require.NoError(t, os.WriteFile(dbPath, []byte(content), 0o600))
+
+	// use a real *os.File so the reader is seekable, mirroring the resolver's behavior
+	lrc := newLocationReadCloser(t, dbPath)
+
+	pkgs, _, err := parseApkDB(context.Background(), nil, new(generic.Environment), lrc)
+	require.NoError(t, err)
+
+	// both the package before the oversized field and the one carrying it must survive
+	assert.Equal(t, []string{"alpha", "beta"}, toPackageNames(pkgs))
 }
 
 func toPackageNames(pkgs []pkg.Package) []string {


### PR DESCRIPTION
## Description

* Attempt to read the ApkDB with the default 64KB max token length
* If this results in `ErrTooLong` tried again with a 512KB record
* Add test (`Test_parseApkDB_recoversFromOversizedField`) to exercise this


## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
Fixes #5094

## Test

```sh
go build -o /tmp/syft-fixed ./cmd/syft
mkdir -p repro/lib/apk/db
python3 create_sbom.py 3000 # script from the linked issue

/tmp/syft-fixed dir:./repro -o json | jq '[.artifacts[] | select(.type=="apk") | .name]'
[
  "alpha",
  "beta"
]
```
