### PR TITLE
fix: add correct CPE vendor/product candidates for Git for Windows PE binary

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_for_pe.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_for_pe.go
@@ -32,6 +32,11 @@ func candidateVendorsForPE(p pkg.Package) fieldCandidateSet {
 		candidates.addValue("artifex")
 	}
 
+	if product == "git" || fileDesc == "git setup" || company == "the git development community" {
+		candidates.addValue("git_for_windows_project")
+		candidates.addValue("gitforwindows")
+	}
+
 	return candidates
 }
 
@@ -57,6 +62,11 @@ func candidateProductsForPE(p pkg.Package) fieldCandidateSet {
 
 	if strings.Contains(product, "ghostscript") || strings.Contains(fileDesc, "ghostscript") {
 		candidates.addValue("ghostscript")
+	}
+
+	if product == "git" || fileDesc == "git setup" {
+		candidates.addValue("git_for_windows")
+		candidates.addValue("git")
 	}
 
 	return candidates


### PR DESCRIPTION
## Description

Prior to this change the syft portable executable binary cataloger produces a single CPE like `"cpe:2.3:a:Git:Git:2.55.0.3:*:*:*:*:*:*:*"` when given a Git For Windows exe.  This does not align with the CPEs used in the corresponding vulnerability data from NVD, currently the following variations:
- `"cpe:2.3:a:git_for_windows_project:git_for_windows:*:*:*:*:*:*:*:*"`
- `"cpe:2.3:a:gitforwindows:git:*:*:*:*:*:*:*:*"`

Using release binary: [Git-2.55.0.3-arm64.exe](https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.3/Git-2.55.0.3-arm64.exe)

Before:
```sh
syft -o json ~/Downloads/Git-2.55.0.3-arm64.exe | jq .artifacts
 ✔ Indexed file system                                                                                                                                                  /Users/weston/Downloads/Git-2.55.0.3-arm64.exe
 ✔ Cataloged contents                                                                                                                                 43e46b13963470e8028af1df5a777c9dc4461537ba125838623b372f979e1899
   ├── ✔ Packages                        [1 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File metadata                   [1 locations]
[
  {
    "id": "3853c07d7bff5662",
    "name": "Git",
    "version": "2.55.0.3",
    "type": "binary",
    "foundBy": "pe-binary-package-cataloger",
    "locations": [
      {
        "path": "/Git-2.55.0.3-arm64.exe",
        "accessPath": "/Git-2.55.0.3-arm64.exe",
        "annotations": {
          "evidence": "primary"
        }
      }
    ],
    "licenses": [],
    "language": "",
    "cpes": [
      {
        "cpe": "cpe:2.3:a:Git:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      }
    ],
    "purl": "",
    "metadataType": "pe-binary",
    "metadata": {
      "VersionResources": [
        {
          "key": "Comments",
          "value": "This installation was built with Inno Setup."
        },
        {
          "key": "CompanyName",
          "value": "The Git Development Community"
        },
        {
          "key": "FileDescription",
          "value": "Git Setup"
        },
        {
          "key": "FileVersion",
          "value": "2.55.0.3"
        },
        {
          "key": "LegalCopyright",
          "value": ""
        },
        {
          "key": "OriginalFileName",
          "value": ""
        },
        {
          "key": "ProductName",
          "value": "Git"
        },
        {
          "key": "ProductVersion",
          "value": "2.55.0.3"
        }
      ]
    }
  }
]
```

After:
```sh
go run cmd/syft/main.go -o json ~/Downloads/Git-2.55.0.3-arm64.exe | jq .artifacts
 ✔ Indexed file system                                                                                                                                                  /Users/weston/Downloads/Git-2.55.0.3-arm64.exe
 ✔ Cataloged contents                                                                                                                                 43e46b13963470e8028af1df5a777c9dc4461537ba125838623b372f979e1899
   ├── ✔ Packages                        [1 packages]
   ├── ✔ Executables                     [1 executables]
   ├── ✔ File digests                    [1 files]
[
  {
    "id": "3853c07d7bff5662",
    "name": "Git",
    "version": "2.55.0.3",
    "type": "binary",
    "foundBy": "pe-binary-package-cataloger",
    "locations": [
      {
        "path": "/Git-2.55.0.3-arm64.exe",
        "accessPath": "/Git-2.55.0.3-arm64.exe",
        "annotations": {
          "evidence": "primary"
        }
      }
    ],
    "licenses": [],
    "language": "",
    "cpes": [
      {
        "cpe": "cpe:2.3:a:git-for-windows-project:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows-project:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows_project:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows_project:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:gitforwindows:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:gitforwindows:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows-project:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows-project:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows_project:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows_project:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:Git:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:Git:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for-windows:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git:git-for-windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git:git_for_windows:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for_windows:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:gitforwindows:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:gitforwindows:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git-for:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git_for:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:Git:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:Git:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git:Git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      },
      {
        "cpe": "cpe:2.3:a:git:git:2.55.0.3:*:*:*:*:*:*:*",
        "source": "syft-generated"
      }
    ],
    "purl": "",
    "metadataType": "pe-binary",
    "metadata": {
      "VersionResources": [
        {
          "key": "Comments",
          "value": "This installation was built with Inno Setup."
        },
        {
          "key": "CompanyName",
          "value": "The Git Development Community"
        },
        {
          "key": "FileDescription",
          "value": "Git Setup"
        },
        {
          "key": "FileVersion",
          "value": "2.55.0.3"
        },
        {
          "key": "LegalCopyright",
          "value": ""
        },
        {
          "key": "OriginalFileName",
          "value": ""
        },
        {
          "key": "ProductName",
          "value": "Git"
        },
        {
          "key": "ProductVersion",
          "value": "2.55.0.3"
        }
      ]
    }
  }
]
```

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (please discuss with the team first; Syft is 1.0 software and we won't accept breaking changes without going to 2.0)
- [ ] Documentation (updates the documentation)
- [ ] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)
- [ ] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [ ] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
