### PR TITLE
fix(dotnet): correct inverted dependency-of relationship direction in packages.lock.json parser

### DIFF
--- a/syft/pkg/cataloger/dotnet/parse_packages_lock.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock.go
@@ -101,8 +101,8 @@ func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Envi
 			}
 
 			rel := artifact.Relationship{
-				From: parentPkg,
-				To:   childPkg,
+				From: childPkg,
+				To:   parentPkg,
 				Type: artifact.DependencyOfRelationship,
 			}
 			relationships = append(relationships, rel)

--- a/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
@@ -169,28 +169,28 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 
 	expectedRelationships := []artifact.Relationship{
 		{
-			From: autoMapperPkg,
+			From: extensionOptionsPkg,
+			To:   autoMapperPkg,
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: dependencyInjectionAbstractionsPkg,
 			To:   extensionOptionsPkg,
-			Type: artifact.DependencyOfRelationship,
-		},
-		{
-			From: extensionOptionsPkg,
-			To:   dependencyInjectionAbstractionsPkg,
-			Type: artifact.DependencyOfRelationship,
-		},
-		{
-			From: extensionOptionsPkg,
-			To:   extensionPrimitivesPkg,
 			Type: artifact.DependencyOfRelationship,
 		},
 		{
 			From: extensionPrimitivesPkg,
-			To:   compilerServicesUnsafePkg,
+			To:   extensionOptionsPkg,
 			Type: artifact.DependencyOfRelationship,
 		},
 		{
-			From: microsoftLoggingPkg,
-			To:   extensionOptionsPkg,
+			From: compilerServicesUnsafePkg,
+			To:   extensionPrimitivesPkg,
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: extensionOptionsPkg,
+			To:   microsoftLoggingPkg,
 			Type: artifact.DependencyOfRelationship,
 		},
 	}


### PR DESCRIPTION
Motivation:
parseDotnetPackagesLock built each artifact.Relationship as
{From: parentPkg, To: childPkg, Type: DependencyOfRelationship}, where
parentPkg is the package that depends on childPkg. Every other cataloger
in this repo that emits DependencyOfRelationship (golang/parse_go_mod.go,
cpp/parse_conanlock.go, dotnet/deps_binary_cataloger.go) does the
opposite: From is the dependency, To is the package that depends on it.
Because cyclonedxhelpers.ToFormatModel builds its "dependencies" graph by
appending each relationship's From-ref onto the To-ref's dependency list,
the inverted direction produced a backwards CycloneDX dependency graph
for any project cataloged from a packages.lock.json file (no crash, no
data loss — just an inverted graph edge for this one lock-file format).

Approach:
Swap From/To in the single relationship construction in
parse_packages_lock.go so it matches the repo-wide convention
(From: childPkg, To: parentPkg), and update the expected relationships
in parse_packages_lock_test.go to match the fixture's actual dependency
directions (e.g. AutoMapper depends on Microsoft.Extensions.Options, so
the relationship is now From: extensionOptionsPkg, To: autoMapperPkg).

Validation:
- go build ./...  (passes)
- go test ./syft/pkg/cataloger/dotnet/... -run 'TestParseDotnetPackagesLock|Test_corruptDotnetPackagesLock' -v  (both pass)
- go test ./syft/pkg/cataloger/dotnet/...  still fails on unrelated
  TestDotnetDepsCataloger_regressions/TestCataloger subtests because
  this sandbox has no docker binary; confirmed via `git stash` that
  those same subtests fail identically on unmodified code, so they are
  a pre-existing environment limitation, not a regression from this change.

Fixes #5125

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>