### PR TITLE
directory resolver ignores --exclude for symlink targets

### DIFF
--- a/syft/source/directorysource/directory_source.go
+++ b/syft/source/directorysource/directory_source.go
@@ -160,14 +160,23 @@ func GetDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 
 	return []fileresolver.PathIndexVisitor{
 		func(_, path string, info os.FileInfo, _ error) error {
-			for _, exclusion := range exclusions {
-				// this is required to handle Windows filepaths
-				path = filepath.ToSlash(path)
-				matches, err := doublestar.Match(exclusion, path)
-				if err != nil {
-					return nil
+			// this is required to handle Windows filepaths
+			path = filepath.ToSlash(path)
+
+			// A symlink can point into an excluded directory even though the link
+			// itself sits on an unexcluded path, and the indexer follows such links
+			// by indexing the resolved target as an additional root (see indexAllRoots).
+			// That second pass never visits the excluded directory entry itself, so
+			// resolve the real path here and apply the exclusions to it as well.
+			realPath := path
+			if info != nil && info.Mode()&os.ModeSymlink != 0 {
+				if resolved, err := filepath.EvalSymlinks(path); err == nil {
+					realPath = filepath.ToSlash(resolved)
 				}
-				if matches {
+			}
+
+			for _, exclusion := range exclusions {
+				if exclusionMatches(exclusion, path) || exclusionMatches(exclusion, realPath) {
 					if info != nil && info.IsDir() {
 						return filepath.SkipDir
 					}
@@ -177,6 +186,31 @@ func GetDirectoryExclusionFunctions(root string, exclusions []string) ([]fileres
 			return nil
 		},
 	}, nil
+}
+
+// exclusionMatches reports whether the given path is covered by the exclusion
+// pattern. Exclusion patterns are absolute paths relative to the scan root.
+//
+// Besides the glob semantics of doublestar.Match, literal patterns (with no glob
+// metacharacters) are treated as directory exclusions: they must also match
+// descendants. The directory entry itself normally carries the exclusion via
+// SkipDir during the primary walk, but paths that are reached by other means
+// (e.g. symlink targets indexed as separate roots) never pass through the
+// excluded directory entry, so the path-prefix check is required to keep the
+// exclusion contract intact.
+func exclusionMatches(exclusion, path string) bool {
+	matches, err := doublestar.Match(exclusion, path)
+	if err != nil {
+		return false
+	}
+	if matches {
+		return true
+	}
+
+	if !strings.ContainsAny(exclusion, "*?[{") {
+		return strings.HasPrefix(path, exclusion+"/")
+	}
+	return false
 }
 
 // deriveIDFromDirectory generates an artifact ID from the given directory config. If an alias is provided, then

--- a/syft/source/directorysource/directory_source_symlink_exclude_test.go
+++ b/syft/source/directorysource/directory_source_symlink_exclude_test.go
@@ -1,0 +1,125 @@
+package directorysource
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/internal/fileresolver"
+)
+
+func Test_DirectoryExclusionFunctions_ExcludeVsSymlinkTarget(t *testing.T) {
+	// regression test for https://github.com/anchore/syft/issues/5232
+	//
+	// a directory excluded with --exclude is still indexed (and its contents
+	// cataloged) when a symlink on an unexcluded path points into it. the
+	// indexer follows symlinks by indexing the resolved target as a separate
+	// root, so the excluded directory entry is never visited on that second
+	// pass and the exclusion never fires.
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	writeFile := func(rel string) {
+		p := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte("contents"), 0o644))
+	}
+
+	writeFile(filepath.Join("boot", "grub2", "grub.cfg"))
+	writeFile(filepath.Join("keep", "file.txt"))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "etc"), 0o755))
+
+	indexAll := func(exclusion string) []string {
+		visitors, err := GetDirectoryExclusionFunctions(root, []string{exclusion})
+		require.NoError(t, err)
+
+		res, err := fileresolver.NewFromDirectory(root, root, visitors...)
+		require.NoError(t, err)
+
+		var indexed []string
+		for l := range res.AllLocations(context.Background()) {
+			indexed = append(indexed, l.RealPath)
+		}
+		return indexed
+	}
+
+	// locations are reported relative to the resolver base, e.g. "/etc"
+	assertNoExcludedContent := func(t *testing.T, indexed []string) {
+		t.Helper()
+		for _, p := range indexed {
+			require.False(t, strings.HasPrefix(p, "/boot/") || p == "/boot", "path under excluded directory was indexed: %s", p)
+		}
+	}
+
+	t.Run("file symlink into excluded directory", func(t *testing.T) {
+		link := filepath.Join(root, "etc", "grub2.cfg")
+		require.NoError(t, os.Symlink(filepath.Join("..", "boot", "grub2", "grub.cfg"), link))
+		t.Cleanup(func() { require.NoError(t, os.Remove(link)) })
+
+		indexed := indexAll("./boot")
+
+		assertNoExcludedContent(t, indexed)
+		require.NotContains(t, indexed, "/etc/grub2.cfg", "symlink pointing into an excluded directory was indexed")
+		require.Contains(t, indexed, "/keep/file.txt")
+	})
+
+	t.Run("symlink chain into excluded directory", func(t *testing.T) {
+		l1 := filepath.Join(root, "etc", "l1.cfg")
+		l2 := filepath.Join(root, "etc", "l2.cfg")
+		require.NoError(t, os.Symlink("l2.cfg", l1))
+		require.NoError(t, os.Symlink(filepath.Join("..", "boot", "grub2", "grub.cfg"), l2))
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(l1))
+			require.NoError(t, os.Remove(l2))
+		})
+
+		indexed := indexAll("./boot")
+
+		assertNoExcludedContent(t, indexed)
+		require.NotContains(t, indexed, "/etc/l1.cfg")
+		require.NotContains(t, indexed, "/etc/l2.cfg")
+	})
+
+	t.Run("directory symlink into excluded directory", func(t *testing.T) {
+		link := filepath.Join(root, "etc", "bootlink")
+		require.NoError(t, os.Symlink(filepath.Join("..", "boot"), link))
+		t.Cleanup(func() { require.NoError(t, os.Remove(link)) })
+
+		indexed := indexAll("./boot")
+
+		assertNoExcludedContent(t, indexed)
+		require.NotContains(t, indexed, "/etc/bootlink", "symlink pointing into an excluded directory was indexed")
+	})
+
+	t.Run("symlink to excluded file", func(t *testing.T) {
+		link := filepath.Join(root, "etc", "grub2.cfg")
+		require.NoError(t, os.Symlink(filepath.Join("..", "boot", "grub2", "grub.cfg"), link))
+		t.Cleanup(func() { require.NoError(t, os.Remove(link)) })
+
+		indexed := indexAll("./boot/grub2/grub.cfg")
+
+		require.NotContains(t, indexed, "/etc/grub2.cfg", "symlink pointing at an excluded file was indexed")
+		require.NotContains(t, indexed, "/boot/grub2/grub.cfg")
+	})
+
+	t.Run("symlink to unexcluded path stays indexed", func(t *testing.T) {
+		link := filepath.Join(root, "etc", "keep-link.txt")
+		require.NoError(t, os.Symlink(filepath.Join("..", "keep", "file.txt"), link))
+		t.Cleanup(func() { require.NoError(t, os.Remove(link)) })
+
+		indexed := indexAll("./boot")
+
+		require.Contains(t, indexed, "/etc/keep-link.txt", "symlink to an unexcluded path should be indexed")
+		require.Contains(t, indexed, "/keep/file.txt")
+	})
+
+	t.Run("excluded directory itself is skipped in primary walk", func(t *testing.T) {
+		indexed := indexAll("./boot")
+
+		assertNoExcludedContent(t, indexed)
+	})
+}


