### PR TITLE
fix(terraform): generate terraform-provider-specific CPEs for terraform lock packages

### DIFF
--- a/syft/pkg/cataloger/internal/cpegenerate/generate.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate.go
@@ -189,6 +189,8 @@ func candidateTargetSw(p pkg.Package) []string {
 		return []string{"wordpress"}
 	case pkg.RustPkg:
 		return []string{"rust"}
+	case pkg.TerraformPkg:
+		return []string{"terraform"}
 	}
 
 	return []string{cpe.Any}
@@ -287,6 +289,9 @@ func candidateVendorsByType(p pkg.Package, vendors fieldCandidateSet) fieldCandi
 	case pkg.WordpressPluginEntry:
 		vendors.clear()
 		vendors.union(candidateVendorsForWordpressPlugin(p))
+	case pkg.TerraformLockProviderEntry:
+		vendors.clear()
+		vendors.union(candidateVendorsForTerraformProvider(p))
 	}
 	return vendors
 }
@@ -332,6 +337,9 @@ func candidateProductSet(p pkg.Package) fieldCandidateSet {
 	case pkg.WordpressPluginEntry:
 		products.clear()
 		products.union(candidateProductsForWordpressPlugin(p))
+	case pkg.TerraformLockProviderEntry:
+		products.clear()
+		products.union(candidateProductsForTerraformProvider(p))
 	}
 
 	// it is never OK to have candidates with these values ["" and "*"] (since CPEs will match any other value)

