### PR TITLE
feat(java): add support for palantir gradle-consistent-versions versions.lock lockfiles

### DIFF
--- a/syft/pkg/cataloger/java/cataloger.go
+++ b/syft/pkg/cataloger/java/cataloger.go
@@ -41,7 +41,8 @@ func NewPomCataloger(cfg ArchiveCatalogerConfig) pkg.Cataloger {
 // Note: Older versions of lockfiles aren't supported yet
 func NewGradleLockfileCataloger() pkg.Cataloger {
 	return generic.NewCataloger("java-gradle-lockfile-cataloger").
-		WithParserByGlobs(parseGradleLockfile, "**/gradle.lockfile*")
+		WithParserByGlobs(parseGradleLockfile, "**/gradle.lockfile*").
+		WithParserByGlobs(parseGradleConsistentVersionsLockfile, "**/versions.lock")
 }
 
 // NewJvmDistributionCataloger returns packages representing JDK/JRE installations (of multiple distribution types).

--- a/syft/pkg/cataloger/java/parse_gradle_consistent_versions_lockfile.go
+++ b/syft/pkg/cataloger/java/parse_gradle_consistent_versions_lockfile.go
@@ -1,0 +1,77 @@
+package java
+
+import (
+	"bufio"
+	"context"
+	"strings"
+
+	"github.com/anchore/syft/syft/artifact"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/generic"
+)
+
+// parseGradleConsistentVersionsLockfile parses Palantir gradle-consistent-versions
+// lockfiles (versions.lock). Each resolved dependency is listed on its own line as:
+//
+//	<group>:<artifact>:<version> (<N> constraints: <hash>)
+//
+// The constraint/hash suffix is ignored; only group:artifact:version is needed.
+func parseGradleConsistentVersionsLockfile(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+	var pkgs []pkg.Package
+
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// trim leading and trailing whitespace from the line
+		line = strings.TrimSpace(line)
+
+		// skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// drop the constraint summary suffix, e.g. " (1 constraints: 38053b3b)"
+		if idx := strings.Index(line, "("); idx >= 0 {
+			line = line[:idx]
+		}
+		line = strings.TrimSpace(line)
+
+		parts := strings.Split(line, ":")
+		if len(parts) != 3 {
+			continue
+		}
+
+		group, name, version := parts[0], parts[1], parts[2]
+		if group == "" || name == "" || version == "" {
+			continue
+		}
+
+		archive := pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    group,
+				ArtifactID: name,
+				Version:    version,
+				Name:       name,
+			},
+		}
+
+		mappedPkg := pkg.Package{
+			Name:    name,
+			Version: version,
+			Locations: file.NewLocationSet(
+				reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation),
+			),
+			Language: pkg.Java,
+			Type:     pkg.JavaPkg,
+			PURL:     packageURL(name, version, archive),
+			Metadata: archive,
+		}
+		mappedPkg.SetID()
+		pkgs = append(pkgs, mappedPkg)
+	}
+
+	return pkgs, nil, nil
+}

