### PR TITLE
docs: mention additional install methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -sSfL https://get.anchore.io/syft | sudo sh -s -- -b /usr/local/bin
 ```
 
 > [!TIP]
-> **See [Installation docs](https://oss.anchore.com/docs/installation/syft/) for more ways to get Syft, including Homebrew, Docker, Scoop, Chocolatey, Nix, and more!**
+> **See [Installation docs](https://oss.anchore.com/docs/installation/syft/) for more ways to get Syft, including Homebrew, Docker, Scoop, Chocolatey, Nix, Snap, deb-get, and more!**
 
 ## The basics
 


### PR DESCRIPTION
## Summary
- mention Snap and deb-get alongside the other installation methods in the README installation tip

Fixes anchore/syft#3198

## Verification
- `git diff --check`