--- a/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/generate_test.go
@@ -856,6 +856,40 @@ func TestGeneratePackageCPEs(t *testing.T) {
 			expected: []string{},
 		},
 		{
+			name: "terraform provider generates provider-specific CPEs not application CPEs",
+			p: pkg.Package{
+				Name:     "registry.terraform.io/grafana/grafana",
+				Version:  "4.45.2",
+				Type:     pkg.TerraformPkg,
+				Language: pkg.Go,
+				Metadata: pkg.TerraformLockProviderEntry{
+					URL:     "registry.terraform.io/grafana/grafana",
+					Version: "4.45.2",
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:grafana:terraform-provider-grafana:4.45.2:*:*:*:*:terraform:*:*",
+				"cpe:2.3:a:grafana:terraform_provider_grafana:4.45.2:*:*:*:*:terraform:*:*",
+			},
+		},
+		{
+			name: "terraform provider with different namespace and type",
+			p: pkg.Package{
+				Name:     "registry.terraform.io/hashicorp/aws",
+				Version:  "5.72.1",
+				Type:     pkg.TerraformPkg,
+				Language: pkg.Go,
+				Metadata: pkg.TerraformLockProviderEntry{
+					URL:     "registry.terraform.io/hashicorp/aws",
+					Version: "5.72.1",
+				},
+			},
+			expected: []string{
+				"cpe:2.3:a:hashicorp:terraform-provider-aws:5.72.1:*:*:*:*:terraform:*:*",
+				"cpe:2.3:a:hashicorp:terraform_provider_aws:5.72.1:*:*:*:*:terraform:*:*",
+			},
+		},
+		{
 			name: "rust package",
 			p: pkg.Package{
 				Name:     "rust-package",

--- a/syft/pkg/cataloger/internal/cpegenerate/terraform.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/terraform.go
@@ -1,0 +1,39 @@
+package cpegenerate
+
+import (
+	"strings"
+
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func candidateVendorsForTerraformProvider(p pkg.Package) fieldCandidateSet {
+	vendors := newFieldCandidateSet()
+
+	namespace, _ := parseTerraformProviderName(p.Name)
+	if namespace != "" {
+		vendors.addValue(namespace)
+	}
+
+	return vendors
+}
+
+func candidateProductsForTerraformProvider(p pkg.Package) fieldCandidateSet {
+	products := newFieldCandidateSet()
+
+	_, providerType := parseTerraformProviderName(p.Name)
+	if providerType != "" {
+		products.addValue("terraform-provider-" + providerType)
+	}
+
+	return products
+}
+
+// parseTerraformProviderName extracts the namespace and type from a terraform provider
+// source address. The expected format is "registry.terraform.io/<namespace>/<type>".
+func parseTerraformProviderName(name string) (namespace, providerType string) {
+	parts := strings.Split(name, "/")
+	if len(parts) < 3 {
+		return "", ""
+	}
+	return parts[len(parts)-2], parts[len(parts)-1]
+}

--- a/syft/pkg/cataloger/internal/cpegenerate/terraform_test.go
+++ b/syft/pkg/cataloger/internal/cpegenerate/terraform_test.go
@@ -1,0 +1,136 @@
+package cpegenerate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/anchore/syft/syft/pkg"
+)
+
+func Test_candidateVendorsForTerraformProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      pkg.Package
+		expected []string
+	}{
+		{
+			name: "hashicorp/aws provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/hashicorp/aws",
+			},
+			expected: []string{"hashicorp"},
+		},
+		{
+			name: "grafana/grafana provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/grafana/grafana",
+			},
+			expected: []string{"grafana"},
+		},
+		{
+			name: "hashicorp/google provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/hashicorp/google",
+			},
+			expected: []string{"hashicorp"},
+		},
+		{
+			name: "malformed name with fewer than 3 segments",
+			pkg: pkg.Package{
+				Name: "hashicorp/aws",
+			},
+			expected: []string{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := candidateVendorsForTerraformProvider(test.pkg).uniqueValues()
+			assert.ElementsMatch(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_candidateProductsForTerraformProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      pkg.Package
+		expected []string
+	}{
+		{
+			name: "hashicorp/aws provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/hashicorp/aws",
+			},
+			expected: []string{"terraform-provider-aws"},
+		},
+		{
+			name: "grafana/grafana provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/grafana/grafana",
+			},
+			expected: []string{"terraform-provider-grafana"},
+		},
+		{
+			name: "hashicorp/google provider",
+			pkg: pkg.Package{
+				Name: "registry.terraform.io/hashicorp/google",
+			},
+			expected: []string{"terraform-provider-google"},
+		},
+		{
+			name: "malformed name with fewer than 3 segments",
+			pkg: pkg.Package{
+				Name: "hashicorp/aws",
+			},
+			expected: []string{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := candidateProductsForTerraformProvider(test.pkg).uniqueValues()
+			assert.ElementsMatch(t, test.expected, actual)
+		})
+	}
+}
+
+func Test_parseTerraformProviderName(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expectedNamespace string
+		expectedType      string
+	}{
+		{
+			name:              "standard provider",
+			input:             "registry.terraform.io/hashicorp/aws",
+			expectedNamespace: "hashicorp",
+			expectedType:      "aws",
+		},
+		{
+			name:              "provider where namespace matches type",
+			input:             "registry.terraform.io/grafana/grafana",
+			expectedNamespace: "grafana",
+			expectedType:      "grafana",
+		},
+		{
+			name:              "too few segments",
+			input:             "hashicorp/aws",
+			expectedNamespace: "",
+			expectedType:      "",
+		},
+		{
+			name:              "single segment",
+			input:             "aws",
+			expectedNamespace: "",
+			expectedType:      "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespace, providerType := parseTerraformProviderName(test.input)
+			assert.Equal(t, test.expectedNamespace, namespace)
+			assert.Equal(t, test.expectedType, providerType)
+		})
+	}
+}


### PR DESCRIPTION
The `terraform-lock-cataloger` sets `Language` to `Go`, which causes the Go CPE heuristic to run for terraform provider packages. This produces application-level CPEs that are identical to the actual software — for example, `registry.terraform.io/grafana/grafana` gets `cpe:2.3:a:grafana:grafana:4.45.2`, which is the same CPE as the Grafana web application. Grype then matches these against NVD and flags providers with unrelated CVEs (e.g. CVE-2021-39226).

This adds terraform-specific vendor/product candidate functions following the WordPress plugin pattern. For a provider like `registry.terraform.io/grafana/grafana@4.45.2`, the generated CPE is now `cpe:2.3:a:grafana:terraform-provider-grafana:4.45.2:*:*:*:*:terraform:*:*`, which matches the NVD naming convention for terraform provider vulnerabilities.

Changes:
- New `terraform.go` with vendor/product/name-parsing helpers
- Wire `TerraformLockProviderEntry` into `candidateVendorsByType` and `candidateProductSet` (clears the Go-derived values and replaces them)
- Add `TerraformPkg` to `candidateTargetSw` with `"terraform"`
- Tests for all new functions plus two integration cases in `TestGeneratePackageCPEs`