### PR TITLE
fix(javascript): strip underscore peer-dep suffixes from pnpm v5 lockfile versions

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
@@ -86,6 +86,8 @@ func (p *pnpmV6LockYaml) Parse(version float64, data []byte) ([]pnpmPackage, err
 		return nil, fmt.Errorf("failed to unmarshal pnpm v6 lockfile: %w", err)
 	}
 
+	isV5 := version < 6.0
+
 	packages := make(map[string]pnpmPackage)
 
 	// Direct dependencies — use sorted keys for deterministic output
@@ -94,6 +96,9 @@ func (p *pnpmV6LockYaml) Parse(version float64, data []byte) ([]pnpmPackage, err
 		if err != nil {
 			log.WithFields("package", name, "error", err).Trace("unable to parse pnpm dependency")
 			continue
+		}
+		if isV5 {
+			ver = stripPnpmV5PeerSuffix(ver)
 		}
 		key := name + "@" + ver
 		packages[key] = pnpmPackage{Name: name, Version: ver}
@@ -111,6 +116,9 @@ func (p *pnpmV6LockYaml) Parse(version float64, data []byte) ([]pnpmPackage, err
 			log.WithFields("key", key).Trace("unable to parse pnpm package key")
 			continue
 		}
+		if isV5 {
+			ver = stripPnpmV5PeerSuffix(ver)
+		}
 		pkgKey := name + "@" + ver
 
 		integrity := ""
@@ -121,6 +129,9 @@ func (p *pnpmV6LockYaml) Parse(version float64, data []byte) ([]pnpmPackage, err
 		dependencies := make(map[string]string)
 		for depName, depVersion := range sortedIter(pkgInfo.Dependencies) {
 			var normalizedVersion = strings.SplitN(depVersion, "(", 2)[0]
+			if isV5 {
+				normalizedVersion = stripPnpmV5PeerSuffix(normalizedVersion)
+			}
 			dependencies[depName] = normalizedVersion
 		}
 
@@ -231,6 +242,22 @@ func parseVersionField(name string, info any) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported dependency type %T for %q", info, name)
 	}
+}
+
+// stripPnpmV5PeerSuffix removes the underscore-delimited peer dependency suffix used by
+// pnpm v5 lockfiles, e.g. "5.3.2_acorn@8.8.0" or "4.10.0_fzn43tb6bdtdxy2s3aqevve2su" -> "5.3.2" / "4.10.0".
+// Lockfile v6+ encodes the same information in parentheses, which is stripped separately.
+// Only values that look like a registry version (leading digit) are stripped, so that
+// link:/file:/git specifiers are left untouched.
+func stripPnpmV5PeerSuffix(version string) string {
+	idx := strings.Index(version, "_")
+	if idx <= 0 {
+		return version
+	}
+	if version[0] < '0' || version[0] > '9' {
+		return version
+	}
+	return version[:idx]
 }
 
 // parsePnpmPackageKey extracts the package name and version from a lockfile package key.

--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
@@ -307,6 +307,66 @@ func TestParsePnpmV6Lock(t *testing.T) {
 	pkgtest.TestFileParser(t, fixture, adapter.parsePnpmLock, expectedPkgs, expectedRelationships)
 }
 
