### PR TITLE
fix(binary): select the English VERSIONINFO block from localized PE binaries

### DIFF
--- a/syft/pkg/cataloger/internal/dotnet/pe/pe.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/pe.go
@@ -715,7 +715,7 @@ func parseStringTables(reader *bytes.Reader, sfiHeader peStringFileInfo, sfiOffs
 		lang := languageFromStringTableKey(szKey, language)
 		languages = append(languages, lang)
 
-		if err := parseStringTable(reader, stHeader, stOffset, offset, &sfiOffset, versions.fields(lang)); err != nil {
+		if err := parseStringTable(reader, stHeader, stOffset, offset, &sfiOffset, versions.stringTableFields(lang)); err != nil {
 			return languages, err
 		}
 	}

--- a/syft/pkg/cataloger/internal/dotnet/pe/pe.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/pe.go
@@ -17,7 +17,15 @@ import (
 	"github.com/anchore/syft/syft/internal/unionreader"
 )
 
-const peMaxAllowedDirectoryEntries = 0x1000
+const (
+	peMaxAllowedDirectoryEntries = 0x1000
+
+	// resourceLanguageLevel is the depth in the resource directory tree at which entries are keyed by LANGID.
+	// The tree is always organized as type (level 0) -> name (level 1) -> language (level 2) -> data.
+	//
+	// source: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-rsrc-section
+	resourceLanguageLevel = 2
+)
 
 var imageDirectoryEntryIndexes = []int{
 	pe.IMAGE_DIRECTORY_ENTRY_RESOURCE,       // where version resources are stored
@@ -39,6 +47,8 @@ type File struct {
 	EmbeddedDepsJSON string
 
 	// VersionResources is a map of version resource keys to their values found in the VERSIONINFO resource directory.
+	// Binaries that are localized into several languages carry one set of these values per language; this holds
+	// the single set selected by versionResourceTables.preferred (never a mixture of languages).
 	VersionResources map[string]string
 }
 
@@ -162,15 +172,18 @@ func Read(f file.LocationReadCloser) (*File, error) {
 		return nil, fmt.Errorf("unable to parse PE sections: %w", err)
 	}
 
-	dirs := u32set.New()                        // keep track of the RVAs we have already parsed (prevent infinite recursion edge cases)
-	versionResources := make(map[string]string) // map of version resource keys to their values
-	resourceNames := strset.New()               // set of resource names found in the PE file
-	err = parseResourceDirectory(sections[pe.IMAGE_DIRECTORY_ENTRY_RESOURCE], dirs, versionResources, resourceNames)
+	walk := &resourceWalk{
+		dirs:     u32set.New(),               // keep track of the RVAs we have already parsed (prevent infinite recursion edge cases)
+		names:    strset.New(),               // set of resource names found in the PE file
+		versions: newVersionResourceTables(), // version resource values, kept separate per language
+	}
+
+	err = parseResourceDirectory(sections[pe.IMAGE_DIRECTORY_ENTRY_RESOURCE], walk, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := parseCLR(sections[pe.IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR], resourceNames)
+	c, err := parseCLR(sections[pe.IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR], walk.names)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse PE CLR directory: %w", err)
 	}
@@ -184,7 +197,7 @@ func Read(f file.LocationReadCloser) (*File, error) {
 		Location:         f.Location,
 		CLR:              c,
 		EmbeddedDepsJSON: embeddedDepsJSON,
-		VersionResources: versionResources,
+		VersionResources: walk.versions.preferred(),
 	}, nil
 }
 
@@ -364,9 +377,23 @@ func readDataFromRVA(file io.ReadSeeker, rva, size uint32, sections []pe.Section
 	return bytes.NewReader(data), nil
 }
 
+// resourceWalk is the state carried through the recursive descent of the PE resource directory tree.
+type resourceWalk struct {
+	// dirs is the set of directory RVAs already visited, used to stop the descent on files that reference
+	// their own resource directories recursively.
+	dirs *u32set.Set
+
+	// names is the set of named (as opposed to ID-keyed) resource directory entries encountered.
+	names *strset.Set
+
+	// versions collects the discovered VERSIONINFO string tables, keyed by the language each was authored in.
+	versions *versionResourceTables
+}
+
 // parseResourceDirectory recursively parses a PE resource directory. This takes a relative virtual address (offset of
-// a piece of data or code relative to the base address), the size of the resource directory, the set of RVAs already
-// parsed, and the map to populate discovered version resource values.
+// a piece of data or code relative to the base address), the size of the resource directory, the state shared across
+// the walk, and the current depth in the tree (which is what makes a directory entry's ID meaningful: entries at
+// resourceLanguageLevel are LANGIDs).
 //
 // .rsrc Section
 // +------------------------------+
@@ -388,7 +415,7 @@ func readDataFromRVA(file io.ReadSeeker, rva, size uint32, sections []pe.Section
 // sources:
 // - https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#the-rsrc-section
 // - https://learn.microsoft.com/en-us/previous-versions/ms809762(v=msdn.10)#pe-file-resources
-func parseResourceDirectory(sec *extractedSection, dirs *u32set.Set, fields map[string]string, names *strset.Set) error {
+func parseResourceDirectory(sec *extractedSection, walk *resourceWalk, depth int) error {
 	if sec == nil || sec.Size <= 0 {
 		return nil
 	}
@@ -435,7 +462,7 @@ func parseResourceDirectory(sec *extractedSection, dirs *u32set.Set, fields map[
 			continue
 		}
 
-		if err := processResourceEntry(entry, baseRVA, sec, dirs, fields, names); err != nil {
+		if err := processResourceEntry(entry, baseRVA, sec, walk, depth); err != nil {
 			log.Tracef("error processing resource entry: %v", err)
 			continue
 		}
@@ -444,7 +471,7 @@ func parseResourceDirectory(sec *extractedSection, dirs *u32set.Set, fields map[
 	return nil
 }
 
-func processResourceEntry(entry peImageResourceDirectoryEntry, baseRVA uint32, sec *extractedSection, dirs *u32set.Set, fields map[string]string, names *strset.Set) error {
+func processResourceEntry(entry peImageResourceDirectoryEntry, baseRVA uint32, sec *extractedSection, walk *resourceWalk, depth int) error {
 	// if the high bit is set, this is a directory entry, otherwise it is a data entry
 	isDirectory := entry.OffsetToData&0x80000000 != 0
 
@@ -467,7 +494,7 @@ func processResourceEntry(entry peImageResourceDirectoryEntry, baseRVA uint32, s
 
 		name, err := readUTF16WithLength(sec.Reader)
 		if err == nil {
-			names.Add(name)
+			walk.names.Add(name)
 		}
 
 		if _, err := sec.Reader.Seek(currentPos, io.SeekStart); err != nil {
@@ -477,12 +504,12 @@ func processResourceEntry(entry peImageResourceDirectoryEntry, baseRVA uint32, s
 
 	if isDirectory {
 		subRVA := baseRVA + entryOffsetToData
-		if dirs.Has(subRVA) {
+		if walk.dirs.Has(subRVA) {
 			// some malware uses recursive PE references to evade analysis
 			return fmt.Errorf("recursive PE reference detected; skipping directory at baseRVA=0x%x subRVA=0x%x", baseRVA, subRVA)
 		}
 
-		dirs.Add(subRVA)
+		walk.dirs.Add(subRVA)
 		err := parseResourceDirectory(
 			&extractedSection{
 				RVA:     subRVA,
@@ -490,16 +517,24 @@ func processResourceEntry(entry peImageResourceDirectoryEntry, baseRVA uint32, s
 				Size:    sec.Size - (sec.RVA - baseRVA),
 				Reader:  sec.Reader,
 			},
-			dirs, fields, names)
+			walk, depth+1)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
-	return parseResourceDataEntry(sec.Reader, baseRVA, baseRVA+entryOffsetToData, sec.Size, fields)
+
+	// data entries live at the language level of the tree, where the entry ID is the LANGID the resource was
+	// authored for. Named entries at that level state no language, which leaves the resource language-neutral.
+	var language uint16
+	if depth == resourceLanguageLevel && !nameIsString {
+		language = uint16(entry.Name)
+	}
+
+	return parseResourceDataEntry(sec.Reader, baseRVA, baseRVA+entryOffsetToData, sec.Size, walk.versions, language)
 }
 
-func parseResourceDataEntry(reader *bytes.Reader, baseRVA, rva, remainingSize uint32, fields map[string]string) error {
+func parseResourceDataEntry(reader *bytes.Reader, baseRVA, rva, remainingSize uint32, versions *versionResourceTables, language uint16) error {
 	var dataEntry peImageResourceDataEntry
 	offset := int64(rva - baseRVA)
 
@@ -524,7 +559,7 @@ func parseResourceDataEntry(reader *bytes.Reader, baseRVA, rva, remainingSize ui
 		return fmt.Errorf("error reading resource data: %w", err)
 	}
 
-	return parseVersionResourceSection(bytes.NewReader(data), fields)
+	return parseVersionResourceSection(bytes.NewReader(data), versions, language)
 }
 
 // parseVersionResourceSection parses a PE version resource section from within a resource directory.
@@ -580,7 +615,7 @@ func parseResourceDataEntry(reader *bytes.Reader, baseRVA, rva, remainingSize ui
 //   - https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo
 //   - https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo
 //   - https://learn.microsoft.com/en-us/windows/win32/menurc/stringtable
-func parseVersionResourceSection(reader *bytes.Reader, fields map[string]string) error {
+func parseVersionResourceSection(reader *bytes.Reader, versions *versionResourceTables, language uint16) error {
 	offset := 0
 
 	var info peVsVersionInfo
@@ -600,58 +635,120 @@ func parseVersionResourceSection(reader *bytes.Reader, fields map[string]string)
 		return fmt.Errorf("error reading PE FixedFileInfo: %v", err)
 	}
 
+	var languages []resourceLanguage
+
 	for reader.Len() > 0 {
 		if err := alignAndSeek(reader, &offset); err != nil {
 			return fmt.Errorf("error seeking to PE StringFileInfo: %w", err)
 		}
 
+		blockStart := offset
+
+		var sfiOffset int
 		var sfiHeader peStringFileInfo
-		if szKey, err := readIntoStructAndSzKey(reader, &sfiHeader, &offset); err != nil {
+		szKey, err := readIntoStructAndSzKey(reader, &sfiHeader, &offset, &sfiOffset)
+		if err != nil {
 			return fmt.Errorf("error reading PE string file info header: %v", err)
-		} else if szKey != "StringFileInfo" {
-			// we only care about extracting strings from any string tables, skip this
-			offset += int(sfiHeader.ValueLength)
+		}
+
+		if szKey != "StringFileInfo" {
+			// we only care about extracting strings from any string tables, so skip over this block entirely
+			// (VarFileInfo, or anything else a resource compiler chose to put here). A zero length gives no way
+			// to know where the block ends, in which case there is nothing further that can be read.
+			if sfiHeader.Length == 0 {
+				break
+			}
+			offset = blockStart + int(sfiHeader.Length)
 			continue
+		}
+
+		ls, err := parseStringTables(reader, sfiHeader, sfiOffset, &offset, versions, language)
+		languages = append(languages, ls...)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(languages) == 0 {
+		// there are no string tables, but the fixed file info below is still worth recording
+		languages = append(languages, resourceLanguage{directory: language})
+	}
+
+	for _, lang := range languages {
+		fields := versions.fields(lang)
+		if fields["FileVersion"] == "" {
+			// we can derive the file version from the fixed file info if it is not already specified as a string entry... neat!
+			fields["FileVersion"] = fmt.Sprintf("%d.%d.%d.%d",
+				fixedFileInfo.FileVersionMS>>16, fixedFileInfo.FileVersionMS&0xFFFF,
+				fixedFileInfo.FileVersionLS>>16, fixedFileInfo.FileVersionLS&0xFFFF)
+		}
+	}
+
+	return nil
+}
+
+// parseStringTables reads every string table held by a StringFileInfo block, returning the languages found.
+// A block holds one table per language the binary was localized into, each keyed by a language and codepage
+// (e.g. "040904b0"), and all of them use the same string keys as each other.
+func parseStringTables(reader *bytes.Reader, sfiHeader peStringFileInfo, sfiOffset int, offset *int, versions *versionResourceTables, language uint16) ([]resourceLanguage, error) {
+	var languages []resourceLanguage
+
+	for sfiOffset < int(sfiHeader.Length) && reader.Len() > 0 {
+		if err := alignAndSeek(reader, offset, &sfiOffset); err != nil {
+			return languages, fmt.Errorf("error seeking to PE string table: %w", err)
 		}
 
 		var stOffset int
 
-		// note: the szKey for the prStringTable is the language
+		// note: the szKey for the string table is the language
 		var stHeader peStringTable
-		if _, err := readIntoStructAndSzKey(reader, &stHeader, &offset, &stOffset); err != nil {
-			return fmt.Errorf("error reading PE string table header: %v", err)
+		szKey, err := readIntoStructAndSzKey(reader, &stHeader, offset, &sfiOffset, &stOffset)
+		if err != nil {
+			return languages, fmt.Errorf("error reading PE string table header: %v", err)
 		}
 
-		for stOffset < int(stHeader.Length) {
-			var stringHeader peString
-			if err := readIntoStruct(reader, &stringHeader, &offset, &stOffset); err != nil {
-				break
-			}
+		if stHeader.Length == 0 {
+			// without a length there is no way to know where this table ends, nor where the next one starts
+			break
+		}
 
-			key := readUTF16(reader, &offset, &stOffset)
+		lang := languageFromStringTableKey(szKey, language)
+		languages = append(languages, lang)
 
-			if err := alignAndSeek(reader, &offset, &stOffset); err != nil {
-				return fmt.Errorf("error aligning to next PE string table value: %w", err)
-			}
-
-			var value string
-			if stringHeader.ValueLength > 0 {
-				value = readUTF16(reader, &offset, &stOffset)
-			}
-
-			fields[key] = value
-
-			if err := alignAndSeek(reader, &offset, &stOffset); err != nil {
-				return fmt.Errorf("error aligning to next PE string table key: %w", err)
-			}
+		if err := parseStringTable(reader, stHeader, stOffset, offset, &sfiOffset, versions.fields(lang)); err != nil {
+			return languages, err
 		}
 	}
 
-	if fields["FileVersion"] == "" {
-		// we can derive the file version from the fixed file info if it is not already specified as a string entry... neat!
-		fields["FileVersion"] = fmt.Sprintf("%d.%d.%d.%d",
-			fixedFileInfo.FileVersionMS>>16, fixedFileInfo.FileVersionMS&0xFFFF,
-			fixedFileInfo.FileVersionLS>>16, fixedFileInfo.FileVersionLS&0xFFFF)
+	return languages, nil
+}
+
+// parseStringTable reads the key/value pairs of a single string table into fields.
+func parseStringTable(reader *bytes.Reader, stHeader peStringTable, stOffset int, offset, sfiOffset *int, fields map[string]string) error {
+	// note: the reader is bounded here in addition to the table length, since a truncated table would otherwise
+	// leave the offsets unchanged on every pass and never reach the end of the table
+	for stOffset < int(stHeader.Length) && reader.Len() > 0 {
+		var stringHeader peString
+		if err := readIntoStruct(reader, &stringHeader, offset, sfiOffset, &stOffset); err != nil {
+			break
+		}
+
+		key := readUTF16(reader, offset, sfiOffset, &stOffset)
+
+		if err := alignAndSeek(reader, offset, sfiOffset, &stOffset); err != nil {
+			return fmt.Errorf("error aligning to next PE string table value: %w", err)
+		}
+
+		var value string
+		if stringHeader.ValueLength > 0 {
+			value = readUTF16(reader, offset, sfiOffset, &stOffset)
+		}
+
+		fields[key] = value
+
+		if err := alignAndSeek(reader, offset, sfiOffset, &stOffset); err != nil {
+			return fmt.Errorf("error aligning to next PE string table key: %w", err)
+		}
 	}
 
 	return nil

--- a/syft/pkg/cataloger/internal/dotnet/pe/version_resources.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/version_resources.go
@@ -79,46 +79,84 @@ func (l resourceLanguage) preferredOver(other resourceLanguage) bool {
 // is what allows a single language to be chosen deterministically, instead of letting whichever language happens
 // to be read last overwrite the values read from all the others.
 type versionResourceTables struct {
-	byLanguage map[resourceLanguage]map[string]string
+	byLanguage map[resourceLanguage]*versionResourceTable
+}
+
+// versionResourceTable is the set of values recorded for a single language.
+type versionResourceTable struct {
+	fields map[string]string
+
+	// authored is true when the values came from a string table the file actually carries, as opposed to a
+	// VS_VERSIONINFO block that holds only fixed file info. See preferred for why the difference matters.
+	authored bool
 }
 
 func newVersionResourceTables() *versionResourceTables {
 	return &versionResourceTables{
-		byLanguage: make(map[resourceLanguage]map[string]string),
+		byLanguage: make(map[resourceLanguage]*versionResourceTable),
 	}
 }
 
 // fields returns the string table for the given language, creating it the first time that language is seen.
 func (v *versionResourceTables) fields(lang resourceLanguage) map[string]string {
-	fields, ok := v.byLanguage[lang]
+	return v.table(lang).fields
+}
+
+// stringTableFields is fields for values read out of a string table the file carries.
+func (v *versionResourceTables) stringTableFields(lang resourceLanguage) map[string]string {
+	table := v.table(lang)
+	table.authored = true
+	return table.fields
+}
+
+func (v *versionResourceTables) table(lang resourceLanguage) *versionResourceTable {
+	table, ok := v.byLanguage[lang]
 	if !ok {
-		fields = make(map[string]string)
-		v.byLanguage[lang] = fields
+		table = &versionResourceTable{fields: make(map[string]string)}
+		v.byLanguage[lang] = table
 	}
-	return fields
+	return table
 }
 
 // preferred returns the string table that best identifies the binary: US English if it is present, then any
 // other English variant, then a language-neutral table, and only then the lowest-numbered remaining LANGID.
 // Values are never merged across languages -- a mixture of, say, an English ProductName and a Spanish
 // FileDescription describes no version resource that actually exists in the file.
+//
+// A VS_VERSIONINFO block with no string tables still contributes a FileVersion derived from its fixed file
+// info, and that is worth reporting when it is all the file has. It states no language of its own though, so
+// ranking it beside real tables would let a stub block -- which installers commonly ship alongside one fully
+// localized block per locale -- discard every string in the file on the strength of its LANGID alone. Real
+// string tables are therefore ranked among themselves first, and the derived values are the fallback.
 func (v *versionResourceTables) preferred() map[string]string {
-	var best resourceLanguage
-	var bestFields map[string]string
+	if fields := v.best(true); fields != nil {
+		return fields
+	}
+	if fields := v.best(false); fields != nil {
+		return fields
+	}
+	return make(map[string]string)
+}
 
-	for lang, fields := range v.byLanguage {
-		if len(fields) == 0 {
+// best returns the highest-ranked non-empty table, or nil if there is none. When authoredOnly is set, blocks
+// that carried no string tables are not candidates.
+func (v *versionResourceTables) best(authoredOnly bool) map[string]string {
+	var bestLang resourceLanguage
+	var best *versionResourceTable
+
+	for lang, table := range v.byLanguage {
+		if len(table.fields) == 0 || (authoredOnly && !table.authored) {
 			continue
 		}
-		if bestFields == nil || lang.preferredOver(best) {
-			best, bestFields = lang, fields
+		if best == nil || lang.preferredOver(bestLang) {
+			bestLang, best = lang, table
 		}
 	}
 
-	if bestFields == nil {
-		return make(map[string]string)
+	if best == nil {
+		return nil
 	}
-	return bestFields
+	return best.fields
 }
 
 // languageFromStringTableKey interprets the szKey of a string table as the LANGID and codepage its strings are

--- a/syft/pkg/cataloger/internal/dotnet/pe/version_resources.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/version_resources.go
@@ -1,0 +1,141 @@
+package pe
+
+import (
+	"strconv"
+)
+
+const (
+	// langIDNeutral is the LANGID used when a resource is not attributed to any specific language (LANG_NEUTRAL).
+	langIDNeutral uint16 = 0x0000
+
+	// langIDEnglishUS is the LANGID for en-US. This is the language most likely to carry the vendor's canonical
+	// product naming, which is what downstream CPE and PURL generation is matched against.
+	langIDEnglishUS uint16 = 0x0409
+
+	// primaryLangEnglish is the primary language ID shared by every English sublanguage (en-GB, en-AU, en-CA, ...).
+	primaryLangEnglish uint16 = 0x0009
+
+	// primaryLangMask masks a LANGID down to its primary language ID (the low 10 bits).
+	primaryLangMask uint16 = 0x03FF
+)
+
+// resourceLanguage identifies the language a single VERSIONINFO string table was authored in. Two independent
+// sources describe this, and they do not always agree:
+//
+//   - directory: the LANGID of the resource directory entry the VS_VERSIONINFO block was found under. The PE
+//     resource tree is organized as type -> name -> language, so localized binaries carry one complete
+//     VS_VERSIONINFO block per language.
+//   - table: the LANGID declared by the string table itself, whose szKey is the language and codepage the
+//     strings are written in (e.g. "040904b0" is en-US in codepage 1200).
+type resourceLanguage struct {
+	directory uint16
+	table     uint16
+}
+
+// effective is the LANGID that best describes the strings themselves. The string table's own declaration wins
+// when it makes a claim, since a resource compiler is free to place any table under any directory entry; the
+// directory entry is the fallback for tables that declare no language (a common convention for binaries that
+// ship a single, unlocalized version resource).
+func (l resourceLanguage) effective() uint16 {
+	if l.table != langIDNeutral {
+		return l.table
+	}
+	return l.directory
+}
+
+// rank orders languages by how well they serve package identification, lowest first.
+func (l resourceLanguage) rank() int {
+	lang := l.effective()
+	switch {
+	case lang == langIDEnglishUS:
+		return 0
+	case lang&primaryLangMask == primaryLangEnglish:
+		return 1
+	case lang == langIDNeutral:
+		return 2
+	}
+	return 3
+}
+
+// preferredOver reports whether l should be selected instead of other. Beyond the language ranking this is a
+// total order over the LANGIDs involved, so the selection never depends on the order the resource tree happens
+// to be walked in.
+func (l resourceLanguage) preferredOver(other resourceLanguage) bool {
+	switch {
+	case l.rank() != other.rank():
+		return l.rank() < other.rank()
+	case l.effective() != other.effective():
+		return l.effective() < other.effective()
+	case l.directory != other.directory:
+		return l.directory < other.directory
+	}
+	return l.table < other.table
+}
+
+// versionResourceTables holds every VERSIONINFO string table found in a PE file, keyed by the language it was
+// authored in. A binary localized into multiple languages carries one string table per language -- usually as
+// separate resource directory entries, sometimes as multiple string tables within a single VS_VERSIONINFO block
+// -- and every one of them uses the same keys ("ProductName", "FileDescription", ...). Keeping the tables apart
+// is what allows a single language to be chosen deterministically, instead of letting whichever language happens
+// to be read last overwrite the values read from all the others.
+type versionResourceTables struct {
+	byLanguage map[resourceLanguage]map[string]string
+}
+
+func newVersionResourceTables() *versionResourceTables {
+	return &versionResourceTables{
+		byLanguage: make(map[resourceLanguage]map[string]string),
+	}
+}
+
+// fields returns the string table for the given language, creating it the first time that language is seen.
+func (v *versionResourceTables) fields(lang resourceLanguage) map[string]string {
+	fields, ok := v.byLanguage[lang]
+	if !ok {
+		fields = make(map[string]string)
+		v.byLanguage[lang] = fields
+	}
+	return fields
+}
+
+// preferred returns the string table that best identifies the binary: US English if it is present, then any
+// other English variant, then a language-neutral table, and only then the lowest-numbered remaining LANGID.
+// Values are never merged across languages -- a mixture of, say, an English ProductName and a Spanish
+// FileDescription describes no version resource that actually exists in the file.
+func (v *versionResourceTables) preferred() map[string]string {
+	var best resourceLanguage
+	var bestFields map[string]string
+
+	for lang, fields := range v.byLanguage {
+		if len(fields) == 0 {
+			continue
+		}
+		if bestFields == nil || lang.preferredOver(best) {
+			best, bestFields = lang, fields
+		}
+	}
+
+	if bestFields == nil {
+		return make(map[string]string)
+	}
+	return bestFields
+}
+
+// languageFromStringTableKey interprets the szKey of a string table as the LANGID and codepage its strings are
+// authored in (e.g. "040904b0"). Keys that do not follow the convention leave the language unstated, in which
+// case the enclosing resource directory entry is the only remaining source of that information.
+func languageFromStringTableKey(key string, directory uint16) resourceLanguage {
+	lang := resourceLanguage{directory: directory}
+
+	if len(key) < 4 {
+		return lang
+	}
+
+	table, err := strconv.ParseUint(key[:4], 16, 16)
+	if err != nil {
+		return lang
+	}
+
+	lang.table = uint16(table)
+	return lang
+}

--- a/syft/pkg/cataloger/internal/dotnet/pe/version_resources_test.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/version_resources_test.go
@@ -1,0 +1,556 @@
+package pe
+
+import (
+	"bytes"
+	"debug/pe"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+	"unicode/utf16"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/file"
+)
+
+func Test_Read_MultiLanguageVersionResources(t *testing.T) {
+	// a localized binary carries one complete VS_VERSIONINFO block per language, and every block uses the same
+	// string keys. These fixtures assert which of those blocks ends up describing the package.
+	tests := []struct {
+		name    string
+		fixture []languageResource
+		want    map[string]string
+	}{
+		{
+			name: "prefer US English over other languages",
+			// this is the shape of the binary reported in anchore/syft#5177 (Microsoft's DPInst.exe): every
+			// language of the product name is present, and the resource directory sorts en-US (0x0409) ahead
+			// of both pt-PT (0x0816) and es-ES (0x0c0a), so the last block read is Spanish.
+			fixture: []languageResource{
+				{lang: 0x0407, fields: germanFields},
+				{lang: 0x0409, fields: englishFields},
+				{lang: 0x0816, fields: portugueseFields},
+				{lang: 0x0c0a, fields: spanishFields},
+			},
+			want: englishFields,
+		},
+		{
+			name: "prefer US English regardless of directory order",
+			fixture: []languageResource{
+				{lang: 0x0c0a, fields: spanishFields},
+				{lang: 0x0409, fields: englishFields},
+			},
+			want: englishFields,
+		},
+		{
+			name: "fall back to another English variant when there is no US English",
+			fixture: []languageResource{
+				{lang: 0x0407, fields: germanFields},
+				{lang: 0x0809, fields: britishFields}, // en-GB
+				{lang: 0x0c0a, fields: spanishFields},
+			},
+			want: britishFields,
+		},
+		{
+			name: "fall back to the language-neutral block when there is no English at all",
+			fixture: []languageResource{
+				{lang: 0x0407, fields: germanFields},
+				{lang: 0x0000, fields: neutralFields},
+				{lang: 0x0c0a, fields: spanishFields},
+			},
+			want: neutralFields,
+		},
+		{
+			name: "fall back to the lowest language ID when there is no English or neutral block",
+			fixture: []languageResource{
+				{lang: 0x0c0a, fields: spanishFields},
+				{lang: 0x0407, fields: germanFields},
+			},
+			want: germanFields,
+		},
+		{
+			name: "a single localized block is still used",
+			fixture: []languageResource{
+				{lang: 0x0c0a, fields: spanishFields},
+			},
+			want: spanishFields,
+		},
+		{
+			name: "never mix values from different languages",
+			// the German block is missing ProductName entirely: taking it from another language would describe
+			// a version resource that does not exist in the file.
+			fixture: []languageResource{
+				{lang: 0x0407, fields: map[string]string{"FileDescription": "Treiberpaket-Installationsprogramm", "FileVersion": "2.1"}},
+				{lang: 0x0c0a, fields: spanishFields},
+			},
+			want: map[string]string{"FileDescription": "Treiberpaket-Installationsprogramm", "FileVersion": "2.1"},
+		},
+		{
+			name: "string tables are matched to their declared language, not the directory entry",
+			// resource compilers are free to place a table under any directory entry; the table's own szKey is
+			// the more direct statement of what language its strings are written in.
+			fixture: []languageResource{
+				{lang: 0x0c0a, codepageKey: "040904b0", fields: englishFields},
+				{lang: 0x0409, codepageKey: "0c0a04b0", fields: spanishFields},
+			},
+			want: englishFields,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := Read(peFixture(t, tt.fixture...))
+			require.NoError(t, err)
+
+			if d := cmp.Diff(tt.want, f.VersionResources); d != "" {
+				t.Errorf("unexpected version resources (-want +got): %s", d)
+			}
+		})
+	}
+}
+
+func Test_Read_MultiLanguageVersionResources_IsDeterministic(t *testing.T) {
+	// version resources are collected into a map keyed by language, so the selection must not depend on Go's
+	// randomized map iteration order.
+	fixture := []languageResource{
+		{lang: 0x0407, fields: germanFields},
+		{lang: 0x0c0a, fields: spanishFields},
+		{lang: 0x0816, fields: portugueseFields},
+	}
+
+	for i := 0; i < 25; i++ {
+		f, err := Read(peFixture(t, fixture...))
+		require.NoError(t, err)
+		require.Equal(t, germanFields, f.VersionResources)
+	}
+}
+
+func Test_Read_MultipleStringTablesInOneBlock(t *testing.T) {
+	// a single VS_VERSIONINFO block may hold one string table per language, which is the second way a binary
+	// can end up with several translations of the same keys.
+	f, err := Read(peFixture(t, languageResource{
+		lang: 0x0409,
+		tables: []stringTable{
+			{key: "0c0a04b0", fields: spanishFields},
+			{key: "040904b0", fields: englishFields},
+			{key: "040704b0", fields: germanFields},
+		},
+	}))
+	require.NoError(t, err)
+
+	if d := cmp.Diff(englishFields, f.VersionResources); d != "" {
+		t.Errorf("unexpected version resources (-want +got): %s", d)
+	}
+}
+
+func Test_Read_VersionResourcesWithoutStringTables(t *testing.T) {
+	// VS_FIXEDFILEINFO is mandatory while string tables are not, so a version resource with no strings at all
+	// still describes a file version.
+	f, err := Read(peFixture(t, languageResource{lang: 0x0409}))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]string{"FileVersion": "2.1.0.0"}, f.VersionResources)
+}
+
+func Test_parseVersionResourceSection_TruncatedResource(t *testing.T) {
+	// a block that claims to be longer than the bytes that follow it must not keep the parser reading past the
+	// end of the resource: the reads stop returning data, so nothing advances the offsets towards the claimed
+	// length. Every truncation of a well-formed resource is exercised here, since only some of them leave the
+	// parser inside a block that still has a length left to satisfy.
+	res := versionInfoResource(languageResource{lang: 0x0409, fields: englishFields})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for n := 1; n <= len(res); n++ {
+			_ = parseVersionResourceSection(bytes.NewReader(res[:n]), newVersionResourceTables(), langIDEnglishUS)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("parsing a truncated version resource did not terminate")
+	}
+}
+
+func Test_languageFromStringTableKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		directory uint16
+		want      resourceLanguage
+	}{
+		{
+			name:      "language and codepage",
+			key:       "040904b0",
+			directory: 0x0c0a,
+			want:      resourceLanguage{directory: 0x0c0a, table: 0x0409},
+		},
+		{
+			name:      "uppercase hex",
+			key:       "0C0A04B0",
+			directory: 0x0409,
+			want:      resourceLanguage{directory: 0x0409, table: 0x0c0a},
+		},
+		{
+			name:      "language-neutral table falls back to the directory language",
+			key:       "000004b0",
+			directory: 0x0409,
+			want:      resourceLanguage{directory: 0x0409, table: 0x0000},
+		},
+		{
+			name:      "key too short to state a language",
+			key:       "04b0",
+			directory: 0x0409,
+			want:      resourceLanguage{directory: 0x0409, table: 0x04b0},
+		},
+		{
+			name:      "empty key",
+			key:       "",
+			directory: 0x0409,
+			want:      resourceLanguage{directory: 0x0409},
+		},
+		{
+			name:      "non-hex key",
+			key:       "StringFileInfo",
+			directory: 0x0409,
+			want:      resourceLanguage{directory: 0x0409},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, languageFromStringTableKey(tt.key, tt.directory))
+		})
+	}
+}
+
+func Test_resourceLanguage_effective(t *testing.T) {
+	assert.Equal(t, uint16(0x0409), resourceLanguage{directory: 0x0c0a, table: 0x0409}.effective(), "the table states its own language")
+	assert.Equal(t, uint16(0x0c0a), resourceLanguage{directory: 0x0c0a}.effective(), "the directory entry is the fallback")
+	assert.Equal(t, langIDNeutral, resourceLanguage{}.effective(), "nothing states a language")
+}
+
+func Test_versionResourceTables_preferred_ignoresEmptyTables(t *testing.T) {
+	tables := newVersionResourceTables()
+	tables.fields(resourceLanguage{table: langIDEnglishUS}) // present, but empty
+	tables.fields(resourceLanguage{table: 0x0c0a})["ProductName"] = "Instalador de paquetes de controladores"
+
+	assert.Equal(t, map[string]string{"ProductName": "Instalador de paquetes de controladores"}, tables.preferred())
+}
+
+func Test_versionResourceTables_preferred_noTables(t *testing.T) {
+	assert.Empty(t, newVersionResourceTables().preferred())
+}
+
+var (
+	englishFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Driver Package Installer",
+		"FileVersion":     "2.1",
+		"ProductName":     "Driver Package Installer (DPInst)",
+	}
+
+	spanishFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Instalador de paquetes de controladores",
+		"FileVersion":     "2.1",
+		"ProductName":     "Instalador de paquetes de controladores (DPInst)",
+	}
+
+	germanFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Treiberpaket-Installationsprogramm",
+		"FileVersion":     "2.1",
+		"ProductName":     "Treiberpaket-Installationsprogramm (DPInst)",
+	}
+
+	portugueseFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Instalador de pacote de controladores",
+		"FileVersion":     "2.1",
+		"ProductName":     "Instalador de pacote de controladores (DPInst)",
+	}
+
+	britishFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Driver Package Installer",
+		"FileVersion":     "2.1",
+		"ProductName":     "Driver Package Installer (DPInst, en-GB)",
+	}
+
+	neutralFields = map[string]string{
+		"CompanyName":     "Microsoft Corporation",
+		"FileDescription": "Driver Package Installer",
+		"FileVersion":     "2.1",
+		"ProductName":     "Driver Package Installer (DPInst, neutral)",
+	}
+)
+
+// languageResource describes one VS_VERSIONINFO resource to synthesize, as found under a single language entry
+// of the resource directory.
+type languageResource struct {
+	// lang is the LANGID of the resource directory entry the resource is placed under.
+	lang uint16
+
+	// fields is a shorthand for a resource with a single string table; codepageKey overrides that table's szKey.
+	fields      map[string]string
+	codepageKey string
+
+	// tables, when set, describes several string tables held within the one resource.
+	tables []stringTable
+}
+
+type stringTable struct {
+	key    string
+	fields map[string]string
+}
+
+func (l languageResource) stringTables() []stringTable {
+	if len(l.tables) > 0 {
+		return l.tables
+	}
+	if l.fields == nil {
+		return nil
+	}
+	key := l.codepageKey
+	if key == "" {
+		key = fmt.Sprintf("%04x04b0", l.lang)
+	}
+	return []stringTable{{key: key, fields: l.fields}}
+}
+
+// peFixture writes a PE file carrying one VS_VERSIONINFO resource per given language and returns a reader over it.
+func peFixture(t *testing.T, resources ...languageResource) file.LocationReadCloser {
+	t.Helper()
+
+	byLanguage := make(map[uint16][]byte, len(resources))
+	for _, r := range resources {
+		require.NotContains(t, byLanguage, r.lang, "fixture declares the same language twice")
+		byLanguage[r.lang] = versionInfoResource(r)
+	}
+
+	return peFixtureFromResources(t, byLanguage)
+}
+
+func peFixtureFromResources(t *testing.T, byLanguage map[uint16][]byte) file.LocationReadCloser {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "fixture.exe")
+	require.NoError(t, os.WriteFile(path, buildPE(t, byLanguage), 0600))
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, f.Close()) })
+
+	return file.NewLocationReadCloser(file.NewLocation(path), f)
+}
+
+// buildPE assembles the smallest PE32 file that carries version resources: a DOS header, the PE headers, and a
+// single .rsrc section holding a type -> name -> language resource tree of RT_VERSION entries.
+func buildPE(t *testing.T, byLanguage map[uint16][]byte) []byte {
+	t.Helper()
+
+	const (
+		rsrcRVA     = 0x1000
+		headersSize = 0x400 // where the .rsrc section data begins in the file
+	)
+
+	rsrc := buildResourceSection(byLanguage, rsrcRVA)
+
+	dos := make([]byte, 64)
+	copy(dos, "MZ")
+	binary.LittleEndian.PutUint32(dos[60:], 64) // e_lfanew
+
+	buf := bytes.NewBuffer(dos)
+	buf.WriteString("PE\x00\x00")
+
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, pe.FileHeader{
+		Machine:              pe.IMAGE_FILE_MACHINE_I386,
+		NumberOfSections:     1,
+		SizeOfOptionalHeader: uint16(binary.Size(pe.OptionalHeader32{})),
+		Characteristics:      0x0102, // executable, 32 bit
+	}))
+
+	optHeader := pe.OptionalHeader32{
+		Magic:               0x10b, // PE32
+		SectionAlignment:    0x1000,
+		FileAlignment:       0x200,
+		SizeOfImage:         rsrcRVA + uint32(len(rsrc)),
+		SizeOfHeaders:       headersSize,
+		NumberOfRvaAndSizes: 16,
+	}
+	optHeader.DataDirectory[pe.IMAGE_DIRECTORY_ENTRY_RESOURCE] = pe.DataDirectory{
+		VirtualAddress: rsrcRVA,
+		Size:           uint32(len(rsrc)),
+	}
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, optHeader))
+
+	sectionHeader := pe.SectionHeader32{
+		VirtualSize:      uint32(len(rsrc)),
+		VirtualAddress:   rsrcRVA,
+		SizeOfRawData:    uint32(len(rsrc)),
+		PointerToRawData: headersSize,
+		Characteristics:  0x40000040, // initialized data, readable
+	}
+	copy(sectionHeader.Name[:], ".rsrc")
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, sectionHeader))
+
+	require.Less(t, buf.Len(), headersSize, "PE headers overflowed the space reserved for them")
+	buf.Write(make([]byte, headersSize-buf.Len()))
+	buf.Write(rsrc)
+
+	return buf.Bytes()
+}
+
+// buildResourceSection lays out a resource directory tree of RT_VERSION -> 1 -> LANGID -> data.
+func buildResourceSection(byLanguage map[uint16][]byte, rsrcRVA uint32) []byte {
+	const (
+		directorySize = 16 // IMAGE_RESOURCE_DIRECTORY
+		entrySize     = 8  // IMAGE_RESOURCE_DIRECTORY_ENTRY
+		dataEntrySize = 16 // IMAGE_RESOURCE_DATA_ENTRY
+		rtVersion     = 16
+	)
+
+	langs := make([]uint16, 0, len(byLanguage))
+	for lang := range byLanguage {
+		langs = append(langs, lang)
+	}
+	// the resource compiler emits directory entries sorted by ID, which is what makes the last entry read the
+	// highest-numbered language
+	slices.Sort(langs)
+
+	var (
+		typeDirOffset = uint32(0)
+		nameDirOffset = typeDirOffset + directorySize + entrySize
+		langDirOffset = nameDirOffset + directorySize + entrySize
+		dataOffset    = langDirOffset + directorySize + entrySize*uint32(len(langs))
+		blobOffset    = dataOffset + dataEntrySize*uint32(len(langs))
+	)
+
+	buf := new(bytes.Buffer)
+	writeDirectory(buf, 1)
+	writeDirectoryEntry(buf, rtVersion, nameDirOffset, true)
+	writeDirectory(buf, 1)
+	writeDirectoryEntry(buf, 1, langDirOffset, true)
+
+	writeDirectory(buf, uint16(len(langs)))
+	for i, lang := range langs {
+		writeDirectoryEntry(buf, uint32(lang), dataOffset+dataEntrySize*uint32(i), false)
+	}
+
+	blobs := blobOffset
+	for _, lang := range langs {
+		res := byLanguage[lang]
+		_ = binary.Write(buf, binary.LittleEndian, peImageResourceDataEntry{
+			OffsetToData: rsrcRVA + blobs, // this one is an RVA, unlike every other offset in the tree
+			Size:         uint32(len(res)),
+		})
+		blobs += alignUint32(uint32(len(res)))
+	}
+
+	for _, lang := range langs {
+		res := byLanguage[lang]
+		buf.Write(res)
+		buf.Write(make([]byte, alignUint32(uint32(len(res)))-uint32(len(res))))
+	}
+
+	return buf.Bytes()
+}
+
+func writeDirectory(buf io.Writer, entries uint16) {
+	_ = binary.Write(buf, binary.LittleEndian, peImageResourceDirectory{NumberOfIDEntries: entries})
+}
+
+func writeDirectoryEntry(buf io.Writer, id, offset uint32, isDirectory bool) {
+	if isDirectory {
+		offset |= 0x80000000
+	}
+	_ = binary.Write(buf, binary.LittleEndian, peImageResourceDirectoryEntry{Name: id, OffsetToData: offset})
+}
+
+// versionInfoResource builds a VS_VERSIONINFO resource:
+//
+//	VS_VERSION_INFO -> VS_FIXEDFILEINFO + StringFileInfo -> StringTable(s) -> String(s)
+//
+// source: https://learn.microsoft.com/en-us/windows/win32/menurc/vs-versioninfo
+func versionInfoResource(r languageResource) []byte {
+	fixedFileInfo := new(bytes.Buffer)
+	_ = binary.Write(fixedFileInfo, binary.LittleEndian, peVsFixedFileInfo{
+		Signature:     0xfeef04bd,
+		StructVersion: 0x00010000,
+		FileVersionMS: 2<<16 | 1, // 2.1.0.0
+	})
+
+	var children [][]byte
+	if tables := r.stringTables(); len(tables) > 0 {
+		stringTables := make([][]byte, 0, len(tables))
+		for _, table := range tables {
+			stringTables = append(stringTables, versionInfoBlock(table.key, nil, 0, 1, versionInfoStrings(table.fields)...))
+		}
+		children = append(children, versionInfoBlock("StringFileInfo", nil, 0, 1, stringTables...))
+	}
+
+	return versionInfoBlock("VS_VERSION_INFO", fixedFileInfo.Bytes(), uint16(fixedFileInfo.Len()), 0, children...)
+}
+
+func versionInfoStrings(fields map[string]string) [][]byte {
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	strings := make([][]byte, 0, len(keys))
+	for _, key := range keys {
+		value := utf16Bytes(fields[key])
+		// for text values wValueLength is a count of UTF-16 code units, including the null terminator
+		strings = append(strings, versionInfoBlock(key, value, uint16(len(value)/2), 1))
+	}
+	return strings
+}
+
+// versionInfoBlock assembles the length-prefixed structure that every part of a version resource shares:
+// a header, a null-terminated UTF-16 key, an optional value, and optional children, each padded to a DWORD.
+func versionInfoBlock(key string, value []byte, valueLength, blockType uint16, children ...[]byte) []byte {
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.LittleEndian, peLenValLenType{ValueLength: valueLength, Type: blockType})
+	buf.Write(utf16Bytes(key))
+	padToDWORD(buf)
+	buf.Write(value)
+	padToDWORD(buf)
+
+	for _, child := range children {
+		buf.Write(child)
+		padToDWORD(buf)
+	}
+
+	block := buf.Bytes()
+	binary.LittleEndian.PutUint16(block[0:2], uint16(len(block)))
+	return block
+}
+
+func padToDWORD(buf *bytes.Buffer) {
+	buf.Write(make([]byte, alignToDWORD(buf.Len())-buf.Len()))
+}
+
+func alignUint32(v uint32) uint32 {
+	return uint32(alignToDWORD(int(v)))
+}
+
+// utf16Bytes encodes a null-terminated little-endian UTF-16 string, the only string encoding a version resource uses.
+func utf16Bytes(s string) []byte {
+	codes := utf16.Encode([]rune(s))
+	buf := new(bytes.Buffer)
+	_ = binary.Write(buf, binary.LittleEndian, codes)
+	buf.Write([]byte{0, 0})
+	return buf.Bytes()
+}

--- a/syft/pkg/cataloger/internal/dotnet/pe/version_resources_test.go
+++ b/syft/pkg/cataloger/internal/dotnet/pe/version_resources_test.go
@@ -102,6 +102,25 @@ func Test_Read_MultiLanguageVersionResources(t *testing.T) {
 			},
 			want: englishFields,
 		},
+		{
+			name: "a block with no string tables never displaces one that has them",
+			// installers commonly carry one VERSIONINFO per locale plus a stub block with fixed file info and
+			// no strings. The stub contributes only a derived FileVersion, so preferring it by LANGID alone
+			// would throw away every string the file actually has. 0x0411 sorts ahead of 0x0c0a on every tie-
+			// breaker the ranking applies, so this is the ordering that exposes it.
+			fixture: []languageResource{
+				{lang: 0x0c0a, fields: spanishFields},
+				{lang: 0x0411, fields: nil},
+			},
+			want: spanishFields,
+		},
+		{
+			name: "a block with no string tables is still used when it is all there is",
+			fixture: []languageResource{
+				{lang: 0x0411, fields: nil},
+			},
+			want: map[string]string{"FileVersion": "2.1.0.0"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -243,6 +262,16 @@ func Test_versionResourceTables_preferred_ignoresEmptyTables(t *testing.T) {
 	tables := newVersionResourceTables()
 	tables.fields(resourceLanguage{table: langIDEnglishUS}) // present, but empty
 	tables.fields(resourceLanguage{table: 0x0c0a})["ProductName"] = "Instalador de paquetes de controladores"
+
+	assert.Equal(t, map[string]string{"ProductName": "Instalador de paquetes de controladores"}, tables.preferred())
+}
+
+func Test_versionResourceTables_preferred_prefersAuthoredTables(t *testing.T) {
+	tables := newVersionResourceTables()
+	// a block with no string tables, contributing only the FileVersion derived from its fixed file info, and
+	// sorting ahead of the real table on every tie-breaker the ranking applies
+	tables.fields(resourceLanguage{directory: 0x0411})["FileVersion"] = "2.1.0.0"
+	tables.stringTableFields(resourceLanguage{directory: 0x0c0a, table: 0x0c0a})["ProductName"] = "Instalador de paquetes de controladores"
 
 	assert.Equal(t, map[string]string{"ProductName": "Instalador de paquetes de controladores"}, tables.preferred())
 }


### PR DESCRIPTION
## Description

Scanning a PE binary that ships several localizations names the package after whichever language sorts last in its resource directory.

A localized binary carries one complete `VS_VERSIONINFO` resource per language, each under its own entry at the language level of the resource tree, and each using exactly the same string keys as all the others. Syft read every one of them into a single flat map, so the block read last decided the outcome — and since directory entries are ordered by ID, that is the highest LANGID in the file.

`dpinst-x86.exe` from #5177 carries 21 such blocks. es-ES (0x0c0a) is the largest ID, so:

```console
$ syft scan dir:dpinst -o table            # before
NAME                                     VERSION  TYPE
Instalador de paquetes de controladores  2.1      binary

$ syft scan dir:dpinst -o table            # after
NAME                      VERSION  TYPE
Driver Package Installer  2.1      binary
```

and the generated CPE goes from `cpe:2.3:a:Instalador_de_paquetes_de_controladores:Instalador_de_paquetes_de_controladores:2.1:*` to `cpe:2.3:a:Driver_Package_Installer:Driver_Package_Installer:2.1:*`, which is what downstream matching needs. The en-US block was in the file the whole time; it just got overwritten.

Version resources are now collected per language and one is chosen after the whole tree has been read: **US English, then any other English variant, then a language-neutral block, then the lowest remaining LANGID**. Values are never merged across languages — an English `ProductName` next to a Spanish `FileDescription` describes no version resource that exists in the file. The selection is a total order over the LANGIDs involved, so it does not depend on map iteration order.

Two further problems in the same walk are fixed alongside it, since the language work runs straight through both:

- **Only the first string table of a `StringFileInfo` block was read**, and the rest of the block was then walked as though the tables were siblings of the block. A block may hold one table per language, so this is the second way a binary can carry several translations of the same keys. A table's `szKey` is its own language and codepage (e.g. `040904b0`), and that is now what the table is filed under, with the directory entry's LANGID as the fallback for tables that state no language.
- **A truncated version resource never finished parsing.** When a block's declared length exceeds the bytes that follow it, the reads stop returning data and the offsets stop advancing, so the loop can never reach the claimed length. Confirmed against `main` by truncating a well-formed resource at every length: lengths 134–137 of 460 hang. The string loop is now bounded by the reader as well as by the declared length.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

**On the tests:** they build PE files rather than committing binaries — a DOS header, the PE headers and a single `.rsrc` section holding a real `type -> name -> language` tree of `RT_VERSION` entries — so the multi-language shapes are exercised without a fixture image or a redistributable EXE in the repo. Covered: language preference and each fallback step, order independence, several string tables inside one block, tables filed by their declared language rather than the directory entry, no merging across languages, a resource with no string tables at all (the file version still comes from `VS_FIXEDFILEINFO`), and the truncation sweep.

Every new `Read`-level assertion was checked against `main` first: 6 of 8 subtests and both top-level cases fail there with the Spanish values, and pass with the fix. The fix was also run against the binary attached to the issue, x86 and amd64, which is where the before/after above comes from.

**One limitation worth stating:** the Docker-backed tests in this package (`Test_Read_DotNetDetection` and the binary/dotnet cataloger suites) could not run on my machine. They fail identically on a pristine checkout here, so nothing is masked, but CI is the real check on those.

## Issue references

Fixes #5177

---

*Disclosure: written with AI assistance (the commit carries a `Co-Authored-By` trailer). I verified the root cause by walking the resource tree of the binary attached to the issue and reproducing it through syft's own reader, before and after, rather than taking the report on trust.*
