### PR TITLE
Fix generated cpe for rust packages

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate.go
@@ -221,29 +221,7 @@ func candidateVendors(p pkg.Package) []string {
 		}
 	}
 
-	switch p.Metadata.(type) {
-	case pkg.DotnetDepsEntry, pkg.DotnetPackagesLockEntry, pkg.DotnetPortableExecutableEntry:
-		vendors.clear()
-		vendors.union(candidateVendorsForDotnet(p))
-	case pkg.RpmDBEntry, pkg.RpmArchive:
-		vendors.union(candidateVendorsForRPM(p))
-	case pkg.RubyGemspec:
-		vendors.union(candidateVendorsForRuby(p))
-	case pkg.PythonPackage:
-		vendors.union(candidateVendorsForPython(p))
-	case pkg.JavaArchive:
-		vendors.union(candidateVendorsForJava(p))
-	case pkg.ApkDBEntry:
-		vendors.union(candidateVendorsForAPK(p))
-	case pkg.NpmPackage:
-		vendors.union(candidateVendorsForJavascript(p))
-	case pkg.PEBinary:
-		// Add PE-specific vendor hints (e.g. ghostscript -> artifex)
-		vendors.union(candidateVendorsForPE(p))
-	case pkg.WordpressPluginEntry:
-		vendors.clear()
-		vendors.union(candidateVendorsForWordpressPlugin(p))
-	}
+	vendors = candidateVendorsByType(p, vendors)
 
 	if p.Type == pkg.BinaryPkg && endsWithNumber(p.Name) {
 		// add binary package digit-suffix variations (e.g. Qt5 -> Qt)
@@ -284,6 +262,33 @@ func candidateVendors(p pkg.Package) []string {
 	}
 
 	return uniqueVendors
+}
+
+func candidateVendorsByType(p pkg.Package, vendors fieldCandidateSet) fieldCandidateSet {
+	switch p.Metadata.(type) {
+	case pkg.DotnetDepsEntry, pkg.DotnetPackagesLockEntry, pkg.DotnetPortableExecutableEntry:
+		vendors.clear()
+		vendors.union(candidateVendorsForDotnet(p))
+	case pkg.RpmDBEntry, pkg.RpmArchive:
+		vendors.union(candidateVendorsForRPM(p))
+	case pkg.RubyGemspec:
+		vendors.union(candidateVendorsForRuby(p))
+	case pkg.PythonPackage:
+		vendors.union(candidateVendorsForPython(p))
+	case pkg.JavaArchive:
+		vendors.union(candidateVendorsForJava(p))
+	case pkg.ApkDBEntry:
+		vendors.union(candidateVendorsForAPK(p))
+	case pkg.NpmPackage:
+		vendors.union(candidateVendorsForJavascript(p))
+	case pkg.PEBinary:
+		// Add PE-specific vendor hints (e.g. ghostscript -> artifex)
+		vendors.union(candidateVendorsForPE(p))
+	case pkg.WordpressPluginEntry:
+		vendors.clear()
+		vendors.union(candidateVendorsForWordpressPlugin(p))
+	}
+	return vendors
 }
 
 func candidateProducts(p pkg.Package) []string {

--- a/syft/pkg/cataloger/internal/cpegenerate/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate.go
@@ -184,9 +184,13 @@ func FromPackageAttributes(p pkg.Package) []cpe.CPE {
 }
 
 func candidateTargetSw(p pkg.Package) []string {
-	if p.Type == pkg.WordpressPluginPkg {
+	switch p.Type {
+	case pkg.WordpressPluginPkg:
 		return []string{"wordpress"}
+	case pkg.RustPkg:
+		return []string{"rust"}
 	}
+
 	return []string{cpe.Any}
 }
 
@@ -253,6 +257,11 @@ func candidateVendors(p pkg.Package) []string {
 
 	// try swapping hyphens for underscores, vice versa, and removing separators altogether
 	addDelimiterVariations(vendors)
+
+	// rust vendor name needs to be added after the `addDelimiterVariations` call as `-project` suffix is used otherwise
+	if p.Language == pkg.Rust {
+		vendors.addValue(p.Name + "_project")
+	}
 
 	// generate sub-selections of each candidate based on separators (e.g. jenkins-ci -> [jenkins, jenkins-ci])
 	addAllSubSelections(vendors)

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -865,6 +865,7 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{
 				"cpe:2.3:a:rust-package_project:rust-package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust-package_project:rust_package:0.5.0:*:*:*:*:rust:*:*",
 				"cpe:2.3:a:rust-package:rust-package:0.5.0:*:*:*:*:rust:*:*",
 				"cpe:2.3:a:rust-package:rust_package:0.5.0:*:*:*:*:rust:*:*",
 				"cpe:2.3:a:rust:rust-package:0.5.0:*:*:*:*:rust:*:*",

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -855,6 +855,24 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			},
 			expected: []string{},
 		},
+		{
+			name: "rust package",
+			p: pkg.Package{
+				Name:     "rust-package",
+				Version:  "0.5.0",
+				Type:     pkg.RustPkg,
+				Language: pkg.Rust,
+			},
+			expected: []string{
+				"cpe:2.3:a:rust-package_project:rust-package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust-package:rust-package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust-package:rust_package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust:rust-package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust:rust_package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust_package:rust-package:0.5.0:*:*:*:*:rust:*:*",
+				"cpe:2.3:a:rust_package:rust_package:0.5.0:*:*:*:*:rust:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Rust packages seem to have the `target_sw` field set to `rust` and the crate name suffixed with `_project` as the `vendor` field.

## Description

Rust packages are confused with other cpes. In my case the `gitlab` api crate which got confused with `gitlab` itself.
As discussed in the linked issue TargetSW is commonly set to rust for crates.
Additionally the `_project` suffix is used for Vendors.

Hope I understood how this works correctly, but from inspecting the generated SBOM this seems to work.
Not sure if the change in cpes is considered a breaking change here, but as this fixes broken cpes I checked non breaking bug fix for now.

<!-- Please include a summary of the changes along with any relevant motivation and context -->

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->
Fixes #3956
