### PR TITLE
fix(javascript): carry lockfile resolved/integrity into CycloneDX

### DIFF
--- a/syft/format/internal/cyclonedxutil/helpers/component_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/component_test.go
@@ -149,6 +149,27 @@ func Test_encodeComponentProperties(t *testing.T) {
 				{Name: "syft:metadata:sourceRpm", Value: "dive-0.9.2-1.src.rpm"},
 			},
 		},
+		{
+			// resolved and integrity are the lockfile's provenance: which registry served the
+			// tarball, and the SRI hash npm itself checks it against. Both are carried only
+			// because the fields are tagged, so removing either tag silently drops it here.
+			name: "from npm package-lock",
+			input: pkg.Package{
+				Name:    "lodash",
+				Version: "4.17.21",
+				Type:    pkg.NpmPkg,
+				Metadata: pkg.NpmPackageLockEntry{
+					Resolved:  "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					Integrity: "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+				},
+			},
+			expected: []cyclonedx.Property{
+				{Name: "syft:package:metadataType", Value: "javascript-npm-package-lock-entry"},
+				{Name: "syft:package:type", Value: "npm"},
+				{Name: "syft:metadata:integrity", Value: "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="},
+				{Name: "syft:metadata:resolved", Value: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/syft/pkg/npm.go
+++ b/syft/pkg/npm.go
@@ -27,10 +27,10 @@ type NpmPackage struct {
 // NpmPackageLockEntry represents a single entry within the "packages" section of a package-lock.json file.
 type NpmPackageLockEntry struct {
 	// Resolved is URL where this package was downloaded from (registry source)
-	Resolved string `mapstructure:"resolved" json:"resolved"`
+	Resolved string `mapstructure:"resolved" json:"resolved" cyclonedx:"resolved"`
 
 	// Integrity is Subresource Integrity hash for verification using standard SRI format (sha512-... or sha1-...). npm changed from SHA-1 to SHA-512 in newer versions. For registry sources this is the integrity from registry, for remote tarballs it's SHA-512 of the file. npm verifies tarball matches this hash before unpacking, throwing EINTEGRITY error if mismatch detected.
-	Integrity string `mapstructure:"integrity" json:"integrity"`
+	Integrity string `mapstructure:"integrity" json:"integrity" cyclonedx:"integrity"`
 
 	// Dependencies is a map of dependencies and their version markers, i.e. "lodash": "^1.0.0"
 	Dependencies map[string]string `mapstructure:"dependencies" json:"dependencies"`
@@ -39,10 +39,10 @@ type NpmPackageLockEntry struct {
 // YarnLockEntry represents a single entry section of a yarn.lock file.
 type YarnLockEntry struct {
 	// Resolved is URL where this package was downloaded from
-	Resolved string `mapstructure:"resolved" json:"resolved"`
+	Resolved string `mapstructure:"resolved" json:"resolved" cyclonedx:"resolved"`
 
 	// Integrity is Subresource Integrity hash for verification (SRI format)
-	Integrity string `mapstructure:"integrity" json:"integrity"`
+	Integrity string `mapstructure:"integrity" json:"integrity" cyclonedx:"integrity"`
 
 	// Dependencies is a map of dependencies and their versions
 	Dependencies map[string]string `mapstructure:"dependencies" json:"dependencies"`
@@ -51,7 +51,7 @@ type YarnLockEntry struct {
 // PnpmLockResolution contains package resolution metadata from pnpm lockfiles, including the integrity hash used for verification.
 type PnpmLockResolution struct {
 	// Integrity is Subresource Integrity hash for verification (SRI format)
-	Integrity string `mapstructure:"integrity" json:"integrity"`
+	Integrity string `mapstructure:"integrity" json:"integrity" cyclonedx:"integrity"`
 }
 
 // PnpmLockEntry represents a single entry in the "packages" section of a pnpm-lock.yaml file.
@@ -66,7 +66,7 @@ type PnpmLockEntry struct {
 // BunLockEntry represents a single entry in the "packages" section of a bun.lock file
 type BunLockEntry struct {
 	// Integrity is Subresource Integrity hash for verification (SRI format)
-	Integrity string `mapstructure:"integrity" json:"integrity"`
+	Integrity string `mapstructure:"integrity" json:"integrity" cyclonedx:"integrity"`
 
 	// Dependencies is a map of runtime dependencies and their version specifiers
 	Dependencies map[string]string `mapstructure:"dependencies" json:"dependencies"`


### PR DESCRIPTION
## What

Adds the `cyclonedx` struct tag to `Resolved` and `Integrity` on the four npm-ecosystem lockfile entry types — `NpmPackageLockEntry`, `YarnLockEntry`, `PnpmLockResolution`, `BunLockEntry` — so they reach CycloneDX output as `syft:metadata:resolved` and `syft:metadata:integrity`.

## Why

`EncodeProperties` uses `CycloneDXFields = RequiredTag("cyclonedx")`, so a metadata field is emitted **only** if it carries that tag (opt-in allowlist). `GolangModuleEntry.H1Digest` has it, these fields don't.

```go
// golang.go — carried into CycloneDX
H1Digest  string `json:"h1Digest,omitempty" cyclonedx:"h1Digest"`

// npm.go — dropped
Resolved  string `mapstructure:"resolved" json:"resolved"`
Integrity string `mapstructure:"integrity" json:"integrity"`
```

Same encoder, same mechanism, different outcome. Not a CycloneDX limitation or a deliberate exclusion as far as I can tell?

The purl spec's own [npm type definition](https://github.com/package-url/purl-spec/blob/main/types/npm-definition.json) declares:

```json
"repository": { "use_repository": true, "default_repository_url": "https://registry.npmjs.org/" }
```

So `pkg:npm/name@version` resolves against the public registry **by specification default**. Dropping `Resolved` therefore doesn't merely omit provenance.

Concrete case, from `firebase/firebase-js-sdk` (public, current `master`). Its `yarn.lock` pins:

```
"closure-net@git+https://github.com/google/closure-net.git#6f48f578d3e80fe7a85e530a5d95b9351433d135":
  version "0.0.0"
```

syft's native JSON records the resolution correctly. The CycloneDX output is:

```json
{ "name": "closure-net", "version": "0.0.0", "purl": "pkg:npm/closure-net@0.0.0",
  "properties": [ ...foundBy, language, type, metadataType, location:0:path ] }
```

— structurally identical to `rimraf@2.7.1` beside it, with no VCS marker and no `externalReferences`. npm has never served `closure-net@0.0.0`; the registry holds only `0.0.1-security`, the security-holder placeholder left after a malware takedown in January. So a consumer of that SBOM either matches nothing, or matches the squatted registry package. Both directions are wrong, from one dropped string.

`Integrity` is the second half: an SRI hash npm itself uses to refuse a mismatched tarball, currently absent from CycloneDX entirely. (CycloneDX has a first-class `hashes` field that could carry it — deliberately out of scope here, not my mapping decision.)

## Scope

Measured across `syft/pkg/*.go` on `main`: **85 tagged fields across 11 of 63 metadata files**. The tagged set is the OS/container lineage — alpm, apk, dpkg, rpm, portage — plus Java, Go and the ML formats. Eleven untagged files hold provenance or integrity fields: npm (7), rust (3), python (3), deno (3), conda (2), and six more with one each.

I have only changed npm. I have verified what `resolved` means in npm lockfiles by parsing them directly; I have not done that for conda or rockspec. If maintainers want the wider sweep, the measurement above is the starting list and I am happy to do it as follow-ups.

## Verification

- `./syft/format/cyclonedxjson`, `./syft/format/cyclonedxxml`, `./syft/format/internal/cyclonedxutil/...`, `./syft/pkg` — all pass.
- **Snapshot goldens unchanged.** The fixtures carry no npm lockfile entry with these fields populated, so nothing needed regenerating.
- Built and run against firebase's real `yarn.lock` (1,755 packages). Before: neither field present. After:

```
syft:metadata:resolved  = git+https://github.com/google/closure-net.git#6f48f578...
syft:metadata:integrity = sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409V...   (rimraf)
```

Component count unchanged; registry packages gain `resolved`/`integrity` and are otherwise untouched.

## Context

Found while auditing why a malicious-package advisory (`MAL-2026-276`) matched a dependency that could not have come from the registry. Happy to adjust scope, naming, or split the `Integrity` half out if you would rather take them separately.
