### PR TITLE
perf(spdx): make findRootPackages linear instead of packages x relationships

### DIFF
--- a/syft/format/common/spdxhelpers/find_root_packages_test.go
+++ b/syft/format/common/spdxhelpers/find_root_packages_test.go
@@ -1,0 +1,181 @@
+package spdxhelpers
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/spdx/tools-golang/spdx"
+	"github.com/spdx/tools-golang/spdx/v2/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests in this file cover findRootPackages, which locates the packages an SPDX document declares it DESCRIBES
+// (or which declare themselves DESCRIBED_BY the document). Until it was rewritten, this function compared every
+// package against every relationship, so its cost grew with packages x relationships. On real documents that made
+// SPDX decoding quadratic in document size: a 119MB SPDX JSON document (70k packages, 153k relationships) spent
+// 72s here, a 238MB document 266s, and a 1.3GB document did not finish within 90 minutes. Encoding the same
+// documents, and decoding equivalently sized syft-json or CycloneDX documents, is linear and takes seconds.
+//
+// Test_findRootPackages pins the exact semantics of the original implementation, including the corner cases a
+// rewrite could easily change: result order follows package order, an element described twice appears twice, and
+// only edges that touch the DOCUMENT element count. Test_findRootPackages_scalesLinearly is the regression guard
+// for the performance fix itself.
+
+func Test_findRootPackages(t *testing.T) {
+	pkgA := &spdx.Package{PackageSPDXIdentifier: "Package-a"}
+	pkgB := &spdx.Package{PackageSPDXIdentifier: "Package-b"}
+	pkgC := &spdx.Package{PackageSPDXIdentifier: "Package-c"}
+
+	describes := func(id common.ElementID) *spdx.Relationship {
+		return &spdx.Relationship{
+			RefA:         common.DocElementID{ElementRefID: "DOCUMENT"},
+			RefB:         common.DocElementID{ElementRefID: id},
+			Relationship: spdx.RelationshipDescribes,
+		}
+	}
+	describedBy := func(id common.ElementID) *spdx.Relationship {
+		return &spdx.Relationship{
+			RefA:         common.DocElementID{ElementRefID: id},
+			RefB:         common.DocElementID{ElementRefID: "DOCUMENT"},
+			Relationship: spdx.RelationshipDescribedBy,
+		}
+	}
+
+	tests := []struct {
+		name          string
+		packages      []*spdx.Package
+		relationships []*spdx.Relationship
+		want          []*spdx.Package
+	}{
+		{
+			name:          "no relationships",
+			packages:      []*spdx.Package{pkgA, pkgB},
+			relationships: nil,
+			want:          nil,
+		},
+		{
+			name:     "document describes one package",
+			packages: []*spdx.Package{pkgA, pkgB, pkgC},
+			relationships: []*spdx.Relationship{
+				{RefA: common.DocElementID{ElementRefID: "Package-a"}, RefB: common.DocElementID{ElementRefID: "Package-b"}, Relationship: spdx.RelationshipContains},
+				describes("Package-b"),
+			},
+			want: []*spdx.Package{pkgB},
+		},
+		{
+			name:     "package described by the document",
+			packages: []*spdx.Package{pkgA, pkgB, pkgC},
+			relationships: []*spdx.Relationship{
+				describedBy("Package-c"),
+			},
+			want: []*spdx.Package{pkgC},
+		},
+		{
+			name:     "multiple roots are returned in package order",
+			packages: []*spdx.Package{pkgA, pkgB, pkgC},
+			relationships: []*spdx.Relationship{
+				describes("Package-c"),
+				describedBy("Package-a"),
+			},
+			want: []*spdx.Package{pkgA, pkgC},
+		},
+		{
+			name:     "duplicate edges yield duplicate roots (preserved behavior)",
+			packages: []*spdx.Package{pkgA, pkgB},
+			relationships: []*spdx.Relationship{
+				describes("Package-a"),
+				describedBy("Package-a"),
+			},
+			want: []*spdx.Package{pkgA, pkgA},
+		},
+		{
+			name:     "describes edges not from the document are ignored",
+			packages: []*spdx.Package{pkgA, pkgB},
+			relationships: []*spdx.Relationship{
+				{RefA: common.DocElementID{ElementRefID: "Package-a"}, RefB: common.DocElementID{ElementRefID: "Package-b"}, Relationship: spdx.RelationshipDescribes},
+				{RefA: common.DocElementID{ElementRefID: "Package-b"}, RefB: common.DocElementID{ElementRefID: "Package-a"}, Relationship: spdx.RelationshipDescribedBy},
+			},
+			want: nil,
+		},
+		{
+			name:     "described element that is not a package is ignored",
+			packages: []*spdx.Package{pkgA},
+			relationships: []*spdx.Relationship{
+				describes("File-1"),
+			},
+			want: nil,
+		},
+		{
+			name:     "nil packages and relationships are skipped",
+			packages: []*spdx.Package{nil, pkgA},
+			relationships: []*spdx.Relationship{
+				nil,
+				describes("Package-a"),
+			},
+			want: []*spdx.Package{pkgA},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findRootPackages(&spdx.Document{
+				Packages:      tt.packages,
+				Relationships: tt.relationships,
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// Test_findRootPackages_scalesLinearly guards against reintroducing a packages x relationships scan. At 50k
+// packages and 100k relationships (5e9 comparisons) the previous implementation needs on the order of a minute on
+// a fast laptop and several minutes on a CI runner, whereas the indexed implementation completes in about a
+// millisecond. The 10s bound is therefore loose enough never to flake on slow hardware yet far below what any
+// quadratic implementation could achieve.
+func Test_findRootPackages_scalesLinearly(t *testing.T) {
+	doc := largeSPDXDocument(50_000, 100_000)
+
+	start := time.Now()
+	got := findRootPackages(doc)
+	elapsed := time.Since(start)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, common.ElementID("Package-0"), got[0].PackageSPDXIdentifier)
+	assert.Less(t, elapsed, 10*time.Second, "findRootPackages took %s on %d packages and %d relationships", elapsed, len(doc.Packages), len(doc.Relationships))
+}
+
+// Benchmark_findRootPackages measures the same 50k x 100k document as the scaling test so the two can be compared
+// directly: run with `go test ./syft/format/common/spdxhelpers/ -run xxx -bench findRootPackages`.
+func Benchmark_findRootPackages(b *testing.B) {
+	doc := largeSPDXDocument(50_000, 100_000)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = findRootPackages(doc)
+	}
+}
+
+// largeSPDXDocument builds a document with the given number of packages and relationships where the document
+// describes exactly the first package and every other relationship links packages to one another.
+func largeSPDXDocument(packages int, relationships int) *spdx.Document {
+	doc := &spdx.Document{}
+	for i := 0; i < packages; i++ {
+		doc.Packages = append(doc.Packages, &spdx.Package{
+			PackageSPDXIdentifier: common.ElementID(fmt.Sprintf("Package-%d", i)),
+		})
+	}
+	doc.Relationships = append(doc.Relationships, &spdx.Relationship{
+		RefA:         common.DocElementID{ElementRefID: "DOCUMENT"},
+		RefB:         common.DocElementID{ElementRefID: "Package-0"},
+		Relationship: spdx.RelationshipDescribes,
+	})
+	for i := 1; i < relationships; i++ {
+		doc.Relationships = append(doc.Relationships, &spdx.Relationship{
+			RefA:         common.DocElementID{ElementRefID: common.ElementID(fmt.Sprintf("Package-%d", i%packages))},
+			RefB:         common.DocElementID{ElementRefID: common.ElementID(fmt.Sprintf("Package-%d", (i+1)%packages))},
+			Relationship: spdx.RelationshipDependsOn,
+		})
+	}
+	return doc
+}

--- a/syft/format/common/spdxhelpers/to_syft_model.go
+++ b/syft/format/common/spdxhelpers/to_syft_model.go
@@ -83,20 +83,30 @@ func removeRelationships(relationships []*spdx.Relationship, spdxID spdx.Element
 }
 
 func findRootPackages(doc *spdx.Document) (out []*spdx.Package) {
+	// index the DESCRIBES / DESCRIBED_BY relationships once, counting how many
+	// times each element is described by the document, so that the result
+	// matches the previous packages x relationships scan exactly (one entry per
+	// matching relationship) without the quadratic cost.
+	describedCount := make(map[spdx.ElementID]int)
+	for _, r := range doc.Relationships {
+		if r == nil {
+			continue
+		}
+		switch {
+		case r.RefA.ElementRefID == "DOCUMENT" && r.Relationship == spdx.RelationshipDescribes:
+			describedCount[r.RefB.ElementRefID]++
+		case r.RefB.ElementRefID == "DOCUMENT" && r.Relationship == spdx.RelationshipDescribedBy:
+			describedCount[r.RefA.ElementRefID]++
+		}
+	}
+	if len(describedCount) == 0 {
+		return nil
+	}
 	for _, p := range doc.Packages {
-		for _, r := range doc.Relationships {
-			describes := r.RefA.ElementRefID == "DOCUMENT" &&
-				r.Relationship == spdx.RelationshipDescribes &&
-				r.RefB.ElementRefID == p.PackageSPDXIdentifier
-
-			describedBy := r.RefB.ElementRefID == "DOCUMENT" &&
-				r.Relationship == spdx.RelationshipDescribedBy &&
-				r.RefA.ElementRefID == p.PackageSPDXIdentifier
-
-			if !describes && !describedBy {
-				continue
-			}
-
+		if p == nil {
+			continue
+		}
+		for i := 0; i < describedCount[p.PackageSPDXIdentifier]; i++ {
 			out = append(out, p)
 		}
 	}


### PR DESCRIPTION
## Description

Decoding SPDX documents into the syft model is quadratic in document size, which makes `syft convert` (and anything else that decodes SPDX, such as the SBOM cataloger) unusable on large documents. A 119MB SPDX JSON document takes 68 seconds to round-trip, a 238MB one 291 seconds, and a 1.3GB one did not finish in 91 minutes.

**Root cause.** `findRootPackages` in `syft/format/common/spdxhelpers/to_syft_model.go` locates the packages the document `DESCRIBES` (or which are `DESCRIBED_BY` the document) by scanning every relationship for every package. On the 119MB document that is 70,701 packages by 153,301 relationships, about 1.1e10 comparisons. A CPU profile attributes 91 percent of all samples to this one function at 119MB and 95 percent at 238MB. Everything else on the decode path is map-indexed and linear, and the underlying `spdx/tools-golang` parse is linear too (4.5 s and 9.3 s respectively). The scan was introduced in 9480f10c (top-level SPDX package support, July 2023) and survived the later SPDX 3 refactor unchanged.

**Fix.** Index the `DESCRIBES` / `DESCRIBED_BY` relationships once, counting how many times each element is described by `DOCUMENT`, then walk the packages once. Complexity goes from O(P x R) to O(P + R). Semantics are preserved exactly: results follow package order, an element described by more than one edge still appears once per edge (so the existing "exactly one root" check behaves as before), only edges touching `DOCUMENT` count, and nil entries are skipped.

### Performance

Apple M1 Max (10 cores, 32GB), `/usr/bin/time -l`, `syft convert <spdx> -o <format>=<file>`. Documents were produced by converting a real syft-json SBOM inflated to size, so they carry realistic package and relationship shapes. "main" is `origin/main` at 392539dc.

| Input | Target | main | this PR |
|---|---|---|---|
| 119 MB SPDX 2.3 | spdx-json@2.3 | 68.2 s, 1.3 GB | **10.4 s**, 1.3 GB |
| 119 MB SPDX 2.3 | spdx-json@2.2 | 70.2 s, 1.3 GB | **12.6 s**, 1.3 GB |
| 238 MB SPDX 2.3 | spdx-json@2.3 | 291.2 s, 2.3 GB | **20.9 s**, 2.6 GB |
| 1.3 GB SPDX 2.3 | spdx-json@2.3 | killed after 91 min at 99% CPU | **115.5 s**, 13.6 GB |
| 1.3 GB SPDX 2.3 | spdx-json@2.2 | not attempted | 136.3 s, 14.1 GB |
| 1.3 GB SPDX 2.3 | syft-json | not attempted | 102.6 s, 14.1 GB |
| 1.3 GB SPDX 2.3 | cyclonedx-json@1.6 | not attempted | 114.1 s, 13.1 GB |

Doubling the input from 119MB to 238MB multiplied `main`'s time by 4.3; with this change it multiplies by 2.0. Extrapolating `main`'s curve to 1.3GB gives roughly 2.4 hours, consistent with the killed run.

Isolating the syft conversion step (`ToSyftModel`) from the `tools-golang` parse, under a CPU profile:

| Input | tools-golang parse | ToSyftModel before | ToSyftModel after |
|---|---|---|---|
| 119 MB | 4.5 s | 72.3 s | 1.5 s |
| 238 MB | 9.3 s | 265.8 s | 3.1 s |

Memory is unchanged by this PR. What remains, roughly ten times the input size, is in `spdx/tools-golang`, which buffers the whole input and parses the document several times over (once to read `spdxVersion`, twice for the document, twice per package). That is a separate upstream concern.

### Regression testing

Output equivalence: ten SPDX documents (the eight SPDX fixtures in this repository under `syft/format/spdxjson/testdata`, `syft/format/spdxtagvalue/testdata` and `cmd/syft/internal/test/integration/testdata`, plus the 119MB and 238MB documents) were converted to `syft-json`, `spdx-json@2.3`, `spdx-json@2.2`, `spdx-tag-value` and `cyclonedx-json@1.6` with both the `main` binary and this one. After removing the fields that legitimately differ between runs (`created`, `documentNamespace`, `serialNumber`, `timestamp`), all 50 output pairs are byte-identical.

Unit tests for `syft/format/common/spdxhelpers`, `syft/format/spdxjson`, `syft/format/spdxtagvalue` and `syft/format` pass.

### Upstream

No existing issue was found in either `anchore/syft` or `spdx/tools-golang` for this (searched for slow, performance, memory, quadratic, hang, and large-document terms).

## Type of change

- [x] Performance (make Syft run faster or use less memory, without changing visible behavior much)

## Checklist

- [x] I have added unit tests that cover changed behavior
  - `Test_findRootPackages` pins the original semantics across eight cases: no relationships, `DESCRIBES`, `DESCRIBED_BY`, multiple roots in package order, duplicate edges yielding duplicate roots, describes-edges not from `DOCUMENT` ignored, described elements that are not packages ignored, and nil entries skipped.
  - `Test_findRootPackages_scalesLinearly` builds a 50,000 package by 100,000 relationship document and requires completion within 10 s. The previous implementation takes about a minute on it on a fast laptop; the new one about a millisecond.
  - `Benchmark_findRootPackages` measures the same document for direct comparison.
  - The test file carries a header comment recording the problem, the measured impact and what each test protects, so the reasoning survives the PR.
- [x] I have tested my code in common scenarios and confirmed there are no regressions
  - 50 of 50 output-equivalence comparisons against `main` are identical, as described above.
  - Format package tests pass. Docker-dependent tests were not run locally.
- [x] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

No linked issue. Found while benchmarking `syft convert` on gigabyte-scale SBOMs, where SPDX decoding was the only path that did not complete.
