### PR TITLE
fix(make): don't let ambient RACE leak into raceEnabled test

### DIFF
--- a/.make/main_test.go
+++ b/.make/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/anchore/go-make/config"
@@ -23,8 +24,11 @@ func TestRaceEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.env != "" {
-				t.Setenv("RACE", tt.env)
+			// always go through t.Setenv (it registers the restore) so an ambient
+			// RACE from the caller's environment can't leak into the unset cases
+			t.Setenv("RACE", tt.env)
+			if tt.env == "" {
+				os.Unsetenv("RACE")
 			}
 			orig := config.CI
 			config.CI = tt.ci


### PR DESCRIPTION
The two "RACE is unset" cases in `TestRaceEnabled` only skipped the `t.Setenv` call, which means they picked up whatever `RACE` happened to be in the environment.

So running `make test` in a job that exports `RACE=false` broke the CI-default case, which wants the unset behavior (`true`). `default locally` passed by luck since it wants `false` anyway.

Now every case goes through `t.Setenv` (for the restore) and the unset cases explicitly `os.Unsetenv`. The flag itself was fine.