### PR TITLE
fix(dotnet): preserve requested version range in packages.lock.json metadata (#5211)

### DIFF
--- a/syft/pkg/cataloger/dotnet/parse_packages_lock.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock.go
@@ -121,6 +121,7 @@ func newDotnetPackagesLockPackage(name string, dep dotnetPackagesLockDep, locati
 		Version:     dep.Resolved,
 		ContentHash: dep.ContentHash,
 		Type:        dep.Type,
+		Requested:   dep.Requested,
 	}
 
 	p := &pkg.Package{

--- a/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
+++ b/syft/pkg/cataloger/dotnet/parse_packages_lock_test.go
@@ -32,6 +32,7 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 			Version:     "13.0.1",
 			ContentHash: "/Fx1SbJ16qS7dU4i604Sle+U9VLX+WSNVJggk6MupKVkYvvBm4XqYaeFuf67diHefHKHs50uQIS2YEDFhPCakQ==",
 			Type:        "Direct",
+			Requested:   "[13.0.1, )",
 		},
 	}
 
@@ -47,6 +48,7 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 			Version:     "5.0.0",
 			ContentHash: "NKQFzFwrfWOMjTwr+X/2iJyCveuAGF+fNzkxyB0YW45+InVhcE9PUxoL1a8Vmc/Lq9E/CQd4DjO8kU32P4w/Gg==",
 			Type:        "Direct",
+			Requested:   "[5.0.0, )",
 		},
 	}
 
@@ -62,6 +64,7 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 			Version:     "2.0.5",
 			ContentHash: "AEqPZz+v+OikfnR2SqRVdQPnSaLq5y9Iz1CfRQZ9kTKPYCXHG6zYmDHb7wJotICpDLMr/JqokyjiqKAjUKp0ng==",
 			Type:        "Direct",
+			Requested:   "[2.0.5, )",
 		},
 	}
 
@@ -77,6 +80,7 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 			Version:     "1.2.15",
 			ContentHash: "KPajjkU1rbF6uY2rnakbh36LB9z9FVcYlciyOi6C5SJ3AMNywxjCGxBTN/Hl5nQEinRLuWvHWPF8W7YHh9sONw==",
 			Type:        "Direct",
+			Requested:   "[1.2.15, )",
 		},
 	}
 
@@ -152,6 +156,7 @@ func TestParseDotnetPackagesLock(t *testing.T) {
 			Version:     "9.0.0",
 			ContentHash: "crjWyORoug0kK7RSNJBTeSE6VX8IQgLf3nUpTB9m62bPXp/tzbnOsnbe8TXEG0AASNaKZddnpHKw7fET8E++Pg==",
 			Type:        "Direct",
+			Requested:   "[9.0.0, )",
 		},
 	}
 

--- a/syft/pkg/dotnet.go
+++ b/syft/pkg/dotnet.go
@@ -37,6 +37,10 @@ type DotnetPackagesLockEntry struct {
 
 	// Type is the dependency type indicating how this dependency was added (Direct=explicit in project file, Transitive=pulled in by another package, Project=project reference)
 	Type string `mapstructure:"type" json:"type"`
+
+	// Requested is the requested version range from packages.lock.json (e.g. "[13.0.3, )").
+	// It is empty for entries that do not declare one (e.g. Transitive dependencies).
+	Requested string `mapstructure:"requested" json:"requested,omitempty"`
 }
 
 // DotnetPortableExecutableEntry is a struct that represents a single entry found within "VersionResources" section of a .NET Portable Executable binary file.


### PR DESCRIPTION
## Description

The `packages.lock.json` parser dropped the `requested` field entirely, so downstream consumers lose the original version-range constraint (e.g. `[13.0.3, )`) that the project declared in its lockfile.

This PR:
- Adds `Requested` to the `DotnetPackagesLockEntry` struct (`json:"requested,omitempty"` — `omitempty` keeps `Transitive` entries that declare no `requested` value clean).
- Populates it from the parsed dependency in `newDotnetPackagesLockPackage`.
- Extends the existing `TestParseDotnetPackagesLock` golden package expectations with the resolved `requested` ranges.

This closes the **lossiness half** of #5211. The determinism and Direct-preference halves are handled separately in #5210 (maintainer fix), which I independently verified in round rev 79. This change is orthogonal and stacks cleanly on top of it.

## Verification

- `go test ./syft/pkg/cataloger/dotnet/ -run TestParseDotnetPackagesLock -count=10` → PASS (also `go vet` clean).
- End-to-end on a byte-identical `packages.lock.json` fixture where `Newtonsoft.Json` is declared `Direct` with `requested: "[13.0.3, )"`:

  ```json
  "metadata": {
    "name": "Newtonsoft.Json",
    "version": "13.0.3",
    "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ==",
    "type": "Direct",
    "requested": "[13.0.3, )"
  }
  ```

  Before this change, `requested` was absent.

The other dotnet-cataloger tests that shell out to `docker` fail in this environment for lack of a Docker daemon — they are unrelated to this change and fail identically on unmodified `main`.

## Checklist

- [x] Added/updated tests (the golden `TestParseDotnetPackagesLock` expectations now assert `Requested`).
- [x] Used DCO-signed commits (`Signed-off-by: Shurong Cao <170531907+CAOShurong@users.noreply.github.com>`).

Relates to #5211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)