### PR TITLE
fix(java): resolve ${project.groupId} inherited from a parent POM

### DIFF
--- a/syft/pkg/cataloger/java/internal/maven/resolver.go
+++ b/syft/pkg/cataloger/java/internal/maven/resolver.go
@@ -186,7 +186,7 @@ func (r *Resolver) resolveProjectProperty(ctx context.Context, resolutionContext
 					if pom.Version == nil && pom.Parent.Version != nil {
 						return r.resolveExpression(ctx, resolutionContext, *pom.Parent.Version, resolving)
 					}
-				case "groupID":
+				case "groupId":
 					if pom.GroupID == nil && pom.Parent.GroupID != nil {
 						return r.resolveExpression(ctx, resolutionContext, *pom.Parent.GroupID, resolving)
 					}

--- a/syft/pkg/cataloger/java/internal/maven/resolver_test.go
+++ b/syft/pkg/cataloger/java/internal/maven/resolver_test.go
@@ -41,6 +41,31 @@ func Test_resolveProperty(t *testing.T) {
 			expected: "org.some.group",
 		},
 		{
+			// a child module that omits its own <groupId> inherits it from the parent,
+			// so ${project.groupId} must resolve to the parent's groupId (mirrors the
+			// ${project.version} inheritance handled just above it in resolveProjectProperty)
+			name:     "groupId inherited from parent",
+			property: "${project.groupId}",
+			pom: Project{
+				GroupID: nil,
+				Parent: &Parent{
+					GroupID: ptr("org.some.parent"),
+				},
+			},
+			expected: "org.some.parent",
+		},
+		{
+			name:     "version inherited from parent",
+			property: "${project.version}",
+			pom: Project{
+				Version: nil,
+				Parent: &Parent{
+					Version: ptr("1.2.3"),
+				},
+			},
+			expected: "1.2.3",
+		},
+		{
 			name:     "parent groupId",
 			property: "${project.parent.groupId}",
 			pom: Project{


### PR DESCRIPTION
`resolveProjectProperty` has a special case so `${project.version}` and `${project.groupId}` fall back to the parent POM when a child module doesn't declare its own value. The `groupId` arm uses `case "groupID":`, but the property segment (and the gopom xml tag on `Project.GroupID`) is `groupId`, so the arm never runs. `${project.version}` works because its label matches.

The effect shows up when a child module omits `<groupId>` and inherits it from the parent, and then references `${project.groupId}` somewhere — for example a dependency declared as `<groupId>${project.groupId}</groupId>` to point at a sibling module. With the arm dead, the reflection fallback lands on the nil `GroupID` pointer and the expression resolves to an empty string instead of the parent's groupId (the error is swallowed in `resolveExpression`). That empty value flows through `ResolveDependencyID`, so the dependency's Maven coordinates and PURL namespace come out wrong.

The change is the one-character case label. I added a `Test_resolveProperty` case for the inherited `groupId` (fails before, passes after) and a matching one for the already-working inherited `version` so both stay covered.
