### PR TITLE
feat: inventory X.509 certificates for CycloneDX CBOM

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/cataloging/pkgcataloging"
+	"github.com/anchore/syft/syft/file/cataloger/certificate"
 	"github.com/anchore/syft/syft/file/cataloger/executable"
 	"github.com/anchore/syft/syft/file/cataloger/filecontent"
 	"github.com/anchore/syft/syft/pkg/cataloger/binary"
@@ -157,6 +158,10 @@ func (cfg Catalog) ToFilesConfig() filecataloging.Config {
 		Executable: executable.Config{
 			MIMETypes: executable.DefaultConfig().MIMETypes,
 			Globs:     cfg.File.Executable.Globs,
+		},
+		Certificates: certificate.Config{
+			Enabled: cfg.File.Certificates.Enabled,
+			Globs:   cfg.File.Certificates.Globs,
 		},
 	}
 }

--- a/cmd/syft/internal/options/file.go
+++ b/cmd/syft/internal/options/file.go
@@ -12,9 +12,10 @@ import (
 )
 
 type fileConfig struct {
-	Metadata   fileMetadata   `yaml:"metadata" json:"metadata" mapstructure:"metadata"`
-	Content    fileContent    `yaml:"content" json:"content" mapstructure:"content"`
-	Executable fileExecutable `yaml:"executable" json:"executable" mapstructure:"executable"`
+	Metadata     fileMetadata     `yaml:"metadata" json:"metadata" mapstructure:"metadata"`
+	Content      fileContent      `yaml:"content" json:"content" mapstructure:"content"`
+	Executable   fileExecutable   `yaml:"executable" json:"executable" mapstructure:"executable"`
+	Certificates fileCertificates `yaml:"certificates" json:"certificates" mapstructure:"certificates"`
 }
 
 type fileMetadata struct {
@@ -31,6 +32,11 @@ type fileExecutable struct {
 	Globs []string `yaml:"globs" json:"globs" mapstructure:"globs"`
 }
 
+type fileCertificates struct {
+	Enabled bool     `yaml:"enabled" json:"enabled" mapstructure:"enabled"`
+	Globs   []string `yaml:"globs" json:"globs" mapstructure:"globs"`
+}
+
 func defaultFileConfig() fileConfig {
 	return fileConfig{
 		Metadata: fileMetadata{
@@ -43,6 +49,7 @@ func defaultFileConfig() fileConfig {
 		Executable: fileExecutable{
 			Globs: nil,
 		},
+		Certificates: fileCertificates{},
 	}
 }
 
@@ -75,4 +82,6 @@ Options include:
 	descriptions.Add(&c.Content.Globs, `file globs for the cataloger to match on`)
 
 	descriptions.Add(&c.Executable.Globs, `file globs for the cataloger to match on`)
+	descriptions.Add(&c.Certificates.Enabled, `discover public X.509 certificates and include them as cryptographic assets in supported formats`)
+	descriptions.Add(&c.Certificates.Globs, `file globs used to discover X.509 certificate candidates`)
 }

--- a/internal/task/file_tasks.go
+++ b/internal/task/file_tasks.go
@@ -8,6 +8,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cataloging/filecataloging"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/file/cataloger/certificate"
 	"github.com/anchore/syft/syft/file/cataloger/executable"
 	"github.com/anchore/syft/syft/file/cataloger/filecontent"
 	"github.com/anchore/syft/syft/file/cataloger/filedigest"
@@ -22,7 +23,29 @@ func DefaultFileTaskFactories() Factories {
 		newFileMetadataCatalogerTaskFactory("file-metadata"),
 		newFileContentCatalogerTaskFactory("content"),
 		newExecutableCatalogerTaskFactory("binary-metadata"),
+		newCertificateCatalogerTaskFactory("certificate"),
 	}
+}
+
+func newCertificateCatalogerTaskFactory(tags ...string) factory {
+	return func(cfg CatalogingFactoryConfig) Task {
+		if !cfg.FilesConfig.Certificates.Enabled {
+			return nil
+		}
+		return newCertificateCatalogerTask(cfg.FilesConfig.Certificates, tags...)
+	}
+}
+
+func newCertificateCatalogerTask(cfg certificate.Config, tags ...string) Task {
+	fn := func(ctx context.Context, resolver file.Resolver, builder sbomsync.Builder) error {
+		if !cfg.Enabled {
+			return nil
+		}
+		result, err := certificate.NewCataloger(cfg).Catalog(ctx, resolver)
+		builder.(sbomsync.Accessor).WriteToSBOM(func(value *sbom.SBOM) { value.Artifacts.Certificates = result })
+		return err
+	}
+	return NewTask("certificate-cataloger", fn, commonFileTags(tags)...)
 }
 
 func newFileDigestCatalogerTaskFactory(tags ...string) factory {

--- a/syft/cataloging/filecataloging/config.go
+++ b/syft/cataloging/filecataloging/config.go
@@ -9,21 +9,24 @@ import (
 	intFile "github.com/anchore/syft/internal/file"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/file/cataloger/certificate"
 	"github.com/anchore/syft/syft/file/cataloger/executable"
 	"github.com/anchore/syft/syft/file/cataloger/filecontent"
 )
 
 type Config struct {
-	Selection  file.Selection     `yaml:"selection" json:"selection" mapstructure:"selection"`
-	Hashers    []crypto.Hash      `yaml:"hashers" json:"hashers" mapstructure:"hashers"`
-	Content    filecontent.Config `yaml:"content" json:"content" mapstructure:"content"`
-	Executable executable.Config  `yaml:"executable" json:"executable" mapstructure:"executable"`
+	Selection    file.Selection     `yaml:"selection" json:"selection" mapstructure:"selection"`
+	Hashers      []crypto.Hash      `yaml:"hashers" json:"hashers" mapstructure:"hashers"`
+	Content      filecontent.Config `yaml:"content" json:"content" mapstructure:"content"`
+	Executable   executable.Config  `yaml:"executable" json:"executable" mapstructure:"executable"`
+	Certificates certificate.Config `yaml:"certificates" json:"certificates" mapstructure:"certificates"`
 }
 
 type configMarshaledForm struct {
-	Selection file.Selection     `yaml:"selection" json:"selection" mapstructure:"selection"`
-	Hashers   []string           `yaml:"hashers" json:"hashers" mapstructure:"hashers"`
-	Content   filecontent.Config `yaml:"content" json:"content" mapstructure:"content"`
+	Selection    file.Selection      `yaml:"selection" json:"selection" mapstructure:"selection"`
+	Hashers      []string            `yaml:"hashers" json:"hashers" mapstructure:"hashers"`
+	Content      filecontent.Config  `yaml:"content" json:"content" mapstructure:"content"`
+	Certificates *certificate.Config `yaml:"certificates,omitempty" json:"certificates,omitempty" mapstructure:"certificates"`
 }
 
 func DefaultConfig() Config {
@@ -32,10 +35,11 @@ func DefaultConfig() Config {
 		log.WithFields("error", err).Warn("unable to create file hashers")
 	}
 	return Config{
-		Selection:  file.FilesOwnedByPackageSelection,
-		Hashers:    hashers,
-		Content:    filecontent.DefaultConfig(),
-		Executable: executable.DefaultConfig(),
+		Selection:    file.FilesOwnedByPackageSelection,
+		Hashers:      hashers,
+		Content:      filecontent.DefaultConfig(),
+		Executable:   executable.DefaultConfig(),
+		Certificates: certificate.DefaultConfig(),
 	}
 }
 
@@ -43,6 +47,9 @@ func (cfg Config) MarshalJSON() ([]byte, error) {
 	marshaled := configMarshaledForm{
 		Selection: cfg.Selection,
 		Hashers:   hashersToString(cfg.Hashers),
+	}
+	if cfg.Certificates.Enabled {
+		marshaled.Certificates = &cfg.Certificates
 	}
 	return json.Marshal(marshaled)
 }
@@ -67,6 +74,9 @@ func (cfg *Config) UnmarshalJSON(data []byte) error {
 	}
 	cfg.Selection = marshaled.Selection
 	cfg.Hashers = hashers
+	if marshaled.Certificates != nil {
+		cfg.Certificates = *marshaled.Certificates
+	}
 	return nil
 }
 

--- a/syft/crypto/certificate.go
+++ b/syft/crypto/certificate.go
@@ -1,0 +1,77 @@
+package crypto
+
+import (
+	"slices"
+	"time"
+
+	"github.com/anchore/syft/syft/file"
+)
+
+// Certificate describes public X.509 certificate metadata discovered in a source.
+// Raw certificate and private-key material are intentionally not retained.
+type Certificate struct {
+	Fingerprint        string
+	Subject            string
+	Issuer             string
+	SerialNumber       string
+	NotBefore          time.Time
+	NotAfter           time.Time
+	PublicKeyAlgorithm string
+	PublicKeyDetails   string
+	SignatureAlgorithm string
+	KeyUsage           []string
+	ExtendedKeyUsage   []string
+	IsCA               bool
+	Format             string
+	Locations          []file.Location
+}
+
+// Certificates is a deterministic, fingerprint-deduplicated certificate collection.
+type Certificates []Certificate
+
+func NewCertificates(certificates ...Certificate) Certificates {
+	byFingerprint := make(map[string]Certificate)
+	for _, certificate := range certificates {
+		if existing, ok := byFingerprint[certificate.Fingerprint]; ok {
+			existing.Locations = uniqueLocations(append(existing.Locations, certificate.Locations...))
+			byFingerprint[certificate.Fingerprint] = existing
+			continue
+		}
+		certificate.Locations = uniqueLocations(certificate.Locations)
+		byFingerprint[certificate.Fingerprint] = certificate
+	}
+	result := make(Certificates, 0, len(byFingerprint))
+	for _, certificate := range byFingerprint {
+		result = append(result, certificate)
+	}
+	slices.SortFunc(result, func(a, b Certificate) int { return compare(a.Fingerprint, b.Fingerprint) })
+	return result
+}
+
+func uniqueLocations(locations []file.Location) []file.Location {
+	byID := make(map[string]file.Location)
+	for _, location := range locations {
+		byID[string(location.ID())] = location
+	}
+	result := make([]file.Location, 0, len(byID))
+	for _, location := range byID {
+		result = append(result, location)
+	}
+	slices.SortFunc(result, func(a, b file.Location) int {
+		if value := compare(a.RealPath, b.RealPath); value != 0 {
+			return value
+		}
+		return compare(a.FileSystemID, b.FileSystemID)
+	})
+	return result
+}
+
+func compare(a, b string) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}

