### PR TITLE
Fix wrong SPDX license expression when a package has multiple licenses

### DIFF
--- a/internal/spdxlicense/license.go
+++ b/internal/spdxlicense/license.go
@@ -62,3 +62,30 @@ func stripScheme(url string) string {
 	url = strings.TrimPrefix(url, "http://")
 	return url
 }
+
+// HasTopLevelOr reports whether the expression has an OR operator outside of every parenthesised
+// group.
+//
+// It matters when an expression is joined onto others with AND, because SPDX applies AND before
+// OR: joining "MIT OR (Apache-2.0 AND BSD-3-Clause)" unwrapped gives
+// "MIT OR (Apache-2.0 AND BSD-3-Clause) AND GPL-3.0-only", which reads as
+// "MIT OR ((Apache-2.0 AND BSD-3-Clause) AND GPL-3.0-only)" and drops GPL-3.0-only from the first
+// choice. Testing only the first and last character misses that, and misses
+// "(MIT OR Apache-2.0) OR (GPL-3.0-only AND MIT)" as well.
+func HasTopLevelOr(expression string) bool {
+	depth := 0
+	for i, c := range expression {
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		default:
+			if depth <= 0 && strings.HasPrefix(expression[i:], " OR ") {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/spdxlicense/license_test.go
+++ b/internal/spdxlicense/license_test.go
@@ -83,3 +83,28 @@ func TestSPDXIDRecognition(t *testing.T) {
 		})
 	}
 }
+
+func TestHasTopLevelOr(t *testing.T) {
+	tests := []struct {
+		expression string
+		want       bool
+	}{
+		{"", false},
+		{"MIT", false},
+		{"MIT AND Apache-2.0", false},
+		{"Apache-2.0 WITH LLVM-exception", false},
+		{"MIT OR Apache-2.0", true},
+		{"(MIT OR Apache-2.0)", false},
+		{"ISC AND (BSD-3-Clause OR MIT)", false},
+		{"MIT OR (Apache-2.0 AND BSD-3-Clause)", true},
+		{"(GPL-2.0-only WITH Linux-syscall-note) OR MIT", true},
+		{"(MIT OR Apache-2.0) OR (GPL-3.0-only AND LGPL-2.1-only)", true},
+		{"(MIT AND (Apache-2.0 OR BSD-3-Clause))", false},
+		{"LicenseRef-one-thing-first", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expression, func(t *testing.T) {
+			assert.Equal(t, tt.want, HasTopLevelOr(tt.expression))
+		})
+	}
+}

--- a/syft/format/internal/cyclonedxutil/helpers/licenses.go
+++ b/syft/format/internal/cyclonedxutil/helpers/licenses.go
@@ -194,8 +194,11 @@ func processLicenseURLs(l pkg.License, spdxID string, populate *cyclonedx.Licens
 func mergeSPDX(ex []string) string {
 	var candidate []string
 	for _, e := range ex {
-		// if the expression does not have balanced parens add them
-		if !strings.HasPrefix(e, "(") && !strings.HasSuffix(e, ")") {
+		// wrap when the expression does not have balanced parens, and also when it carries an OR
+		// outside of any parens: SPDX applies AND before OR, so joining
+		// "MIT OR (Apache-2.0 AND BSD-3-Clause)" as-is changes what it means, and the
+		// prefix/suffix check on its own does not catch that
+		if spdxlicense.HasTopLevelOr(e) || (!strings.HasPrefix(e, "(") && !strings.HasSuffix(e, ")")) {
 			e = "(" + e + ")"
 		}
 		candidate = append(candidate, e)

--- a/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/licenses_test.go
@@ -314,3 +314,40 @@ func TestDecodeLicenses(t *testing.T) {
 		})
 	}
 }
+
+func Test_mergeSPDX(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			// without the parens this reads as
+			// "((GPL-3.0-only AND MIT-0) AND MIT) OR (Apache-2.0 AND BSD-3-Clause)",
+			// so Apache-2.0 plus BSD-3-Clause alone would satisfy it
+			name:     "expression with a top-level OR is wrapped",
+			input:    []string{"MIT OR (Apache-2.0 AND BSD-3-Clause)", "GPL-3.0-only AND MIT-0"},
+			expected: "(MIT OR (Apache-2.0 AND BSD-3-Clause)) AND (GPL-3.0-only AND MIT-0)",
+		},
+		{
+			name:     "top-level AND keeps the text it has today",
+			input:    []string{"ISC AND (BSD-3-Clause OR MIT)", "GPL-3.0-only AND MIT-0"},
+			expected: "ISC AND (BSD-3-Clause OR MIT) AND (GPL-3.0-only AND MIT-0)",
+		},
+		{
+			name:     "single expression is unwrapped by reduceOuter",
+			input:    []string{"MIT OR Apache-2.0"},
+			expected: "MIT OR Apache-2.0",
+		},
+		{
+			name:     "plain ids",
+			input:    []string{"MIT", "Apache-2.0"},
+			expected: "(MIT) AND (Apache-2.0)",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, mergeSPDX(test.input))
+		})
+	}
+}

