### PR TITLE
fix(cyclonedx): write the authors list instead of the deprecated author field for 1.6 and later

### DIFF
--- a/syft/format/cyclonedxjson/encoder_test.go
+++ b/syft/format/cyclonedxjson/encoder_test.go
@@ -196,3 +196,56 @@ func defaultFormatEncoders() []sbom.FormatEncoder {
 	}
 	return encs
 }
+
+// Test_ComponentAuthorByVersion asserts which of the two author fields a document is written with, and that
+// either one is read back to the same package. The author field on a component is deprecated as of CycloneDX
+// 1.6 in favor of a list of authors, and the two do not coexist in syft's output.
+//
+// see anchore/syft#4580
+func Test_ComponentAuthorByVersion(t *testing.T) {
+	subject := testutil.DirectoryInputWithAuthorField(t)
+
+	for _, version := range SupportedVersions() {
+		t.Run("v"+version, func(t *testing.T) {
+			enc, err := NewFormatEncoderWithConfig(EncoderConfig{Version: version})
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			require.NoError(t, enc.Encode(&buf, subject))
+
+			doc := buf.String()
+
+			if version < "1.6" {
+				assert.Contains(t, doc, `"author":"test-author"`, "the deprecated field is all this version has")
+				assert.NotContains(t, doc, `"authors":`, "the authors list does not exist before 1.6")
+			} else {
+				assert.Contains(t, doc, `"authors":[{"name":"test-author"}]`)
+				assert.NotContains(t, doc, `"author":`, "the deprecated field should not be written when the list can be")
+			}
+
+			if version == "1.2" {
+				// package metadata is carried in component properties, which 1.2 has no place for, so there is
+				// no metadata to read an author back into
+				return
+			}
+
+			decoded, _, _, err := NewFormatDecoder().Decode(bytes.NewReader(buf.Bytes()))
+			require.NoError(t, err)
+
+			assert.Equal(t, "test-author", decodedPythonAuthor(t, decoded), "the author did not survive the round trip")
+		})
+	}
+}
+
+func decodedPythonAuthor(t *testing.T, s *sbom.SBOM) string {
+	t.Helper()
+
+	for p := range s.Artifacts.Packages.Enumerate() {
+		if metadata, ok := p.Metadata.(pkg.PythonPackage); ok {
+			return metadata.Author
+		}
+	}
+
+	t.Fatal("no python package in the decoded document")
+	return ""
+}

