### PR TITLE
fix(java): use the OSGi Bundle-Name as the artifact ID

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/java_groupid_map.go
@@ -156,6 +156,7 @@ var DefaultArtifactIDToGroupID = map[string]string{
 	"tomcat-catalina-jmx-remote":                  "org.apache.tomcat",
 	"tomcat-catalina-ws":                          "org.apache.tomcat",
 	"tomcat-coyote":                               "org.apache.tomcat",
+	"tomcat-coyote-ffm":                           "org.apache.tomcat",
 	"tomcat-dbcp":                                 "org.apache.tomcat",
 	"tomcat-el-api":                               "org.apache.tomcat",
 	"tomcat-i18n-cs":                              "org.apache.tomcat",

--- a/syft/pkg/cataloger/java/parse_java_manifest.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest.go
@@ -145,6 +145,48 @@ func extractNameFromApacheMavenBundlePlugin(manifest *pkg.JavaManifest) string {
 	return ""
 }
 
+// extractNameFromOSGiBundleName returns the maven artifact ID declared by an OSGi bundle that was not
+// built with the Apache Maven Bundle Plugin. Projects that hand-write their OSGi headers set Bundle-Name
+// to the artifact ID and compose Bundle-SymbolicName as "<prefix><separator><artifact ID>". Apache Tomcat
+// does this for every jar it ships:
+//
+//	Bundle-Name:         tomcat-catalina
+//	Bundle-SymbolicName: org.apache.tomcat-catalina
+//
+// Bundle-Name on its own is not trustworthy, since it is often a human readable title (catalina.jar's
+// sibling tomcat-jdbc.jar uses "Apache Tomcat JDBC Connection Pool"), so only use it when the symbolic
+// name is built from it. When the two agree the manifest is a better source for the artifact ID than the
+// filename, which is frequently a shortened alias: catalina.jar is org.apache.tomcat:tomcat-catalina.
+func extractNameFromOSGiBundleName(manifest *pkg.JavaManifest) string {
+	if manifest == nil {
+		return ""
+	}
+
+	bundleName := manifest.Main.MustGet("Bundle-Name")
+	symbolicName := removeOSCIDirectives(manifest.Main.MustGet("Bundle-SymbolicName"))
+
+	if bundleName == "" || symbolicName == "" || bundleName == symbolicName {
+		return ""
+	}
+
+	// artifact IDs do not contain whitespace, but bundle titles do
+	if strings.ContainsFunc(bundleName, unicode.IsSpace) {
+		return ""
+	}
+
+	if !strings.HasSuffix(symbolicName, bundleName) {
+		return ""
+	}
+
+	// require a separator between the prefix and the artifact ID, otherwise this is a coincidental suffix
+	// match (Bundle-Name "log" against Bundle-SymbolicName "org.example.catalog")
+	if separator := symbolicName[len(symbolicName)-len(bundleName)-1]; separator != '.' && separator != '-' {
+		return ""
+	}
+
+	return bundleName
+}
+
 func extractNameFromArchiveFilename(a archiveFilename) string {
 	if strings.Contains(a.name, ".") {
 		// special case: this *might* be a group id + artifact id. By convention artifact ids do not have "." in them;
@@ -190,6 +232,11 @@ func isValidJavaIdentifier(field string) bool {
 
 func selectName(manifest *pkg.JavaManifest, filenameObj archiveFilename) string {
 	name := extractNameFromApacheMavenBundlePlugin(manifest)
+	if name != "" {
+		return name
+	}
+
+	name = extractNameFromOSGiBundleName(manifest)
 	if name != "" {
 		return name
 	}

--- a/syft/pkg/cataloger/java/parse_java_manifest_test.go
+++ b/syft/pkg/cataloger/java/parse_java_manifest_test.go
@@ -245,6 +245,53 @@ func TestSelectName(t *testing.T) {
 			expected: "atlassian-gadgets-api",
 		},
 		{
+			// example: pkg:maven/org.apache.tomcat/tomcat-catalina@10.1.54
+			desc: "Use the artifact ID from Bundle-Name when Bundle-SymbolicName is built from it",
+			manifest: pkg.JavaManifest{
+				Main: pkg.KeyValues{
+					{Key: "Bundle-Name", Value: "tomcat-catalina"},
+					{Key: "Bundle-SymbolicName", Value: "org.apache.tomcat-catalina"},
+					{Key: "Implementation-Title", Value: "Apache Tomcat"},
+				},
+			},
+			archive:  newJavaArchiveFilename("/usr/local/tomcat/lib/catalina.jar"),
+			expected: "tomcat-catalina",
+		},
+		{
+			desc: "A Bundle-Name that is a human readable title does not override the filename",
+			manifest: pkg.JavaManifest{
+				Main: pkg.KeyValues{
+					{Key: "Bundle-Name", Value: "Apache Tomcat JDBC Connection Pool"},
+					{Key: "Bundle-SymbolicName", Value: "org.apache.tomcat.jdbc"},
+					{Key: "Implementation-Title", Value: "Apache Tomcat"},
+				},
+			},
+			archive:  newJavaArchiveFilename("/usr/local/tomcat/lib/tomcat-jdbc.jar"),
+			expected: "tomcat-jdbc",
+		},
+		{
+			desc: "A coincidental Bundle-Name suffix does not override the filename",
+			manifest: pkg.JavaManifest{
+				Main: pkg.KeyValues{
+					{Key: "Bundle-Name", Value: "log"},
+					{Key: "Bundle-SymbolicName", Value: "org.example.catalog"},
+				},
+			},
+			archive:  newJavaArchiveFilename("/something/catalog.jar"),
+			expected: "catalog",
+		},
+		{
+			desc: "A Bundle-Name equal to Bundle-SymbolicName does not override the filename",
+			manifest: pkg.JavaManifest{
+				Main: pkg.KeyValues{
+					{Key: "Bundle-Name", Value: "org.example.foo"},
+					{Key: "Bundle-SymbolicName", Value: "org.example.foo"},
+				},
+			},
+			archive:  newJavaArchiveFilename("/something/foo-1.0.jar"),
+			expected: "foo",
+		},
+		{
 			// example: pkg:maven/org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-beans@5.3.26_1
 			desc: "Apache Maven Bundle Plugin might bake a version in the created-by field",
 			manifest: pkg.JavaManifest{


### PR DESCRIPTION
## Description

Tomcat hand-writes the OSGi headers for every jar it ships and includes no pom, so syft names those jars from the filename. `catalina.jar` comes out as `pkg:maven/org.apache.tomcat-catalina/catalina@10.1.54` when the published artifact is `org.apache.tomcat:tomcat-catalina`, and nothing is published under the former, so a stock Tomcat install matches no advisories at all.

The artifact ID is already in the manifest as `Bundle-Name`. That field is often a human readable title rather than an ID, so this only prefers it over the filename when `Bundle-SymbolicName` is composed from it. In the same directory `tomcat-jdbc.jar` ("Apache Tomcat JDBC Connection Pool") and `ecj-4.27.jar` ("Eclipse Compiler for Java(TM)") both fail that check and keep the names they get today.

```
# before
pkg:maven/org.apache.tomcat-catalina/catalina@10.1.54
# after
pkg:maven/org.apache.tomcat/tomcat-catalina@10.1.54
```

15 of the 35 jars in `apache-tomcat-10.1.54/lib` get corrected coordinates and all 15 resolve on Maven Central under `org.apache.tomcat`. Scanning the before and after SBOMs with grype v0.117.0 goes from 0 matches to 7 on 10.1.54 (3 critical, 3 high, 1 low, all on tomcat-catalina) and from 4 to 17 on both 9.0.111 and 11.0.13. Every new match is an exact-direct-match against a GHSA advisory for that artifact rather than CPE over-matching, and no existing match is lost. The group ID table already had the corrected names except `tomcat-coyote-ffm`, which is added here. I also ran a before/after over 39 jars pulled from Maven Central (spring, jetty, felix, eclipse platform, servicemix, cxf, camel, activemq, jackson, netty and others) and no purls changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4097

Also the cause of https://github.com/anchore/grype/issues/3491, and the reason #4953 could not work on its own: the group ID mapping was already correct, but the artifact ID was still coming from the filename.
