### PR TITLE
fix(cyclonedx): preserve source name, version, and supplier on decode

### DIFF
--- a/syft/format/cyclonedxjson/decoder_test.go
+++ b/syft/format/cyclonedxjson/decoder_test.go
@@ -1,6 +1,7 @@
 package cyclonedxjson
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/format/internal/testutil"
 )
 
 func TestDecoder_Decode(t *testing.T) {
@@ -132,6 +134,29 @@ func TestDecoder_Identify(t *testing.T) {
 			formatID, formatVersion := dec.Identify(reader)
 			assert.Equal(t, test.id, formatID)
 			assert.Equal(t, test.version, formatVersion)
+		})
+	}
+}
+
+// the source name and version (as set by --source-name and --source-version) are only expressed
+// as the CycloneDX metadata.component name and version, so they must survive an encode-decode
+// round trip. see https://github.com/anchore/grype/issues/2418
+func TestDecoder_SourceNameAndVersionRoundTrip(t *testing.T) {
+	subject := testutil.DirectoryInput(t, t.TempDir())
+	subject.Source.Name = "my-app"
+	subject.Source.Version = "0.1.0"
+
+	for _, enc := range defaultFormatEncoders() {
+		t.Run(enc.Version(), func(t *testing.T) {
+			var buf bytes.Buffer
+			require.NoError(t, enc.Encode(&buf, subject))
+
+			s, _, _, err := NewFormatDecoder().Decode(bytes.NewReader(buf.Bytes()))
+			require.NoError(t, err)
+			require.NotNil(t, s)
+
+			assert.Equal(t, subject.Source.Name, s.Source.Name)
+			assert.Equal(t, subject.Source.Version, s.Source.Version)
 		})
 	}
 }

--- a/syft/format/internal/cyclonedxutil/helpers/decoder.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder.go
@@ -221,6 +221,16 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 		supplier = meta.Supplier.Name
 	}
 
+	// the component name, version, and supplier describe the source itself, so they are preserved
+	// regardless of the component type; this is what allows the source name and version to survive
+	// an encode-decode round trip
+	// see https://github.com/anchore/grype/issues/2418
+	desc := source.Description{
+		Name:     c.Name,
+		Version:  c.Version,
+		Supplier: supplier,
+	}
+
 	switch c.Type {
 	case cyclonedx.ComponentTypeContainer:
 		var labels map[string]string
@@ -229,29 +239,22 @@ func extractComponents(meta *cyclonedx.Metadata) source.Description {
 			labels = decodeProperties(*meta.Properties, "syft:image:labels:")
 		}
 
-		return source.Description{
-			ID:       "",
-			Supplier: supplier,
-			// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
+		// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
 
-			Metadata: source.ImageMetadata{
-				UserInput:      c.Name,
-				ID:             c.BOMRef,
-				ManifestDigest: c.Version,
-				Labels:         labels,
-			},
+		desc.Metadata = source.ImageMetadata{
+			UserInput:      c.Name,
+			ID:             c.BOMRef,
+			ManifestDigest: c.Version,
+			Labels:         labels,
 		}
 	case cyclonedx.ComponentTypeFile:
 		// TODO: can we decode alias name-version somehow? (it isn't be encoded in the first place yet)
 
 		// TODO: this is lossy... we can't know if this is a file or a directory
-		return source.Description{
-			ID:       "",
-			Supplier: supplier,
-			Metadata: source.FileMetadata{Path: c.Name},
-		}
+		desc.Metadata = source.FileMetadata{Path: c.Name}
 	}
-	return source.Description{}
+
+	return desc
 }
 
 // if there is more than one tool in meta.Tools' list the last item will be used

--- a/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
+++ b/syft/format/internal/cyclonedxutil/helpers/decoder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/pkg"
 	"github.com/anchore/syft/syft/sbom"
