### PR TITLE
fix(test): drop apt from java-no-main-package fixture

### DIFF
--- a/cmd/syft/internal/test/integration/testdata/image-java-no-main-package/Dockerfile
+++ b/cmd/syft/internal/test/integration/testdata/image-java-no-main-package/Dockerfile
@@ -8,8 +8,6 @@ RUN mkdir tmp
 
 WORKDIR /usr/share/jenkins/tmp
 
-RUN apt-get update 2>&1 > /dev/null && apt-get install -y less zip 2>&1 > /dev/null
-
 RUN unzip ../jenkins.war 2>&1 > /dev/null
 
 RUN rm -rf ./META-INF/MANIFEST.MF ./WEB-INF ./jsbundles ./scripts ./css
@@ -18,7 +16,8 @@ WORKDIR /usr/share/jenkins
 
 RUN rm -rf jenkins.war
 
-RUN cd ./tmp && zip -r ../jenkins.war . && cd ..
+# use jar (from the JDK in the base image) to rezip -- M keeps it manifest-less, which is the point of this fixture
+RUN cd ./tmp && jar cfM ../jenkins.war . && cd ..
 
 RUN rm -rf ./tmp
 


### PR DESCRIPTION
the base image is digest-pinned to a bullseye snapshot whose InRelease has expired, so `apt-get update` now exits 100 on any cold fixture build. rather than disable Check-Valid-Until (which just delays the next break), skip apt entirely:

- `less` was never used and `unzip` already ships in the base image
- rezip with `jar cfM` from the base JDK instead of installing `zip`

the `-M` matters here: this fixture intentionally has no META-INF/MANIFEST.MF, and plain `jar cf` would generate one.
