### PR TITLE
fix(test): pull elf fixture build tools from archive.debian.org

### DIFF
--- a/syft/file/cataloger/executable/testdata/elf/Dockerfile
+++ b/syft/file/cataloger/executable/testdata/elf/Dockerfile
@@ -1,6 +1,12 @@
 FROM gcc:9.5.0
 
-RUN apt update -y && apt install -y clang cmake git make m4 pkg-config zlib1g-dev
+# bullseye is EOL: deb.debian.org dropped it, so pull from archive.debian.org (whose Release files are
+# permanently expired, hence Check-Valid-Until). bullseye-security is deliberately omitted -- its index is
+# still served but the pool behind it 404s, and it has not been moved to the archive yet. These are throwaway
+# fixture build tools, so base bullseye package versions are fine.
+RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archive.debian.org/debian bullseye-updates main\n' > /etc/apt/sources.list \
+    && apt -o Acquire::Check-Valid-Until=false update -y \
+    && apt install -y clang cmake git make m4 pkg-config zlib1g-dev
 
 ## from https://github.com/runsafesecurity/selfrando/blob/tb-v0.4.2/docs/linux-build-instructions.md
 #RUN git clone https://github.com/runsafesecurity/selfrando.git && \


### PR DESCRIPTION
bullseye went EOL and deb.debian.org dropped it, so the elf executable fixture image stopped building and took the whole unit test job with it (fixture generation runs before any test does).

Two separate breakages, both handled here:

- the base repo moved to `archive.debian.org`, whose Release files are permanently expired, so `Acquire::Check-Valid-Until=false` is required

- `bullseye-security` is worse off: its index is still served but every package in the pool behind it 404s, and it has not landed on the archive yet. dropping it is the only option right now. these are throwaway fixture build tools, so base bullseye versions are fine.

## Type of change

- [x] Chore (improve the developer experience, fix a test flake, etc, without changing the visible behavior of Syft)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
