### PR TITLE
feat(terraform): add license detection for terraform providers

### DIFF
--- a/cmd/syft/internal/options/catalog.go
+++ b/cmd/syft/internal/options/catalog.go
@@ -28,6 +28,7 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/kernel"
 	"github.com/anchore/syft/syft/pkg/cataloger/nix"
 	"github.com/anchore/syft/syft/pkg/cataloger/python"
+	"github.com/anchore/syft/syft/pkg/cataloger/terraform"
 	"github.com/anchore/syft/syft/source"
 )
 
@@ -53,6 +54,7 @@ type Catalog struct {
 	LinuxKernel linuxKernelConfig `yaml:"linux-kernel" json:"linux-kernel" mapstructure:"linux-kernel"`
 	Nix         nixConfig         `yaml:"nix" json:"nix" mapstructure:"nix"`
 	Python      pythonConfig      `yaml:"python" json:"python" mapstructure:"python"`
+	Terraform   terraformConfig   `yaml:"terraform" json:"terraform" mapstructure:"terraform"`
 
 	// configuration for the source (the subject being analyzed)
 	Registry   registryConfig `yaml:"registry" json:"registry" mapstructure:"registry"`
@@ -84,6 +86,7 @@ func DefaultCatalog() Catalog {
 		Nix:           defaultNixConfig(),
 		Cpp:           defaultCppConfig(),
 		Dotnet:        defaultDotnetConfig(),
+		Terraform:     defaultTerraformConfig(),
 		Golang:        defaultGolangConfig(),
 		Java:          defaultJavaConfig(),
 		File:          defaultFileConfig(),
@@ -214,6 +217,9 @@ func (cfg Catalog) ToPackagesConfig() pkgcataloging.Config {
 			WithSearchRemoteLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Python), cfg.Python.SearchRemoteLicenses)).
 			WithPypiBaseURL(cfg.Python.PypiBaseURL).
 			WithGuessUnpinnedRequirements(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Python), cfg.Python.GuessUnpinnedRequirements)),
+		Terraform: terraform.DefaultCatalogerConfig().
+			WithSearchRemoteLicenses(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Terraform), cfg.Terraform.SearchRemoteLicenses)).
+			WithRegistryBaseURL(cfg.Terraform.RegistryBaseURL),
 		JavaArchive: java.DefaultArchiveCatalogerConfig().
 			WithUseMavenLocalRepository(*multiLevelOption(false, enrichmentEnabled(cfg.Enrich, task.Java, task.Maven), cfg.Java.UseMavenLocalRepository)).
 			WithMavenLocalRepositoryDir(cfg.Java.MavenLocalRepositoryDir).
@@ -308,6 +314,7 @@ var publicisedEnrichmentOptions = []string{
 	task.Java,
 	task.JavaScript,
 	task.Python,
+	task.Terraform,
 	task.Vcpkg,
 }
 

--- a/cmd/syft/internal/options/terraform.go
+++ b/cmd/syft/internal/options/terraform.go
@@ -1,0 +1,27 @@
+package options
+
+import (
+	"github.com/anchore/clio"
+	"github.com/anchore/syft/syft/pkg/cataloger/terraform"
+)
+
+type terraformConfig struct {
+	SearchRemoteLicenses *bool  `json:"search-remote-licenses" yaml:"search-remote-licenses" mapstructure:"search-remote-licenses"`
+	RegistryBaseURL      string `json:"registry-base-url" yaml:"registry-base-url" mapstructure:"registry-base-url"`
+}
+
+var _ interface {
+	clio.FieldDescriber
+} = (*terraformConfig)(nil)
+
+func defaultTerraformConfig() terraformConfig {
+	def := terraform.DefaultCatalogerConfig()
+	return terraformConfig{
+		RegistryBaseURL: def.RegistryBaseURL,
+	}
+}
+
+func (o *terraformConfig) DescribeFields(descriptions clio.FieldDescriptionSet) {
+	descriptions.Add(&o.SearchRemoteLicenses, `enables Syft to use the network to download provider archives and extract license information`)
+	descriptions.Add(&o.RegistryBaseURL, `base Terraform Registry URL to use`)
+}

