### PR TITLE
fix(test): use immutable URL for dpkg archive fixture

### DIFF
--- a/cmd/syft/internal/test/integration/testdata/image-pkg-coverage/Dockerfile
+++ b/cmd/syft/internal/test/integration/testdata/image-pkg-coverage/Dockerfile
@@ -16,7 +16,7 @@ RUN unxz /lib/modules/6.0.7-301.fc37.x86_64/kernel/drivers/tty/ttynull.ko.xz
 # dotnet pkg coverage
 # https://nuget.info/packages/DocuSign.eSign.dll/6.8.0
 # https://github.com/docusign/docusign-esign-csharp-client/blob/master/LICENSE
-RUN curl -LO https://www.nuget.org/api/v2/package/DocuSign.eSign.dll/6.8.0
+RUN curl -fLO https://www.nuget.org/api/v2/package/DocuSign.eSign.dll/6.8.0
 RUN unzip 6.8.0
 RUN chmod 600 lib/net462/DocuSign.eSign.dll
 RUN rm 6.8.0

--- a/syft/file/cataloger/executable/testdata/elf/Dockerfile
+++ b/syft/file/cataloger/executable/testdata/elf/Dockerfile
@@ -19,4 +19,4 @@ RUN printf 'deb http://archive.debian.org/debian bullseye main\ndeb http://archi
 #RUN cd selfrando && make -j`nprocs --all`
 #RUN cd selfrando && make install
 
-RUN curl -o /bin/checksec https://raw.githubusercontent.com/slimm609/checksec.sh/2.6.0/checksec && chmod +x /bin/checksec
+RUN curl -f -o /bin/checksec https://raw.githubusercontent.com/slimm609/checksec.sh/2.6.0/checksec && chmod +x /bin/checksec

--- a/syft/pkg/cataloger/debian/testdata/image-single-dpkg/Dockerfile
+++ b/syft/pkg/cataloger/debian/testdata/image-single-dpkg/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:22.04 AS downloader
 
 RUN apt-get update && apt-get install -y curl
 
-RUN curl -o zlib1g.deb http://archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb
+# launchpad's +files URLs are immutable, unlike pool/main which only keeps the current version
+RUN curl -fsSL -o zlib1g.deb https://launchpad.net/ubuntu/+archive/primary/+files/zlib1g_1.3.dfsg-3.1ubuntu2.1_amd64.deb
 
 FROM scratch
 

--- a/syft/pkg/cataloger/redhat/testdata/image-rpm-archive/Dockerfile
+++ b/syft/pkg/cataloger/redhat/testdata/image-rpm-archive/Dockerfile
@@ -17,7 +17,7 @@ FROM --platform=linux/amd64 rockylinux:9 AS rpm-downloader
 # $ rpm -qp --qf '%{NAME}-%{VERSION}-%{RELEASE} %{RSAHEADER:pgpsig}\n' basesystem-11-13.el9.0.1.noarch.rpm
 #   basesystem-11-13.el9.0.1 RSA/SHA256, Thu Feb 29 17:37:22 2024, Key ID 702d426d350d275d
 
-RUN curl -O https://dl.rockylinux.org/vault/rocky/9.3/BaseOS/x86_64/os/Packages/b/basesystem-11-13.el9.0.1.noarch.rpm
+RUN curl -fO https://dl.rockylinux.org/vault/rocky/9.3/BaseOS/x86_64/os/Packages/b/basesystem-11-13.el9.0.1.noarch.rpm
 
 FROM scratch
 


### PR DESCRIPTION
`archive.ubuntu.com/ubuntu/pool/main` only keeps the current version of a package, so the pinned `zlib1g 1:1.3.dfsg-3.1ubuntu2.1` URL started 404ing. `curl` without `-f` wrote the error page into `zlib1g.deb` and exited 0, so the fixture image built clean and just contained a non-deb, failing `TestDpkgArchiveCataloger` only when the fixture cache was cold.

Now points at the launchpad `+files` URL, which is immutable. Also added `-f` to the other fixture Dockerfiles that curl a pinned artifact so the next bit of URL rot fails the build instead of quietly poisoning a fixture.

This fixes the nightly publish cache workflow.