--- a/syft/crypto/certificate_test.go
+++ b/syft/crypto/certificate_test.go
@@ -1,0 +1,19 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCertificatesDeduplicatesAndSorts(t *testing.T) {
+	certificates := NewCertificates(
+		Certificate{Fingerprint: "b", Locations: []file.Location{file.NewLocation("/b")}},
+		Certificate{Fingerprint: "a", Locations: []file.Location{file.NewLocation("/z")}},
+		Certificate{Fingerprint: "a", Locations: []file.Location{file.NewLocation("/a")}},
+	)
+	require.Len(t, certificates, 2)
+	require.Equal(t, "a", certificates[0].Fingerprint)
+	require.Equal(t, []string{"/a", "/z"}, []string{certificates[0].Locations[0].RealPath, certificates[0].Locations[1].RealPath})
+}

--- a/syft/file/cataloger/certificate/cataloger.go
+++ b/syft/file/cataloger/certificate/cataloger.go
@@ -1,0 +1,147 @@
+package certificate
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"slices"
+
+	syftcrypto "github.com/anchore/syft/syft/crypto"
+	"github.com/anchore/syft/syft/file"
+)
+
+const maxCertificateFileSize = 10 * 1024 * 1024
+
+var defaultGlobs = []string{"**/*.cer", "**/*.crt", "**/*.der", "**/*.pem"}
+
+type Config struct {
+	Enabled bool     `yaml:"enabled" json:"enabled" mapstructure:"enabled"`
+	Globs   []string `yaml:"globs" json:"globs" mapstructure:"globs"`
+}
+
+func DefaultConfig() Config { return Config{Globs: slices.Clone(defaultGlobs)} }
+
+type Cataloger struct{ globs []string }
+
+func NewCataloger(cfg Config) Cataloger {
+	globs := cfg.Globs
+	if len(globs) == 0 {
+		globs = defaultGlobs
+	}
+	return Cataloger{globs: slices.Clone(globs)}
+}
+
+func (c Cataloger) Catalog(_ context.Context, resolver file.Resolver) (syftcrypto.Certificates, error) {
+	locations, err := resolver.FilesByGlob(c.globs...)
+	if err != nil {
+		return nil, fmt.Errorf("find certificate candidates: %w", err)
+	}
+	var certificates []syftcrypto.Certificate
+	for _, location := range locations {
+		reader, err := resolver.FileContentsByLocation(location)
+		if err != nil {
+			continue
+		}
+		contents, readErr := io.ReadAll(io.LimitReader(reader, maxCertificateFileSize+1))
+		closeErr := reader.Close()
+		if readErr != nil || closeErr != nil || len(contents) > maxCertificateFileSize {
+			continue
+		}
+		certificates = append(certificates, parseCertificates(contents, location)...)
+	}
+	return syftcrypto.NewCertificates(certificates...), nil
+}
+
+func parseCertificates(contents []byte, location file.Location) []syftcrypto.Certificate {
+	var result []syftcrypto.Certificate
+	remainder := contents
+	for {
+		block, rest := pem.Decode(remainder)
+		if block == nil {
+			break
+		}
+		remainder = rest
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if certificate, err := x509.ParseCertificate(block.Bytes); err == nil {
+			result = append(result, toCertificate(certificate, "PEM", location))
+		}
+	}
+	if len(result) == 0 {
+		if certificate, err := x509.ParseCertificate(contents); err == nil {
+			result = append(result, toCertificate(certificate, "DER", location))
+		}
+	}
+	return result
+}
+
+func toCertificate(certificate *x509.Certificate, format string, location file.Location) syftcrypto.Certificate {
+	fingerprint := sha256.Sum256(certificate.Raw)
+	return syftcrypto.Certificate{
+		Fingerprint: hex.EncodeToString(fingerprint[:]), Subject: certificate.Subject.String(),
+		Issuer: certificate.Issuer.String(), SerialNumber: certificate.SerialNumber.String(),
+		NotBefore: certificate.NotBefore, NotAfter: certificate.NotAfter,
+		PublicKeyAlgorithm: certificate.PublicKeyAlgorithm.String(), PublicKeyDetails: publicKeyDetails(certificate.PublicKey),
+		SignatureAlgorithm: certificate.SignatureAlgorithm.String(), KeyUsage: keyUsages(certificate.KeyUsage),
+		ExtendedKeyUsage: extendedKeyUsages(certificate.ExtKeyUsage), IsCA: certificate.IsCA,
+		Format: format, Locations: []file.Location{location},
+	}
+}
+
+func publicKeyDetails(publicKey any) string {
+	switch key := publicKey.(type) {
+	case *rsa.PublicKey:
+		return fmt.Sprintf("%d bits", key.N.BitLen())
+	case *ecdsa.PublicKey:
+		return key.Curve.Params().Name
+	case ed25519.PublicKey:
+		return fmt.Sprintf("%d bits", len(key)*8)
+	default:
+		return ""
+	}
+}
+
+func keyUsages(usage x509.KeyUsage) []string {
+	values := []struct {
+		flag x509.KeyUsage
+		name string
+	}{
+		{x509.KeyUsageDigitalSignature, "digital-signature"}, {x509.KeyUsageContentCommitment, "content-commitment"},
+		{x509.KeyUsageKeyEncipherment, "key-encipherment"}, {x509.KeyUsageDataEncipherment, "data-encipherment"},
+		{x509.KeyUsageKeyAgreement, "key-agreement"}, {x509.KeyUsageCertSign, "certificate-signing"},
+		{x509.KeyUsageCRLSign, "crl-signing"}, {x509.KeyUsageEncipherOnly, "encipher-only"},
+		{x509.KeyUsageDecipherOnly, "decipher-only"},
+	}
+	var result []string
+	for _, value := range values {
+		if usage&value.flag != 0 {
+			result = append(result, value.name)
+		}
+	}
+	return result
+}
+
+func extendedKeyUsages(usages []x509.ExtKeyUsage) []string {
+	names := map[x509.ExtKeyUsage]string{
+		x509.ExtKeyUsageAny: "any", x509.ExtKeyUsageServerAuth: "server-auth", x509.ExtKeyUsageClientAuth: "client-auth",
+		x509.ExtKeyUsageCodeSigning: "code-signing", x509.ExtKeyUsageEmailProtection: "email-protection",
+		x509.ExtKeyUsageTimeStamping: "time-stamping", x509.ExtKeyUsageOCSPSigning: "ocsp-signing",
+	}
+	result := make([]string, 0, len(usages))
+	for _, usage := range usages {
+		if name, ok := names[usage]; ok {
+			result = append(result, name)
+		} else {
+			result = append(result, fmt.Sprintf("unknown-%d", usage))
+		}
+	}
+	return result
+}