--- a/internal/capabilities/appconfig.yaml
+++ b/internal/capabilities/appconfig.yaml
@@ -68,3 +68,7 @@ application: # AUTO-GENERATED - application-level config keys
     description: base Pypi url to use
   - key: python.search-remote-licenses
     description: enables Syft to use the network to fill in more detailed license information
+  - key: terraform.registry-base-url
+    description: base Terraform Registry URL to use
+  - key: terraform.search-remote-licenses
+    description: enables Syft to use the network to download provider archives and extract license information

--- a/internal/task/package_tasks.go
+++ b/internal/task/package_tasks.go
@@ -58,6 +58,9 @@ const (
 	// Python ecosystem labels
 	Python = "python"
 
+	// Terraform ecosystem labels
+	Terraform = "terraform"
+
 	// C/C++ ecosystem labels
 	Cpp   = "cpp"
 	Vcpkg = "vcpkg"
@@ -185,7 +188,12 @@ func DefaultPackageTaskFactories() Factories {
 		newSimplePackageTaskFactory(sbomCataloger.NewCataloger, "sbom"), // note: not evidence of installed packages
 		newSimplePackageTaskFactory(bitnamiSbomCataloger.NewCataloger, "bitnami", pkgcataloging.InstalledTag, pkgcataloging.ImageTag),
 		newSimplePackageTaskFactory(wordpress.NewWordpressPluginCataloger, pkgcataloging.DirectoryTag, pkgcataloging.ImageTag, "wordpress"),
-		newSimplePackageTaskFactory(terraform.NewLockCataloger, pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, "terraform"),
+		newPackageTaskFactory(
+			func(cfg CatalogingFactoryConfig) pkg.Cataloger {
+				return terraform.NewLockCataloger(cfg.PackagesConfig.Terraform)
+			},
+			pkgcataloging.DeclaredTag, pkgcataloging.DirectoryTag, Terraform,
+		),
 		newSimplePackageTaskFactory(homebrew.NewCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "homebrew"),
 		newSimplePackageTaskFactory(apple.NewAppBundleCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.ImageTag, "apple"),
 		newSimplePackageTaskFactory(conda.NewCondaMetaCataloger, pkgcataloging.DirectoryTag, pkgcataloging.InstalledTag, pkgcataloging.PackageTag, "conda"),

--- a/syft/cataloging/pkgcataloging/config.go
+++ b/syft/cataloging/pkgcataloging/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/kernel"
 	"github.com/anchore/syft/syft/pkg/cataloger/nix"
 	"github.com/anchore/syft/syft/pkg/cataloger/python"
+	"github.com/anchore/syft/syft/pkg/cataloger/terraform"
 )
 
 type Config struct {
@@ -22,6 +23,7 @@ type Config struct {
 	LinuxKernel kernel.LinuxKernelCatalogerConfig `yaml:"linux-kernel" json:"linux-kernel" mapstructure:"linux-kernel"`
 	Nix         nix.Config                        `yaml:"nix" json:"nix" mapstructure:"nix"`
 	Python      python.CatalogerConfig            `yaml:"python" json:"python" mapstructure:"python"`
+	Terraform   terraform.CatalogerConfig         `yaml:"terraform" json:"terraform" mapstructure:"terraform"`
 }
 
 func DefaultConfig() Config {
@@ -34,6 +36,7 @@ func DefaultConfig() Config {
 		LinuxKernel: kernel.DefaultLinuxKernelCatalogerConfig(),
 		Nix:         nix.DefaultConfig(),
 		Python:      python.DefaultCatalogerConfig(),
+		Terraform:   terraform.DefaultCatalogerConfig(),
 	}
 }
 
@@ -79,5 +82,10 @@ func (c Config) WithPythonConfig(cfg python.CatalogerConfig) Config {
 
 func (c Config) WithJavaArchiveConfig(cfg java.ArchiveCatalogerConfig) Config {
 	c.JavaArchive = cfg
+	return c
+}
+
+func (c Config) WithTerraformConfig(cfg terraform.CatalogerConfig) Config {
+	c.Terraform = cfg
 	return c
 }

--- a/syft/pkg/cataloger/terraform/capabilities.yaml
+++ b/syft/pkg/cataloger/terraform/capabilities.yaml
@@ -1,5 +1,14 @@
 # Cataloger capabilities. See ../README.md for documentation.
 
+configs: # AUTO-GENERATED - config structs and their fields
+  terraform.CatalogerConfig:
+    fields:
+      - key: SearchRemoteLicenses
+        description: SearchRemoteLicenses enables downloading provider archives from the Terraform Registry to extract license information.
+        app_key: terraform.search-remote-licenses
+      - key: RegistryBaseURL
+        description: RegistryBaseURL specifies the base URL for the Terraform Registry API used when searching for remote license information.
+        app_key: terraform.registry-base-url
 catalogers:
   - ecosystem: terraform # MANUAL
     name: terraform-lock-cataloger # AUTO-GENERATED
@@ -7,6 +16,7 @@ catalogers:
     source: # AUTO-GENERATED
       file: syft/pkg/cataloger/terraform/cataloger.go
       function: NewLockCataloger
+    config: terraform.CatalogerConfig # AUTO-GENERATED
     selectors: # AUTO-GENERATED
       - declared
       - directory
@@ -28,7 +38,7 @@ catalogers:
           - TerraformLockProviderEntry
         capabilities: # MANUAL - preserved across regeneration
           - name: license
-            default: false
+            default: true
           - name: dependency.depth
             default:
               - direct

--- a/syft/pkg/cataloger/terraform/cataloger.go
+++ b/syft/pkg/cataloger/terraform/cataloger.go
@@ -5,7 +5,8 @@ import (
 	"github.com/anchore/syft/syft/pkg/cataloger/generic"
 )
 
-func NewLockCataloger() pkg.Cataloger {
+func NewLockCataloger(cfg CatalogerConfig) pkg.Cataloger {
+	lr := newTerraformLicenseResolver(cfg)
 	return generic.NewCataloger("terraform-lock-cataloger").
-		WithParserByGlobs(parseTerraformLock, "**/.terraform.lock.hcl")
+		WithParserByGlobs(lr.parseTerraformLock, "**/.terraform.lock.hcl")
 }

--- a/syft/pkg/cataloger/terraform/cataloger_test.go
+++ b/syft/pkg/cataloger/terraform/cataloger_test.go
@@ -4,6 +4,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/artifact"
 	"github.com/anchore/syft/syft/file"
 	"github.com/anchore/syft/syft/internal/fileresolver"
 	"github.com/anchore/syft/syft/pkg"
@@ -11,7 +15,7 @@ import (
 )
 
 func TestTerraformCataloger(t *testing.T) {
-	c := NewLockCataloger()
+	c := NewLockCataloger(DefaultCatalogerConfig())
 
 	fileLoc := file.NewLocation(".terraform.lock.hcl")
 	location := fileLoc.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)
@@ -100,4 +104,35 @@ func TestTerraformCataloger(t *testing.T) {
 				TestCataloger(t, c)
 		})
 	}
+}
+
+func TestTerraformCatalogerWithLicenses(t *testing.T) {
+	c := NewLockCataloger(DefaultCatalogerConfig())
+
+	pkgtest.NewCatalogTester().
+		WithResolver(fileresolver.NewFromUnindexedDirectory(filepath.Join("testdata", "with-licenses"))).
+		ExpectsAssertion(func(t *testing.T, pkgs []pkg.Package, relationships []artifact.Relationship) {
+			require.Len(t, pkgs, 2)
+
+			var awsPkg, gcpPkg pkg.Package
+			for _, p := range pkgs {
+				switch p.Name {
+				case "registry.terraform.io/hashicorp/aws":
+					awsPkg = p
+				case "registry.terraform.io/hashicorp/google":
+					gcpPkg = p
+				}
+			}
+
+			require.Equal(t, "5.72.1", awsPkg.Version)
+			require.Equal(t, "6.8.0", gcpPkg.Version)
+
+			awsLicenses := awsPkg.Licenses.ToSlice()
+			require.Len(t, awsLicenses, 1, "expected AWS provider to have one license from local .terraform cache")
+			assert.Equal(t, "MIT", awsLicenses[0].SPDXExpression)
+			assert.Equal(t, "MIT", awsLicenses[0].Value)
+
+			assert.True(t, gcpPkg.Licenses.Empty(), "expected Google provider to have no licenses")
+		}).
+		TestCataloger(t, c)
 }

--- a/syft/pkg/cataloger/terraform/config.go
+++ b/syft/pkg/cataloger/terraform/config.go
@@ -1,0 +1,31 @@
+package terraform
+
+const defaultRegistryBaseURL = "https://registry.terraform.io"
+
+type CatalogerConfig struct {
+	// SearchRemoteLicenses enables downloading provider archives from the Terraform Registry to extract license information.
+	// app-config: terraform.search-remote-licenses
+	SearchRemoteLicenses bool `yaml:"search-remote-licenses" json:"search-remote-licenses" mapstructure:"search-remote-licenses"`
+	// RegistryBaseURL specifies the base URL for the Terraform Registry API used when searching for remote license information.
+	// app-config: terraform.registry-base-url
+	RegistryBaseURL string `yaml:"registry-base-url" json:"registry-base-url" mapstructure:"registry-base-url"`
+}
+
+func DefaultCatalogerConfig() CatalogerConfig {
+	return CatalogerConfig{
+		SearchRemoteLicenses: false,
+		RegistryBaseURL:      defaultRegistryBaseURL,
+	}
+}
+
+func (c CatalogerConfig) WithSearchRemoteLicenses(input bool) CatalogerConfig {
+	c.SearchRemoteLicenses = input
+	return c
+}
+
+func (c CatalogerConfig) WithRegistryBaseURL(input string) CatalogerConfig {
+	if input != "" {
+		c.RegistryBaseURL = input
+	}
+	return c
+}

--- a/syft/pkg/cataloger/terraform/license.go
+++ b/syft/pkg/cataloger/terraform/license.go
@@ -1,0 +1,221 @@
+package terraform
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/anchore/syft/internal"
+	"github.com/anchore/syft/internal/cache"
+	"github.com/anchore/syft/internal/log"
+	"github.com/anchore/syft/internal/tmpdir"
+	"github.com/anchore/syft/syft/file"
+	"github.com/anchore/syft/syft/pkg"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/licenses"
+)
+
+type terraformLicenseResolver struct {
+	cfg          CatalogerConfig
+	licenseCache cache.Resolver[[]pkg.License]
+}
+
+func newTerraformLicenseResolver(cfg CatalogerConfig) terraformLicenseResolver {
+	return terraformLicenseResolver{
+		cfg:          cfg,
+		licenseCache: cache.GetResolverCachingErrors[[]pkg.License]("terraform", "v1"),
+	}
+}
+
+func (r *terraformLicenseResolver) getLicenses(ctx context.Context, resolver file.Resolver, lockFileDir, providerURL, version string) pkg.LicenseSet {
+	found := r.findLocalLicenses(ctx, resolver, lockFileDir, providerURL, version)
+	if len(found) > 0 {
+		return pkg.NewLicenseSet(found...)
+	}
+
+	if r.cfg.SearchRemoteLicenses {
+		remoteLicenses, err := r.findRemoteLicenses(ctx, providerURL, version)
+		if err != nil {
+			log.WithFields("error", err, "provider", providerURL, "version", version).Debug("unable to fetch terraform provider licenses from registry")
+		}
+		if len(remoteLicenses) > 0 {
+			return pkg.NewLicenseSet(remoteLicenses...)
+		}
+	}
+
+	return pkg.NewLicenseSet()
+}
+
+func (r *terraformLicenseResolver) findLocalLicenses(ctx context.Context, resolver file.Resolver, lockFileDir, providerURL, version string) []pkg.License {
+	glob := path.Join(lockFileDir, ".terraform", "providers", providerURL, version, "*", "*")
+	return licenses.FindByGlob(ctx, resolver, glob)
+}
+
+func (r *terraformLicenseResolver) findRemoteLicenses(ctx context.Context, providerURL, version string) ([]pkg.License, error) {
+	return r.licenseCache.Resolve(fmt.Sprintf("%s/%s", providerURL, version), func() ([]pkg.License, error) {
+		return r.downloadAndScanProvider(ctx, providerURL, version)
+	})
+}
+
+// registryDownloadResponse represents the JSON response from the Terraform Registry provider download endpoint.
+type registryDownloadResponse struct {
+	DownloadURL string `json:"download_url"`
+}
+
+func (r *terraformLicenseResolver) downloadAndScanProvider(ctx context.Context, providerURL, version string) ([]pkg.License, error) {
+	namespace, providerType, err := parseProviderURL(providerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	downloadURL, err := r.getProviderDownloadURL(namespace, providerType, version)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get download URL for provider %s@%s: %w", providerURL, version, err)
+	}
+
+	fsys, cleanup, err := downloadProviderZip(ctx, downloadURL)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to download provider archive for %s@%s: %w", providerURL, version, err)
+	}
+
+	return findLicensesInFS(ctx, downloadURL+"#", fsys)
+}
+
+// parseProviderURL extracts namespace and type from a provider URL like "registry.terraform.io/hashicorp/aws".
+func parseProviderURL(providerURL string) (namespace, providerType string, err error) {
+	parts := strings.Split(providerURL, "/")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("invalid provider URL %q: expected at least 3 segments (registry/namespace/type)", providerURL)
+	}
+	return parts[len(parts)-2], parts[len(parts)-1], nil
+}
+
+func (r *terraformLicenseResolver) getProviderDownloadURL(namespace, providerType, version string) (string, error) {
+	reqURL := fmt.Sprintf("%s/v1/providers/%s/%s/%s/download/linux/amd64", r.cfg.RegistryBaseURL, namespace, providerType, version)
+
+	log.WithFields("url", reqURL).Info("querying terraform registry for provider download URL")
+
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("unable to create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("unable to query terraform registry: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.WithFields("error", closeErr).Trace("unable to close response body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("terraform registry returned status %d for %s", resp.StatusCode, reqURL)
+	}
+
+	var dlResp registryDownloadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dlResp); err != nil {
+		return "", fmt.Errorf("unable to decode terraform registry response: %w", err)
+	}
+
+	if dlResp.DownloadURL == "" {
+		return "", fmt.Errorf("terraform registry returned empty download URL for %s/%s@%s", namespace, providerType, version)
+	}
+
+	return dlResp.DownloadURL, nil
+}
+
+const maxProviderZipSize = 500 * 1024 * 1024
+
+func downloadProviderZip(ctx context.Context, downloadURL string) (fs.FS, func(), error) {
+	log.WithFields("url", downloadURL).Info("downloading terraform provider archive")
+
+	resp, err := http.Get(downloadURL) //nolint:gosec
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to download provider: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("provider download returned status %d", resp.StatusCode)
+	}
+
+	td := tmpdir.FromContext(ctx)
+	if td == nil {
+		return nil, nil, fmt.Errorf("no temp dir factory in context")
+	}
+
+	tmpFile, cleanupFile, err := td.NewFile("terraform-provider-*.zip")
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create temp file: %w", err)
+	}
+
+	cleanup := func() {
+		_ = tmpFile.Close()
+		cleanupFile()
+	}
+
+	size, err := io.Copy(tmpFile, io.LimitReader(resp.Body, maxProviderZipSize))
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("unable to download provider zip: %w", err)
+	}
+	if size >= maxProviderZipSize {
+		cleanup()
+		return nil, nil, fmt.Errorf("provider zip exceeds %d byte size limit", maxProviderZipSize)
+	}
+
+	if _, err := tmpFile.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("unable to seek provider zip: %w", err)
+	}
+
+	zipReader, err := zip.NewReader(tmpFile, size)
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("unable to read provider zip: %w", err)
+	}
+
+	return zipReader, cleanup, nil
+}
+
+func findLicensesInFS(ctx context.Context, urlPrefix string, fsys fs.FS) ([]pkg.License, error) {
+	var out []pkg.License
+	err := fs.WalkDir(fsys, ".", func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d == nil || d.IsDir() {
+			return nil
+		}
+		if !licenses.IsLicenseFile(d.Name()) {
+			return nil
+		}
+		rdr, err := fsys.Open(filePath)
+		if err != nil {
+			log.WithFields("error", err, "path", filePath).Debug("unable to open license file in provider archive")
+			return nil
+		}
+		defer internal.CloseAndLogError(rdr, filePath)
+
+		foundLicenses := pkg.NewLicensesFromReadCloserWithContext(ctx, file.NewLocationReadCloser(file.NewLocation(filePath), rdr))
+		for _, l := range foundLicenses {
+			l.URLs = []string{urlPrefix + filePath}
+			l.Locations = file.NewLocationSet()
+			out = append(out, l)
+		}
+		return nil
+	})
+	return out, err
+}

