### PR TITLE
stop reading the mount table for every single-file source

### DIFF
--- a/syft/internal/fileresolver/file_indexer.go
+++ b/syft/internal/fileresolver/file_indexer.go
@@ -29,11 +29,15 @@ func newFileIndexer(path, base string, visitors ...PathIndexVisitor) *fileIndexe
 		base:  base,
 		tree:  filetree.New(),
 		index: filetree.NewIndex(),
+		// Unlike the directory indexer there is no skipPathsByMountTypeAndName here: it exists
+		// to keep a directory walk out of /proc, /sys and similar, and to do so it reads the
+		// whole mount table on construction. A file source indexes exactly one file and its
+		// parent, so there is nothing to walk into, and the mount table read is paid for
+		// every file source with nothing in return.
 		pathIndexVisitors: append(
 			[]PathIndexVisitor{
 				requireFileInfo,
 				disallowByFileType,
-				skipPathsByMountTypeAndName(path),
 			},
 			visitors...,
 		),

--- a/syft/internal/fileresolver/file_indexer_bench_test.go
+++ b/syft/internal/fileresolver/file_indexer_bench_test.go
@@ -1,0 +1,51 @@
+package fileresolver
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/moby/sys/mountinfo"
+)
+
+// BenchmarkNewFromFile is the cost of building a resolver for a single-file source, which is
+// paid once per file by callers that catalog files individually. The default case is
+// NewFromFile as shipped. The with-mount-skipper case attaches skipPathsByMountTypeAndName
+// the way the file indexer used to, so the difference is what reading the mount table for
+// every file source cost. That cost scales with the mount table, so its size is reported as
+// the mounts metric: expect a bigger gap on a container host than on a laptop.
+//
+//	go test ./syft/internal/fileresolver/ -run '^$' -bench NewFromFile -benchmem -count 6 | tee bench.txt
+//	benchstat -col /variant bench.txt
+func BenchmarkNewFromFile(b *testing.B) {
+	path := filepath.Join(b.TempDir(), "file.txt")
+	if err := os.WriteFile(path, []byte("hello\n"), 0o644); err != nil {
+		b.Fatal(err)
+	}
+	mounts, err := mountinfo.GetMounts(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("variant=default", func(b *testing.B) {
+		for b.Loop() {
+			if _, err := NewFromFile(path); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(len(mounts)), "mounts")
+	})
+
+	b.Run("variant=with-mount-skipper", func(b *testing.B) {
+		for b.Loop() {
+			r, err := newFromFileWithoutIndex(path, skipPathsByMountTypeAndName(path))
+			if err != nil {
+				b.Fatal(err)
+			}
+			if err := r.buildIndex(); err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.ReportMetric(float64(len(mounts)), "mounts")
+	})
+}


### PR DESCRIPTION
## Summary

`fileresolver.newFileIndexer` no longer attaches `skipPathsByMountTypeAndName`. That visitor reads and parses the whole mount table on construction, and a single-file source has nothing for it to skip. The directory indexer keeps it.

## Motivation

- `skipPathsByMountTypeAndName` keeps a directory walk out of `/proc`, `/sys`, `/dev` and similar, and to know where those are it calls `mountinfo.GetMounts` and parses every line. The file indexer attached the same visitor, so every `filesource` paid a full mount-table read to index one file and its parent. Callers that catalog a filesystem one file at a time, with a file source per file, pay it per file, and the cost grows with the host's mount table. Container hosts routinely have hundreds of overlay and volume mounts.
- A side effect of the old visitor: a file source under a proc, sysfs or dev mount was rejected as filtered even though the caller named that exact file. `disallowByFileType` still rejects irregular files.

## Benchmark

`BenchmarkNewFromFile` in `syft/internal/fileresolver` builds a resolver for one file two ways: `variant=default` is `NewFromFile` as it now is, `variant=with-mount-skipper` attaches the skipper the way the indexer used to. The difference is the removed read. The `mounts` metric is the machine's mount-table size, which the removed read scales with.

    go test ./syft/internal/fileresolver/ -run '^$' -bench NewFromFile -benchmem -count 6 | tee bench.txt
    benchstat -col /variant bench.txt

macOS, Apple M5 Pro, 14 mounts, n=6:

                   │   default   │        with-mount-skipper         │
                   │   sec/op    │   sec/op     vs base              │
    NewFromFile-15   78.63µ ± 1%   86.17µ ± 1%  +9.58% (p=0.002 n=6)

                   │   default    │          with-mount-skipper          │
                   │     B/op     │     B/op      vs base                │
    NewFromFile-15   35.46Ki ± 0%   71.63Ki ± 0%  +101.99% (p=0.002 n=6)

                   │  default   │        with-mount-skipper         │
                   │ allocs/op  │ allocs/op   vs base               │
    NewFromFile-15   350.0 ± 0%   426.0 ± 0%  +21.71% (p=0.002 n=6)

Linux with 1,000 tmpfs mounts, run in a privileged container from a clean checkout:

    docker run --rm --privileged -v "$PWD":/src -w /src golang:1.26 bash -c \
      'for i in $(seq 1 1000); do mkdir -p /mnt/m$i && mount -t tmpfs -o size=64k none /mnt/m$i; done;
       go test ./syft/internal/fileresolver/ -run "^$" -bench NewFromFile -benchmem -count 6'

linux/arm64 in the container, 1,012 mounts, n=6. The read is 34x the cost of building the resolver itself, 24x the bytes and 22x the allocations:

                   │   default   │          with-mount-skipper           │
                   │   sec/op    │    sec/op     vs base                 │
    NewFromFile-15   17.26µ ± 3%   581.75µ ± 1%  +3269.64% (p=0.002 n=6)

                   │   default    │           with-mount-skipper           │
                   │     B/op     │     B/op       vs base                 │
    NewFromFile-15   19.40Ki ± 0%   472.69Ki ± 0%  +2336.10% (p=0.002 n=6)

                   │  default   │          with-mount-skipper          │
                   │ allocs/op  │  allocs/op   vs base                 │
    NewFromFile-15   190.0 ± 0%   4283.0 ± 0%  +2154.21% (p=0.002 n=6)

## Changes

- `syft/internal/fileresolver/file_indexer.go`: remove `skipPathsByMountTypeAndName(path)` from the file indexer's default visitors, with a comment explaining why the directory indexer keeps it.
- `syft/internal/fileresolver/file_indexer_bench_test.go`: `BenchmarkNewFromFile` with the two variants.

No API changes. Directory sources are unaffected.

## Type of change

- [x] Performance

## Checklist

- [x] Added unit tests covering the changed behaviour: `Test_ignoresPathIfFiltered` and `Test_ignoresPathIfParentFiltered` cover the remaining filter path; the benchmark covers the cost
- [x] Tested common scenarios for regressions: `go test ./syft/internal/fileresolver/`, `go vet`, golangci-lint clean on the changed files
- [x] Commented code that is hard to understand