--- a/syft/format/internal/spdxutil/helpers/license.go
+++ b/syft/format/internal/spdxutil/helpers/license.go
@@ -42,20 +42,31 @@ func joinLicenses(licenses []SPDXLicense) string {
 
 	for _, l := range licenses {
 		v := l.ID
-		// check if license does not start or end with parens
-		if !strings.HasPrefix(v, "(") && !strings.HasSuffix(v, ")") {
-			// if license contains AND, OR, or WITH, then wrap in parens
-			if strings.Contains(v, " AND ") ||
-				strings.Contains(v, " OR ") ||
-				strings.Contains(v, " WITH ") {
-				newLicenses = append(newLicenses, "("+v+")")
-				continue
-			}
+		if needsParens(v) {
+			v = "(" + v + ")"
 		}
 		newLicenses = append(newLicenses, v)
 	}
 
 	return strings.Join(newLicenses, " AND ")
+}
+
+// needsParens reports whether an expression has to be wrapped before it is joined onto the others
+// with AND. An expression carrying a top-level OR has to be, or the join changes what it means.
+// The rest is the rule this used before, so expressions that are already emitted correctly keep
+// the text they have today.
+func needsParens(expression string) bool {
+	if spdxlicense.HasTopLevelOr(expression) {
+		return true
+	}
+
+	if strings.HasPrefix(expression, "(") || strings.HasSuffix(expression, ")") {
+		return false
+	}
+
+	return strings.Contains(expression, " AND ") ||
+		strings.Contains(expression, " OR ") ||
+		strings.Contains(expression, " WITH ")
 }
 
 type SPDXLicense struct {

--- a/syft/format/internal/spdxutil/helpers/license_test.go
+++ b/syft/format/internal/spdxutil/helpers/license_test.go
@@ -170,6 +170,46 @@ func Test_joinLicenses(t *testing.T) {
 			args: []SPDXLicense{{ID: "MIT AND Apache"}, {ID: "GPL-3.0-only"}},
 			want: "(MIT AND Apache) AND GPL-3.0-only",
 		},
+		{
+			// without the parens this reads as "MIT OR (Apache-2.0 AND BSD-3-Clause AND GPL-3.0-only)",
+			// which allows MIT on its own and drops the GPL-3.0-only obligation
+			name: "expression ending in a paren is still wrapped",
+			args: []SPDXLicense{{ID: "MIT OR (Apache-2.0 AND BSD-3-Clause)"}, {ID: "GPL-3.0-only"}},
+			want: "(MIT OR (Apache-2.0 AND BSD-3-Clause)) AND GPL-3.0-only",
+		},
+		{
+			name: "expression starting with a paren is still wrapped",
+			args: []SPDXLicense{{ID: "(MIT OR Apache-2.0) OR GPL-3.0-only"}, {ID: "LGPL-2.1-only"}},
+			want: "((MIT OR Apache-2.0) OR GPL-3.0-only) AND LGPL-2.1-only",
+		},
+		{
+			name: "separate groups joined at the top level are wrapped",
+			args: []SPDXLicense{{ID: "(MIT OR Apache-2.0) OR (GPL-3.0-only AND LGPL-2.1-only)"}, {ID: "GPL-3.0-only"}},
+			want: "((MIT OR Apache-2.0) OR (GPL-3.0-only AND LGPL-2.1-only)) AND GPL-3.0-only",
+		},
+		{
+			name: "a single parenthesised group is not wrapped again",
+			args: []SPDXLicense{{ID: "(MIT OR Apache-2.0)"}, {ID: "GPL-3.0-only"}},
+			want: "(MIT OR Apache-2.0) AND GPL-3.0-only",
+		},
+		{
+			// top-level operator is AND, so joining is already safe and the text must not move
+			name: "expression whose top-level operator is AND keeps its text",
+			args: []SPDXLicense{{ID: "ISC AND (BSD-3-Clause OR MIT)"}, {ID: "MIT"}},
+			want: "ISC AND (BSD-3-Clause OR MIT) AND MIT",
+		},
+		{
+			// nothing is joined onto it, so the parens are redundant, but a lone compound
+			// expression is already wrapped today and this keeps the two shapes consistent
+			name: "single expression with a top-level OR is wrapped",
+			args: []SPDXLicense{{ID: "(GPL-2.0-only WITH Linux-syscall-note) OR MIT"}},
+			want: "((GPL-2.0-only WITH Linux-syscall-note) OR MIT)",
+		},
+		{
+			name: "single expression without parens keeps the wrapping it has today",
+			args: []SPDXLicense{{ID: "MIT OR Apache-2.0"}},
+			want: "(MIT OR Apache-2.0)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Both the SPDX and the CycloneDX encoder parenthesise a license expression before joining it onto the other licenses with `AND`, and both lean on the same check — does it start with `(` or end with `)`:

```go
// syft/format/internal/spdxutil/helpers/license.go
if !strings.HasPrefix(v, "(") && !strings.HasSuffix(v, ")") {
// syft/format/internal/cyclonedxutil/helpers/licenses.go
if !strings.HasPrefix(e, "(") && !strings.HasSuffix(e, ")") {
```

An expression can do either and still carry an `OR` at the top level. SPDX applies `AND` before `OR`, so those get joined unwrapped and the result stops meaning what was declared. Both checks came in together in 42fa9e49.

**SPDX side.** Syft's Arch cataloger splits pacman's `%LICENSE%` block line by line (`syft/pkg/cataloger/arch/package.go`), so an Arch package can carry many licenses. `linux-lts-headers` 6.18.41 ships 42 of them, 8 skip the wrapping and 7 of those carry a top-level `OR` — `(GPL-2.0-only WITH Linux-syscall-note) OR BSD-2-Clause`, `... OR MIT`, and so on. Scanning a pacman root holding that real license block:

```
before: ... AND MIT AND (GPL-2.0-only WITH Linux-syscall-note) OR BSD-2-Clause AND ...
after:  ... AND MIT AND ((GPL-2.0-only WITH Linux-syscall-note) OR BSD-2-Clause) AND ...
```

What that costs, checked with `spdxexp.Satisfies` (already in go.mod) on the same shape as the AUR `android-*-liburing` packages, whose `%LICENSE%` is `["(GPL-2.0-only WITH Linux-syscall-note) OR MIT", "LGPL-2.0-or-later", "MIT"]`:

| allowed licenses | emitted today | with this change |
| --- | --- | --- |
| `GPL-2.0-only WITH Linux-syscall-note` | satisfied | not satisfied |

So the SBOM says the package can be taken under the kernel syscall-note GPL on its own, dropping the LGPL-2.0-or-later and MIT declared next to it.

Being straight about how often that fires: I walked all 10045 Core+Extra x86_64 packages on archlinux.org and **3** hit it — `core/linux-lts-headers`, `extra/linux-rt-headers`, `extra/linux-rt-lts-headers`. Other ecosystems mostly carry one license string per package, so there is nothing to join.

**CycloneDX side.** `mergeSPDX` has the same defect, reached when every license on a package is a compound expression. `syft convert` on a CycloneDX SBOM whose component carries two expressions:

```
before: (GPL-3.0-only AND MIT-0) AND MIT OR (Apache-2.0 AND BSD-3-Clause)
after:  (GPL-3.0-only AND MIT-0) AND (MIT OR (Apache-2.0 AND BSD-3-Clause))
```

`Satisfies` on the emitted one with `Apache-2.0` plus `BSD-3-Clause` alone is true today and false after — the `GPL-3.0-only` drops out the same way. Any SBOM in that shape is corrupted on re-encode, so this half is not tied to one distro.

**The change** adds `spdxlicense.HasTopLevelOr` — both packages already import `internal/spdxlicense`, no new imports — and wraps when it reports true. The rest of each condition is untouched, so expressions whose top-level operator is `AND` keep the text they have today: `ISC AND (BSD-3-Clause OR MIT)`, the real alpine `libretls` value in `syft/format/testdata/alpine-syft.json`, does not move. Scanning this repo with a binary built before and after gives identical license fields for all 2113 SPDX packages and all 2649 CycloneDX components.

One output change beyond the corruption, so it is not a surprise in review: a package with a **single** license whose expression has a top-level `OR` and a paren at an edge now gains a redundant outer paren (`(GPL-2.0-only WITH Linux-syscall-note) OR MIT` → `((GPL-2.0-only WITH Linux-syscall-note) OR MIT)`). Nothing is joined onto it so the parens are redundant, but a lone `MIT OR Apache-2.0` is already wrapped today, so this makes the two shapes consistent rather than splitting on whether a paren happens to sit at the edge. Both are pinned by tests. Happy to special-case `len == 1` instead if you would rather that output stayed exactly as-is.

Not addressed: `spdxexp.ValidateLicenses` accepts operators written without surrounding spaces, like `MIT OR(Apache-2.0)`, and neither the old check nor this one wraps those. Pre-existing, left alone.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

Eleven cases added across the two tables: five fail on main, six pin behaviour that must not change. `mergeSPDX` had no test naming it — it was covered incidentally through `Test_encodeLicense` — so `Test_mergeSPDX` is its first direct one. `go build ./...`, `go test ./syft/format/... ./internal/spdxlicense/ ./syft/pkg/ ./syft/license/...` and `golangci-lint run --timeout 15m ./...` are clean.
