### PR TITLE
fix(golang): skip remote license lookup for standard library module paths

### DIFF
--- a/syft/pkg/cataloger/golang/licenses.go
+++ b/syft/pkg/cataloger/golang/licenses.go
@@ -111,8 +111,9 @@ func (c *goLicenseResolver) getLicenses(ctx context.Context, resolver file.Resol
 		}
 	}
 
-	// download from remote sources
-	if c.opts.SearchRemoteLicenses {
+	// download from remote sources; standard library and toolchain paths are not publishable
+	// module paths, so neither a proxy nor a repository has anything to resolve for them
+	if c.opts.SearchRemoteLicenses && !isStandardImportPath(moduleName) {
 		pkgLicenses, err = c.getLicensesFromRemote(ctx, moduleName, moduleVersion)
 		if err != nil {
 			log.WithFields("error", err, "module", moduleName, "version", moduleVersion).Debug("unable to read golang licenses remote")

--- a/syft/pkg/cataloger/golang/licenses_test.go
+++ b/syft/pkg/cataloger/golang/licenses_test.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -231,6 +232,35 @@ func Test_LicenseSearch(t *testing.T) {
 			l := newGoLicenseResolver("", test.config)
 			lics := l.getLicenses(ctx, fileresolver.Empty{}, test.name, test.version)
 			require.EqualValues(t, test.expected, lics)
+		})
+	}
+}
+
+func Test_remoteLicenseSearchSkipsStandardLibrary(t *testing.T) {
+	ctx := pkgtest.Context(t)
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	// module paths whose first element carries no dot are never publishable, so there is
+	// nothing for a proxy or a repository to resolve
+	for _, moduleName := range []string{"cmd/cgo", "std", "runtime", "internal/abi", "command-line-arguments"} {
+		t.Run(moduleName, func(t *testing.T) {
+			requests.Store(0)
+
+			l := newGoLicenseResolver("", CatalogerConfig{
+				SearchRemoteLicenses: true,
+				Proxies:              []string{server.URL},
+			})
+
+			lics := l.getLicenses(ctx, fileresolver.Empty{}, moduleName, "(devel)")
+
+			require.Empty(t, lics)
+			require.Zero(t, requests.Load(), "expected no remote lookup for a standard library module path")
 		})
 	}
 }


### PR DESCRIPTION
## Description

With `search-remote-licenses` enabled, `getLicenses` sends every module name to the proxy list, including paths that are not publishable module paths at all.

Toolchain binaries such as `/usr/local/go/pkg/tool/*/cgo` carry no main module in their build info, so `createMainModuleFromPath` synthesizes one from the package path and the cataloger ends up asking for `cmd/cgo` at `(devel)`. The proxy answers 404 for that, the lowercase retry answers 404 as well, and then the `direct` proxy hands the path to `getModuleRepository`, which treats it as a repository host. go-git appends the smart HTTP discovery endpoint and the request the issue reports comes out:

```
https://cmd/cgo/info/refs?service=git-upload-pack
```

Small correction to the issue text, since it matters for anyone reading this later: the module is `cmd/cgo`, not `cmd/cgo/info`. The `info/refs` part is git's discovery endpoint, not part of the module path.

The change reuses `isStandardImportPath`, which already lives in this package (`symbols.go`), and skips the remote search for paths whose first element carries no dot. That is the same rule the Go toolchain uses, and those paths cannot be resolved by a proxy or by a repository, so the lookup had nothing to find in the first place.

The guard sits in `getLicenses` rather than in the dependency loop, because the path that bleeds is `makeGoMainPackage`, not the dependency walk, and `getLicenses` is the common point for all four call sites.

One consequence worth naming: `command-line-arguments` also has no dot in its first element, so it stops going to the network too. That is the intended outcome, it is not a publishable module path either, but it is a behaviour change beyond the standard library proper.

Nothing changes when `search-remote-licenses` is off, which is the default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Testing

`Test_remoteLicenseSearchSkipsStandardLibrary` in `syft/pkg/cataloger/golang/licenses_test.go` points the resolver at an `httptest` server and counts the requests it receives. On `main` each of `cmd/cgo`, `std`, `runtime`, `internal/abi` and `command-line-arguments` produces 2 requests, the original and the lowercase retry. With this change the count is 0. The test asserts the absence of the request rather than the absence of a license, which is the part that actually matters here.

Run in a Linux container on Go 1.26.6:

- `go test -count=1 ./syft/pkg/cataloger/golang/...` before and after the change gives the same two failures, `Test_getGOARCHFromBin` and `Test_PackageCataloger_Binary`. Both build their binary fixtures through Docker, which I could not nest inside the container, so they fail on a clean checkout here as well. Everything else in the package passes, including `Test_LicenseSearch`.
- `go build ./...` is clean and `go vet ./syft/...` reports only findings that are already on `main`, all in `syft/pkg/cataloger/redhat` test files.
- `gofmt -l syft/pkg/cataloger/golang/` reports nothing.

I did not run the Docker-backed parts of the suite, so `make integration` and `make cli` are untested from my side.

## Issue references

Fixes #3149

Disclosure: I used an AI coding assistant while working on this. Every command and result reported above I ran and checked myself.