### PR DESCRIPTION
## Description

Ran into this while digging through the exclusion code after #5232 popped up: `--exclude` only ever matches the excluded directory entry itself. That's fine for the primary walk (hitting the entry returns SkipDir), but the directory indexer follows symlinks by resolving the target and queueing it as a second index root. That second pass starts at the target file, the excluded directory entry is never visited, and the exclusion never fires.

So with `--exclude ./boot` and a symlink like `etc/grub2.cfg -> ../boot/grub2/grub.cfg`, everything under `/boot` still ends up indexed and cataloged. Reproduced it with the fixture from the issue: 745 npm packages cataloged from a yarn.lock that lives in the excluded tree, purely through the symlink.

The fix does two things:

- symlink entries get their real path resolved and checked against the exclusions, so a link pointing into an excluded tree is skipped before its target ever becomes an index root
- literal (non-glob) exclusion patterns now also match by directory prefix, so descendants reached through routes other than the primary walk are covered too

Glob patterns keep the same doublestar behavior as before, just applied to both the visited path and the resolved path. Dangling links behave the same as today (resolve to nothing, nothing gets indexed).

Verified end to end on the fixture: before, `syft scan dir:. --exclude ./boot` cataloged 745 npm artifacts through the symlink; after, the same command catalogs 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #5232