--- a/syft/file/cataloger/certificate/cataloger_test.go
+++ b/syft/file/cataloger/certificate/cataloger_test.go
@@ -1,0 +1,55 @@
+package certificate
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCertificates(t *testing.T) {
+	der := testCertificate(t)
+	pemCertificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	privateKey := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not retained")})
+	location := file.NewLocation("/etc/ssl/test.pem")
+
+	certificates := parseCertificates(append(append(pemCertificate, privateKey...), pemCertificate...), location)
+	require.Len(t, certificates, 2)
+	require.Equal(t, certificates[0].Fingerprint, certificates[1].Fingerprint)
+	require.Equal(t, "CN=example.test", certificates[0].Subject)
+	require.Equal(t, "RSA", certificates[0].PublicKeyAlgorithm)
+	require.Equal(t, "2048 bits", certificates[0].PublicKeyDetails)
+	require.Equal(t, "PEM", certificates[0].Format)
+	require.Equal(t, []string{"digital-signature", "key-encipherment"}, certificates[0].KeyUsage)
+}
+
+func TestParseCertificatesDERAndMalformedInput(t *testing.T) {
+	location := file.NewLocation("/certificate.der")
+	certificates := parseCertificates(testCertificate(t), location)
+	require.Len(t, certificates, 1)
+	require.Equal(t, "DER", certificates[0].Format)
+	require.Empty(t, parseCertificates([]byte("not a certificate"), location))
+	require.Empty(t, parseCertificates(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("secret")}), location))
+}
+
+func testCertificate(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(42), Subject: pkix.Name{CommonName: "example.test"},
+		Issuer: pkix.Name{CommonName: "example.test"}, NotBefore: time.Unix(1700000000, 0).UTC(),
+		NotAfter: time.Unix(1800000000, 0).UTC(), KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return der
+}

