### PR TITLE
fix: don't suppress binaries owned by unrelated OS packages

### DIFF
--- a/internal/relationship/exclude_binaries_by_file_ownership_overlap.go
+++ b/internal/relationship/exclude_binaries_by_file_ownership_overlap.go
@@ -3,6 +3,7 @@ package relationship
 import (
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
@@ -31,6 +32,26 @@ var (
 		reflect.TypeFor[pkg.JavaVMInstallation]().Name(),
 	}
 )
+
+// osPackageShipsBinary reports whether an OS package name plausibly ships the
+// given binary. Package names commonly embed the upstream name with prefixes
+// and suffixes ("libopenssl3", "openssl-3.2.3-150700.1.1", "golang-go"), so an
+// exact match is not required; very short binary names only match exactly, to
+// avoid suppressing on incidental substrings.
+func osPackageShipsBinary(pkgName, binaryName string) bool {
+	p := strings.ToLower(pkgName)
+	b := strings.ToLower(binaryName)
+
+	if p == b {
+		return true
+	}
+
+	if len(b) < 3 {
+		return false
+	}
+
+	return strings.Contains(p, b)
+}
 
 func ExcludeBinariesByFileOwnershipOverlap(accessor sbomsync.Accessor) {
 	accessor.WriteToSBOM(func(s *sbom.SBOM) {
@@ -118,6 +139,16 @@ func identifyOverlappingOSRelationship(parent *pkg.Package, child *pkg.Package) 
 	}
 
 	if slices.Contains(binaryCatalogerTypes, child.Type) {
+		// The overlap only means the OS package ships this binary when the
+		// package plausibly relates to it. An unrelated owner (e.g. a vendor
+		// RPM bundling its own copy of a library, with none of the library's
+		// metadata) must not suppress the binary finding — otherwise the
+		// binary's vulnerabilities go entirely unreported
+		// (https://github.com/anchore/grype/issues/3670).
+		if !osPackageShipsBinary(parent.Name, child.Name) {
+			return ""
+		}
+
 		return child.ID()
 	}
 

--- a/internal/relationship/exclude_binaries_by_file_ownership_overlap_test.go
+++ b/internal/relationship/exclude_binaries_by_file_ownership_overlap_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 func TestExcludeByFileOwnershipOverlap(t *testing.T) {
-	packageA := pkg.Package{Name: "package-a", Type: pkg.ApkPkg}
+	packageA := pkg.Package{Name: "libopenssl3", Type: pkg.ApkPkg}
 	packageB := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg, Metadata: pkg.JavaVMInstallation{}}
-	packageC := pkg.Package{Name: "package-c", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{Type: "rpm"}}
+	packageC := pkg.Package{Name: "openssl", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{Type: "rpm"}}
 	packageD := pkg.Package{Name: "package-d", Type: pkg.BitnamiPkg}
-	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD} {
+	packageE := pkg.Package{Name: "vendor-product", Type: pkg.RpmPkg}
+	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE} {
 		p.SetID()
 	}
 
@@ -34,6 +35,19 @@ func TestExcludeByFileOwnershipOverlap(t *testing.T) {
 			},
 			packages:      pkg.NewCollection(packageA, packageC),
 			shouldExclude: true,
+		},
+		{
+			// prove that an OS package unrelated to the binary does NOT exclude it
+			// (a vendor RPM bundling its own copy of a library must not hide the
+			// binary's vulnerabilities: https://github.com/anchore/grype/issues/3670)
+			name: "no exclusion from unrelated os pkg -> elf binary",
+			relationship: artifact.Relationship{
+				Type: artifact.OwnershipByFileOverlapRelationship,
+				From: packageE, // unrelated RPM
+				To:   packageC, // ELF binary
+			},
+			packages:      pkg.NewCollection(packageE, packageC),
+			shouldExclude: false,
 		},
 		{
 			// prove that bin -> JVM exclusions are wired
@@ -72,13 +86,15 @@ func TestExcludeByFileOwnershipOverlap(t *testing.T) {
 }
 
 func TestIdentifyOverlappingOSRelationship(t *testing.T) {
-	packageA := pkg.Package{Name: "package-a", Type: pkg.ApkPkg} // OS package
-	packageB := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg}
-	packageC := pkg.Package{Name: "package-c", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
+	packageA := pkg.Package{Name: "libopenssl3", Type: pkg.ApkPkg} // OS package shipping the binary
+	packageB := pkg.Package{Name: "openssl", Type: pkg.BinaryPkg}
+	packageC := pkg.Package{Name: "openssl", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
 	packageD := pkg.Package{Name: "package-d", Type: pkg.PythonPkg} // Language package
-	packageE := pkg.Package{Name: "package-e", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
+	packageE := pkg.Package{Name: "openssl", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
+	packageF := pkg.Package{Name: "vendor-product", Type: pkg.RpmPkg} // unrelated OS owner
+	packageG := pkg.Package{Name: "gc", Type: pkg.BinaryPkg}          // very short binary name
 
-	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE} {
+	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE, &packageF, &packageG} {
 		p.SetID()
 	}
 
@@ -92,13 +108,13 @@ func TestIdentifyOverlappingOSRelationship(t *testing.T) {
 			name:       "OS -> binary without metadata",
 			parent:     &packageA,
 			child:      &packageB,
-			expectedID: packageB.ID(), // OS package to binary package, should return child ID
+			expectedID: packageB.ID(), // OS package shipping the binary, should return child ID
 		},
 		{
 			name:       "OS -> binary with binary metadata",
 			parent:     &packageA,
 			child:      &packageC,
-			expectedID: packageC.ID(), // OS package to binary package with binary metadata, should return child ID
+			expectedID: packageC.ID(), // OS package shipping the binary with binary metadata, should return child ID
 		},
 		{
 			name:       "OS -> non-binary package",
@@ -110,13 +126,26 @@ func TestIdentifyOverlappingOSRelationship(t *testing.T) {
 			name:       "OS -> binary with ELF metadata",
 			parent:     &packageA,
 			child:      &packageE,
-			expectedID: packageE.ID(), // OS package to binary package with ELF metadata, should return child ID
+			expectedID: packageE.ID(), // OS package shipping the binary with ELF metadata, should return child ID
 		},
 		{
 			name:       "non-OS parent",
 			parent:     &packageD, // non-OS package
 			child:      &packageC,
 			expectedID: "", // non-OS parent, no exclusion
+		},
+		{
+			// https://github.com/anchore/grype/issues/3670
+			name:       "unrelated OS owner does not exclude the binary",
+			parent:     &packageF,
+			child:      &packageB,
+			expectedID: "", // vendor RPM bundling its own copy must not suppress the finding
+		},
+		{
+			name:       "very short binary name only matches exactly",
+			parent:     &packageF, // "vendor-product" contains no "gc"
+			child:      &packageG,
+			expectedID: "",
 		},
 	}
 


### PR DESCRIPTION
## What?

`exclude-binary-overlap-by-ownership: true` (the default) suppresses a binary finding when **any** OS package owns the file — even when the owning package is completely unrelated to the binary and carries none of its metadata. In grype this silently drops critical CVEs: a vendor RPM bundling its own OpenSSL 3.5.0 owns `/opt/VendorProduct/bin/openssl`, the unrelated `vendor-product` RPM suppresses the binary finding, and CVE-2025-15467 goes unreported with no warning anywhere (https://github.com/anchore/grype/issues/3670).

Fixes the syft side of https://github.com/anchore/grype/issues/3670

## Why?

`identifyOverlappingOSRelationship` excluded the child binary package purely on `parent.Type ∈ OS types` — no relation between the *names* of the owning package and the detected binary was ever considered. The exclusion exists to deduplicate a binary against the distro package that legitimately ships it (#931); applied to an unrelated owner it doesn't deduplicate anything, it just hides the only package record that knew the vendored library's identity and version.

## How?

Gate the OS→binary exclusion on the owning package plausibly shipping the binary: `osPackageShipsBinary(pkgName, binaryName)` — exact match always qualifies; otherwise the binary name (case-insensitive) must appear in the package name, which covers the common shapes (`libopenssl3`, `openssl-3.2.3-150700.1.1`, `golang-go`); binary names shorter than 3 characters only match exactly, so incidental substrings can't suppress anything.

- related owner (the original #931 dedupe intent): unchanged — the binary is still excluded;
- unrelated owner: the binary finding is kept, so grype can match its CVEs;
- JVM and Bitnami overlap paths: untouched.

## Testing

The existing fixtures used unrelated placeholder names (`package-a` owning `package-c`), which under the gate correctly no longer exclude — they now use realistic related names (`libopenssl3` → `openssl`). New cases:

- `unrelated OS owner does not exclude the binary` (the #3670 shape: `vendor-product` RPM → `openssl` binary);
- `very short binary name only matches exactly`.

**Differential**: on `main` the unrelated-owner case fails — the binary is excluded, exactly the reported silent suppression. With this change the whole `internal/relationship` suite passes (`go test ./internal/relationship/`, full package, 1.6s).