### PR TITLE
fix(conan): add libexpat_project CPE candidates for expat packages

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go
@@ -518,6 +518,11 @@ var defaultCandidateAdditions = buildCandidateLookup(
 			candidateKey{PkgName: "libxml2"},
 			candidateAddition{AdditionalVendors: []string{"xmlsoft"}},
 		},
+		{
+			pkg.ConanPkg,
+			candidateKey{PkgName: "expat"},
+			candidateAddition{AdditionalVendors: []string{"libexpat_project"}, AdditionalProducts: []string{"libexpat"}},
+		},
 	})
 
 var defaultCandidateRemovals = buildCandidateRemovalLookup(

--- a/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type_test.go
@@ -245,3 +245,10 @@ func Test_defaultCandidateAdditions_conan_libxml2(t *testing.T) {
 	vendors := findAdditionalVendors(defaultCandidateAdditions, pkg.ConanPkg, "libxml2", "")
 	assert.Contains(t, vendors, "xmlsoft")
 }
+
+func Test_defaultCandidateAdditions_conan_expat(t *testing.T) {
+	vendors := findAdditionalVendors(defaultCandidateAdditions, pkg.ConanPkg, "expat", "")
+	assert.Contains(t, vendors, "libexpat_project")
+	products := findAdditionalProducts(defaultCandidateAdditions, pkg.ConanPkg, "expat")
+	assert.Contains(t, products, "libexpat")
+}

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -874,6 +874,22 @@ func TestGeneratePackageCPEs(t *testing.T) {
 				"cpe:2.3:a:rust_package:rust_package:0.5.0:*:*:*:*:rust:*:*",
 			},
 		},
+		{
+			name: "conan expat: libexpat_project vendor and libexpat product",
+			p: pkg.Package{
+				Name:    "expat",
+				Version: "2.5.0",
+				Type:    pkg.ConanPkg,
+			},
+			expected: []string{
+				"cpe:2.3:a:expat:expat:2.5.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:expat:libexpat:2.5.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libexpat:expat:2.5.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libexpat:libexpat:2.5.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libexpat_project:expat:2.5.0:*:*:*:*:*:*:*",
+				"cpe:2.3:a:libexpat_project:libexpat:2.5.0:*:*:*:*:*:*:*",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description

Adds curated CPE candidates for Conan `expat` packages so their CVEs (published under `libexpat_project:expat`) are matched, following the existing poco/libxml2 pattern in the Conan block.

### Problem

Conan packages named `expat` (from `conanfile.txt` / `conan.lock`) only get name-derived CPEs such as `cpe:2.3:a:expat:expat:2.5.0:*:*:*:*:*:*:*`. NVD records libexpat vulnerabilities under `cpe:2.3:a:libexpat_project:libexpat:...` (for example CVE-2024-45492, CVE-2024-45491, CVE-2024-45490), so a scanner consuming the syft SBOM matches nothing and reports zero CVEs for a vulnerable expat version. The reporter confirmed that manually adding the `libexpat_project:libexpat` CPE to the SBOM makes grype find the expected CVEs.

### Root cause

`syft/pkg/cataloger/internal/cpegenerate/candidate_by_package_type.go:510-521` (the `// Conan packages` block of `defaultCandidateAdditions`) only carries curated vendor additions for `poco` and `libxml2`. Conan manifests have no vendor-bearing field and the CPE dictionary does not cover the Conan ecosystem, so `FromPackageAttributes` (`generate.go:141`) falls back to the package name for both vendor and product and never produces the `libexpat_project` vendor or the `libexpat` product.

### Fix

Add one entry to the Conan block, following the existing `poco -> pocoproject` / `libxml2 -> xmlsoft` pattern:

```go
{
	pkg.ConanPkg,
	candidateKey{PkgName: "expat"},
	candidateAddition{AdditionalVendors: []string{"libexpat_project"}, AdditionalProducts: []string{"libexpat"}},
},
```

These are additions only; the name-derived candidates are kept, so no existing match is removed. Because `candidateVendors` also considers every product candidate as a vendor (`generate.go:204`), the generated set for `expat/2.5.0` becomes:

```
cpe:2.3:a:expat:expat:2.5.0:*:*:*:*:*:*:*
cpe:2.3:a:expat:libexpat:2.5.0:*:*:*:*:*:*:*
cpe:2.3:a:libexpat:expat:2.5.0:*:*:*:*:*:*:*
cpe:2.3:a:libexpat:libexpat:2.5.0:*:*:*:*:*:*:*
cpe:2.3:a:libexpat_project:expat:2.5.0:*:*:*:*:*:*:*
cpe:2.3:a:libexpat_project:libexpat:2.5.0:*:*:*:*:*:*:*
```

### How tested

Two unit tests were added first and run against `main` to reproduce the gap:

- `Test_defaultCandidateAdditions_conan_expat` in `candidate_by_package_type_test.go` (mirrors `Test_defaultCandidateAdditions_conan_libxml2`, also checks the product addition)
- a `conan expat` case in `TestGeneratePackageCPEs` (`generate_test.go`) asserting the full generated CPE set

Before the fix:

```
--- FAIL: Test_defaultCandidateAdditions_conan_expat (0.00s)
    Error: []string(nil) does not contain "libexpat_project"
    Error: []string(nil) does not contain "libexpat"
--- FAIL: TestGeneratePackageCPEs/conan_expat:_libexpat_project_vendor_and_libexpat_product (0.00s)
    generate_test.go:918: missing CPEs:
       "syft-generated:cpe:2.3:a:expat:libexpat:2.5.0:*:*:*:*:*:*:*",
       "syft-generated:cpe:2.3:a:libexpat_project:expat:2.5.0:*:*:*:*:*:*:*",
       "syft-generated:cpe:2.3:a:libexpat_project:libexpat:2.5.0:*:*:*:*:*:*:*",
FAIL	github.com/anchore/syft/syft/pkg/cataloger/internal/cpegenerate	0.008s
```

After the fix:

```
--- PASS: Test_defaultCandidateAdditions_conan_expat (0.00s)
--- PASS: TestGeneratePackageCPEs (0.00s)
    --- PASS: TestGeneratePackageCPEs/conan_expat:_libexpat_project_vendor_and_libexpat_product (0.00s)
ok  	github.com/anchore/syft/syft/pkg/cataloger/internal/cpegenerate	0.007s
```

`go test ./syft/pkg/cataloger/internal/cpegenerate/...` passes, `gofmt -l` is clean, `go vet` passes, `go build ./syft/... ./cmd/...` succeeds, and `golangci-lint run` on the package reports the same pre-existing findings as `main` with nothing new.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions

## Issue references

Fixes #4771

## Links

- https://github.com/anchore/syft/issues/4771
- Precedent for the same class of fix: https://github.com/anchore/syft/pull/5016 (conan libxml2), https://github.com/anchore/syft/pull/2740 (conan poco)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