--- a/syft/format/cyclonedxjson/testdata/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxjson/testdata/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -10,7 +10,11 @@
       "components": [
         {
           "type": "application",
-          "author": "anchore",
+          "authors": [
+            {
+              "name": "anchore"
+            }
+          ],
           "name": "syft",
           "version": "v0.42.0-bogus"
         }

--- a/syft/format/cyclonedxjson/testdata/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxjson/testdata/snapshot/TestCycloneDxImageEncoder.golden
@@ -10,7 +10,11 @@
       "components": [
         {
           "type": "application",
-          "author": "anchore",
+          "authors": [
+            {
+              "name": "anchore"
+            }
+          ],
           "name": "syft",
           "version": "v0.42.0-bogus"
         }

--- a/syft/format/cyclonedxxml/testdata/snapshot/TestCycloneDxDirectoryEncoder.golden
+++ b/syft/format/cyclonedxxml/testdata/snapshot/TestCycloneDxDirectoryEncoder.golden
@@ -5,7 +5,11 @@
     <tools>
       <components>
         <component type="application">
-          <author>anchore</author>
+          <authors>
+            <author>
+              <name>anchore</name>
+            </author>
+          </authors>
           <name>syft</name>
           <version>v0.42.0-bogus</version>
         </component>

--- a/syft/format/cyclonedxxml/testdata/snapshot/TestCycloneDxImageEncoder.golden
+++ b/syft/format/cyclonedxxml/testdata/snapshot/TestCycloneDxImageEncoder.golden
@@ -5,7 +5,11 @@
     <tools>
       <components>
         <component type="application">
-          <author>anchore</author>
+          <authors>
+            <author>
+              <name>anchore</name>
+            </author>
+          </authors>
           <name>syft</name>
           <version>v0.42.0-bogus</version>
         </component>

--- a/syft/format/internal/cyclonedxutil/encoder.go
+++ b/syft/format/internal/cyclonedxutil/encoder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/CycloneDX/cyclonedx-go"
 
 	"github.com/anchore/syft/syft/format/common/cyclonedxhelpers"
+	"github.com/anchore/syft/syft/format/internal/cyclonedxutil/helpers"
 	"github.com/anchore/syft/syft/sbom"
 )
 
@@ -29,6 +30,11 @@ func NewEncoder(version string, format cyclonedx.BOMFileFormat, pretty bool) (En
 
 func (e Encoder) Encode(writer io.Writer, s sbom.SBOM) error {
 	bom := cyclonedxhelpers.ToFormatModel(s)
+
+	// the model is built against the oldest supported spec version, so anything a later version states
+	// differently is translated here, where the target version is known
+	helpers.ConvertComponentAuthors(bom, e.version)
+
 	enc := cyclonedx.NewBOMEncoder(writer, e.format)
 	enc.SetPretty(e.pretty)
 	enc.SetEscapeHTML(false)

--- a/syft/format/internal/cyclonedxutil/helpers/author.go
+++ b/syft/format/internal/cyclonedxutil/helpers/author.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/CycloneDX/cyclonedx-go"
+
 	"github.com/anchore/syft/syft/pkg"
 )
 
@@ -44,4 +46,99 @@ func decodeAuthor(author string, metadata any) {
 	case *pkg.RubyGemspec:
 		meta.Authors = strings.Split(author, ",")
 	}
+}
+
+// ConvertComponentAuthors rewrites the deprecated component author field into the authors list that replaced it
+// in CycloneDX 1.6.
+//
+// The format model is built with the deprecated field, since that is the only one earlier spec versions have,
+// so the translation happens on the way out and only for targets that can express the replacement. Both fields
+// remain valid in 1.6 and later, but a document should not be written with a field the spec has deprecated when
+// the current one says the same thing.
+//
+// source: https://cyclonedx.org/docs/1.6/json/#components_items_author
+func ConvertComponentAuthors(bom *cyclonedx.BOM, version cyclonedx.SpecVersion) {
+	if bom == nil || version < cyclonedx.SpecVersion1_6 {
+		return
+	}
+
+	if bom.Metadata != nil {
+		convertComponentAuthor(bom.Metadata.Component)
+
+		if bom.Metadata.Tools != nil {
+			convertComponentAuthors(bom.Metadata.Tools.Components)
+		}
+	}
+
+	convertComponentAuthors(bom.Components)
+}
+
+func convertComponentAuthors(components *[]cyclonedx.Component) {
+	if components == nil {
+		return
+	}
+
+	for i := range *components {
+		convertComponentAuthor(&(*components)[i])
+	}
+}
+
+func convertComponentAuthor(c *cyclonedx.Component) {
+	if c == nil {
+		return
+	}
+
+	// a component may carry components of its own, each with an author of its own
+	convertComponentAuthors(c.Components)
+
+	if c.Author == "" || c.Authors != nil {
+		return
+	}
+
+	c.Authors = &[]cyclonedx.OrganizationalContact{authorContact(c.Author)}
+	c.Author = ""
+}
+
+// authorContact splits an author into a contact, recognizing only the "name <email>" form that encodeAuthor
+// produces. Where syft has more than one author to describe it joins them with a separator of the ecosystem's
+// own choosing, so splitting that string apart here would mean guessing at a convention that differs per
+// ecosystem -- and guessing wrong would change what the document claims. Carrying the value across whole says
+// exactly what the deprecated field said, and no more.
+func authorContact(author string) cyclonedx.OrganizationalContact {
+	name, email, found := strings.Cut(author, " <")
+	if !found {
+		return cyclonedx.OrganizationalContact{Name: author}
+	}
+
+	return cyclonedx.OrganizationalContact{
+		Name:  name,
+		Email: strings.TrimSuffix(email, ">"),
+	}
+}
+
+// componentAuthor reads the author of a component regardless of which of the two fields the document used to
+// state it, so that a 1.6 document -- syft's own output included -- decodes to the same package metadata as the
+// equivalent 1.5 one.
+func componentAuthor(c *cyclonedx.Component) string {
+	if c.Authors == nil || len(*c.Authors) == 0 {
+		return c.Author
+	}
+
+	authors := make([]string, 0, len(*c.Authors))
+	for _, a := range *c.Authors {
+		switch {
+		case a.Name != "" && a.Email != "":
+			authors = append(authors, fmt.Sprintf("%s <%s>", a.Name, a.Email))
+		case a.Name != "":
+			authors = append(authors, a.Name)
+		case a.Email != "":
+			authors = append(authors, a.Email)
+		}
+	}
+
+	if len(authors) == 0 {
+		return c.Author
+	}
+
+	return strings.Join(authors, ",")
 }

--- a/syft/format/internal/cyclonedxutil/helpers/author_conversion_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/author_conversion_test.go
@@ -1,0 +1,224 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ConvertComponentAuthors(t *testing.T) {
+	tests := []struct {
+		name    string
+		version cyclonedx.SpecVersion
+		bom     func() *cyclonedx.BOM
+		want    func() *cyclonedx.BOM
+	}{
+		{
+			name:    "1.5 keeps the deprecated field, which is all it has",
+			version: cyclonedx.SpecVersion1_5,
+			bom:     func() *cyclonedx.BOM { return bomWithAuthors("anchore", "someone") },
+			want:    func() *cyclonedx.BOM { return bomWithAuthors("anchore", "someone") },
+		},
+		{
+			name:    "1.6 replaces the deprecated field everywhere it can appear",
+			version: cyclonedx.SpecVersion1_6,
+			bom:     func() *cyclonedx.BOM { return bomWithAuthors("anchore", "someone") },
+			want: func() *cyclonedx.BOM {
+				b := bomWithAuthors("", "")
+				b.Metadata.Component.Authors = contacts(cyclonedx.OrganizationalContact{Name: "someone"})
+				(*b.Metadata.Tools.Components)[0].Authors = contacts(cyclonedx.OrganizationalContact{Name: "anchore"})
+				(*b.Components)[0].Authors = contacts(cyclonedx.OrganizationalContact{Name: "someone"})
+				(*(*b.Components)[0].Components)[0].Authors = contacts(cyclonedx.OrganizationalContact{Name: "someone"})
+				return b
+			},
+		},
+		{
+			name:    "1.7 replaces it as well",
+			version: cyclonedx.SpecVersion1_7,
+			bom: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{Name: "p", Author: "someone"}}}
+			},
+			want: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{
+					Name:    "p",
+					Authors: contacts(cyclonedx.OrganizationalContact{Name: "someone"}),
+				}}}
+			},
+		},
+		{
+			name:    "an author with an email becomes a contact with an email",
+			version: cyclonedx.SpecVersion1_6,
+			bom: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{Author: "some one <some@one.com>"}}}
+			},
+			want: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{
+					Authors: contacts(cyclonedx.OrganizationalContact{Name: "some one", Email: "some@one.com"}),
+				}}}
+			},
+		},
+		{
+			name:    "authors that are already stated are left alone",
+			version: cyclonedx.SpecVersion1_6,
+			bom: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{
+					Author:  "someone",
+					Authors: contacts(cyclonedx.OrganizationalContact{Name: "someone else"}),
+				}}}
+			},
+			want: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{
+					Author:  "someone",
+					Authors: contacts(cyclonedx.OrganizationalContact{Name: "someone else"}),
+				}}}
+			},
+		},
+		{
+			name:    "no author states no authors",
+			version: cyclonedx.SpecVersion1_6,
+			bom: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{Name: "p"}}}
+			},
+			want: func() *cyclonedx.BOM {
+				return &cyclonedx.BOM{Components: &[]cyclonedx.Component{{Name: "p"}}}
+			},
+		},
+		{
+			name:    "an empty document is not a special case",
+			version: cyclonedx.SpecVersion1_6,
+			bom:     func() *cyclonedx.BOM { return &cyclonedx.BOM{} },
+			want:    func() *cyclonedx.BOM { return &cyclonedx.BOM{} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.bom()
+			ConvertComponentAuthors(got, tt.version)
+			assert.Equal(t, tt.want(), got)
+		})
+	}
+}
+
+func Test_ConvertComponentAuthors_nilBOM(t *testing.T) {
+	require.NotPanics(t, func() { ConvertComponentAuthors(nil, cyclonedx.SpecVersion1_6) })
+}
+
+func Test_componentAuthor(t *testing.T) {
+	tests := []struct {
+		name      string
+		component cyclonedx.Component
+		want      string
+	}{
+		{
+			name:      "the deprecated field",
+			component: cyclonedx.Component{Author: "someone"},
+			want:      "someone",
+		},
+		{
+			name:      "a single author",
+			component: cyclonedx.Component{Authors: contacts(cyclonedx.OrganizationalContact{Name: "someone"})},
+			want:      "someone",
+		},
+		{
+			name: "an author with an email",
+			component: cyclonedx.Component{
+				Authors: contacts(cyclonedx.OrganizationalContact{Name: "some one", Email: "some@one.com"}),
+			},
+			want: "some one <some@one.com>",
+		},
+		{
+			name: "an author with only an email",
+			component: cyclonedx.Component{
+				Authors: contacts(cyclonedx.OrganizationalContact{Email: "some@one.com"}),
+			},
+			want: "some@one.com",
+		},
+		{
+			name: "several authors, as another tool may well write them",
+			component: cyclonedx.Component{
+				Authors: contacts(
+					cyclonedx.OrganizationalContact{Name: "someone"},
+					cyclonedx.OrganizationalContact{Name: "someone else"},
+				),
+			},
+			want: "someone,someone else",
+		},
+		{
+			name: "authors that say nothing fall back to the deprecated field",
+			component: cyclonedx.Component{
+				Author:  "someone",
+				Authors: contacts(cyclonedx.OrganizationalContact{}),
+			},
+			want: "someone",
+		},
+		{
+			name:      "an empty list falls back to the deprecated field",
+			component: cyclonedx.Component{Author: "someone", Authors: contacts()},
+			want:      "someone",
+		},
+		{
+			name:      "no author at all",
+			component: cyclonedx.Component{},
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, componentAuthor(&tt.component))
+		})
+	}
+}
+
+// Test_ConvertComponentAuthors_roundTrip asserts that what the conversion writes is what componentAuthor reads
+// back, which is what keeps syft able to decode its own output.
+func Test_ConvertComponentAuthors_roundTrip(t *testing.T) {
+	authors := []string{
+		"anchore",
+		"some one <some@one.com>",
+		"someone,someone else",
+		"<some@one.com>",
+	}
+
+	for _, author := range authors {
+		t.Run(author, func(t *testing.T) {
+			bom := &cyclonedx.BOM{Components: &[]cyclonedx.Component{{Author: author}}}
+
+			ConvertComponentAuthors(bom, cyclonedx.SpecVersion1_6)
+			require.Empty(t, (*bom.Components)[0].Author, "the deprecated field should no longer be in use")
+
+			assert.Equal(t, author, componentAuthor(&(*bom.Components)[0]))
+		})
+	}
+}
+
+func contacts(c ...cyclonedx.OrganizationalContact) *[]cyclonedx.OrganizationalContact {
+	if c == nil {
+		c = []cyclonedx.OrganizationalContact{}
+	}
+	return &c
+}
+
+// bomWithAuthors builds a document with an author in every place a component can appear.
+func bomWithAuthors(toolAuthor, packageAuthor string) *cyclonedx.BOM {
+	return &cyclonedx.BOM{
+		Metadata: &cyclonedx.Metadata{
+			Component: &cyclonedx.Component{Name: "the-source", Author: packageAuthor},
+			Tools: &cyclonedx.ToolsChoice{
+				Components: &[]cyclonedx.Component{{Name: "syft", Author: toolAuthor}},
+			},
+		},
+		Components: &[]cyclonedx.Component{
+			{
+				Name:   "package-1",
+				Author: packageAuthor,
+				Components: &[]cyclonedx.Component{
+					{Name: "nested-package", Author: packageAuthor},
+				},
+			},
+		},
+	}
+}

