### PR TITLE
feat(golang): detect native Go FIPS 140 mode in binaries

### DIFF
--- a/syft/pkg/cataloger/golang/scan_binary.go
+++ b/syft/pkg/cataloger/golang/scan_binary.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"runtime/debug"
+	"strings"
 
 	"github.com/kastenhq/goversion/version"
 
@@ -51,6 +52,7 @@ func scanFile(location file.Location, reader unionreader.UnionReader, captureSym
 			// we can still catalog packages, even if we can't get the crypto information
 			errs = unknown.Appendf(errs, location, "unable to read golang version info: %w", err)
 		}
+		v = append(v, getNativeFIPSSettings(bi.Settings)...)
 		arch := getGOARCH(bi.Settings)
 		if arch == "" {
 			arch, err = getGOARCHFromBin(r)
@@ -97,6 +99,25 @@ func getCryptoSettingsFromVersion(v version.Version) []string {
 	}
 	if v.FIPSOnly {
 		cryptoSettings = append(cryptoSettings, "crypto/tls/fipsonly")
+	}
+	return cryptoSettings
+}
+
+func getNativeFIPSSettings(settings []debug.BuildSetting) []string {
+	var cryptoSettings []string
+	for _, s := range settings {
+		switch s.Key {
+		case "GOFIPS140":
+			if s.Value != "" {
+				cryptoSettings = append(cryptoSettings, "GOFIPS140="+s.Value)
+			}
+		case "DefaultGODEBUG":
+			for _, kv := range strings.Split(s.Value, ",") {
+				if setting, val, ok := strings.Cut(kv, "="); ok && setting == "fips140" {
+					cryptoSettings = append(cryptoSettings, "GODEBUG=fips140="+val)
+				}
+			}
+		}
 	}
 	return cryptoSettings
 }

--- a/syft/pkg/cataloger/golang/scan_binary_test.go
+++ b/syft/pkg/cataloger/golang/scan_binary_test.go
@@ -110,3 +110,50 @@ func Test_getCryptoSettingsFromVersion(t *testing.T) {
 		})
 	}
 }
+
+func Test_getNativeFIPSSettings(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		settings []debug.BuildSetting
+		result   []string
+	}{
+		{
+			name:     "not set",
+			settings: []debug.BuildSetting{{Key: "GOARCH", Value: "arm64"}},
+			result:   nil,
+		},
+		{
+			name:     "GOFIPS140=off is reported verbatim",
+			settings: []debug.BuildSetting{{Key: "GOFIPS140", Value: "off"}},
+			result:   []string{"GOFIPS140=off"},
+		},
+		{
+			name: "pinned module version with mode on",
+			settings: []debug.BuildSetting{
+				{Key: "GOFIPS140", Value: "v1.0.0"},
+				{Key: "DefaultGODEBUG", Value: "fips140=on"},
+			},
+			result: []string{"GOFIPS140=v1.0.0", "GODEBUG=fips140=on"},
+		},
+		{ // GOFIPS140=latest enables FIPS mode without pinning a module version
+			name: "latest with mode on",
+			settings: []debug.BuildSetting{
+				{Key: "GOFIPS140", Value: "latest"},
+				{Key: "DefaultGODEBUG", Value: "fips140=on"},
+			},
+			result: []string{"GOFIPS140=latest", "GODEBUG=fips140=on"},
+		},
+		{ // fips140 is one entry among many in DefaultGODEBUG
+			name: "fips140 among other godebug defaults",
+			settings: []debug.BuildSetting{
+				{Key: "DefaultGODEBUG", Value: "asynctimerchan=1,fips140=on,tlssha1=1"},
+			},
+			result: []string{"GODEBUG=fips140=on"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res := getNativeFIPSSettings(tt.settings)
+			assert.ElementsMatch(t, res, tt.result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

[Go 1.24 introduced a native FIPS 140-3 mode](https://go.dev/doc/security/fips140), selected at build time via the `GOFIPS140` build flag and at run time via the `fips140` GODEBUG setting. Both are recorded in the binary's build info (`GOFIPS140` and the `fips140=` entry within `DefaultGODEBUG`).

Syft's existing Go crypto detection only recognized the older BoringCrypto / `crypto/tls/fipsonly` markers, so binaries built with the new native FIPS mode were reported with no FIPS-related crypto settings at all.

This adds a `getNativeFIPSSettings` helper that reads those two build settings and appends them to the existing `goCryptoSettings` metadata field, e.g.:

```
goCryptoSettings:
  - GOFIPS140=v1.0.0
  - GODEBUG=fips140=on
```

No new metadata field or JSON schema version is needed — the values populate the existing `goCryptoSettings` list.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections