### PR TITLE
fix(relationship): restore same-name guard for binary-overlap exclusion (fixes #5214)

### DIFF
--- a/internal/relationship/exclude_binaries_by_file_ownership_overlap.go
+++ b/internal/relationship/exclude_binaries_by_file_ownership_overlap.go
@@ -3,6 +3,7 @@ package relationship
 import (
 	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
@@ -75,6 +76,15 @@ func excludeByFileOwnershipOverlap(r artifact.Relationship, c *pkg.Collection) a
 	return ""
 }
 
+// isSamePackageName indicates whether both packages refer to the same software by name.
+func isSamePackageName(parent *pkg.Package, child *pkg.Package) bool {
+	if parent == nil || child == nil {
+		return false
+	}
+
+	return strings.EqualFold(parent.Name, child.Name)
+}
+
 // identifyOverlappingJVMRelationship indicates the package to remove if this is a binary -> binary pkg relationship
 // with a java binary signature package and a more authoritative JVM release package.
 func identifyOverlappingJVMRelationship(parent *pkg.Package, child *pkg.Package) artifact.ID {
@@ -112,8 +122,19 @@ func identifyOverlappingJVMRelationship(parent *pkg.Package, child *pkg.Package)
 
 // identifyOverlappingOSRelationship indicates the package ID to remove if this is an OS pkg -> bin pkg relationship.
 // This was implemented as a way to help resolve: https://github.com/anchore/syft/issues/931
+//
+// The exclusion only applies when the OS package and the binary package refer to the
+// same software (identical names), e.g. an "openssl" RPM that owns an "openssl" binary
+// detection. When the owning OS package is unrelated software (e.g. a vendor product
+// RPM bundling its own copy of a library), the binary detection must be preserved,
+// otherwise vulnerabilities in vendored libraries go unreported:
+// https://github.com/anchore/syft/issues/5214
 func identifyOverlappingOSRelationship(parent *pkg.Package, child *pkg.Package) artifact.ID {
 	if !slices.Contains(osCatalogerTypes, parent.Type) {
+		return ""
+	}
+
+	if !isSamePackageName(parent, child) {
 		return ""
 	}
 
@@ -133,8 +154,17 @@ func identifyOverlappingOSRelationship(parent *pkg.Package, child *pkg.Package) 
 }
 
 // identifyOverlappingBitnamiRelationship indicates the package ID to remove if this is a Bitnami pkg -> bin pkg relationship.
+// This was implemented as a way to help resolve: https://github.com/anchore/syft/issues/931
+//
+// As with the OS-package exclusion, the exclusion only applies when the Bitnami
+// package and the binary package refer to the same software (identical names):
+// https://github.com/anchore/syft/issues/5214
 func identifyOverlappingBitnamiRelationship(parent *pkg.Package, child *pkg.Package) artifact.ID {
 	if !slices.Contains(bitnamiCatalogerTypes, parent.Type) {
+		return ""
+	}
+
+	if !isSamePackageName(parent, child) {
 		return ""
 	}
 

--- a/internal/relationship/exclude_binaries_by_file_ownership_overlap_test.go
+++ b/internal/relationship/exclude_binaries_by_file_ownership_overlap_test.go
@@ -10,10 +10,13 @@ import (
 )
 
 func TestExcludeByFileOwnershipOverlap(t *testing.T) {
-	packageA := pkg.Package{Name: "package-a", Type: pkg.ApkPkg}
-	packageB := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg, Metadata: pkg.JavaVMInstallation{}}
-	packageC := pkg.Package{Name: "package-c", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{Type: "rpm"}}
-	packageD := pkg.Package{Name: "package-d", Type: pkg.BitnamiPkg}
+	// OS package and binary detection refer to the same software by name (e.g. an
+	// "openssl" RPM owning the file behind an "openssl" binary classifier match)
+	sameName := "package-a"
+	packageA := pkg.Package{Name: sameName, Type: pkg.ApkPkg}
+	packageB := pkg.Package{Name: sameName, Type: pkg.BinaryPkg, Metadata: pkg.JavaVMInstallation{}}
+	packageC := pkg.Package{Name: sameName, Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{Type: "rpm"}}
+	packageD := pkg.Package{Name: sameName, Type: pkg.BitnamiPkg}
 	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD} {
 		p.SetID()
 	}
@@ -73,12 +76,18 @@ func TestExcludeByFileOwnershipOverlap(t *testing.T) {
 
 func TestIdentifyOverlappingOSRelationship(t *testing.T) {
 	packageA := pkg.Package{Name: "package-a", Type: pkg.ApkPkg} // OS package
-	packageB := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg}
-	packageC := pkg.Package{Name: "package-c", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
+	packageB := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg}
+	packageC := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
 	packageD := pkg.Package{Name: "package-d", Type: pkg.PythonPkg} // Language package
-	packageE := pkg.Package{Name: "package-e", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
+	packageE := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
 
-	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE} {
+	// same software name as the OS package, but owned by an unrelated vendor RPM (e.g. vendored library)
+	vendorRPM := pkg.Package{Name: "vendor-product", Type: pkg.RpmPkg}                                    // unrelated OS package
+	vendoredBinary := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg}                                 // binary detection named after the OS package
+	unrelatedBinary := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg}                                // binary detection named differently from the OS package
+	sameNameUpper := pkg.Package{Name: "PACKAGE-A", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}} // case-insensitive match
+
+	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE, &vendorRPM, &vendoredBinary, &unrelatedBinary, &sameNameUpper} {
 		p.SetID()
 	}
 
@@ -118,6 +127,24 @@ func TestIdentifyOverlappingOSRelationship(t *testing.T) {
 			child:      &packageC,
 			expectedID: "", // non-OS parent, no exclusion
 		},
+		{
+			name:       "unrelated OS package owns binary with same name as another package (vendored library)",
+			parent:     &vendorRPM, // vendor-product RPM
+			child:      &vendoredBinary,
+			expectedID: "", // names differ: vendor-product != package-a, no exclusion (issue #5214)
+		},
+		{
+			name:       "same-name unrelated OS package does not exclude differently-named binary",
+			parent:     &packageA,        // package-a OS package
+			child:      &unrelatedBinary, // package-b binary
+			expectedID: "",               // names differ: package-a != package-b, no exclusion
+		},
+		{
+			name:       "OS package excludes binary with matching name case-insensitively",
+			parent:     &packageA, // package-a OS package
+			child:      &sameNameUpper,
+			expectedID: sameNameUpper.ID(), // PACKAGE-A matches package-a, excluded
+		},
 	}
 
 	for _, tt := range tests {
@@ -130,12 +157,14 @@ func TestIdentifyOverlappingOSRelationship(t *testing.T) {
 
 func TestIdentifyOverlappingBitnamiRelationship(t *testing.T) {
 	packageA := pkg.Package{Name: "package-a", Type: pkg.BitnamiPkg} // Bitnami package
-	packageB := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg}
-	packageC := pkg.Package{Name: "package-c", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
+	packageB := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg}
+	packageC := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg, Metadata: pkg.BinarySignature{}}
 	packageD := pkg.Package{Name: "package-d", Type: pkg.PythonPkg} // Language package
-	packageE := pkg.Package{Name: "package-e", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
+	packageE := pkg.Package{Name: "package-a", Type: pkg.BinaryPkg, Metadata: pkg.ELFBinaryPackageNoteJSONPayload{}}
 
-	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE} {
+	unrelatedBinary := pkg.Package{Name: "package-b", Type: pkg.BinaryPkg} // binary detection named differently
+
+	for _, p := range []*pkg.Package{&packageA, &packageB, &packageC, &packageD, &packageE, &unrelatedBinary} {
 		p.SetID()
 	}
 
@@ -174,6 +203,12 @@ func TestIdentifyOverlappingBitnamiRelationship(t *testing.T) {
 			parent:     &packageD, // non-Bitnami package
 			child:      &packageC,
 			expectedID: "", // non-Bitnami parent, no exclusion
+		},
+		{
+			name:       "Bitnami package does not exclude differently-named binary",
+			parent:     &packageA, // bitnami pkg "package-a"
+			child:      &unrelatedBinary,
+			expectedID: "", // names differ, no exclusion (issue #5214)
 		},
 	}
 


### PR DESCRIPTION
Fixes #5214

## Root cause

The ownership-overlap exclusion introduced in #1948 (fixing #931) documents four conditions for excluding a binary package when an OS/Bitnami package owns the same file. One of them is that the parent and child have identical names, so an OS package should suppress a detected binary only when both findings refer to the same software.

The refactors in `identifyOverlappingOSRelationship` and `identifyOverlappingBitnamiRelationship` dropped that name check. As a result, any OS or Bitnami package owning a file could suppress a differently named binary detection. That reproduces #5214: an unrelated vendor package can hide a vendored component from the SBOM.

## Change

- Restore a case-insensitive `isSamePackageName` gate in both the OS and Bitnami paths.
- Add regression coverage for unrelated owners, differently named children, case-insensitive same-name matches, and the Bitnami equivalent.
- Refresh the CentOS 8.2.2004 acceptance fixture with the two additional binary packages exposed by the corrected behavior:
  - `krb5 1.17` from `/usr/lib64/libkrb5.so.3.3`
  - `python 3.6.8` from `/usr/lib64/libpython3.6m.so.1.0`

The acceptance report was regenerated with this branch and contains 177 packages. To avoid unrelated churn from newer Syft JSON-schema fields, the golden fixture update carries only those two generated package records in the fixture's existing schema shape.

## Verification (exact head `5c76d89dbfc462b6369b1d9452a214db19123bf6`)

- `python test/compare/compare.py test/compare/testdata/acceptance-centos-8.2.2004.json <generated-report>`: quality gate PASS, 177/177 packages matched
- `go test ./internal/relationship -count=1`: PASS
- `go vet ./internal/relationship`: PASS
- `go build ./...`: PASS
- `git diff HEAD^ HEAD --check`: PASS

AI assistance disclosure: OpenAI Codex assisted with the failure investigation and fixture update. The generated package records and all validation commands above were checked on the exact pushed head.