+	"github.com/anchore/syft/syft/source"
 )
 
 func Test_decode(t *testing.T) {
@@ -480,4 +481,89 @@ func Test_useBomRefOverDerivedSyftArtifactID(t *testing.T) {
 	assert.Len(t, pkgsWithoutID, 1)
 	assert.NotEqual(t, "", pkgsWithoutID[0].ID())
 
+}
+
+// the metadata.component name, version, and supplier describe the source itself and must not be
+// dropped regardless of the component type, otherwise the source name and version set by
+// --source-name / --source-version cannot survive an encode-decode round trip.
+// see https://github.com/anchore/grype/issues/2418
+func Test_extractComponents_sourcePreservation(t *testing.T) {
+	tests := []struct {
+		name string
+		meta *cyclonedx.Metadata
+		want source.Description
+	}{
+		{
+			name: "application component",
+			meta: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeApplication,
+					Name:    "my-app",
+					Version: "0.1.0",
+				},
+			},
+			want: source.Description{
+				Name:    "my-app",
+				Version: "0.1.0",
+			},
+		},
+		{
+			name: "file component",
+			meta: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeFile,
+					Name:    "my-app",
+					Version: "0.1.0",
+				},
+			},
+			want: source.Description{
+				Name:     "my-app",
+				Version:  "0.1.0",
+				Metadata: source.FileMetadata{Path: "my-app"},
+			},
+		},
+		{
+			name: "container component keeps image metadata and gains name/version",
+			meta: &cyclonedx.Metadata{
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeContainer,
+					Name:    "alpine",
+					Version: "sha256:deadbeef",
+					BOMRef:  "ref-1",
+				},
+			},
+			want: source.Description{
+				Name:    "alpine",
+				Version: "sha256:deadbeef",
+				Metadata: source.ImageMetadata{
+					UserInput:      "alpine",
+					ID:             "ref-1",
+					ManifestDigest: "sha256:deadbeef",
+				},
+			},
+		},
+		{
+			name: "supplier falls back from metadata to component",
+			meta: &cyclonedx.Metadata{
+				Supplier: &cyclonedx.OrganizationalEntity{Name: "acme"},
+				Component: &cyclonedx.Component{
+					Type:    cyclonedx.ComponentTypeApplication,
+					Name:    "my-app",
+					Version: "0.1.0",
+				},
+			},
+			want: source.Description{
+				Name:     "my-app",
+				Version:  "0.1.0",
+				Supplier: "acme",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := extractComponents(test.meta)
+			assert.Equal(t, test.want, got)
+		})
+	}
 }


### PR DESCRIPTION
## What

`extractComponents` in the CycloneDX decoder only populated `source.Description` for container and file components, and returned an empty description for any other component type (e.g. `application`). Since `metadata.component` is the only place the source name and version (as set by `--source-name` / `--source-version`) are expressed in CycloneDX, they were silently lost on every decode, breaking the encode-decode round trip.

This change populates the name, version, and supplier on the description **regardless of component type**, while keeping the existing type-specific metadata handling (image metadata, file path, labels) untouched.

## Why

This is the syft-side root cause of https://github.com/anchore/grype/issues/2418: running an SBOM through grype and emitting CycloneDX loses `metadata.component.version`. Once this lands and grype picks up the new syft version, the round trip is preserved.

This revives the intent of #5104 (closed without merge), with the same approach plus unit tests for the decoder helper.

## How it's tested

- New `TestDecoder_SourceNameAndVersionRoundTrip` in `cyclonedxjson`: encodes a directory-scan SBOM with `Source.Name`/`Source.Version` set, decodes it back, and asserts both survive \u2014 across all supported CycloneDX versions (1.2\u20131.7).
- New `Test_extractComponents_sourcePreservation` in `helpers`: asserts name/version/supplier survive for `application`, `file`, and `container` component types, plus the supplier fallback from metadata to component level.
- `go test ./syft/format/cyclonedxjson/... ./syft/format/internal/cyclonedxutil/...` \u2014 all green, no snapshot changes needed.