### PR TITLE
fix(python): keep epoch-pinned requirements in the SBOM

### DIFF
--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -188,7 +188,10 @@ func parseVersion(version string, guessFromConstraint bool) string {
 
 func parsePinnedVersion(version string) string {
 	version = strings.TrimSpace(version)
-	if strings.ContainsAny(version, "*,<>!") {
+	// a wildcard, range, or list of constraints is not a single pinned version. the "!=" exclusion
+	// operator is checked as a substring rather than by the bare "!" character, since a lone "!"
+	// is also the PEP 440 epoch separator (e.g. "1!2.0.0") and must not disqualify an exact pin.
+	if strings.ContainsAny(version, "*,<>") || strings.Contains(version, "!=") {
 		return ""
 	}
 

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -563,6 +563,26 @@ func Test_parseVersion(t *testing.T) {
 			want:    "1.0a1.post2.dev3+local.1",
 		},
 		{
+			name:    "epoch",
+			version: "== 1!2.0.0",
+			want:    "1!2.0.0",
+		},
+		{
+			name:    "epoch with all segments combined",
+			version: "== 1!1.0a1.post2.dev3+local.1",
+			want:    "1!1.0a1.post2.dev3+local.1",
+		},
+		{
+			name:    "arbitrary equality with epoch",
+			version: "=== 1!2.0.0",
+			want:    "1!2.0.0",
+		},
+		{
+			name:    "bare exclusion is not a pin",
+			version: "!= 1.1.0",
+			want:    "",
+		},
+		{
 			name:    "resolve lowest, simple constraint",
 			version: " >= 1.0.0 ",
 			guess:   true,


### PR DESCRIPTION
### What

`parsePinnedVersion` (`syft/pkg/cataloger/python/parse_requirements.go`) rejects any version constraint that contains `!`, to skip the `!=` exclusion operator. PEP 440 epochs also use `!` — `1!2.0.0` means epoch 1, release 2.0.0 — so an exact pin like `pkg == 1!2.0.0` is treated as unparseable and `parseVersion` returns `""`.

`parseRequirementsTxt` skips any requirement whose version resolves to `""`, so an epoch-pinned package is dropped from the SBOM entirely. Both the pinned path and the `guess-unpinned-requirements` path return `""` for it.

The fix checks for the `!=` operator as a substring instead of the bare `!` character. In a valid PEP 440 version the `!` epoch separator is always followed by a digit, so `!=` still uniquely identifies the exclusion operator and keeps getting rejected.

### How I found it

`parseVersion("== 1!2.0.0", ...)` returns `""` in both modes, while `pep440.Parse("1!2.0.0")` (the same library this file already imports) parses it fine. Running the requirements parser over a file with `flask==2.0.0` and `epochpkg==1!2.0.0` yields one package — the epoch pin is gone.

### Test

Added `Test_parseVersion` cases for an epoch pin, an epoch pin with all version segments, and an arbitrary-equality (`===`) epoch pin — all return `""` before the change and the correct version after. Kept a `!= 1.1.0` case as a control to confirm a bare exclusion is still not treated as a pin. `go test ./syft/pkg/cataloger/python/` passes.