### PR TITLE
fix(javascript): pass a yaml node to the pnpm v5 collision test

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
@@ -654,18 +654,18 @@ packages:
 	}
 
 	// v5 lockfile with two entries that collapse to the same key (underscore peer-dep suffixes)
-	lockfileV5 := []byte(`
+	lockfileV5 := `
 lockfileVersion: 5.4
 packages:
   /some-pkg/1.0.0_peer-b@2.0.0:
     resolution: {integrity: sha512-BBB}
   /some-pkg/1.0.0_peer-a@1.0.0:
     resolution: {integrity: sha512-AAA}
-`)
+`
 
 	for range 10 {
 		parser := &pnpmV6LockYaml{}
-		pkgs, err := parser.Parse(5.4, lockfileV5)
+		pkgs, err := parser.Parse(5.4, yamlDocument(t, lockfileV5))
 		require.NoError(t, err)
 		require.Len(t, pkgs, 1, "expected exactly one package after key collision")
 


### PR DESCRIPTION
#5188 changed `pnpmV6LockYaml.Parse` to take a `*yaml.Node` and #5175 added this test against the old `[]byte` signature. both were green on their own branches, so main does not compile.

the v9 and v6 cases in the same test already go through the `yamlDocument` helper, this is just the v5 one that was missed.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections