### PR TITLE
fix(java): do not catalog declared dependencies of an embedded pom.xml

### DIFF
--- a/syft/pkg/cataloger/java/parse_pom_xml.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml.go
@@ -3,6 +3,7 @@ package java
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 
 	"github.com/anchore/syft/internal"
@@ -73,6 +74,16 @@ func (p pomXMLCataloger) Catalog(ctx context.Context, fileResolver file.Resolver
 	for _, pom := range poms {
 		location := pomLocations[pom] // should always exist
 
+		if isArchiveMetaPom(location) {
+			// This pom is the copy that maven-archiver embeds into a built artifact
+			// (META-INF/maven/<groupId>/<artifactId>/pom.xml). Its main package is real --
+			// it is the artifact that was unpacked -- but its <dependencies> describe what
+			// the artifact was compiled against, not what ships next to it: test, provided
+			// and optional dependencies are listed just the same, and none of them is
+			// necessarily present. Reporting them would invent packages.
+			continue
+		}
+
 		id := r.ResolveID(ctx, pom)
 		mainPkg := resolved[id]
 
@@ -83,6 +94,19 @@ func (p pomXMLCataloger) Catalog(ctx context.Context, fileResolver file.Resolver
 	}
 
 	return pkgs, relationships, errs
+}
+
+// isArchiveMetaPom reports whether the pom.xml sits under a META-INF/maven/ directory, i.e. it is
+// the copy that maven-archiver embeds into a built artifact rather than a project pom. The match is
+// anchored on a directory boundary ("/META-INF/maven/" or a "META-INF/maven/" prefix) so that paths
+// which merely contain the substring (e.g. "X-META-INF/maven/") are not affected.
+//
+// The detector is shared with the approach in anchore/syft#4832 by Thomas Bechtold; the difference
+// is what is done with a match: the artifact's own package is still cataloged here, only its
+// declared dependencies are not.
+func isArchiveMetaPom(location file.Location) bool {
+	p := filepath.ToSlash(location.Path())
+	return strings.Contains(p, "/META-INF/maven/") || strings.HasPrefix(p, "META-INF/maven/")
 }
 
 func readPomFromLocation(fileResolver file.Resolver, pomLocation file.Location) (*maven.Project, error) {

--- a/syft/pkg/cataloger/java/parse_pom_xml_test.go
+++ b/syft/pkg/cataloger/java/parse_pom_xml_test.go
@@ -834,3 +834,134 @@ func expectedTransientPackageData() expected {
 		},
 	}
 }
+
+func Test_isArchiveMetaPom(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "META-INF maven pom", path: "META-INF/maven/com.example/my-lib/pom.xml", expected: true},
+		{name: "nested META-INF maven pom", path: "some/path/META-INF/maven/org.apache/commons/pom.xml", expected: true},
+		{name: "exploded spring boot app", path: "app/BOOT-INF/classes/META-INF/maven/com.example/app/pom.xml", expected: true},
+		{name: "project pom.xml", path: "pom.xml", expected: false},
+		{name: "module pom.xml", path: "submodule/pom.xml", expected: false},
+		{name: "META-INF but not maven", path: "META-INF/pom.xml", expected: false},
+		{name: "substring only, not a directory boundary", path: "X-META-INF/maven/com.example/my-lib/pom.xml", expected: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isArchiveMetaPom(file.NewLocation(test.path)))
+		})
+	}
+}
+
+func embeddedPomCatalogerForTest() pkg.Cataloger {
+	return NewPomCataloger(ArchiveCatalogerConfig{
+		ArchiveSearchConfig: cataloging.ArchiveSearchConfig{
+			IncludeIndexedArchives:   true,
+			IncludeUnindexedArchives: true,
+		},
+	})
+}
+
+func Test_pomCatalogerKeepsEmbeddedArtifactButNotItsDeclaredDependencies(t *testing.T) {
+	// A pom.xml under META-INF/maven/ is the copy maven-archiver embeds into a built
+	// artifact. The artifact itself is real (it is what was unpacked), so it is cataloged;
+	// what it merely declares -- an unresolvable phantom and a test-scoped dependency -- is not.
+	myLibLocation := file.NewLocationSet(file.NewLocation("META-INF/maven/com.example/my-lib/pom.xml"))
+
+	myLib := pkg.Package{
+		Name:      "my-lib",
+		Version:   "1.0.0",
+		PURL:      "pkg:maven/com.example/my-lib@1.0.0",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: myLibLocation,
+		Metadata: pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    "com.example",
+				ArtifactID: "my-lib",
+				Version:    "1.0.0",
+			},
+		},
+	}
+	finalizePackage(&myLib)
+
+	pkgtest.NewCatalogTester().
+		FromDirectory(t, "testdata/pom/meta-inf-archive").
+		Expects([]pkg.Package{myLib}, nil).
+		TestCataloger(t, embeddedPomCatalogerForTest())
+}
+
+func Test_pomCatalogerEmbeddedPomNextToProjectPom(t *testing.T) {
+	// A project pom.xml keeps its dependencies; the embedded pom beside it contributes
+	// only the artifact it describes.
+	projectLocation := file.NewLocationSet(file.NewLocation("pom.xml"))
+	embeddedLocation := file.NewLocationSet(file.NewLocation("META-INF/maven/com.example/embedded-lib/pom.xml"))
+
+	myApp := pkg.Package{
+		Name:      "my-app",
+		Version:   "2.0.0",
+		PURL:      "pkg:maven/org.anchore/my-app@2.0.0",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: projectLocation,
+		Metadata: pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    "org.anchore",
+				ArtifactID: "my-app",
+				Version:    "2.0.0",
+			},
+		},
+	}
+	finalizePackage(&myApp)
+
+	guava := pkg.Package{
+		Name:      "guava",
+		Version:   "31.1-jre",
+		PURL:      "pkg:maven/com.google.guava/guava@31.1-jre",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: projectLocation,
+		Metadata: pkg.JavaArchive{
+			PomProperties: &pkg.JavaPomProperties{
+				GroupID:    "com.google.guava",
+				ArtifactID: "guava",
+			},
+		},
+	}
+	finalizePackage(&guava)
+
+	embeddedLib := pkg.Package{
+		Name:      "embedded-lib",
+		Version:   "3.0.0",
+		PURL:      "pkg:maven/com.example/embedded-lib@3.0.0",
+		Language:  pkg.Java,
+		Type:      pkg.JavaPkg,
+		FoundBy:   pomCatalogerName,
+		Locations: embeddedLocation,
+		Metadata: pkg.JavaArchive{
+			PomProject: &pkg.JavaPomProject{
+				GroupID:    "com.example",
+				ArtifactID: "embedded-lib",
+				Version:    "3.0.0",
+			},
+		},
+	}
+	finalizePackage(&embeddedLib)
+
+	pkgtest.NewCatalogTester().
+		FromDirectory(t, "testdata/pom/mixed-meta-inf-and-project").
+		Expects(
+			[]pkg.Package{myApp, guava, embeddedLib},
+			[]artifact.Relationship{
+				{From: guava, To: myApp, Type: artifact.DependencyOfRelationship},
+			},
+		).
+		TestCataloger(t, embeddedPomCatalogerForTest())
+}

--- a/syft/pkg/cataloger/java/testdata/pom/meta-inf-archive/META-INF/maven/com.example/my-lib/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/meta-inf-archive/META-INF/maven/com.example/my-lib/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>my-lib</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.phantom</groupId>
+            <artifactId>phantom-dep</artifactId>
+            <version>${phantom.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testonly</groupId>
+            <artifactId>test-dep</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/META-INF/maven/com.example/embedded-lib/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/META-INF/maven/com.example/embedded-lib/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>embedded-lib</artifactId>
+    <version>3.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.phantom</groupId>
+            <artifactId>should-not-appear</artifactId>
+            <version>${unresolvable.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/pom.xml
+++ b/syft/pkg/cataloger/java/testdata/pom/mixed-meta-inf-and-project/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.anchore</groupId>
+    <artifactId>my-app</artifactId>
+    <version>2.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Description

When a jar is unpacked on disk, `java-pom-cataloger` picks up `META-INF/maven/<groupId>/<artifactId>/pom.xml` — maven-archiver's copy of the build descriptor — and catalogs the artifact **and every dependency the pom declares**, with no scope filtering. Those declarations say what the artifact was compiled against, so test, provided and optional dependencies are cataloged as packages of the scanned tree even though nothing of them is present.

**On the real `xmlsec-2.3.4.jar` from Maven Central, unpacked** (`syft scan dir:xmlsec-2.3.4_extracted -q`):

```
main:     20 packages — xmlsec 2.3.4, commons-codec, slf4j-api, woodstox-core,
                        jakarta.xml.bind-api 2.3.3,
                        and the test-scope set: bcprov-jdk18on 1.76, junit-jupiter-engine,
                        junit-jupiter-params, jetty-server/-servlet/-servlets 9.4.53,
                        xalan 2.7.3, serializer 2.7.3, xmlunit-core, xmlunit-matchers,
                        hamcrest-library, saaj-impl, jaxb-runtime 2.3.3, log4j-slf4j-impl,
                        junit-benchmarks 0.7.2
this PR:   1 package  — xmlsec 2.3.4
```

The jar ships one thing. Of the nineteen extras, fifteen are declared `<scope>test</scope>` in that pom. Three more -- `jakarta.xml.bind-api`, `jaxb-runtime`, `saaj-impl` -- are not in `<dependencies>` at all: they come from the pom's `jdk19-plus` profile, and the cataloger reads profile dependencies without evaluating activation, so they are reported whatever JDK the scan ran under.

**On a real 1.3 GB Java delivery** (558 jars, 202 embedded poms, unpacked by our extractor so the original jar sits next to each exploded copy):

| | total | java-archive | java-pom | pom-only¹ |
|---|---|---|---|---|
| `main` | 1542 | 900 | 627 | **412** |
| this PR | 1117 | 900 | 202 | 0 |
| #4832 | 915 | 900 | 0 | 0 |

¹ distinct `name@version` pairs that appear through a pom and are never found as an archive anywhere in the tree.

Of the 627 pom packages on `main`, 202 are the embedded artifacts themselves and 425 are declared dependencies; 413 of those dependency entries are the pom-only set above. A further 227 of the 627 carry version `UNKNOWN`, because the declaration uses a `${property}` the cataloger cannot resolve — a package a matcher can do nothing with. The pom-only set is what you would expect from build descriptors: `assertj-core` at three versions, `byte-buddy-agent`, `awaitility`, `cglib-nodep`, `aws-java-sdk-test-utils`, `blockhound`, `apacheds-protocol-dns`, `ant 1.10.11`, `bcprov-jdk18on 1.76`.

**The fix:** keep the main package for an embedded pom — it is the artifact that was unpacked — and skip `collectDependencies` for it. The pom stays registered with the resolver, so it can still serve as a parent or dependency source for a real project pom in the same tree.

### Relation to #4832

@toabctl's #4832 detects the same files (the detector here is identical, credited in the code) and drops the pom entirely, which removes the artifact along with its declared dependencies. Measured with binaries built from `main`, #4832 and this branch:

| fixture | `main` | #4832 | this PR |
|---|---|---|---|
| real `xmlsec-2.3.4.jar`, unpacked, jar not kept | 20 packages | **0** | xmlsec 2.3.4 |
| exploded WAR: `META-INF/maven/com.example/myapp/pom.xml` + `WEB-INF/lib/log4j-*.jar` | myapp, log4j-core ×2, log4j-api | **log4j-core, log4j-api** (myapp lost) | myapp, log4j-core, log4j-api |
| the delivery above (jar kept beside each exploded copy) | 1542 | 915 | 1117 |

Where the original jar is kept next to the exploded copy both approaches remove the phantoms, because the archive cataloger finds the artifact anyway. The difference shows when it is not — `unzip` in a Dockerfile layer, an exploded WAR or fat jar — and there the pom cataloger is the only thing that sees the artifact at all.

Note the second row: the application's own descriptor and an unpacked third-party jar's descriptor look identical by path, so dropping the file loses the application. Keeping the main package and dropping only the declared dependencies costs nothing there, since anything that really ships under `WEB-INF/lib` is cataloged as an archive.

Happy to fold this into #4832 instead if that is preferred.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior — `Test_isArchiveMetaPom`, `Test_pomCatalogerKeepsEmbeddedArtifactButNotItsDeclaredDependencies` (exploded jar → exactly `my-lib 1.0.0`; on `main`, my-lib plus three declared dependencies), `Test_pomCatalogerEmbeddedPomNextToProjectPom` (project pom + embedded pom → my-app, guava, embedded-lib, one relationship, none of embedded-lib's declared dependencies). The fixtures are the ones from #4832.
- [x] I have tested my code in common scenarios and confirmed there are no regressions — the tables above are from real artifacts, and the whole `syft/pkg/cataloger/java` package behaves the same as on `main` in this environment (`TestSearchMavenForLicenses` fails identically on both: it needs network).
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Related: #4832 (same detector, different action on a match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CsUTRwsaFCwavDJTPwEpW