### PR TITLE
Add fail compliance action

### DIFF
--- a/internal/task/package_task_factory.go
+++ b/internal/task/package_task_factory.go
@@ -66,6 +66,8 @@ func NewPackageTask(cfg CatalogingFactoryConfig, c pkg.Cataloger, tags ...string
 		t.SetCompleted()
 		log.WithFields("name", catalogerName).Trace("package cataloger completed")
 
+		// Return both failures when cataloging succeeds partially but compliance rejects
+		// one or more discovered packages.
 		return errors.Join(err, complianceErr)
 	}
 	tags = append(tags, pkgcataloging.PackageTag)
@@ -126,6 +128,8 @@ type packageReplacement struct {
 func applyCompliance(cfg cataloging.ComplianceConfig, pkgs []pkg.Package, relationships []artifact.Relationship) ([]pkg.Package, []artifact.Relationship, error) {
 	remainingPkgs, droppedPkgs, replacements, complianceErr := filterNonCompliantPackages(pkgs, cfg)
 
+	// Compliance can drop packages or mutate package IDs through stubbing; keep the
+	// relationship set aligned with the package set that will be written to the SBOM.
 	relIdx := relationship.NewIndex(relationships...)
 	for _, p := range droppedPkgs {
 		relIdx.Remove(p.ID())
@@ -143,6 +147,8 @@ func filterNonCompliantPackages(pkgs []pkg.Package, cfg cataloging.ComplianceCon
 	var replacements []packageReplacement
 	var complianceErrs []error
 	for _, p := range pkgs {
+		// Evaluate every package before returning so fail mode reports all missing
+		// fields found by this cataloger, not just the first one.
 		keep, replacement, err := applyComplianceRules(&p, cfg)
 		if err != nil {
 			complianceErrs = append(complianceErrs, err)
@@ -165,6 +171,8 @@ func applyComplianceRules(p *pkg.Package, cfg cataloging.ComplianceConfig) (bool
 	var replacement *packageReplacement
 	var complianceErrs []error
 
+	// The return bool only means "stub this field"; drop/fail actions are tracked
+	// separately because one package can be missing both name and version.
 	applyComplianceRule := func(value, fieldName string, action cataloging.ComplianceAction) (bool, error) {
 		if strings.TrimSpace(value) != "" {
 			return false, nil
@@ -199,6 +207,8 @@ func applyComplianceRules(p *pkg.Package, cfg cataloging.ComplianceConfig) (bool
 
 	ogID := p.ID()
 
+	// Apply name before version so any stubbed name contributes to the final package
+	// ID and to relationship replacement below.
 	if stub, err := applyComplianceRule(p.Name, "name", cfg.MissingName); err != nil {
 		complianceErrs = append(complianceErrs, err)
 	} else if stub {

--- a/internal/task/package_task_factory_test.go
+++ b/internal/task/package_task_factory_test.go
@@ -1,16 +1,20 @@
 package task
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/anchore/syft/internal/sbomsync"
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/cataloging"
 	"github.com/anchore/syft/syft/cpe"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/sbom"
 )
 
 func Test_hasAuthoritativeCPE(t *testing.T) {
@@ -298,4 +302,77 @@ func TestApplyComplianceRules_Fail(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, isCompliant)
 	assert.Nil(t, replacement)
+}
+
+func TestNewPackageTask_ComplianceFail(t *testing.T) {
+	p := pkg.Package{
+		Name:      "dep",
+		Type:      pkg.PythonPkg,
+		Locations: file.NewLocationSet(file.NewLocation("requirements.txt")),
+	}
+	p.SetID()
+
+	cfg := DefaultCatalogingFactoryConfig()
+	cfg.ComplianceConfig = cataloging.ComplianceConfig{
+		MissingName:    cataloging.ComplianceActionKeep,
+		MissingVersion: cataloging.ComplianceActionFail,
+	}
+
+	s := sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: pkg.NewCollection(),
+		},
+	}
+	task := NewPackageTask(cfg, testPackageCataloger{
+		name: "python-package-cataloger",
+		pkgs: []pkg.Package{p},
+	})
+
+	err := task.Execute(context.Background(), file.NewMockResolverForPaths(), sbomsync.NewBuilder(&s))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing version")
+	assert.Contains(t, err.Error(), "requirements.txt")
+}
+
+type testPackageCataloger struct {
+	name string
+	pkgs []pkg.Package
+	rels []artifact.Relationship
+	err  error
+}
+
+func (c testPackageCataloger) Name() string {
+	return c.name
+}
+
+func (c testPackageCataloger) Catalog(context.Context, file.Resolver) ([]pkg.Package, []artifact.Relationship, error) {
+	return c.pkgs, c.rels, c.err
+}
+
+func TestNewPackageTask_ComplianceFailJoinsCatalogerError(t *testing.T) {
+	catalogerErr := errors.New("cataloger failed")
+	p := pkg.Package{Name: "dep", Type: pkg.PythonPkg}
+	p.SetID()
+
+	cfg := DefaultCatalogingFactoryConfig()
+	cfg.ComplianceConfig = cataloging.ComplianceConfig{
+		MissingName:    cataloging.ComplianceActionKeep,
+		MissingVersion: cataloging.ComplianceActionFail,
+	}
+
+	s := sbom.SBOM{
+		Artifacts: sbom.Artifacts{
+			Packages: pkg.NewCollection(),
+		},
+	}
+	task := NewPackageTask(cfg, testPackageCataloger{
+		name: "python-package-cataloger",
+		pkgs: []pkg.Package{p},
+		err:  catalogerErr,
+	})
+
+	err := task.Execute(context.Background(), file.NewMockResolverForPaths(), sbomsync.NewBuilder(&s))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, catalogerErr)
+	assert.Contains(t, err.Error(), "missing version")
 }

--- a/syft/cataloging/compliance.go
+++ b/syft/cataloging/compliance.go
@@ -43,7 +43,7 @@ func (c ComplianceAction) Parse() ComplianceAction {
 		return ComplianceActionDrop
 	case string(ComplianceActionStub), "replace":
 		return ComplianceActionStub
-	case string(ComplianceActionFail):
+	case string(ComplianceActionFail), "error":
 		return ComplianceActionFail
 	}
 	return ComplianceActionKeep

--- a/syft/cataloging/compliance.go
+++ b/syft/cataloging/compliance.go
@@ -8,6 +8,7 @@ const (
 	ComplianceActionKeep ComplianceAction = "keep"
 	ComplianceActionDrop ComplianceAction = "drop"
 	ComplianceActionStub ComplianceAction = "stub"
+	ComplianceActionFail ComplianceAction = "fail"
 )
 
 const UnknownStubValue = "UNKNOWN"
@@ -42,6 +43,8 @@ func (c ComplianceAction) Parse() ComplianceAction {
 		return ComplianceActionDrop
 	case string(ComplianceActionStub), "replace":
 		return ComplianceActionStub
+	case string(ComplianceActionFail):
+		return ComplianceActionFail
 	}
 	return ComplianceActionKeep
 }

--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -142,12 +142,6 @@ func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Re
 		name := removeExtras(req.Name)
 		version := parseVersion(req.VersionConstraint, rp.cfg.GuessUnpinnedRequirements)
 
-		if version == "" {
-			log.WithFields("path", reader.RealPath, "line", line).Trace("unable to determine package version in requirements.txt line")
-			errs = unknown.Appendf(errs, reader, "unable to determine package version in requirements.txt line: %q", line)
-			continue
-		}
-
 		packages = append(
 			packages,
 			newPackageForRequirementsWithMetadata(

--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -26,7 +26,9 @@ const (
 	//      --hash=sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3 \
 	//      --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65  # some comment
 
-	// namePattern matches: requests[security], celery[redis, pytest]
+	// namePattern matches: requests[security], celery[redis, pytest].
+	// Keep this narrower than arbitrary text so lines like "example archive"
+	// are treated as unparsable instead of as an unpinned package named "example".
 	namePattern = `(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*(\[[^\S\r\n]*[A-Za-z0-9._-]+([^\S\r\n]*,[^\S\r\n]*[A-Za-z0-9._-]+)*[^\S\r\n]*\])?)`
 
 	// versionConstraintPattern matches: == 2.8.*
@@ -69,6 +71,9 @@ type unprocessedRequirement struct {
 func newRequirement(raw string) *unprocessedRequirement {
 	var r unprocessedRequirement
 
+	// Match the same text parseRequirementsTxt uses after comments and
+	// continuation markers are removed. This keeps unit-level parser behavior
+	// consistent with whole-file parsing.
 	raw = trimRequirementsTxtLine(raw)
 	values := internal.MatchNamedCaptureGroups(requirementPattern, raw)
 
@@ -145,6 +150,9 @@ func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Re
 		name := removeExtras(req.Name)
 		version := parseVersion(req.VersionConstraint, rp.cfg.GuessUnpinnedRequirements)
 
+		// Keep valid unpinned requirements in the package set with an empty
+		// version. Downstream compliance rules decide whether that is allowed,
+		// stubbed, dropped, or treated as a scan failure.
 		packages = append(
 			packages,
 			newPackageForRequirementsWithMetadata(

--- a/syft/pkg/cataloger/python/parse_requirements.go
+++ b/syft/pkg/cataloger/python/parse_requirements.go
@@ -26,8 +26,8 @@ const (
 	//      --hash=sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3 \
 	//      --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65  # some comment
 
-	// namePattern matches: requests[security]
-	namePattern = `(?P<name>\w[\w\[\],\s-_\.]+)`
+	// namePattern matches: requests[security], celery[redis, pytest]
+	namePattern = `(?P<name>[A-Za-z0-9][A-Za-z0-9._-]*(\[[^\S\r\n]*[A-Za-z0-9._-]+([^\S\r\n]*,[^\S\r\n]*[A-Za-z0-9._-]+)*[^\S\r\n]*\])?)`
 
 	// versionConstraintPattern matches: == 2.8.*
 	// the version token accepts every character PEP 440 versions can contain: digits and letters,
@@ -54,7 +54,8 @@ var requirementPattern = regexp.MustCompile(
 		whiteSpaceNoNewlinePattern +
 		versionConstraintPattern +
 		markersPattern +
-		hashesPattern,
+		hashesPattern +
+		`$`,
 )
 
 type unprocessedRequirement struct {
@@ -68,6 +69,7 @@ type unprocessedRequirement struct {
 func newRequirement(raw string) *unprocessedRequirement {
 	var r unprocessedRequirement
 
+	raw = trimRequirementsTxtLine(raw)
 	values := internal.MatchNamedCaptureGroups(requirementPattern, raw)
 
 	if err := mapstructure.Decode(values, &r); err != nil {
@@ -99,8 +101,9 @@ func newRequirementsParser(cfg CatalogerConfig) requirementsParser {
 	}
 }
 
-// parseRequirementsTxt takes a Python requirements.txt file, returning all Python packages that are locked to a
-// specific version.
+// parseRequirementsTxt takes a Python requirements.txt file, returning all valid Python package requirements. When
+// configured, versions can be inferred from constraints; otherwise valid unpinned requirements are returned without a
+// version so compliance rules can decide how to handle them.
 func (rp requirementsParser) parseRequirementsTxt(ctx context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	var errs error
 	var packages []pkg.Package

--- a/syft/pkg/cataloger/python/parse_requirements_test.go
+++ b/syft/pkg/cataloger/python/parse_requirements_test.go
@@ -154,6 +154,102 @@ func TestParseRequirementsTxt(t *testing.T) {
 		},
 	}
 
+	unpinnedPkgs := []pkg.Package{
+		{
+			Name:      "bar",
+			PURL:      "pkg:pypi/bar",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "bar",
+				VersionConstraint: ">= 1.0.0, <= 2.0.0, != 3.0.0, <= 3.0.0",
+			},
+		},
+		{
+			Name:      "coverage",
+			PURL:      "pkg:pypi/coverage",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "coverage",
+				VersionConstraint: "!= 3.5",
+			},
+		},
+		{
+			Name:      "mopidy-dirble",
+			PURL:      "pkg:pypi/mopidy-dirble",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "Mopidy-Dirble",
+				VersionConstraint: "~= 1.1",
+			},
+		},
+		{
+			Name:      "numpy",
+			PURL:      "pkg:pypi/numpy",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "numpy",
+				VersionConstraint: ">= 3.4.1",
+				Markers:           `sys_platform == 'win32'`,
+			},
+		},
+		{
+			Name:      "numpynew",
+			PURL:      "pkg:pypi/numpynew",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:    "numpyNew",
+				Markers: `sys_platform == 'win32'`,
+			},
+		},
+		{
+			Name:      "requests",
+			PURL:      "pkg:pypi/requests",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "requests",
+				Extras:            []string{"security"},
+				VersionConstraint: "== 2.8.*",
+				Markers:           `python_version < "2.7" and sys_platform == "linux"`,
+			},
+		},
+		{
+			Name:      "sqlalchemy",
+			PURL:      "pkg:pypi/sqlalchemy",
+			Locations: locations,
+			Language:  pkg.Python,
+			Type:      pkg.PythonPkg,
+			Metadata: pkg.PythonRequirementsEntry{
+				Name:              "sqlalchemy",
+				VersionConstraint: ">= 1.0.0, <= 2.0.0, != 3.0.0, <= 3.0.0",
+			},
+		},
+	}
+
+	unguessablePkgs := []pkg.Package{
+		unpinnedPkgs[1], // coverage
+		unpinnedPkgs[4], // numpyNew
+	}
+
+	mergePkgs := func(groups ...[]pkg.Package) []pkg.Package {
+		var out []pkg.Package
+		for _, group := range groups {
+			out = append(out, group...)
+		}
+		return out
+	}
+
 	var testCases = []struct {
 		name                  string
 		fixture               string
@@ -167,7 +263,7 @@ func TestParseRequirementsTxt(t *testing.T) {
 			cfg: CatalogerConfig{
 				GuessUnpinnedRequirements: false,
 			},
-			expectedPkgs: pinnedPkgs,
+			expectedPkgs: mergePkgs(pinnedPkgs, unpinnedPkgs),
 		},
 		{
 			name:    "guess unpinned requirements (lowest version)",
@@ -175,7 +271,7 @@ func TestParseRequirementsTxt(t *testing.T) {
 			cfg: CatalogerConfig{
 				GuessUnpinnedRequirements: true,
 			},
-			expectedPkgs: append([]pkg.Package{
+			expectedPkgs: mergePkgs([]pkg.Package{
 				{
 					Name:      "mopidy-dirble",
 					Version:   "1.1",
@@ -239,7 +335,7 @@ func TestParseRequirementsTxt(t *testing.T) {
 						Markers:           `python_version < "2.7" and sys_platform == "linux"`,
 					},
 				},
-			}, pinnedPkgs...),
+			}, pinnedPkgs, unguessablePkgs),
 		},
 	}
 
@@ -368,6 +464,10 @@ func Test_newRequirement(t *testing.T) {
 				VersionConstraint: ">= 3.4.1",
 				Markers:           "sys_platform == 'win32'",
 			},
+		},
+		{
+			name: "invalid package name with spaces",
+			raw:  "example archive",
 		},
 		{
 			name: "local version identifier",


### PR DESCRIPTION
## Description

Adds a `fail` compliance action for missing package names and versions. When configured, Syft will throw an error and abort the SBOM generation process instead of continuing.

In addition to existing actions, the `missing-name` and `missing-version` config options under `compliance` now accept `fail` (with alias `error`).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #4388
