### PR TITLE
fix(cyclonedx): drop dependency edges that reference packages missing from the catalog

### DIFF
--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -88,7 +88,7 @@ func ToFormatModel(s sbom.SBOM) *cyclonedx.BOM {
 	}
 	cdxBOM.Components = &components
 
-	dependencies := toDependencies(s.Relationships)
+	dependencies := toDependencies(s.Relationships, s.Artifacts.Packages)
 	if len(dependencies) > 0 {
 		cdxBOM.Dependencies = &dependencies
 	}
@@ -250,7 +250,7 @@ func isExpressiblePackageRelationship(ty artifact.RelationshipType) bool {
 	}
 }
 
-func toDependencies(relationships []artifact.Relationship) []cyclonedx.Dependency {
+func toDependencies(relationships []artifact.Relationship, catalog *pkg.Collection) []cyclonedx.Dependency {
 	dependencies := map[string]*cyclonedx.Dependency{}
 	for _, r := range relationships {
 		exists := isExpressiblePackageRelationship(r.Type)
@@ -269,6 +269,14 @@ func toDependencies(relationships []artifact.Relationship) []cyclonedx.Dependenc
 		toPkg, ok := r.To.(pkg.Package)
 		if !ok {
 			log.Tracef("unable to convert relationship toPkg to CycloneDX JSON, dropping: %#v", r)
+			continue
+		}
+
+		// a relationship may reference a package that was filtered out of (or never made it into) the
+		// final catalog. Including it here would create a dependency reference to a component that
+		// does not exist in the BOM, which fails CycloneDX validation.
+		if catalog.Package(fromPkg.ID()) == nil || catalog.Package(toPkg.ID()) == nil {
+			log.Debugf("skipping relationship that references a package not in the catalog: %#v", r)
 			continue
 		}
 

--- a/syft/format/common/cyclonedxhelpers/to_format_model.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model.go
@@ -251,6 +251,10 @@ func isExpressiblePackageRelationship(ty artifact.RelationshipType) bool {
 }
 
 func toDependencies(relationships []artifact.Relationship, catalog *pkg.Collection) []cyclonedx.Dependency {
+	if catalog == nil {
+		return nil
+	}
+
 	dependencies := map[string]*cyclonedx.Dependency{}
 	for _, r := range relationships {
 		exists := isExpressiblePackageRelationship(r.Type)

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -134,6 +134,36 @@ func Test_relationships(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "relationships referencing a package missing from the catalog are dropped",
+			sbom: sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					// p4 is intentionally left out of the catalog (e.g. it was filtered out by a
+					// cataloger after relationships were already built)
+					Packages: pkg.NewCollection(p1, p2, p3),
+				},
+				Relationships: []artifact.Relationship{
+					{
+						From: p2,
+						To:   p1,
+						Type: artifact.DependencyOfRelationship,
+					},
+					{
+						From: p4,
+						To:   p2,
+						Type: artifact.DependencyOfRelationship,
+					},
+				},
+			},
+			expected: &[]cyclonedx.Dependency{
+				{
+					Ref: helpers.DeriveBomRef(p1),
+					Dependencies: &[]string{
+						helpers.DeriveBomRef(p2),
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/syft/format/common/cyclonedxhelpers/to_format_model_test.go
+++ b/syft/format/common/cyclonedxhelpers/to_format_model_test.go
@@ -164,6 +164,22 @@ func Test_relationships(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nil package catalog does not panic and yields no dependencies",
+			sbom: sbom.SBOM{
+				Artifacts: sbom.Artifacts{
+					Packages: nil,
+				},
+				Relationships: []artifact.Relationship{
+					{
+						From: p2,
+						To:   p1,
+						Type: artifact.DependencyOfRelationship,
+					},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Syft's CycloneDX encoder can emit a `dependencies` section that references a component (bom-ref) which does not exist anywhere in the SBOM's `components` list. This happens when an internal `artifact.Relationship` refers to a package that was filtered out of (or never made it into) the final package catalog before formatting — the relationship survives, but the component it points to does not. CycloneDX validators (e.g. cyclonedx-python-lib) reject this with:

```
One or more Components have Dependency references to Components/Services that are not known in this BOM.
```

This change makes `toDependencies()` in the CycloneDX encoder cross-check both sides of a relationship against the final package catalog (`s.Artifacts.Packages`) before emitting a dependency edge, dropping any relationship that references a package not present in the catalog — the same way relationships with un-encodable types are already dropped.

No CLI output or configuration changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Report: https://github.com/anchore/syft/issues/4208

## Validation

- Added `syft/format/common/cyclonedxhelpers/to_format_model_test.go::Test_relationships/relationships_referencing_a_package_missing_from_the_catalog_are_dropped`, which builds an SBOM with only 3 packages in the catalog but a relationship pointing at a 4th package that was never added to it. Verified this test FAILS on the pre-fix code (the dangling dependency edge is emitted) and PASSES after the fix (the dangling edge is dropped, the valid edge is kept).
- `go build ./...` passes.
- `go test ./syft/format/...` passes except for 4 pre-existing test functions that require a local Docker daemon to build image fixtures (`exec: "docker": executable file not found in $PATH`) — unrelated to this change and reproducible identically on the unmodified base commit.
- `make lint` (golangci-lint) passes with no findings on the change.

Note: this fix is scoped to the CycloneDX encoder since that's what the linked issue reports. The SPDX and syft-json encoders have the same unguarded pattern (relationships aren't checked against the final catalog) and may be worth a follow-up, but that's out of scope here to keep this change minimal.

Fixes #4208