--- a/syft/pkg/cataloger/terraform/license_test.go
+++ b/syft/pkg/cataloger/terraform/license_test.go
@@ -1,0 +1,124 @@
+package terraform
+
+import (
+	"archive/zip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/anchore/syft/syft/internal/fileresolver"
+	"github.com/anchore/syft/syft/pkg/cataloger/internal/pkgtest"
+)
+
+func TestFindLocalLicenses(t *testing.T) {
+	ctx := pkgtest.Context(t)
+	resolver := fileresolver.NewFromUnindexedDirectory(filepath.Join("testdata", "with-licenses"))
+	lr := newTerraformLicenseResolver(DefaultCatalogerConfig())
+
+	t.Run("license exists", func(t *testing.T) {
+		found := lr.findLocalLicenses(ctx, resolver, "", "registry.terraform.io/hashicorp/aws", "5.72.1")
+		require.Len(t, found, 1)
+		assert.Equal(t, "MIT", found[0].SPDXExpression)
+	})
+
+	t.Run("no license", func(t *testing.T) {
+		found := lr.findLocalLicenses(ctx, resolver, "", "registry.terraform.io/hashicorp/google", "6.8.0")
+		assert.Empty(t, found)
+	})
+}
+
+func TestParseProviderURL(t *testing.T) {
+	tests := []struct {
+		input     string
+		namespace string
+		provider  string
+		wantErr   bool
+	}{
+		{
+			input:     "registry.terraform.io/hashicorp/aws",
+			namespace: "hashicorp",
+			provider:  "aws",
+		},
+		{
+			input:     "registry.terraform.io/hashicorp/google",
+			namespace: "hashicorp",
+			provider:  "google",
+		},
+		{
+			input:   "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			ns, prov, err := parseProviderURL(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.namespace, ns)
+			assert.Equal(t, tt.provider, prov)
+		})
+	}
+}
+
+func TestFindRemoteLicenses(t *testing.T) {
+	zipData := createTestProviderZip(t)
+
+	downloadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		w.Write(zipData)
+	}))
+	defer downloadServer.Close()
+
+	registryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"download_url": "%s/terraform-provider-test.zip"}`, downloadServer.URL)
+	}))
+	defer registryServer.Close()
+
+	cfg := CatalogerConfig{
+		SearchRemoteLicenses: true,
+		RegistryBaseURL:      registryServer.URL,
+	}
+	lr := newTerraformLicenseResolver(cfg)
+	ctx := pkgtest.Context(t)
+
+	licenses, err := lr.findRemoteLicenses(ctx, "registry.terraform.io/hashicorp/aws", "5.72.1")
+	require.NoError(t, err)
+	require.Len(t, licenses, 1)
+	assert.Equal(t, "MIT", licenses[0].SPDXExpression)
+	assert.Empty(t, licenses[0].Locations.ToSlice())
+}
+
+func createTestProviderZip(t *testing.T) []byte {
+	t.Helper()
+
+	licenseContent, err := os.ReadFile(filepath.Join("testdata", "with-licenses", ".terraform", "providers",
+		"registry.terraform.io", "hashicorp", "aws", "5.72.1", "linux_amd64", "LICENSE.txt"))
+	require.NoError(t, err)
+
+	tmpFile := filepath.Join(t.TempDir(), "test.zip")
+	f, err := os.Create(tmpFile)
+	require.NoError(t, err)
+
+	w := zip.NewWriter(f)
+	entry, err := w.Create("LICENSE.txt")
+	require.NoError(t, err)
+	_, err = entry.Write(licenseContent)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	require.NoError(t, f.Close())
+
+	data, err := os.ReadFile(tmpFile)
+	require.NoError(t, err)
+	return data
+}

--- a/syft/pkg/cataloger/terraform/parse_tf_lock.go
+++ b/syft/pkg/cataloger/terraform/parse_tf_lock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 
 	"github.com/hashicorp/hcl/v2/hclsimple"
 
@@ -17,7 +18,7 @@ type terraformLockFile struct {
 	Providers []pkg.TerraformLockProviderEntry `hcl:"provider,block"`
 }
 
-func parseTerraformLock(_ context.Context, _ file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
+func (r *terraformLicenseResolver) parseTerraformLock(ctx context.Context, resolver file.Resolver, _ *generic.Environment, reader file.LocationReadCloser) ([]pkg.Package, []artifact.Relationship, error) {
 	var lockFile terraformLockFile
 
 	contents, err := io.ReadAll(reader) //nolint:gocritic // hclsimple.Decode requires []byte
@@ -30,14 +31,17 @@ func parseTerraformLock(_ context.Context, _ file.Resolver, _ *generic.Environme
 		return nil, nil, fmt.Errorf("failed to decode terraform lock file: %w", err)
 	}
 
+	lockFileDir := path.Dir(reader.Location.AccessPath)
 	pkgs := make([]pkg.Package, 0, len(lockFile.Providers))
 
 	for _, provider := range lockFile.Providers {
+		licenseSet := r.getLicenses(ctx, resolver, lockFileDir, provider.URL, provider.Version)
+
 		p := pkg.Package{
 			Name:      provider.URL,
 			Version:   provider.Version,
 			Locations: file.NewLocationSet(reader.WithAnnotation(pkg.EvidenceAnnotationKey, pkg.PrimaryEvidenceAnnotation)),
-			Licenses:  pkg.NewLicenseSet(), // TODO: license could be found in .terraform/providers/${name}/${version}/${arch}/LICENSE.txt
+			Licenses:  licenseSet,
 			Language:  pkg.Go,
 			Type:      pkg.TerraformPkg,
 			Metadata:  provider,

--- a/syft/pkg/cataloger/terraform/testdata/with-licenses/.terraform.lock.hcl
+++ b/syft/pkg/cataloger/terraform/testdata/with-licenses/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.72.1"
+  constraints = "> 5.72.0"
+  hashes = [
+    "h1:jhd5O5o0CfZCNEwwN0EiDAzb7ApuFrtxJqa6HXW4EKE=",
+    "zh:0dea6843836e926d33469b48b948744079023816d16a2ff7666bcfb6aa3522d4",
+    "zh:195fa9513f75800a0d62797ebec75ee73e9b8c28d713fe9b63d3b1d1eec129b3",
+    "zh:1ed92f3961715bf0e024bcde3c12dfbdc50b00c1f8a43cc00802cfc45a256208",
+    "zh:2ac687e3a52606466cae4a6813e81d923042488df88d2424e28d3f8530f091bb",
+    "zh:32e7ca75f9314557daada3c44628fe1f3bf964a4f833bfb4b2295d833fe64b6f",
+    "zh:374ee0e6b4327cc6ef666908ce5d6450a3a56e90cd2b785e83c2bcfc100021d2",
+    "zh:5500fd6fdac44f96411fcf9c6d01691159ec35455ed127eb4c3a498e1cc92a64",
+    "zh:723a2dc4b064c12e7ee62ad4fbfd72fa5e025206ea47b735994ef53f3c373152",
+    "zh:89d97b87605f1d734f27e642567cbecf785b521af8ea81dac55c77ccde876221",
+    "zh:951ee1e5731e8d65d521d71b95927e55055b3c4656eef6d46fa580a63328befc",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b2b362470b64ec227b2da64762ab8bc4111c6b80365fd9d82fc5e1e33f44038",
+    "zh:aa6e57d0cb974ff0da5dee5d43ad2745cbbc4a2b507d4c799839b9fa96daf688",
+    "zh:ba0d14c4a6b7aa844a830d47c0bf995b632e37f0795394b5b60c638b62b7fc03",
+    "zh:c9764065a9c5d324db0b02bd201b9e3a2118e49c4960884acdeea377173302e9",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.8.0"
+  hashes = [
+    "h1:GlCaVPk6eKMg2ZbRY7C5tUeHGNIABT+qFtMl8+XWZHM=",
+    "zh:1b78f4451f1617092eb6891c9c13eda79671060601c40947feea6794c732157a",
+    "zh:4c6d7231ce32c6ff2a98218ef363c133d27d423b009354e7fe18459d9feb41d4",
+    "zh:6ae0112e9c733ab6c72436a334ffe3f197a613bb04f49538462b83b236d37a2d",
+    "zh:8bd5651838ad674e0a173a453b76c80b94d08ebcb8ea0b6263ce6da0599b42f5",
+    "zh:94ee7bcd77b0b7c2777113e35282da014e61e813fe46c058a49bf3d616fecdf4",
+    "zh:c0bf014422c2971985d34ad45ddb6aa737373398f83b325884ea5608ac1264aa",
+    "zh:c2cbbf0c249c3d1842ad0ad77fb7ef85bd3e92c688618c4087173bc1d69cd098",
+    "zh:cefa3e06cb353d08b83dafa6135cd78e17540ae735b7c5687833cc1925c3fd8e",
+    "zh:d20bc0216bf7f054f6318467d3902ced05e9f0bfa500ee55bf43b1b41ef0b854",
+    "zh:e54ad5959e53b9e9acafc243d6f4039ab5005cec32c7435a122da964888d184c",
+    "zh:e833c8de147268b3ffc14c60915eccb9347ade5f25b37b3771240a4d68b6aac4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/syft/pkg/cataloger/terraform/testdata/with-licenses/.terraform/providers/registry.terraform.io/hashicorp/aws/5.72.1/linux_amd64/LICENSE.txt
+++ b/syft/pkg/cataloger/terraform/testdata/with-licenses/.terraform/providers/registry.terraform.io/hashicorp/aws/5.72.1/linux_amd64/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2024 HashiCorp, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Resolves the TODO in `parse_tf_lock.go` — the terraform-lock-cataloger now detects licenses for providers.

**Local resolution**: searches for LICENSE files in the `.terraform/providers/` cache directory (always-on, no network).

**Remote resolution**: when enabled, downloads the provider archive from the Terraform Registry and scans it for license files. Opt-in via `terraform.search-remote-licenses` or `--enrich terraform`.

Follows the same pattern as Go, Python, and JavaScript catalogers for remote license enrichment.