### PR TITLE
fix(file-resolver): don't abort scan on inaccessible symlink target

### DIFF
--- a/syft/internal/fileresolver/directory_indexer.go
+++ b/syft/internal/fileresolver/directory_indexer.go
@@ -126,6 +126,14 @@ func (r *directoryIndexer) indexTree(root string, stager *progress.AtomicStage) 
 
 	shouldIndexFullTree, err := isRealPath(root)
 	if err != nil {
+		// a symlink can resolve into a directory we don't have permission to traverse (or into a path
+		// that no longer exists). Like any other inaccessible path, this should be recorded and skipped
+		// with a warning rather than aborting the entire scan (see #3286).
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			r.isFileAccessErr(root, err)
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/syft/internal/fileresolver/directory_indexer_test.go
+++ b/syft/internal/fileresolver/directory_indexer_test.go
@@ -286,6 +286,42 @@ func TestDirectoryIndexer_index_survive_badSymlink(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDirectoryIndexer_index_survive_inaccessibleSymlinkTarget(t *testing.T) {
+	// a symlink that resolves into a directory we don't have permission to traverse should be skipped
+	// with a warning like any other inaccessible path, not abort the entire scan (see #3286).
+	if os.Geteuid() == 0 {
+		t.Skip("cannot run as root: root bypasses the directory permissions that trigger the bug")
+	}
+
+	// resolve any symlinks in the temp path (e.g. macOS /var -> /private/var) so the indexer root is a
+	// real path -- otherwise indexing takes the symlinked-branch code path and never reaches the bug.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	// root/
+	// ├── restricted/           (chmod 0000 -- cannot be traversed)
+	// │   └── nested/
+	// │       └── target.txt
+	// └── link -> root/restricted/nested/target.txt
+	nested := filepath.Join(root, "restricted", "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, "target.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.Symlink(filepath.Join(root, "restricted", "nested", "target.txt"), filepath.Join(root, "link")))
+
+	restricted := filepath.Join(root, "restricted")
+	require.NoError(t, os.Chmod(restricted, 0o000))
+	// restore permissions so t.TempDir cleanup can remove the tree
+	t.Cleanup(func() { _ = os.Chmod(restricted, 0o755) })
+
+	// base is empty, matching a plain `syft <path>` invocation (the reporter's scenario)
+	indexer := newDirectoryIndexer(root, "")
+	_, _, err = indexer.build()
+	require.NoError(t, err)
+
+	// the inaccessible path should be recorded rather than silently dropped
+	require.NotEmpty(t, indexer.errPaths)
+}
+
 func TestDirectoryIndexer_SkipsAlreadyVisitedLinkDestinations(t *testing.T) {
 	var observedPaths []string
 	pathObserver := func(_, p string, _ os.FileInfo, _ error) error {


### PR DESCRIPTION
## Description

Fixes #3286.

When a symlink resolves into a directory the scanner has no permission to traverse, Syft aborts the **entire** scan with a fatal error instead of skipping the inaccessible path:

```
unable to get file resolver: unable to create directory resolver: unable to index filesystem
path="/tmp/dir1/dir2/file": lstat /tmp/dir1/dir2: permission denied
returned code: 1
```

This is inconsistent with how the indexer already treats every other inaccessible path — those are logged (`unable to access path=...`), recorded in `errPaths`, and skipped so indexing continues.

## Root cause

`indexTree` calls `isRealPath(root)`, which runs `filepath.EvalSymlinks` on the path's parent. When the symlink target lives under a directory we can't traverse, that returns a permission `*os.PathError`, and `indexTree` returned it as fatal:

```go
shouldIndexFullTree, err := isRealPath(root)
if err != nil {
    return nil, err   // <- aborts the whole scan
}
```

Notably, `indexBranch` already handles the *same* `EvalSymlinks` error gracefully ("we can't index the path, but we shouldn't consider this to be fatal"). This PR brings `indexTree` in line with that existing behavior.

## Fix

Route the `isRealPath` path error through the indexer's existing `isFileAccessErr` handling, so the offending path is warned + tracked in `errPaths` and skipped, rather than aborting the scan. Non-path errors are still returned as before.

## Testing

Added `TestDirectoryIndexer_index_survive_inaccessibleSymlinkTarget`, which builds the reporter's scenario at runtime (a symlink into a `chmod 0000` directory) and asserts indexing completes without error while recording the inaccessible path. It reproduces the original failure exactly — without the fix it fails with:

```
unable to index filesystem path=".../restricted/nested/target.txt": lstat .../restricted/nested: permission denied
```

The test skips when run as root (root bypasses the permission bits that trigger the bug) and resolves the temp-dir path first so it exercises the real-path (`filepath.Walk`) branch on macOS as well as Linux.

```
go test ./syft/internal/fileresolver/ -run TestDirectoryIndexer   # all pass
gofmt / go vet                                                    # clean
```
