### PR TITLE
fix(portage): read a CONTENTS path that contains spaces

### DIFF
--- a/syft/pkg/cataloger/gentoo/parse_portage_contents.go
+++ b/syft/pkg/cataloger/gentoo/parse_portage_contents.go
@@ -73,19 +73,31 @@ func addFiles(resolver file.Resolver, dbLocation file.Location, entry *pkg.Porta
 	scanner := bufio.NewScanner(contentsReader)
 	for scanner.Scan() {
 		line := strings.Trim(scanner.Text(), "\n")
-		fields := strings.Split(line, " ")
 
-		if fields[0] == "obj" {
-			record := pkg.PortageFileRecord{
-				Path: fields[1],
-			}
-			record.Digest = &file.Digest{
-				Algorithm: "md5",
-				Value:     fields[2],
-			}
+		if record, ok := parseContentsObjectLine(line); ok {
 			entry.Files = append(entry.Files, record)
 		}
 	}
+}
+
+// parseContentsObjectLine reads one "obj <path> <md5> <mtime>" entry of a
+// portage CONTENTS file. An installed path is allowed to contain spaces, so the
+// digest and the mtime are taken from the end of the line rather than from
+// fixed offsets.
+func parseContentsObjectLine(line string) (pkg.PortageFileRecord, bool) {
+	fields := strings.Split(line, " ")
+	// "obj", at least one path field, the digest and the mtime
+	if len(fields) < 4 || fields[0] != "obj" {
+		return pkg.PortageFileRecord{}, false
+	}
+
+	return pkg.PortageFileRecord{
+		Path: strings.Join(fields[1:len(fields)-2], " "),
+		Digest: &file.Digest{
+			Algorithm: "md5",
+			Value:     fields[len(fields)-2],
+		},
+	}, true
 }
 
 func addLicenses(ctx context.Context, resolver file.Resolver, dbLocation file.Location, entry *pkg.PortageEntry) (pkg.LicenseSet, []file.Location) {

--- a/syft/pkg/cataloger/gentoo/parse_portage_contents.go
+++ b/syft/pkg/cataloger/gentoo/parse_portage_contents.go
@@ -76,6 +76,8 @@ func addFiles(resolver file.Resolver, dbLocation file.Location, entry *pkg.Porta
 
 		if record, ok := parseContentsObjectLine(line); ok {
 			entry.Files = append(entry.Files, record)
+		} else if strings.HasPrefix(line, "obj ") {
+			log.WithFields("path", dbLocation.RealPath, "line", line).Debug("skipping malformed portage CONTENTS entry")
 		}
 	}
 }

--- a/syft/pkg/cataloger/gentoo/parse_portage_contents_test.go
+++ b/syft/pkg/cataloger/gentoo/parse_portage_contents_test.go
@@ -1,0 +1,72 @@
+package gentoo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func TestParseContentsObjectLine(t *testing.T) {
+	digest := func(value string) *file.Digest {
+		return &file.Digest{Algorithm: "md5", Value: value}
+	}
+
+	tests := []struct {
+		name     string
+		line     string
+		expected pkg.PortageFileRecord
+		wantOK   bool
+	}{
+		{
+			name:     "plain path",
+			line:     "obj /usr/bin/skopeo 376c02bd3b22804df8fdfdc895e7dbfb 1649284374",
+			expected: pkg.PortageFileRecord{Path: "/usr/bin/skopeo", Digest: digest("376c02bd3b22804df8fdfdc895e7dbfb")},
+			wantOK:   true,
+		},
+		{
+			name:     "path with a space",
+			line:     "obj /usr/share/fonts/My Font.ttf d41d8cd98f00b204e9800998ecf8427e 1649284375",
+			expected: pkg.PortageFileRecord{Path: "/usr/share/fonts/My Font.ttf", Digest: digest("d41d8cd98f00b204e9800998ecf8427e")},
+			wantOK:   true,
+		},
+		{
+			name:     "path with several spaces",
+			line:     "obj /opt/A B/c d/e f.so c01eb6950f03419e09d4fc88cb42ff6f 1649284375",
+			expected: pkg.PortageFileRecord{Path: "/opt/A B/c d/e f.so", Digest: digest("c01eb6950f03419e09d4fc88cb42ff6f")},
+			wantOK:   true,
+		},
+		{
+			name:   "directory entry",
+			line:   "dir /usr/bin",
+			wantOK: false,
+		},
+		{
+			name:   "symlink entry",
+			line:   "sym /usr/lib/libfoo.so -> libfoo.so.1 1649284375",
+			wantOK: false,
+		},
+		{
+			name:   "truncated object entry",
+			line:   "obj /usr/bin/skopeo",
+			wantOK: false,
+		},
+		{
+			name:   "empty line",
+			line:   "",
+			wantOK: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record, ok := parseContentsObjectLine(test.line)
+			assert.Equal(t, test.wantOK, ok)
+			if test.wantOK {
+				assert.Equal(t, test.expected, record)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The portage cataloger splits each CONTENTS line on every space and reads the path from index 1 and the digest from index 2, so an installed file whose path contains a space comes out truncated with part of its own name stored where the MD5 belongs.

Running the parsing as it stands on `main` over a few lines:

```
obj /usr/bin/skopeo 376c02bd3b22804df8fdfdc895e7dbfb 1649284374        -> path="/usr/bin/skopeo" md5="376c02bd3b22804df8fdfdc895e7dbfb"
obj /usr/share/fonts/My Font.ttf d41d8cd98f00b204e9800998ecf8427e 1649284375 -> path="/usr/share/fonts/My" md5="Font.ttf"
obj /opt/A B/c d/e f.so c01eb6950f03419e09d4fc88cb42ff6f 1649284375    -> path="/opt/A" md5="B/c"
obj /usr/bin/skopeo                                                    -> PANIC (index out of range)
```

Two things follow from the truncation. `PortageEntry.OwnedFiles()` hands back a path that points at nothing, and that method is what backs the `FileOwner` interface behind file ownership relationships, so the real file never gets attributed to the package that installed it. And an SBOM consumer checking file digests is given a filename in a field declared as an md5.

The last line is the other half: an `obj` entry with fewer than three fields after it, which is what a truncated or partly written CONTENTS file looks like, indexes past the end of the slice.

Portage's own parser reads the entry anchored at the right. From `lib/portage/dbapi/vartree.py`:

```python
r"(?P<obj>(obj) (.+) (\S+) (\d+))|"
```

The path is greedy and the digest and the mtime are what closes the line, so a path is free to contain spaces. This change reads the line the same way: last field is the mtime, the one before it is the digest, and everything between the keyword and those two is the path. Lines with too few fields are skipped instead of indexed into.

I pulled the line parsing out into its own function so it can be tested without a resolver, and added a table test covering a plain path, a path with one space, a path with several, `dir` and `sym` entries, a truncated `obj` entry and an empty line.

## Type of change

Bug fix

## Checklist

- `go test ./syft/pkg/cataloger/gentoo/...` passes, including the existing `TestPortageCataloger` fixture tests, which are unchanged. The shipped `skopeo-1.5.1` fixture has no path with a space in it, which is why this went unnoticed.
- `go build ./...`, `go vet ./syft/pkg/cataloger/gentoo/...` and `gofmt -l` are clean.