--- a/syft/pkg/cataloger/java/parse_gradle_consistent_versions_lockfile_test.go
+++ b/syft/pkg/cataloger/java/parse_gradle_consistent_versions_lockfile_test.go
@@ -1,0 +1,61 @@
+package java
+
+import (
+	"testing"
+
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
+)
+
+func Test_parseGradleConsistentVersionsLockfile(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []pkg.Package
+	}{
+		{
+			input: "testdata/gradle-consistent-versions/versions.lock",
+			expected: []pkg.Package{
+				{
+					Name:     "jackson-annotations",
+					Version:  "2.12.3",
+					Language: pkg.Java,
+					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.12.3",
+					Metadata: pkg.JavaArchive{
+						PomProject: &pkg.JavaPomProject{GroupID: "com.fasterxml.jackson.core", ArtifactID: "jackson-annotations", Version: "2.12.3", Name: "jackson-annotations"},
+					},
+				},
+				{
+					Name:     "guava",
+					Version:  "30.1.1-jre",
+					Language: pkg.Java,
+					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/com.google.guava/guava@30.1.1-jre",
+					Metadata: pkg.JavaArchive{
+						PomProject: &pkg.JavaPomProject{GroupID: "com.google.guava", ArtifactID: "guava", Version: "30.1.1-jre", Name: "guava"},
+					},
+				},
+				{
+					Name:     "okhttp",
+					Version:  "3.12.0",
+					Language: pkg.Java,
+					Type:     pkg.JavaPkg,
+					PURL:     "pkg:maven/com.squareup.okhttp3/okhttp@3.12.0",
+					Metadata: pkg.JavaArchive{
+						PomProject: &pkg.JavaPomProject{GroupID: "com.squareup.okhttp3", ArtifactID: "okhttp", Version: "3.12.0", Name: "okhttp"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			for i := range test.expected {
+				test.expected[i].Locations.Add(file.NewLocation(test.input))
+			}
+			pkgtest.TestFileParser(t, test.input, parseGradleConsistentVersionsLockfile, test.expected, nil)
+		})
+	}
+}

--- a/syft/pkg/cataloger/java/testdata/gradle-consistent-versions/versions.lock
+++ b/syft/pkg/cataloger/java/testdata/gradle-consistent-versions/versions.lock
@@ -1,0 +1,6 @@
+# example versions.lock file from the palantir/gradle-consistent-versions plugin
+# empty lines and comments should be skipped
+
+com.fasterxml.jackson.core:jackson-annotations:2.12.3 (3 constraints: f311b512)
+com.google.guava:guava:30.1.1-jre (12 constraints: b290ec5e)
+com.squareup.okhttp3:okhttp:3.12.0 (1 constraints: 38053b3b)


### PR DESCRIPTION
## Summary of changes

Adds static parsing support for [Palantir's gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) lockfile (`versions.lock`), as requested in #5176.

- New parser `parseGradleConsistentVersionsLockfile` in the java cataloger package: each line of the form `<group>:<artifact>:<version> (<N> constraints: <hash>)` is parsed as a Maven-coordinate Java package; the constraint/hash suffix, empty lines and comments are ignored.
- The existing `java-gradle-lockfile-cataloger` now also globs `**/versions.lock`, so both `gradle.lockfile` and `versions.lock` are discovered by the same cataloger (no new cataloger name or task registration needed).
- Packages are emitted with the same shape as the existing gradle lockfile parser (`JavaArchive` metadata with `PomProject`, `pkg:maven/...` PURLs).

### Example

Input:
```text
com.fasterxml.jackson.core:jackson-annotations:2.12.3 (3 constraints: f311b512)
com.google.guava:guava:30.1.1-jre (12 constraints: b290ec5e)
```

Output (syft scan dir:. -o json):
```json
[
  {"name": "jackson-annotations", "version": "2.12.3", "type": "java-archive", "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.12.3"},
  {"name": "guava", "version": "30.1.1-jre", "type": "java-archive", "purl": "pkg:maven/com.google.guava/guava@30.1.1-jre"}
]
```

This enables JVM-less, offline SBOM generation for enterprise Gradle projects that pin dependencies with the Palantir plugin, complementing the existing native `gradle.lockfile` support.

Fixes #5176

## How I tested it

Locally on Windows / go1.26.6:

- new unit test `Test_parseGradleConsistentVersionsLockfile` against a fixture modeled on the example from the issue (multi-constraint lines, comments, blank lines): PASS
- existing `Test_parserGradleLockfile` still passes (no behavior change for `gradle.lockfile`)
- end-to-end: built syft from this branch and ran `syft scan dir:. --select-catalogers +java-gradle-lockfile-cataloger -o json` against a directory containing only `versions.lock` — all 3 fixture packages discovered with correct purls; a mixed directory containing both `gradle.lockfile` and `versions.lock` yields the union of both parsers with correct evidence locations
- `go vet ./syft/pkg/cataloger/java/` clean; the remaining failures in `go test ./syft/pkg/cataloger/java/...` on this machine are pre-existing environment failures (tests requiring `make`) identical to those on unmodified main

Thanks for considering!