--- a/syft/format/internal/cyclonedxutil/helpers/component.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component.go
@@ -223,7 +223,7 @@ func decodePackageMetadata(vals map[string]string, c *cyclonedx.Component, typeN
 		metaPtr := Decode(metaPtrTyp, vals, "syft:metadata", CycloneDXFields)
 
 		// Map all explicit metadata properties
-		decodeAuthor(c.Author, metaPtr)
+		decodeAuthor(componentAuthor(c), metaPtr)
 		decodeGroup(c.Group, metaPtr)
 		decodePublisher(c.Publisher, metaPtr)
 		decodeDescription(c.Description, metaPtr)


### PR DESCRIPTION
## Description

CycloneDX 1.6 deprecated `component.author` in favour of `component.authors`, and syft still writes the deprecated one. It shows up in every document syft produces at the default spec version, since `metadata.tools.components` names anchore there:

```console
$ syft scan alpine:latest -o cyclonedx-json | jq .metadata.tools

# before
{ "components": [ { "type": "application", "author": "anchore", "name": "syft", "version": "1.x" } ] }

# after
{ "components": [ { "type": "application", "authors": [ { "name": "anchore" } ], "name": "syft", "version": "1.x" } ] }
```

Taking the approach suggested in #4580: the format model is built once and then encoded to whichever version was asked for, so it has to keep the field that every version has. The translation belongs where the target version is known — the encoder — and that is where this puts it, alongside where the library already decides which fields survive a given spec version. For 1.5 and earlier nothing changes; there is no list to write there, and the library strips `authors` on the way out anyway.

**It applies to every component, not only the tools entry.** Package components carry the same deprecated field (`author` from npm/python/ruby metadata), and a document that used the current shape in one place and the deprecated one in another would be a stranger thing than either alone. Nested components are covered too.

**Decoding reads whichever of the two fields a document states.** Without that half, syft could no longer read an author back from *its own output* at the default version — and nothing would have said so: `TestSupportedVersions` does the encode/decode round trip against a fixture that has no author at all. It also means syft now reads authors from 1.6 documents produced by other tools, which it previously dropped.

**On splitting:** an author is carried across whole, as a single entry. Where syft has more than one author to describe, `encodeAuthor` joins them with a separator of the ecosystem's own choosing (`,` for ruby, whatever npm's author string contains), so splitting that back apart here would mean guessing at a convention that differs per ecosystem — and guessing wrong changes what the document claims. Only the `name <email>` form that `encodeAuthor` itself produces is split, into a name and an email. `componentAuthor` returns exactly what went in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