--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cpe"
+	syftcrypto "github.com/anchore/syft/syft/crypto"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers"
 	"github.com/anchore/syft/syft/linux"
@@ -51,6 +52,7 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 		components[i] = helpers.EncodeComponent(p, s.Source.Supplier, locationSorter)
 	}
 	components = append(components, toOSComponent(s.Artifacts.LinuxDistribution)...)
+	components = append(components, toCertificateComponents(s.Artifacts.Certificates)...)
 
 	artifacts := s.Artifacts
 
@@ -94,6 +96,44 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 	}
 
 	return cdxBOM
+}
+
+func toCertificateComponents(certificates syftcrypto.Certificates) []cyclonedx.Component {
+	components := make([]cyclonedx.Component, 0, len(certificates))
+	for _, certificate := range certificates {
+		name := certificate.Subject
+		if name == "" {
+			name = certificate.Fingerprint
+		}
+		properties := []cyclonedx.Property{
+			{Name: "syft:certificate:public-key-algorithm", Value: certificate.PublicKeyAlgorithm},
+			{Name: "syft:certificate:public-key-details", Value: certificate.PublicKeyDetails},
+			{Name: "syft:certificate:signature-algorithm", Value: certificate.SignatureAlgorithm},
+			{Name: "syft:certificate:is-ca", Value: fmt.Sprintf("%t", certificate.IsCA)},
+		}
+		for _, usage := range certificate.KeyUsage {
+			properties = append(properties, cyclonedx.Property{Name: "syft:certificate:key-usage", Value: usage})
+		}
+		for _, usage := range certificate.ExtendedKeyUsage {
+			properties = append(properties, cyclonedx.Property{Name: "syft:certificate:extended-key-usage", Value: usage})
+		}
+		for _, location := range certificate.Locations {
+			properties = append(properties, cyclonedx.Property{Name: "syft:location:path", Value: location.RealPath})
+		}
+		components = append(components, cyclonedx.Component{
+			BOMRef: "certificate:sha256:" + certificate.Fingerprint, Type: cyclonedx.ComponentTypeCryptographicAsset,
+			Name: name, Properties: &properties,
+			CryptoProperties: &cyclonedx.CryptoProperties{
+				AssetType: cyclonedx.CryptoAssetTypeCertificate,
+				CertificateProperties: &cyclonedx.CertificateProperties{
+					SerialNumber: certificate.SerialNumber, SubjectName: certificate.Subject, IssuerName: certificate.Issuer,
+					NotValidBefore: certificate.NotBefore.UTC().Format(time.RFC3339), NotValidAfter: certificate.NotAfter.UTC().Format(time.RFC3339),
+					CertificateFormat: certificate.Format,
+				},
+			},
+		})
+	}
+	return components
 }
 
 func getCoordinates(s sbom.SBOM) ([]file.Coordinates, func(a, b file.Location) int) {

--- a/syft/format/internal/cyclonedxutil/encoder.go
+++ b/syft/format/internal/cyclonedxutil/encoder.go
@@ -29,6 +29,15 @@ func NewEncoder(version string, format cyclonedx.BOMFileFormat, pretty bool) (En
 
 func (e Encoder) Encode(writer io.Writer, s sbom.SBOM) error {
 	bom := cyclonedxhelpers.ToFormatModel(s)
+	if e.version < cyclonedx.SpecVersion1_6 && bom.Components != nil {
+		components := (*bom.Components)[:0]
+		for _, component := range *bom.Components {
+			if component.Type != cyclonedx.ComponentTypeCryptographicAsset {
+				components = append(components, component)
+			}
+		}
+		bom.Components = &components
+	}
 	enc := cyclonedx.NewBOMEncoder(writer, e.format)
 	enc.SetPretty(e.pretty)
 	enc.SetEscapeHTML(false)

--- a/syft/sbom/sbom.go
+++ b/syft/sbom/sbom.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/crypto"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/linux"
 	"github.com/anchore/syft/syft/pkg"
@@ -28,6 +29,7 @@ type Artifacts struct {
 	Executables       map[file.Coordinates]file.Executable
 	Unknowns          map[file.Coordinates][]string
 	LinuxDistribution *linux.Release
+	Certificates      crypto.Certificates
 }
 
 type Descriptor struct {


### PR DESCRIPTION
## What

Add an opt-in X.509 certificate cataloger that discovers PEM, DER, and PEM bundle certificates in filesystems and container images, retains public metadata only, and emits certificate components as CycloneDX 1.6+ cryptographic assets.

The implementation introduces a small certificate artifact collection rather than representing certificates as packages. Certificates are deduplicated by SHA-256 fingerprint while preserving every observed file location.

Closes #5190.

## Why

Cryptographic inventory is a prerequisite for post-quantum migration and crypto-agility planning. Syft already provides repeatable image and filesystem discovery, while CycloneDX supports certificate assets through CBOM. This adds a focused first inventory slice without requiring a separate scanner.

## Behavior

- disabled by default under `file.certificates.enabled`
- recognizes `.cer`, `.crt`, `.der`, and `.pem` candidates with configurable globs
- parses certificates with Go's `crypto/x509` and `encoding/pem`
- records fingerprint, subject, issuer, serial, validity, public-key and signature algorithms, usages, CA status, format, and locations
- ignores private-key blocks and never retains raw certificate or key material
- treats malformed and oversized candidates as non-fatal
- sorts certificates and locations deterministically
- omits cryptographic assets from CycloneDX versions before 1.6

This is a draft to invite feedback on the proposed first-class certificate collection and task boundary before expanding tests or formats.

## Validation

Passed:

```text
go test ./syft -run TestCreateSBOMConfig_makeTaskGroups -count=1
go test ./syft/cataloging/filecataloging ./syft/crypto ./syft/file/cataloger/certificate ./syft/format/common/cyclonedxhelpers ./syft/format/internal/cyclonedxutil ./internal/task ./cmd/syft/internal/options
go vet ./syft/crypto ./syft/file/cataloger/certificate ./syft/format/common/cyclonedxhelpers ./syft/format/internal/cyclonedxutil ./internal/task ./cmd/syft/internal/options
```

The full `go test ./syft/...` run was attempted. Unrelated fixture suites requiring a running Docker daemon or generated cross-platform binaries could not run in the local environment; the focused packages above pass.
