### PR TITLE
Fix oom when running unit tests in CI

### DIFF
--- a/.github/actions/bootstrap/action.yaml
+++ b/.github/actions/bootstrap/action.yaml
@@ -47,7 +47,17 @@ runs:
         APT_PACKAGES: ${{ inputs.bootstrap-apt-packages }}
       run: |
         IFS=' ' read -ra packages <<< "$APT_PACKAGES"
-        DEBIAN_FRONTEND=noninteractive sudo apt update && sudo -E apt install -y "${packages[@]}"
+        # the AMI already ships most of these, and `apt update` costs ~40MB of index (minutes,
+        # when archive.ubuntu.com throttles us) to find that out. only touch apt if we must.
+        missing=()
+        for pkg in "${packages[@]}"; do
+          dpkg -s "$pkg" >/dev/null 2>&1 || missing+=("$pkg")
+        done
+        if [ ${#missing[@]} -eq 0 ]; then
+          echo "all apt packages already present: ${packages[*]}"
+          exit 0
+        fi
+        DEBIAN_FRONTEND=noninteractive sudo apt update && sudo -E apt install -y "${missing[@]}"
 
     # ORAS cache: restore-only on non-default branches / forks
     - name: Restore ORAS cache from github actions

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -21,10 +21,12 @@ jobs:
     name: "Static analysis"
     # runs-on.com: memory & general purpose instances for testing
     #   spot enabled: ok to interrupt non-production workloads
-    #   tmpfs: faster io-intensive workflows
+    #   tmpfs intentionally omitted -- it RAM-backs /home/runner, /tmp and /var/lib/docker at
+    #   100% of instance memory, leaving no headroom for `make unit` to link ~400 race-enabled
+    #   test binaries. volume gets the IO back on disk.
     #   note: s3-cache intentionally omitted -- PR runs are untrusted and must not write to the
     #   shared cache backend that the trusted release workflow reads from (cache poisoning).
-    runs-on: &test-runner "runs-on=${{ github.run_id }}/cpu=4+8/ram=32+128/family=r5+r6+r7+r8+m4+m5+m6+m7+m8/spot=price-capacity-optimized/extras=tmpfs"
+    runs-on: &test-runner "runs-on=${{ github.run_id }}/cpu=4+8/ram=32+128/family=r5+r6+r7+r8+m4+m5+m6+m7+m8/spot=price-capacity-optimized/volume=80gb:gp3:500mbs:4000iops"
     permissions:
       contents: read
     steps:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -22,11 +22,12 @@ jobs:
     # runs-on.com: memory & general purpose instances for testing
     #   spot enabled: ok to interrupt non-production workloads
     #   tmpfs intentionally omitted -- it RAM-backs /home/runner, /tmp and /var/lib/docker at
-    #   100% of instance memory, leaving no headroom for `make unit` to link ~400 race-enabled
-    #   test binaries. volume gets the IO back on disk.
+    #   100% of instance memory, starving `make unit` of headroom to link with -race.
+    #   volume: the caches and docker images tmpfs used to hold. gp3 baseline throughput is
+    #   enough; a 4 vCPU instance can't pull much more than that anyway.
     #   note: s3-cache intentionally omitted -- PR runs are untrusted and must not write to the
     #   shared cache backend that the trusted release workflow reads from (cache poisoning).
-    runs-on: &test-runner "runs-on=${{ github.run_id }}/cpu=4+8/ram=32+128/family=r5+r6+r7+r8+m4+m5+m6+m7+m8/spot=price-capacity-optimized/volume=80gb:gp3:500mbs:4000iops"
+    runs-on: &test-runner "runs-on=${{ github.run_id }}/cpu=4+8/ram=16+32/family=m5+m6+m7+m8+c5+c6+c7+c8/spot=price-capacity-optimized/volume=100gb"
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Addresses recent failures in CI: we've been using tmpfs mounts to keep CI faster, however, the cache being built/pulled now has outsized the mount. This PR pivots and uses a standard filesystem on cheaper instances, we should see similar performance as earlier.