### PR TITLE
Detect licenses from Maven pom.xml comments

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -728,6 +728,11 @@ func pomProjectByParentPath(ctx context.Context, archivePath string, location fi
 		if pom == nil {
 			continue
 		}
+		if pom.Licenses == nil || len(*pom.Licenses) == 0 {
+			if licenses := maven.ExtractLicensesFromComments(fileContents); len(licenses) > 0 {
+				pom.Licenses = &licenses
+			}
+		}
 
 		projectByParentPath[path.Dir(filePath)] = &parsedPomProject{
 			path:    filePath,

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"archive/zip"
 	"bufio"
 	"fmt"
 	"io"
@@ -87,6 +88,54 @@ func TestSearchMavenForLicenses(t *testing.T) {
 			assert.Equal(t, tc.expectedLicenses, toPkgLicenses(ctx, nil, resolvedLicenses))
 		})
 	}
+}
+
+func TestPomProjectByParentPath_enrichesMissingLicensesFromComments(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "comment-license.jar")
+
+	fh, err := os.Create(archivePath)
+	require.NoError(t, err)
+
+	zw := zip.NewWriter(fh)
+	w, err := zw.Create("META-INF/maven/com.example/demo/pom.xml")
+	require.NoError(t, err)
+
+	_, err = io.WriteString(w, `<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Oracle licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+</project>`)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, fh.Close())
+
+	projects, err := pomProjectByParentPath(t.Context(), archivePath, file.NewLocation(archivePath), []string{"META-INF/maven/com.example/demo/pom.xml"})
+	require.NoError(t, err)
+
+	parsed := projects["META-INF/maven/com.example/demo"]
+	require.NotNil(t, parsed)
+	require.NotNil(t, parsed.project)
+	require.NotNil(t, parsed.project.Licenses)
+	require.Len(t, *parsed.project.Licenses, 1)
+	require.NotNil(t, (*parsed.project.Licenses)[0].Name)
+	require.Equal(t, "Apache-2.0", *(*parsed.project.Licenses)[0].Name)
+
+	licenses, err := maven.NewResolver(nil, maven.DefaultConfig()).ResolveLicenses(t.Context(), parsed.project)
+	require.NoError(t, err)
+	require.Len(t, licenses, 1)
+	require.NotNil(t, licenses[0].Name)
+	require.Equal(t, "Apache-2.0", *licenses[0].Name)
+	require.NotNil(t, licenses[0].URL)
+	require.Equal(t, "http://www.apache.org/licenses/LICENSE-2.0", *licenses[0].URL)
 }
 
 func TestParseJar(t *testing.T) {

--- a/syft/pkg/cataloger/java/internal/maven/comment_license_parser.go
+++ b/syft/pkg/cataloger/java/internal/maven/comment_license_parser.go
@@ -1,0 +1,127 @@
+package maven
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/anchore/syft/internal/spdxlicense"
+)
+
+var (
+	xmlCommentPattern = regexp.MustCompile(`(?s)<!--(.*?)-->`)
+	licenseURLPattern = regexp.MustCompile(`https?://[^\s<>"')]+`)
+	spdxIDPattern     = regexp.MustCompile(`(?i)\b(?:Apache-2\.0|MIT|BSD-2-Clause|BSD-3-Clause|BSD-4-Clause|ISC|MPL-2\.0|EPL-1\.0|EPL-2\.0|CDDL-1\.0|Unlicense|GPL-2\.0(?:-only|-or-later|\+)?|GPL-3\.0(?:-only|-or-later|\+)?|LGPL-2\.1(?:-only|-or-later|\+)?|LGPL-3\.0(?:-only|-or-later|\+)?|AGPL-3\.0(?:-only|-or-later|\+)?)\b`)
+)
+
+var commentLicenseMatchers = []struct {
+	pattern *regexp.Regexp
+	spdxID  string
+}{
+	{pattern: regexp.MustCompile(`(?i)\bapache(?: software)? license(?:,\s*version|\s+version)?\s+2(?:\.0)?\b`), spdxID: "Apache-2.0"},
+	{pattern: regexp.MustCompile(`(?i)\bmit license\b`), spdxID: "MIT"},
+	{pattern: regexp.MustCompile(`(?i)\bisc license\b`), spdxID: "ISC"},
+	{pattern: regexp.MustCompile(`(?i)\bunlicense\b`), spdxID: "Unlicense"},
+	{pattern: regexp.MustCompile(`(?i)\bbsd[\s-]+2[\s-]+clause license\b`), spdxID: "BSD-2-Clause"},
+	{pattern: regexp.MustCompile(`(?i)\bbsd[\s-]+3[\s-]+clause license\b`), spdxID: "BSD-3-Clause"},
+	{pattern: regexp.MustCompile(`(?i)\bbsd[\s-]+4[\s-]+clause license\b`), spdxID: "BSD-4-Clause"},
+	{pattern: regexp.MustCompile(`(?i)\bmozilla public license(?:,\s*version|\s+version)?\s+2(?:\.0)?\b`), spdxID: "MPL-2.0"},
+	{pattern: regexp.MustCompile(`(?i)\beclipse public license(?:,\s*version|\s+version)?\s+1(?:\.0)?\b`), spdxID: "EPL-1.0"},
+	{pattern: regexp.MustCompile(`(?i)\beclipse public license(?:,\s*version|\s+version)?\s+2(?:\.0)?\b`), spdxID: "EPL-2.0"},
+	{pattern: regexp.MustCompile(`(?i)\bcommon development and distribution license(?:,\s*version|\s+version)?\s+1(?:\.0)?\b`), spdxID: "CDDL-1.0"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu general public license(?:,\s*version|\s+version)?\s+2(?:\.0)?\s+or later\b`), spdxID: "GPL-2.0-or-later"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu general public license(?:,\s*version|\s+version)?\s+2(?:\.0)?\b`), spdxID: "GPL-2.0-only"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\s+or later\b`), spdxID: "GPL-3.0-or-later"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\b`), spdxID: "GPL-3.0-only"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu lesser general public license(?:,\s*version|\s+version)?\s+2\.1\s+or later\b`), spdxID: "LGPL-2.1-or-later"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu lesser general public license(?:,\s*version|\s+version)?\s+2\.1\b`), spdxID: "LGPL-2.1-only"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu lesser general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\s+or later\b`), spdxID: "LGPL-3.0-or-later"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu lesser general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\b`), spdxID: "LGPL-3.0-only"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu affero general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\s+or later\b`), spdxID: "AGPL-3.0-or-later"},
+	{pattern: regexp.MustCompile(`(?i)\bgnu affero general public license(?:,\s*version|\s+version)?\s+3(?:\.0)?\b`), spdxID: "AGPL-3.0-only"},
+}
+
+func ExtractLicensesFromComments(rawXML string) []License {
+	type detectedLicense struct {
+		name string
+		url  string
+	}
+
+	if rawXML == "" {
+		return nil
+	}
+
+	comments := xmlCommentPattern.FindAllStringSubmatch(rawXML, -1)
+	if len(comments) == 0 {
+		return nil
+	}
+
+	detected := make(map[string]*detectedLicense)
+	var order []string
+	add := func(key, name, url string) {
+		if key == "" {
+			return
+		}
+		license, exists := detected[key]
+		if !exists {
+			license = &detectedLicense{}
+			detected[key] = license
+			order = append(order, key)
+		}
+		if license.name == "" {
+			license.name = name
+		}
+		if license.url == "" {
+			license.url = url
+		}
+	}
+
+	for _, match := range comments {
+		if len(match) < 2 {
+			continue
+		}
+		comment := match[1]
+
+		for _, url := range licenseURLPattern.FindAllString(comment, -1) {
+			url = strings.TrimRight(strings.TrimSpace(url), ".,:;)")
+			if info, found := spdxlicense.LicenseByURL(url); found {
+				add(info.ID, info.ID, url)
+			}
+		}
+
+		for _, matcher := range commentLicenseMatchers {
+			if matcher.pattern.MatchString(comment) {
+				if canonicalID, ok := spdxlicense.ID(matcher.spdxID); ok {
+					add(canonicalID, canonicalID, "")
+				}
+			}
+		}
+
+		for _, spdxID := range spdxIDPattern.FindAllString(comment, -1) {
+			if canonicalID, ok := spdxlicense.ID(spdxID); ok {
+				add(canonicalID, canonicalID, "")
+			}
+		}
+	}
+
+	var out []License
+	for _, key := range order {
+		license := detected[key]
+		if license == nil || (license.name == "" && license.url == "") {
+			continue
+		}
+
+		var name, url *string
+		if license.name != "" {
+			name = &license.name
+		}
+		if license.url != "" {
+			url = &license.url
+		}
+		out = append(out, License{
+			Name: name,
+			URL:  url,
+		})
+	}
+
+	return out
+}

--- a/syft/pkg/cataloger/java/internal/maven/comment_license_parser_test.go
+++ b/syft/pkg/cataloger/java/internal/maven/comment_license_parser_test.go
@@ -1,0 +1,63 @@
+package maven
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_licensesFromComments(t *testing.T) {
+	licenses := ExtractLicensesFromComments(`<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Oracle licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License. You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+-->
+<project/>`)
+
+	require.Len(t, licenses, 1)
+	require.NotNil(t, licenses[0].Name)
+	require.Equal(t, "Apache-2.0", *licenses[0].Name)
+	require.NotNil(t, licenses[0].URL)
+	require.Equal(t, "http://www.apache.org/licenses/LICENSE-2.0", *licenses[0].URL)
+}
+
+func Test_licensesFromComments_ignoresNonLicenseURLs(t *testing.T) {
+	licenses := ExtractLicensesFromComments(`<?xml version="1.0" encoding="UTF-8"?>
+<!-- build note: see https://github.com/example/project/issues/123 -->
+<project/>`)
+
+	require.Nil(t, licenses)
+}
+
+func TestResolver_ResolveLicenses_prefersStructuredLicensesOverComments(t *testing.T) {
+	pom, err := ParsePomXML(strings.NewReader(`<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: MIT -->
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <licenses>
+    <license>
+      <name>Apache 2</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>missing-parent</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <artifactId>child</artifactId>
+  <version>1.0.0</version>
+</project>`))
+	require.NoError(t, err)
+
+	licenses, err := NewResolver(nil, DefaultConfig()).ResolveLicenses(t.Context(), pom)
+	require.NoError(t, err)
+	require.Len(t, licenses, 1)
+	require.NotNil(t, licenses[0].Name)
+	require.Equal(t, "Apache 2", *licenses[0].Name)
+	require.NotNil(t, licenses[0].URL)
+	require.Equal(t, "http://www.apache.org/licenses/LICENSE-2.0.txt", *licenses[0].URL)
+}

--- a/syft/pkg/cataloger/java/internal/maven/pom_parser.go
+++ b/syft/pkg/cataloger/java/internal/maven/pom_parser.go
@@ -22,12 +22,12 @@ type (
 
 // ParsePomXML decodes a pom XML file, detecting and converting non-UTF-8 charsets. this DOES NOT perform any logic to resolve properties such as groupID, artifactID, and version
 func ParsePomXML(content io.Reader) (project *Project, err error) {
-	inputReader, err := getUtf8Reader(content)
+	pomContents, err := getUtf8Contents(content)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read pom.xml: %w", err)
 	}
 
-	decoder := xml.NewDecoder(inputReader)
+	decoder := xml.NewDecoder(bytes.NewReader(pomContents))
 	// when an xml file has a character set declaration (e.g. '<?xml version="1.0" encoding="ISO-8859-1"?>') read that and use the correct decoder
 	decoder.CharsetReader = charset.NewReaderLabel
 
@@ -40,6 +40,14 @@ func ParsePomXML(content io.Reader) (project *Project, err error) {
 }
 
 func getUtf8Reader(content io.Reader) (io.Reader, error) {
+	pomContents, err := getUtf8Contents(content)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(pomContents), nil
+}
+
+func getUtf8Contents(content io.Reader) ([]byte, error) {
 	pomContents, err := io.ReadAll(content) //nolint:gocritic // charset detection requires full buffer
 	if err != nil {
 		return nil, err
@@ -63,5 +71,5 @@ func getUtf8Reader(content io.Reader) (io.Reader, error) {
 		// characters with the UTF-8 replacement character.
 		inputReader = strings.NewReader(strings.ToValidUTF8(string(pomContents), "�"))
 	}
-	return inputReader, nil
+	return io.ReadAll(inputReader)
 }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes along with any relevant motivation and context -->

Fat/uber JAR scans could miss Maven licenses when embedded `META-INF/maven/**/pom.xml` files omitted `<licenses>` and only documented licensing in XML comments. This change adds an offline fallback that extracts license signals from POM comments before attempting parent POM resolution.

**Disclaimer Note on my use of AI: I used Copilot to come up with this PR.** 
Take it as a base for discussion. I am not experienced with go (comming from the Java world), but I managed to do some some step debugging in VSCode. I will run it against our own project where I identified the issues with the pom.xml
I have no clue how bad / sloppy this go code is but I will try to be helpful comming up with a better solution with help you. 
For example I wonder if the regex parsing of the license is already solved in the codebase somewhere and if this PR reinvents the wheel. Just let me know or use the PR as base. 

- **Comment-based license fallback**
  - Preserve raw normalized POM XML during parse
  - Extract licenses from XML comments via:
    - SPDX identifiers
    - well-known license names
    - SPDX-known license URLs

- **Resolution order**
  - Keep structured `<licenses>` as the first and authoritative source
  - Only use comment extraction when direct POM licenses are absent
  - Run comment fallback before parent-POM traversal

- **Scope control**
  - Accept only recognized license URLs
  - Ignore unrelated URLs in non-license comments to avoid false positives

```xml
<!--
Oracle licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License. You may obtain a copy of the License at
http://www.apache.org/licenses/LICENSE-2.0
-->
```

<!-- If CLI output changed, show an example (before/after if helpful) -->

<!-- If this changes application or API configuration, describe new/changed/removed options -->

## Type of change

<!-- Delete any that are not relevant -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
- [x] This code was generated using AI (original PR https://github.com/chrisrueger/syft/pull/1 ) 


## Issue references

<!-- If this fixes an issue, include "Fixes #<issue-number>" or otherwise list the issue references -->

Fixes #5248


## Summary (Copilot)

This pull request enhances Maven POM license detection by extracting license information from XML comments when structured license data is missing. It introduces a new parser for license comments, updates the main parser logic to use it, and adds comprehensive tests to ensure accuracy and preference for structured data when available.

**License extraction improvements:**

* Added a new function `ExtractLicensesFromComments` in `comment_license_parser.go` to detect and extract SPDX license IDs and URLs from XML comments in POM files, using regex patterns and mappings to known licenses.
* Updated `pomProjectByParentPath` in `archive_parser.go` to enrich missing license data by extracting licenses from XML comments if the structured `<licenses>` block is empty or missing.

**Testing and validation:**

* Added unit tests for the comment license extraction logic in `comment_license_parser_test.go`, covering detection, ignoring non-license URLs, and preferring structured licenses over comment-based detection.
* Added an integration test to `archive_parser_test.go` to verify that license extraction from comments works as expected within the archive parsing workflow.

**Internal refactoring:**

* Refactored POM XML parsing in `pom_parser.go` to read the entire file content for charset detection and to facilitate comment-based license extraction. [[1]](diffhunk://#diff-bafd24cc512b709beca3ff71001fcda3828e6b29f0b414f2f2489f873abb01ecL25-R30) [[2]](diffhunk://#diff-bafd24cc512b709beca3ff71001fcda3828e6b29f0b414f2f2489f873abb01ecR43-R50) [[3]](diffhunk://#diff-bafd24cc512b709beca3ff71001fcda3828e6b29f0b414f2f2489f873abb01ecL66-R74)





