### PR TITLE
fix(binary): normalize comma-separated PE version resources

### DIFF
--- a/syft/pkg/cataloger/binary/pe_package.go
+++ b/syft/pkg/cataloger/binary/pe_package.go
@@ -15,6 +15,10 @@ var (
 	// spaceRegex includes nbsp (#160) considered to be a space character
 	spaceRegex  = regexp.MustCompile(`[\s\xa0]+`)
 	numberRegex = regexp.MustCompile(`\d`)
+	// commaSeparatedVersionRegex matches the comma-separated form that Windows
+	// VERSIONINFO resources often carry (mirroring the FILEVERSION x,y,z,w
+	// declaration in a .rc file), e.g. "3, 0, 21, 0"
+	commaSeparatedVersionRegex = regexp.MustCompile(`^\d+(?:\s*,\s*\d+)+$`)
 )
 
 func newPEPackage(versionResources map[string]string, f file.Location) pkg.Package {
@@ -129,6 +133,7 @@ func findVersionFromVR(versionResources map[string]string) string {
 
 func extractVersionFromResourcesValue(version string) string {
 	version = strings.TrimSpace(version)
+	version = normalizeCommaSeparatedVersion(version)
 	out := ""
 	for i, f := range strings.Fields(version) {
 		if containsNumber(out) && !containsNumber(f) {
@@ -141,6 +146,23 @@ func extractVersionFromResourcesValue(version string) string {
 		}
 	}
 	return out
+}
+
+// normalizeCommaSeparatedVersion converts the comma-separated version form used
+// by Windows VERSIONINFO resources into the canonical dotted form, e.g.
+// "3, 0, 21, 0" becomes "3.0.21.0". Values that are not entirely made up of
+// comma-separated numbers are returned unchanged.
+func normalizeCommaSeparatedVersion(version string) string {
+	if !commaSeparatedVersionRegex.MatchString(version) {
+		return version
+	}
+
+	fields := strings.Split(version, ",")
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+
+	return strings.Join(fields, ".")
 }
 
 func containsNumber(s string) bool {

--- a/syft/pkg/cataloger/binary/pe_package_test.go
+++ b/syft/pkg/cataloger/binary/pe_package_test.go
@@ -3,6 +3,8 @@ package binary
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/anchore/syft/syft/file"
 )
 
@@ -20,5 +22,46 @@ func TestGhostscriptPEGeneratesGenericPURL(t *testing.T) {
 	expected := "pkg:generic/ghostscript@9.54.0"
 	if p.PURL != expected {
 		t.Fatalf("expected purl %q, got %q", expected, p.PURL)
+	}
+}
+
+func Test_findVersionFromVR(t *testing.T) {
+	tests := []struct {
+		name             string
+		versionResources map[string]string
+		want             string
+	}{
+		{
+			name:             "dotted version is kept as-is",
+			versionResources: map[string]string{"ProductVersion": "3.0.21.0"},
+			want:             "3.0.21.0",
+		},
+		{
+			name: "comma separated version is normalized",
+			// VERSIONINFO resources often mirror the .rc FILEVERSION 3,0,21,0 form
+			versionResources: map[string]string{"ProductVersion": "3, 0, 21, 0"},
+			want:             "3.0.21.0",
+		},
+		{
+			name:             "comma separated version without spaces is normalized",
+			versionResources: map[string]string{"FileVersion": "3,0,21,0"},
+			want:             "3.0.21.0",
+		},
+		{
+			name:             "version with trailing comment is unaffected",
+			versionResources: map[string]string{"ProductVersion": "1.2.3 (build 456)"},
+			want:             "1.2.3",
+		},
+		{
+			name:             "non numeric comma separated value is kept as-is",
+			versionResources: map[string]string{"ProductVersion": "1.0, beta"},
+			want:             "1.0,",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, findVersionFromVR(tt.versionResources))
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Normalizes the comma-separated version form found in Windows PE `VERSIONINFO` resources, so `3, 0, 21, 0` becomes `3.0.21.0`.

## Why

Windows resource string tables frequently mirror the `.rc` declaration (`FILEVERSION 3,0,21,0`) rather than the dotted form. Syft used that value verbatim as the package version, which is visible in [#5075](https://github.com/anchore/syft/issues/5075) — VLC is reported as:

```
cpe:2.3:a:VLC_media_player:VLC_media_player:3\,0\,21\,0:*:*:*:*:*:*:*
```

A version containing escaped commas matches nothing in vulnerability data, and the same value flows into the PURL and the package version shown to users.

This only addresses the version portion of that issue; the vendor/product naming discussion there is separate and left alone.

## Details

- `extractVersionFromResourcesValue` now normalizes a value that consists entirely of comma-separated numbers (with optional surrounding spaces) to the dotted form.
- Anything else is returned unchanged, so values like `1.2.3 (build 456)` keep their existing handling and a value such as `1.0, beta` is not rewritten.

## Tests

Added `Test_findVersionFromVR` covering dotted input, both comma-separated forms (`3, 0, 21, 0` and `3,0,21,0`), a version with a trailing comment, and a non-numeric comma value. `go test ./syft/pkg/cataloger/binary/` passes.
