### PR TITLE
fix: use safe type assertion in SafeTensors metadata access

### DIFF
--- a/syft/pkg/cataloger/ai/processor.go
+++ b/syft/pkg/cataloger/ai/processor.go
@@ -154,8 +154,12 @@ type safeTensorsIdentity struct {
 func assembleSafeTensorsPackage(merged pkg.Package, id safeTensorsIdentity) (pkg.Package, bool) {
 	name := pickSafeTensorsName(id.nameOrPath, id.fallbackName)
 	if name == "" {
-		log.Debugf("dropped safetensors model package (metadata hash %q): no name source",
-			merged.Metadata.(pkg.SafeTensorsModelInfo).MetadataHash)
+		if metadata, ok := merged.Metadata.(pkg.SafeTensorsModelInfo); ok {
+			log.Debugf("dropped safetensors model package (metadata hash %q): no name source",
+				metadata.MetadataHash)
+		} else {
+			log.Debugf("dropped safetensors model package: no name source")
+		}
 		return pkg.Package{}, false
 	}
 


### PR DESCRIPTION
## Summary

Fix unsafe type assertion in \ssembleSafeTensorsPackage\ that could panic if metadata type is not \pkg.SafeTensorsModelInfo\.

## Changes

- Replace direct type assertion \merged.Metadata.(pkg.SafeTensorsModelInfo)\ with safe comma-ok pattern
- Add fallback log message when metadata type is unexpected
- Prevents potential panic in production when processing malformed SafeTensors packages

## Context

The function previously accessed \merged.Metadata.(pkg.SafeTensorsModelInfo).MetadataHash\ directly, which would panic if the metadata was not of the expected type. Using the comma-ok pattern (\,ok\) is the idiomatic Go way to handle type assertions safely.

---

I apologize for any inconvenience. Local environment limitations prevent full dynamic testing; relying on CI/CD automated tests for verification.