**Verification**

- `Test_ComponentAuthorByVersion` runs the encode/decode round trip over **every supported version** with a fixture that has an author, and asserts which field the document uses: `"author"` through 1.5, `"authors"` from 1.6, never both. Each half of the change was reverted independently — dropping the encoder half or the decoder half makes 1.6 and 1.7 fail while 1.2–1.5 stay green.
- `Test_ConvertComponentAuthors` covers each place a component can appear (tools, `metadata.component`, top-level and nested components), the `name <email>` form, authors that are already stated, components with no author, and a nil document; a round-trip case asserts `componentAuthor` reads back exactly what the conversion wrote.
- Ran `./syft/format/...` on the branch and on a pristine tree and compared the failure sets — identical, so nothing here newly fails.
- `golangci-lint run` reports nothing on any changed file.

**On the goldens:** the two directory goldens were regenerated with `-update-cyclonedx-json` / `-update-cyclonedx-xml`. The two image goldens need Docker to regenerate, which I do not have here, so the same one-field replacement was applied to them by hand — byte-identical to what regeneration produced in the directory goldens beside them. Each of the four changes by exactly that one field and nothing else, which the diff shows.

## Issue references

Fixes #4580

---

*Disclosure: written with AI assistance (the commit carries a `Co-Authored-By` trailer). Behaviour was checked against the encoder for every supported spec version, before and after, rather than reasoned about from the spec alone.*
