### PR TITLE
fix(java): inherit pom licenses on the parent package when identities match

### DIFF
--- a/syft/pkg/cataloger/java/archive_parser.go
+++ b/syft/pkg/cataloger/java/archive_parser.go
@@ -898,6 +898,12 @@ func updateParentPackage(p pkg.Package, parentPkg *pkg.Package) {
 	// we may have learned more about the type via data in the pom properties
 	parentPkg.Type = p.Type
 
+	// licenses resolved from a pom.xml (including licenses inherited from parent poms) are typically more
+	// accurate than those from a MANIFEST.MF; keep what we already have and add the pom-derived licenses,
+	// merging duplicates by value (see LicenseSet.Add)
+	// https://github.com/anchore/syft/issues/4747
+	parentPkg.Licenses.Add(p.Licenses.ToSlice()...)
+
 	metadata, ok := p.Metadata.(pkg.JavaArchive)
 	if !ok {
 		return

--- a/syft/pkg/cataloger/java/archive_parser_test.go
+++ b/syft/pkg/cataloger/java/archive_parser_test.go
@@ -806,6 +806,7 @@ func TestParseNestedJar(t *testing.T) {
 
 func Test_newPackageFromMavenData(t *testing.T) {
 	virtualPath := "given/virtual/path"
+	pomLicenseLoc := file.NewLocation(virtualPath)
 	tests := []struct {
 		name            string
 		props           pkg.JavaPomProperties
@@ -1132,6 +1133,67 @@ func Test_newPackageFromMavenData(t *testing.T) {
 						GroupID:    "some-group-id",
 						ArtifactID: "some-parent-name",
 						Version:    "NOT_THE_PARENT_VERSION",
+					},
+					Parent: nil,
+				},
+			},
+			expectedPackage: nil,
+		},
+		{
+			name: "child matches parent by key and inherits pom licenses",
+			props: pkg.JavaPomProperties{
+				Name:       "some-name",
+				GroupID:    "some-group-id",
+				ArtifactID: "some-parent-name", // note: matches parent package
+				Version:    "2.0",              // note: matches parent package
+			},
+			project: &parsedPomProject{
+				project: &maven.Project{
+					Name:       ptr("some-parent-name"),
+					GroupID:    ptr("some-group-id"),
+					ArtifactID: ptr("some-parent-name"),
+					Version:    ptr("2.0"),
+					Licenses: &[]maven.License{
+						{
+							Name: ptr("EPL-2.0"),
+							URL:  ptr("https://www.eclipse.org/legal/epl-2.0/"),
+						},
+					},
+				},
+			},
+			parent: &pkg.Package{
+				Name:    "some-parent-name",
+				Version: "2.0",
+				Type:    pkg.JavaPkg,
+				Licenses: pkg.NewLicenseSet(
+					// e.g. a raw Bundle-License value from the MANIFEST.MF
+					pkg.NewLicenseFromFieldsWithContext(pkgtest.Context(t), "EPLv2", "", nil),
+				),
+				Metadata: pkg.JavaArchive{
+					VirtualPath:   "some-parent-virtual-path",
+					Manifest:      nil,
+					PomProperties: nil,
+					Parent:        nil,
+				},
+			},
+			// note: the manifest-derived license is kept and the pom-derived license is added
+			expectedParent: pkg.Package{
+				Name:    "some-parent-name",
+				Version: "2.0",
+				Type:    pkg.JavaPkg,
+				Licenses: pkg.NewLicenseSet(
+					pkg.NewLicenseFromFieldsWithContext(pkgtest.Context(t), "EPLv2", "", nil),
+					pkg.NewLicenseFromFieldsWithContext(pkgtest.Context(t), "EPL-2.0", "https://www.eclipse.org/legal/epl-2.0/", &pomLicenseLoc),
+				),
+				Metadata: pkg.JavaArchive{
+					VirtualPath: "some-parent-virtual-path",
+					Manifest:    nil,
+					// note: we attach the discovered pom properties data
+					PomProperties: &pkg.JavaPomProperties{
+						Name:       "some-name",
+						GroupID:    "some-group-id",
+						ArtifactID: "some-parent-name", // note: matches parent package
+						Version:    "2.0",              // note: matches parent package
 					},
 					Parent: nil,
 				},


### PR DESCRIPTION
## What

When a JAR contains `pom.properties`/`pom.xml` that resolves to the same identity as the package created from its `MANIFEST.MF`, `updateParentPackage` updated the parent's name, version, and type but **discarded the licenses resolved from the pom**.

This change adds the pom-derived licenses to the parent package's existing license set instead of dropping them. Duplicate licenses are merged by value via `LicenseSet.Add`, and existing manifest-derived licenses are kept.

## Why

As described in #4747 (e.g. `ch.qos.logback:logback-core`): jars that carry a `Bundle-License` in `MANIFEST.MF` never got the more precise license data from their `pom.xml` (including licenses inherited from parent poms, which is where logback keeps its SPDX expressions). The result is raw, sometimes unusable license strings (or license URLs) instead of valid SPDX expressions.

In [this comment](https://github.com/anchore/syft/issues/4747#issuecomment-...) `@kzantow` endorsed exactly this direction:

> I agree this is probably the right change to make: in the scenario we have a found license in a maven pom we think is the main package pom, we should update the updateParentPackage function to include the license.

## How it's tested

- New unit test in `Test_newPackageFromMavenData`: `child matches parent by key and inherits pom licenses` — a parent with a manifest-derived license (`EPLv2`) plus a matching pom with `EPL-2.0` ends up with **both** licenses on the parent package.
- All existing `Test_newPackageFromMavenData` cases pass unchanged (pom-only-license scenarios are unaffected; when a pom has no licenses the merge is a no-op).
- `go test ./syft/pkg/cataloger/java/...` — green on the targeted suites.

Fixes #4747