### PR TITLE
fix(dotnet): resolve packages.lock dependencies deterministically 

### DIFF
--- a/syft/pkg/cataloger/dotnet/parse_packages_lock.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 
+	"github.com/anchore/go-version"
 	"github.com/anchore/packageurl-go"
 	"github.com/anchore/syft/internal/log"
 	"github.com/anchore/syft/internal/relationship"
@@ -76,36 +78,43 @@ func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Envi
 		}
 	}
 
-	// fill up relationships
-	for depNameVersion, dep := range allDependencies {
-		parentPkg, ok := pkgMap[depNameVersion]
-		if !ok {
-			log.Debugf("package \"%s\" not found in map of all packages", depNameVersion)
-			continue
-		}
+	// fill up relationships, resolving each dependency within its own target framework so that
+	// lockfiles pinning multiple versions of the same package resolve to the correct one
+	seen := make(map[string]struct{})
+	for _, targetFramework := range slices.Sorted(maps.Keys(lockFile.Dependencies)) {
+		frameworkDeps := lockFile.Dependencies[targetFramework]
 
-		for childDepName, childDepVersion := range dep.Dependencies {
-			childDepNameVersion := createNameAndVersion(childDepName, childDepVersion)
+		for _, name := range slices.Sorted(maps.Keys(frameworkDeps)) {
+			dep := frameworkDeps[name]
+			depNameVersion := createNameAndVersion(name, dep.Resolved)
 
-			// try and find pkg for dependency with exact name and version
-			childPkg, ok := pkgMap[childDepNameVersion]
+			parentPkg, ok := pkgMap[depNameVersion]
 			if !ok {
-				// no exact match found, lets match on name only, lockfile will contain other version of pkg
-				cpkg, ok := findPkgByName(childDepName, pkgMap)
+				log.Debugf("package \"%s\" not found in map of all packages", depNameVersion)
+				continue
+			}
+
+			for _, childDepName := range slices.Sorted(maps.Keys(dep.Dependencies)) {
+				childDepVersion := dep.Dependencies[childDepName]
+
+				childPkg, ok := findDependencyPkg(childDepName, childDepVersion, frameworkDeps, pkgMap)
 				if !ok {
-					log.Debugf("dependency \"%s\" of package \"%s\" not found in map of all packages", childDepNameVersion, depNameVersion)
+					log.Debugf("dependency \"%s\" of package \"%s\" not found in map of all packages", createNameAndVersion(childDepName, childDepVersion), depNameVersion)
 					continue
 				}
 
-				childPkg = *cpkg
-			}
+				key := string(childPkg.ID()) + string(parentPkg.ID())
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
 
-			rel := artifact.Relationship{
-				From: childPkg,
-				To:   parentPkg,
-				Type: artifact.DependencyOfRelationship,
+				relationships = append(relationships, artifact.Relationship{
+					From: *childPkg,
+					To:   parentPkg,
+					Type: artifact.DependencyOfRelationship,
+				})
 			}
-			relationships = append(relationships, rel)
 		}
 	}
 
@@ -151,13 +160,52 @@ func packagesLockPackageURL(name, version string) string {
 	).ToString()
 }
 
-func findPkgByName(pkgName string, pkgMap map[string]pkg.Package) (*pkg.Package, bool) {
-	for pkgNameVersion, pkg := range pkgMap {
-		name, _ := extractNameAndVersion(pkgNameVersion)
-		if name == pkgName {
-			return &pkg, true
+// findDependencyPkg resolves a declared dependency to a package, preferring the version resolved within the
+// same target framework, since the declared version is only a lower bound and the same package may be resolved
+// to different versions across target frameworks.
+func findDependencyPkg(name, declaredVersion string, frameworkDeps map[string]dotnetPackagesLockDep, pkgMap map[string]pkg.Package) (*pkg.Package, bool) {
+	if dep, ok := frameworkDeps[name]; ok {
+		if p, ok := pkgMap[createNameAndVersion(name, dep.Resolved)]; ok {
+			return &p, true
 		}
 	}
 
-	return nil, false
+	if p, ok := pkgMap[createNameAndVersion(name, declaredVersion)]; ok {
+		return &p, true
+	}
+
+	return findPkgByName(name, pkgMap)
+}
+
+// findPkgByName returns the lowest-versioned package matching the given name, which is the version NuGet would
+// select for a lower-bound requirement. Candidates are sorted so that the result is deterministic.
+func findPkgByName(pkgName string, pkgMap map[string]pkg.Package) (*pkg.Package, bool) {
+	var candidates []string
+	for pkgNameVersion := range pkgMap {
+		name, _ := extractNameAndVersion(pkgNameVersion)
+		if name == pkgName {
+			candidates = append(candidates, pkgNameVersion)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil, false
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		_, vi := extractNameAndVersion(candidates[i])
+		_, vj := extractNameAndVersion(candidates[j])
+
+		si, erri := version.NewVersion(vi)
+		sj, errj := version.NewVersion(vj)
+		if erri == nil && errj == nil && !si.Equal(sj) {
+			return si.LessThan(sj)
+		}
+
+		return candidates[i] < candidates[j]
+	})
+
+	p := pkgMap[candidates[0]]
+
+	return &p, true
 }

--- a/syft/pkg/cataloger/dotnet/parse_packages_lock.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock.go
@@ -20,6 +20,9 @@ import (
 
 var _ generic.Parser = parseDotnetPackagesLock
 
+// directDependencyType is the "type" NuGet writes for a package the project references directly.
+const directDependencyType = "Direct"
+
 type dotnetPackagesLock struct {
 	Version      int                                         `json:"version"`
 	Dependencies map[string]map[string]dotnetPackagesLockDep `json:"dependencies"`
@@ -33,11 +36,7 @@ type dotnetPackagesLockDep struct {
 	Dependencies map[string]string `json:"dependencies,omitempty"`
 }
 
-func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) { //nolint:funlen
-	var pkgs []pkg.Package
-	var pkgMap = make(map[string]pkg.Package)
-	var relationships []artifact.Relationship
-
+func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	dec := json.NewDecoder(reader)
 
 	// unmarshal file
@@ -46,27 +45,12 @@ func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Envi
 		return nil, nil, fmt.Errorf("failed to parse packages.lock.json file: %w", err)
 	}
 
-	// collect all deps here
-	allDependencies := make(map[string]dotnetPackagesLockDep)
-
-	var names []string
-	for _, dependencies := range lockFile.Dependencies {
-		for name, dep := range dependencies {
-			depNameVersion := createNameAndVersion(name, dep.Resolved)
-
-			if slices.Contains(names, depNameVersion) {
-				continue
-			}
-
-			names = append(names, depNameVersion)
-			allDependencies[depNameVersion] = dep
-		}
-	}
-
-	// sort the names so that the order of the packages is deterministic
-	sort.Strings(names)
+	names, allDependencies := collectPackagesLockDeps(lockFile)
 
 	// create artifact for each pkg
+	var pkgs []pkg.Package
+	pkgMap := make(map[string]pkg.Package)
+
 	for _, nameVersion := range names {
 		name, _ := extractNameAndVersion(nameVersion)
 
@@ -78,8 +62,49 @@ func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Envi
 		}
 	}
 
-	// fill up relationships, resolving each dependency within its own target framework so that
-	// lockfiles pinning multiple versions of the same package resolve to the correct one
+	relationships := packagesLockRelationships(lockFile, pkgMap)
+
+	// sort the relationships for deterministic output
+	relationship.Sort(relationships)
+
+	return pkgs, relationships, nil
+}
+
+// collectPackagesLockDeps flattens the per-target-framework entries into one entry per name and version, returning
+// the sorted keys alongside the entries so that package order is deterministic. A package may appear under several
+// target frameworks, and "Direct" wins when it does: some target framework references the package directly.
+func collectPackagesLockDeps(lockFile dotnetPackagesLock) ([]string, map[string]dotnetPackagesLockDep) {
+	allDependencies := make(map[string]dotnetPackagesLockDep)
+
+	var names []string
+	for _, targetFramework := range slices.Sorted(maps.Keys(lockFile.Dependencies)) {
+		for _, name := range slices.Sorted(maps.Keys(lockFile.Dependencies[targetFramework])) {
+			dep := lockFile.Dependencies[targetFramework][name]
+			depNameVersion := createNameAndVersion(name, dep.Resolved)
+
+			if existing, ok := allDependencies[depNameVersion]; ok {
+				if existing.Type != directDependencyType && dep.Type == directDependencyType {
+					allDependencies[depNameVersion] = dep
+				}
+				continue
+			}
+
+			names = append(names, depNameVersion)
+			allDependencies[depNameVersion] = dep
+		}
+	}
+
+	// sort the names so that the order of the packages is deterministic
+	sort.Strings(names)
+
+	return names, allDependencies
+}
+
+// packagesLockRelationships resolves each dependency within its own target framework so that lockfiles pinning
+// multiple versions of the same package resolve to the correct one.
+func packagesLockRelationships(lockFile dotnetPackagesLock, pkgMap map[string]pkg.Package) []artifact.Relationship {
+	var relationships []artifact.Relationship
+
 	seen := make(map[string]struct{})
 	for _, targetFramework := range slices.Sorted(maps.Keys(lockFile.Dependencies)) {
 		frameworkDeps := lockFile.Dependencies[targetFramework]
@@ -94,34 +119,41 @@ func parseDotnetPackagesLock(_ context.Context, _ file.Resolver, _ *generic.Envi
 				continue
 			}
 
-			for _, childDepName := range slices.Sorted(maps.Keys(dep.Dependencies)) {
-				childDepVersion := dep.Dependencies[childDepName]
-
-				childPkg, ok := findDependencyPkg(childDepName, childDepVersion, frameworkDeps, pkgMap)
-				if !ok {
-					log.Debugf("dependency \"%s\" of package \"%s\" not found in map of all packages", createNameAndVersion(childDepName, childDepVersion), depNameVersion)
-					continue
-				}
-
-				key := string(childPkg.ID()) + string(parentPkg.ID())
-				if _, exists := seen[key]; exists {
-					continue
-				}
-				seen[key] = struct{}{}
-
-				relationships = append(relationships, artifact.Relationship{
-					From: *childPkg,
-					To:   parentPkg,
-					Type: artifact.DependencyOfRelationship,
-				})
-			}
+			relationships = append(relationships, packagesLockDepRelationships(dep, parentPkg, depNameVersion, frameworkDeps, pkgMap, seen)...)
 		}
 	}
 
-	// sort the relationships for deterministic output
-	relationship.Sort(relationships)
+	return relationships
+}
 
-	return pkgs, relationships, nil
+// packagesLockDepRelationships returns the edges declared by a single package under one target framework, skipping
+// any edge already recorded in seen -- frameworks that resolve to the same versions would otherwise repeat it.
+func packagesLockDepRelationships(dep dotnetPackagesLockDep, parentPkg pkg.Package, depNameVersion string, frameworkDeps map[string]dotnetPackagesLockDep, pkgMap map[string]pkg.Package, seen map[string]struct{}) []artifact.Relationship {
+	var relationships []artifact.Relationship
+
+	for _, childDepName := range slices.Sorted(maps.Keys(dep.Dependencies)) {
+		childDepVersion := dep.Dependencies[childDepName]
+
+		childPkg, ok := findDependencyPkg(childDepName, childDepVersion, frameworkDeps, pkgMap)
+		if !ok {
+			log.Debugf("dependency \"%s\" of package \"%s\" not found in map of all packages", createNameAndVersion(childDepName, childDepVersion), depNameVersion)
+			continue
+		}
+
+		key := string(childPkg.ID()) + string(parentPkg.ID())
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		relationships = append(relationships, artifact.Relationship{
+			From: *childPkg,
+			To:   parentPkg,
+			Type: artifact.DependencyOfRelationship,
+		})
+	}
+
+	return relationships
 }
 
 func newDotnetPackagesLockPackage(name string, dep dotnetPackagesLockDep, locations ...file.Location) *pkg.Package {
@@ -160,9 +192,8 @@ func packagesLockPackageURL(name, version string) string {
 	).ToString()
 }
 
-// findDependencyPkg resolves a declared dependency to a package, preferring the version resolved within the
-// same target framework, since the declared version is only a lower bound and the same package may be resolved
-// to different versions across target frameworks.
+// findDependencyPkg finds the package a dependency points at. The version of a dependency edge is the lower bound
+// of a version range, not a pin, so prefer whatever version this target framework actually resolved to.
 func findDependencyPkg(name, declaredVersion string, frameworkDeps map[string]dotnetPackagesLockDep, pkgMap map[string]pkg.Package) (*pkg.Package, bool) {
 	if dep, ok := frameworkDeps[name]; ok {
 		if p, ok := pkgMap[createNameAndVersion(name, dep.Resolved)]; ok {
@@ -177,8 +208,8 @@ func findDependencyPkg(name, declaredVersion string, frameworkDeps map[string]do
 	return findPkgByName(name, pkgMap)
 }
 
-// findPkgByName returns the lowest-versioned package matching the given name, which is the version NuGet would
-// select for a lower-bound requirement. Candidates are sorted so that the result is deterministic.
+// findPkgByName returns the lowest-versioned package with the given name. This is a last-resort fallback for
+// lockfiles where a dependency edge names a package that is absent from its own target framework
 func findPkgByName(pkgName string, pkgMap map[string]pkg.Package) (*pkg.Package, bool) {
 	var candidates []string
 	for pkgNameVersion := range pkgMap {
@@ -192,13 +223,19 @@ func findPkgByName(pkgName string, pkgMap map[string]pkg.Package) (*pkg.Package,
 		return nil, false
 	}
 
+	// versions that don't parse sort after those that do
 	sort.Slice(candidates, func(i, j int) bool {
 		_, vi := extractNameAndVersion(candidates[i])
 		_, vj := extractNameAndVersion(candidates[j])
 
 		si, erri := version.NewVersion(vi)
 		sj, errj := version.NewVersion(vj)
-		if erri == nil && errj == nil && !si.Equal(sj) {
+
+		if (erri == nil) != (errj == nil) {
+			return erri == nil
+		}
+
+		if erri == nil && !si.Equal(sj) {
 			return si.LessThan(sj)
 		}
 

--- a/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
@@ -197,3 +197,75 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 
 	pkgtest.TestFileParser(t, fixture, parseDotnetPackagesLock, expectedPkgs, expectedRelationships)
 }
+
+func TestParseDotnetPackagesLock_multipleTargetFrameworks(t *testing.T) {
+	fixture := "testdata/packages.lock-multi-framework.json"
+	fixtureLocationSet := file.NewLocationSet(file.NewLocation(fixture))
+
+	myLibPkg := pkg.Package{
+		Name:      "MyLib",
+		Version:   "1.0.0",
+		PURL:      "pkg:nuget/MyLib@1.0.0",
+		Locations: fixtureLocationSet,
+		Language:  pkg.Dotnet,
+		Type:      pkg.DotnetPkg,
+		Metadata: pkg.DotnetPackagesLockEntry{
+			Name:        "MyLib",
+			Version:     "1.0.0",
+			ContentHash: "mylibhash==",
+			Type:        "Direct",
+		},
+	}
+
+	log4net2Pkg := pkg.Package{
+		Name:      "log4net",
+		Version:   "2.0.5",
+		PURL:      "pkg:nuget/log4net@2.0.5",
+		Locations: fixtureLocationSet,
+		Language:  pkg.Dotnet,
+		Type:      pkg.DotnetPkg,
+		Metadata: pkg.DotnetPackagesLockEntry{
+			Name:        "log4net",
+			Version:     "2.0.5",
+			ContentHash: "log4net205hash==",
+			Type:        "Transitive",
+		},
+	}
+
+	log4net1Pkg := pkg.Package{
+		Name:      "log4net",
+		Version:   "1.2.15",
+		PURL:      "pkg:nuget/log4net@1.2.15",
+		Locations: fixtureLocationSet,
+		Language:  pkg.Dotnet,
+		Type:      pkg.DotnetPkg,
+		Metadata: pkg.DotnetPackagesLockEntry{
+			Name:        "log4net",
+			Version:     "1.2.15",
+			ContentHash: "log4net1215hash==",
+			Type:        "Transitive",
+		},
+	}
+
+	expectedPkgs := []pkg.Package{
+		myLibPkg,
+		log4net1Pkg,
+		log4net2Pkg,
+	}
+
+	// the same package is resolved to a different version per target framework, so both edges must be captured
+	expectedRelationships := []artifact.Relationship{
+		{
+			From: log4net1Pkg,
+			To:   myLibPkg,
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: log4net2Pkg,
+			To:   myLibPkg,
+			Type: artifact.DependencyOfRelationship,
+		},
+	}
+
+	pkgtest.TestFileParser(t, fixture, parseDotnetPackagesLock, expectedPkgs, expectedRelationships)
+}

--- a/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
@@ -247,8 +247,25 @@ func TestParseDotnetPackagesLock_multipleTargetFrameworks(t *testing.T) {
 		},
 	}
 
+	// resolved to the same version under both frameworks, but declared "Direct" by only one of them
+	newtonsoftPkg := pkg.Package{
+		Name:      "Newtonsoft.Json",
+		Version:   "13.0.3",
+		PURL:      "pkg:nuget/Newtonsoft.Json@13.0.3",
+		Locations: fixtureLocationSet,
+		Language:  pkg.Dotnet,
+		Type:      pkg.DotnetPkg,
+		Metadata: pkg.DotnetPackagesLockEntry{
+			Name:        "Newtonsoft.Json",
+			Version:     "13.0.3",
+			ContentHash: "newtonsoft1303hash==",
+			Type:        "Direct",
+		},
+	}
+
 	expectedPkgs := []pkg.Package{
 		myLibPkg,
+		newtonsoftPkg,
 		log4net1Pkg,
 		log4net2Pkg,
 	}
@@ -262,6 +279,11 @@ func TestParseDotnetPackagesLock_multipleTargetFrameworks(t *testing.T) {
 		},
 		{
 			From: log4net2Pkg,
+			To:   myLibPkg,
+			Type: artifact.DependencyOfRelationship,
+		},
+		{
+			From: newtonsoftPkg,
 			To:   myLibPkg,
 			Type: artifact.DependencyOfRelationship,
 		},

--- a/syft/pkg/cataloger/dotnet/testdata/packages.lock-multi-framework.json
+++ b/syft/pkg/cataloger/dotnet/testdata/packages.lock-multi-framework.json
@@ -1,0 +1,37 @@
+{
+    "version": 1,
+    "dependencies": {
+        "net8.0": {
+            "MyLib": {
+                "type": "Direct",
+                "requested": "[1.0.0, )",
+                "resolved": "1.0.0",
+                "contentHash": "mylibhash==",
+                "dependencies": {
+                    "log4net": "2.0.5"
+                }
+            },
+            "log4net": {
+                "type": "Transitive",
+                "resolved": "2.0.5",
+                "contentHash": "log4net205hash=="
+            }
+        },
+        "netstandard2.0": {
+            "MyLib": {
+                "type": "Direct",
+                "requested": "[1.0.0, )",
+                "resolved": "1.0.0",
+                "contentHash": "mylibhash==",
+                "dependencies": {
+                    "log4net": "1.2.15"
+                }
+            },
+            "log4net": {
+                "type": "Transitive",
+                "resolved": "1.2.15",
+                "contentHash": "log4net1215hash=="
+            }
+        }
+    }
+}

--- a/syft/pkg/cataloger/dotnet/testdata/packages.lock-multi-framework.json
+++ b/syft/pkg/cataloger/dotnet/testdata/packages.lock-multi-framework.json
@@ -15,6 +15,12 @@
                 "type": "Transitive",
                 "resolved": "2.0.5",
                 "contentHash": "log4net205hash=="
+            },
+            "Newtonsoft.Json": {
+                "type": "Direct",
+                "requested": "[13.0.3, )",
+                "resolved": "13.0.3",
+                "contentHash": "newtonsoft1303hash=="
             }
         },
         "netstandard2.0": {
@@ -24,13 +30,19 @@
                 "resolved": "1.0.0",
                 "contentHash": "mylibhash==",
                 "dependencies": {
-                    "log4net": "1.2.15"
+                    "log4net": "1.2.15",
+                    "Newtonsoft.Json": "13.0.3"
                 }
             },
             "log4net": {
                 "type": "Transitive",
                 "resolved": "1.2.15",
                 "contentHash": "log4net1215hash=="
+            },
+            "Newtonsoft.Json": {
+                "type": "Transitive",
+                "resolved": "13.0.3",
+                "contentHash": "newtonsoft1303hash=="
             }
         }
     }


### PR DESCRIPTION
## Description

Follow-up to #5143.  See https://github.com/anchore/syft/issues/5211 for more details.

While reviewing that fix I saw that the `packages.lock.json` parser resolves dependency edges against a global map of every package in the lockfile.

This resolution would ignore which target framework the edge was declared in.

Multi-targeted projects routinely resolve the same package to different versions per framework. Because the old code looked up the declared version globally and, on a miss, fell back to "any package with this name" via non-deterministic map iteration, edges could point at the wrong version or flip between runs.

Given a lockfile that pins `log4net` to `2.0.5` under `net8.0` and `1.2.15` under `netstandard2.0`:

### Before
Dependency edges were resolved from the global package map. The `netstandard2.0` edge (`log4net 1.2.15`) matched exactly, but a package could fall through to `findPkgByName`, which returned whichever name match Go's map iteration happened to yield first.  

### After
Each edge resolves within its declaring framework, so `net8.0` → `log4net 2.0.5` and `netstandard2.0` → `log4net 1.2.15` happens deterministically.

Changes:
- Sort framework, package, and dependency keys so relationship ordering is stable.
- Deduplicate relationships by (child, parent) package ID, since frameworks that resolve to the same versions would otherwise emit the same edge more than once.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Found during review of #5143