+func TestParsePnpmLockV5PeerSuffix(t *testing.T) {
+	// pnpm v5 lockfiles encode resolved peer dependencies as an underscore-delimited
+	// suffix of the dependency path, either readable (e.g. "5.3.2_acorn@8.8.0") or
+	// hashed (e.g. "4.10.0_fzn43tb6bdtdxy2s3aqevve2su"). The suffix must be stripped
+	// from reported versions, just like the parenthesized form in v6+ lockfiles.
+	fixture := "testdata/pnpm-v5-peer-suffix/pnpm-lock.yaml"
+
+	locationSet := file.NewLocationSet(file.NewLocation(fixture))
+
+	expectedPkgs := []pkg.Package{
+		{
+			Name:      "acorn",
+			Version:   "8.8.0",
+			PURL:      "pkg:npm/acorn@8.8.0",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata: pkg.PnpmLockEntry{
+				Resolution:   pkg.PnpmLockResolution{Integrity: "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="},
+				Dependencies: map[string]string{},
+			},
+		},
+		{
+			Name:      "acorn-jsx",
+			Version:   "5.3.2",
+			PURL:      "pkg:npm/acorn-jsx@5.3.2",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata: pkg.PnpmLockEntry{
+				Resolution: pkg.PnpmLockResolution{Integrity: "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="},
+				Dependencies: map[string]string{
+					"acorn": "8.8.0",
+				},
+			},
+		},
+		{
+			Name:      "webpack-cli",
+			Version:   "4.10.0",
+			PURL:      "pkg:npm/webpack-cli@4.10.0",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata: pkg.PnpmLockEntry{
+				Resolution:   pkg.PnpmLockResolution{Integrity: "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w=="},
+				Dependencies: map[string]string{},
+			},
+		},
+	}
+	expectedRelationships := []artifact.Relationship{
+		{
+			From: expectedPkgs[0],
+			To:   expectedPkgs[1],
+			Type: artifact.DependencyOfRelationship,
+		},
+	}
+	adapter := newGenericPnpmLockAdapter(CatalogerConfig{})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePnpmLock, expectedPkgs, expectedRelationships)
+}
+
 func TestParsePnpmLockV9(t *testing.T) {
 	var expectedRelationships []artifact.Relationship
 	fixture := "testdata/pnpm-v9/pnpm-lock.yaml"
@@ -573,6 +633,27 @@ packages:
 	for range 10 {
 		parser := &pnpmV6LockYaml{}
 		pkgs, err := parser.Parse(6.0, lockfileV6)
+		require.NoError(t, err)
+		require.Len(t, pkgs, 1, "expected exactly one package after key collision")
+
+		assert.Equal(t, "some-pkg", pkgs[0].Name)
+		assert.Equal(t, "1.0.0", pkgs[0].Version)
+		assert.Equal(t, "sha512-BBB", pkgs[0].Integrity, "expected last lexicographic key to win")
+	}
+
+	// v5 lockfile with two entries that collapse to the same key (underscore peer-dep suffixes)
+	lockfileV5 := []byte(`
+lockfileVersion: 5.4
+packages:
+  /some-pkg/1.0.0_peer-b@2.0.0:
+    resolution: {integrity: sha512-BBB}
+  /some-pkg/1.0.0_peer-a@1.0.0:
+    resolution: {integrity: sha512-AAA}
+`)
+
+	for range 10 {
+		parser := &pnpmV6LockYaml{}
+		pkgs, err := parser.Parse(5.4, lockfileV5)
 		require.NoError(t, err)
 		require.Len(t, pkgs, 1, "expected exactly one package after key collision")
 

--- a/syft/pkg/cataloger/javascript/testdata/pnpm-v5-peer-suffix/pnpm-lock.yaml
+++ b/syft/pkg/cataloger/javascript/testdata/pnpm-v5-peer-suffix/pnpm-lock.yaml
@@ -1,0 +1,27 @@
+lockfileVersion: 5.4
+
+specifiers:
+  acorn: ^8.8.0
+  acorn-jsx: ^5.3.2
+  webpack-cli: ^4.10.0
+
+dependencies:
+  acorn: 8.8.0
+  acorn-jsx: 5.3.2_acorn@8.8.0
+  webpack-cli: 4.10.0_fzn43tb6bdtdxy2s3aqevve2su
+
+packages:
+  /acorn/8.8.0:
+    resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn-jsx/5.3.2_acorn@8.8.0:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      acorn: 8.8.0
+
+  /webpack-cli/4.10.0_fzn43tb6bdtdxy2s3aqevve2su:
+    resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}


### PR DESCRIPTION
Fixes #5174

## What

pnpm **v5 lockfiles** (`lockfileVersion: 5.x`, generated by pnpm ≤ 7) encode resolved peer dependencies as an underscore-delimited suffix of the dependency path — either readable (`/acorn-jsx/5.3.2_acorn@8.8.0`) or hashed (`/webpack-cli/4.10.0_fzn43tb6bdtdxy2s3aqevve2su`). Lockfile v6 replaced this with the parenthesized form (`/acorn-jsx@5.3.2(acorn@8.8.0)`) — see pnpm/pnpm#5810.

`parse_pnpm_lock.go` only strips the v6+ parenthesized form, so for v5 lockfiles the whole peer suffix leaks into the reported version and PURL:

```
name="acorn-jsx"   version="5.3.2_acorn@8.8.0"   purl=pkg:npm/acorn-jsx@5.3.2_acorn%408.8.0
```

which is not a valid npm version (breaks downstream version-range matching, e.g. in Grype), and prevents peer variants of the same name+version from being deduplicated the way v6+ variants already are (`TestParsePnpmLock_DeterministicWithCollidingPeerDeps`).

## How

Added a small helper `stripPnpmV5PeerSuffix` and applied it on the v5 code path (`version < 6.0`) in the three places a version is extracted:

- top-level `dependencies` values (`5.3.2_acorn@8.8.0` → `5.3.2`)
- `packages` keys (`/acorn-jsx/5.3.2_acorn@8.8.0` → `5.3.2`)
- per-package `dependencies` map values

The helper only strips when the value starts with a digit, so `link:`/`file:`/git specifiers are left untouched. Registry versions cannot legally contain `_` (semver identifiers only allow `[0-9A-Za-z-.]`), so this cannot truncate a legitimate version. The v6+/v9 paths are unchanged.

## Tests

- New fixture `testdata/pnpm-v5-peer-suffix/pnpm-lock.yaml` (v5.4, one readable and one hashed peer suffix) + table-driven test `TestParsePnpmLockV5PeerSuffix` asserting clean versions, PURLs, and the `acorn` → `acorn-jsx` relationship.
- Extended `TestParsePnpmLock_DeterministicWithCollidingPeerDeps` with a v5 case: two `_`-suffixed peer variants of the same version must collapse into one package deterministically.

Both fail before the fix and pass after:

```
$ go test ./syft/pkg/cataloger/javascript/...   # before fix
--- FAIL: TestParsePnpmLockV5PeerSuffix               (version="5.3.2_acorn@8.8.0")
--- FAIL: TestParsePnpmLock_DeterministicWithCollidingPeerDeps  (2 packages instead of 1)

$ go test ./syft/pkg/cataloger/javascript/...   # after fix
ok  	github.com/anchore/syft/syft/pkg/cataloger/javascript	1.728s
```

Also ran `go build ./...` and `go test ./syft/pkg/...`: the only failures are in catalogers that need externally downloaded test fixtures/images not available in my environment (binary, debian, dotnet, golang, java, kernel, nix, php, python, redhat, rust, internal/dotnet/pe, java/internal/maven) — verified they fail identically on a clean checkout without this change. I was not able to run the Docker-based integration tests locally.

## Disclosure

This fix was prepared with AI assistance; I reproduced the bug and reviewed every change and test result myself.
