### PR TITLE
fix(elixir): use Hex package names from mix.lock

### DIFF
--- a/syft/pkg/cataloger/elixir/cataloger_test.go
+++ b/syft/pkg/cataloger/elixir/cataloger_test.go
@@ -42,3 +42,14 @@ func TestCataloger_Relationships(t *testing.T) {
 		ExpectsRelationshipStrings(expectedRelationships).
 		TestCataloger(t, NewMixLockCataloger())
 }
+
+func TestCataloger_RelationshipsWithHexAlias(t *testing.T) {
+	expectedRelationships := []string{
+		"jason @ 1.3.0 (mix.lock) [dependency-of] consumer @ 1.0.0 (mix.lock)",
+	}
+
+	pkgtest.NewCatalogTester().
+		FromDirectory(t, "testdata/relationships-alias").
+		ExpectsRelationshipStrings(expectedRelationships).
+		TestCataloger(t, NewMixLockCataloger())
+}

--- a/syft/pkg/cataloger/elixir/dependency_test.go
+++ b/syft/pkg/cataloger/elixir/dependency_test.go
@@ -31,6 +31,11 @@ func Test_extractMixLockDependencies(t *testing.T) {
 			want: []string{"cowlib", "ranch"},
 		},
 		{
+			name: "aliased hex dependency",
+			line: `  "consumer": {:hex, :consumer, "1.0.0", "hash", [:mix], [{:my_json, "~> 1.3", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "ext"},`,
+			want: []string{"jason"},
+		},
+		{
 			name: "git source is skipped like hex source",
 			line: `  "mydep": {:git, "https://github.com/example/mydep.git", "ref", [{:jason, "~> 1.0", [hex: :jason]}]},`,
 			want: []string{"jason"},

--- a/syft/pkg/cataloger/elixir/parse_mix_lock.go
+++ b/syft/pkg/cataloger/elixir/parse_mix_lock.go
@@ -19,7 +19,7 @@ import (
 // integrity check
 var _ generic.Parser = parseMixLock
 
-var mixLockDelimiter = regexp.MustCompile(`[%{}\n" ,:]+`)
+var mixLockDelimiter = regexp.MustCompile(`[%{}\r\n" ,:]+`)
 
 // mixLockDependency matches each `{:name, ...` tuple on a mix.lock line. The
 // first match is the entry's own source tuple (e.g. `{:hex, :name, ...}`); the
@@ -122,6 +122,7 @@ func extractMixLockDependencies(line string) []string {
 	deps := make([]string, 0, len(matches)-1)
 	for _, m := range matches[1:] {
 		name := m[1]
+		// This rewrite is only meaningful when the dependency tuple targets a hex package.
 		if hexPackage := mixLockHexPackage.FindStringSubmatch(m[2]); len(hexPackage) == 2 {
 			name = hexPackage[1]
 		}

--- a/syft/pkg/cataloger/elixir/parse_mix_lock.go
+++ b/syft/pkg/cataloger/elixir/parse_mix_lock.go
@@ -21,13 +21,15 @@ var _ generic.Parser = parseMixLock
 
 var mixLockDelimiter = regexp.MustCompile(`[%{}\n" ,:]+`)
 
-// mixLockDependency matches each `{:name,` tuple opener on a mix.lock line. The
+// mixLockDependency matches each `{:name, ...` tuple on a mix.lock line. The
 // first match is the entry's own source tuple (e.g. `{:hex, :name, ...}`); the
-// remaining matches are the entry's dependency tuples within its dependency
-// list (e.g. `[{:cowlib, ...}, {:ranch, ...}]`). Build-tool lists like
-// `[:mix]` or `[:make, :rebar3]` and option keyword lists like
-// `[hex: :cowlib, ...]` use bare atoms, not `{:atom,`, so they don't match.
-var mixLockDependency = regexp.MustCompile(`\{\s*:(\w+)\s*,`)
+// remaining matches are dependency tuples within the dependency list. Dependency
+// tuples can carry a `hex: :real_package` option when the local app name is an
+// alias for a different Hex package.
+var (
+	mixLockDependency = regexp.MustCompile(`\{\s*:(\w+)\s*,([^{}]*)`)
+	mixLockHexPackage = regexp.MustCompile(`\bhex:\s*:(\w+)`)
+)
 
 // parseMixLock parses a mix.lock and returns the discovered Elixir packages.
 func parseMixLock(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
@@ -76,9 +78,13 @@ func parseMixLock(_ context.Context, _ file.Resolver, _ *generic.Environment, re
 			// A path dependency has no version or checksum; tokens[4] is the empty
 			// dependency list `[]`, not a version.
 			name = tokens[1]
+		case "hex":
+			// e.g. `"app_alias": {:hex, :actual_package, "1.0.0", ...}`
+			// tokens[1] is the local application/alias key; tokens[3] is the
+			// package name in the Hex registry.
+			name, version, hash, hashExt = tokens[3], tokens[4], tokens[5], tokens[len(tokens)-2]
 		default:
-			// hex (and any registry-style tuple): keep the original behavior.
-			// tokens: ["", name, "hex", name, version, hash, ..., hashExt, ""]
+			// Any unknown registry-style tuple: keep the original behavior.
 			name, version, hash, hashExt = tokens[1], tokens[4], tokens[5], tokens[len(tokens)-2]
 		}
 
@@ -115,7 +121,11 @@ func extractMixLockDependencies(line string) []string {
 	}
 	deps := make([]string, 0, len(matches)-1)
 	for _, m := range matches[1:] {
-		deps = append(deps, m[1])
+		name := m[1]
+		if hexPackage := mixLockHexPackage.FindStringSubmatch(m[2]); len(hexPackage) == 2 {
+			name = hexPackage[1]
+		}
+		deps = append(deps, name)
 	}
 	return deps
 }

--- a/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
+++ b/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
@@ -1,6 +1,9 @@
 package elixir
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/anchore/syft/syft/artifact"
@@ -270,9 +273,29 @@ func TestParseMixLock(t *testing.T) {
 
 func TestParseMixLockHexAliasUsesPackageName(t *testing.T) {
 	fixture := "testdata/mix-alias.lock"
+
+	pkgtest.TestFileParser(t, fixture, parseMixLock, expectedMixLockAliasPackages(fixture), nil)
+}
+
+func TestParseMixLockHexAliasUsesPackageNameWithCRLF(t *testing.T) {
+	srcFixture := "testdata/mix-alias.lock"
+	content, err := os.ReadFile(srcFixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fixture := filepath.Join(t.TempDir(), "mix.lock")
+	if err = os.WriteFile(fixture, []byte(strings.ReplaceAll(string(content), "\n", "\r\n")), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgtest.TestFileParser(t, fixture, parseMixLock, expectedMixLockAliasPackages(fixture), nil)
+}
+
+func expectedMixLockAliasPackages(fixture string) []pkg.Package {
 	locations := file.NewLocationSet(file.NewLocation(fixture))
 
-	expected := []pkg.Package{
+	return []pkg.Package{
 		{
 			Name:      "jason",
 			Version:   "1.3.0",
@@ -288,6 +311,4 @@ func TestParseMixLockHexAliasUsesPackageName(t *testing.T) {
 			},
 		},
 	}
-
-	pkgtest.TestFileParser(t, fixture, parseMixLock, expected, nil)
 }

--- a/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
+++ b/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
@@ -2,7 +2,6 @@ package elixir
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -284,12 +283,10 @@ func TestParseMixLockHexAliasUsesPackageNameWithCRLF(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fixture := filepath.Join(t.TempDir(), "mix.lock")
-	if err = os.WriteFile(fixture, []byte(strings.ReplaceAll(string(content), "\n", "\r\n")), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	pkgtest.TestFileParser(t, fixture, parseMixLock, expectedMixLockAliasPackages(fixture), nil)
+	pkgtest.NewCatalogTester().
+		FromString(srcFixture, strings.ReplaceAll(string(content), "\n", "\r\n")).
+		Expects(expectedMixLockAliasPackages(srcFixture), nil).
+		TestParser(t, parseMixLock)
 }
 
 func expectedMixLockAliasPackages(fixture string) []pkg.Package {

--- a/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
+++ b/syft/pkg/cataloger/elixir/parse_mix_lock_test.go
@@ -267,3 +267,27 @@ func TestParseMixLock(t *testing.T) {
 
 	pkgtest.TestFileParser(t, fixture, parseMixLock, expected, expectedRelationships)
 }
+
+func TestParseMixLockHexAliasUsesPackageName(t *testing.T) {
+	fixture := "testdata/mix-alias.lock"
+	locations := file.NewLocationSet(file.NewLocation(fixture))
+
+	expected := []pkg.Package{
+		{
+			Name:      "jason",
+			Version:   "1.3.0",
+			Language:  pkg.Elixir,
+			Type:      pkg.HexPkg,
+			Locations: locations,
+			PURL:      "pkg:hex/jason@1.3.0",
+			Metadata: pkg.ElixirMixLockEntry{
+				Name:       "jason",
+				Version:    "1.3.0",
+				PkgHash:    "aaa",
+				PkgHashExt: "bbb",
+			},
+		},
+	}
+
+	pkgtest.TestFileParser(t, fixture, parseMixLock, expected, nil)
+}

--- a/syft/pkg/cataloger/elixir/testdata/mix-alias.lock
+++ b/syft/pkg/cataloger/elixir/testdata/mix-alias.lock
@@ -1,0 +1,3 @@
+%{
+  "my_json": {:hex, :jason, "1.3.0", "aaa", [:mix], [], "hexpm", "bbb"},
+}

--- a/syft/pkg/cataloger/elixir/testdata/relationships-alias/mix.lock
+++ b/syft/pkg/cataloger/elixir/testdata/relationships-alias/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "my_json": {:hex, :jason, "1.3.0", "aaa", [:mix], [], "hexpm", "bbb"},
+  "consumer": {:hex, :consumer, "1.0.0", "ccc", [:mix], [{:my_json, "~> 1.3", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "ddd"},
+}


### PR DESCRIPTION
## Description

`mix.lock` entries can use a local application alias with a different Hex package name, for example `"my_json": {:hex, :jason, ...}`. The parser used the lock key as the package identity, so Syft emitted `pkg:hex/my_json@1.3.0` and dependency relationships pointed at `my_json` instead of the package published in Hex.

This uses the Hex package atom from the `:hex` tuple for package identity, and uses the `hex: :...` option when extracting dependency relationships. Git/path entries keep the existing source-specific handling.

Before this patch the new regression cases fail with `pkg:hex/my_json@1.3.0`; after the fix the package and relationship use `pkg:hex/jason@1.3.0`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

None.
