### PR TITLE
Fix inverted bounds check dropping every Erlang string with a backslash

### DIFF
--- a/syft/pkg/cataloger/erlang/erlang_parser.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser.go
@@ -156,7 +156,7 @@ func parseErlangString(data []byte, i *int) (erlangNode, error) {
 		}
 		if c == '\\' {
 			*i++
-			if len(data) >= *i {
+			if *i >= len(data) {
 				return node(nil), fmt.Errorf("invalid escape without closed string at %d", *i)
 			}
 			c = data[*i]

--- a/syft/pkg/cataloger/erlang/erlang_parser_test.go
+++ b/syft/pkg/cataloger/erlang/erlang_parser_test.go
@@ -96,6 +96,11 @@ func Test_parseErlang(t *testing.T) {
 	{ foo, bar }
 ]}`,
 		},
+		{
+			name: "string with an escaped quote",
+			content: `
+{escaped, ["a\"b"]}`,
+		},
 	}
 
 	for _, test := range tests {
@@ -111,4 +116,15 @@ func Test_parseErlang(t *testing.T) {
 			assert.IsType(t, erlangNode{}, value)
 		})
 	}
+}
+
+func Test_parseErlangString_escapedByte(t *testing.T) {
+	// a backslash escape mid-string used to always error out, since the bounds
+	// check at the escape site was inverted (len(data) >= *i is true for
+	// almost every position, not just an out-of-range one).
+	data := []byte(`"a\"b"`)
+	i := 0
+	got, err := parseErlangString(data, &i)
+	require.NoError(t, err)
+	assert.Equal(t, `a"b`, got.String())
 }


### PR DESCRIPTION
While looking at the Erlang cataloger's hand-written parser I found a bounds check that's flipped, and it's a bad one: it breaks on the very first backslash it sees.

`parseErlangString` advances past a `\` escape and then guards with:

```go
if c == '\\' {
    *i++
    if len(data) >= *i {
        return node(nil), fmt.Errorf("invalid escape without closed string at %d", *i)
    }
    c = data[*i]
}
```

`len(data) >= *i` is true for basically every position in the buffer, it's only false once `*i` has actually run past the end. So this fires as soon as any escape shows up, not just at EOF where the real out-of-range case is. Since `rebar.lock` embeds git refs and paths as quoted strings (`{git,"https://...",...}`), and Windows-style paths or an escaped quote both contain backslashes, any rebar.lock or OTP `.app` file with one hits this and the whole file fails to parse, which drops every package it contains for that scan (the caller in `parse_rebar_lock.go` treats a parse error as "no packages" for that resource).

Fix is a one-character flip to `*i >= len(data)`, so the guard only trips when the escape is genuinely truncated at end of input.

Added `Test_parseErlangString_escapedByte` plus a table case in `Test_parseErlang` covering a string with an escaped quote. Both fail on main with `invalid escape without closed string` and pass with the fix.

```
$ go test ./syft/pkg/cataloger/erlang/...
ok  	github.com/anchore/syft/syft/pkg/cataloger/erlang	1.119s
```
