### PR TITLE
fix(javascript): keep pnpm packages when resolution is nested

### DIFF
--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock.go
@@ -41,7 +41,10 @@ type pnpmLockfileParser interface {
 }
 
 type pnpmV6PackageEntry struct {
-	Resolution   map[string]string `yaml:"resolution"`
+	// Resolution values are usually strings (integrity, tarball), but pnpm can
+	// also record a nested "variations" object for provisioned runtimes. Keep
+	// this as map[string]any so one unrepresentable entry cannot abort decoding.
+	Resolution   map[string]any    `yaml:"resolution"`
 	Dependencies map[string]string `yaml:"dependencies"`
 	Dev          bool              `yaml:"dev"`
 }
@@ -60,7 +63,9 @@ type pnpmV9SnapshotEntry struct {
 }
 
 type pnpmV9PackageEntry struct {
-	Resolution       map[string]string `yaml:"resolution"`
+	// See pnpmV6PackageEntry.Resolution: nested variation resolutions must not
+	// force the whole lockfile decode to fail (anchore/syft#5241).
+	Resolution       map[string]any    `yaml:"resolution"`
 	PeerDependencies map[string]string `yaml:"peerDependencies"`
 	Dev              bool              `yaml:"dev"`
 }
@@ -86,7 +91,14 @@ func newGenericPnpmLockAdapter(cfg CatalogerConfig) genericPnpmLockAdapter {
 // Parse implements the pnpmLockfileParser interface for v6-v8 lockfiles.
 func (p *pnpmV6LockYaml) Parse(version float64, doc *yaml.Node) ([]pnpmPackage, error) {
 	if err := doc.Decode(p); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal pnpm v6 lockfile: %w", err)
+		var typeErr *yaml.TypeError
+		if errors.As(err, &typeErr) {
+			// yaml.v3 still fills fields it could decode; keep those packages
+			// rather than dropping the whole document for one bad entry.
+			log.WithFields("error", err).Trace("partial pnpm v6 lockfile decode; keeping successfully decoded entries")
+		} else {
+			return nil, fmt.Errorf("failed to unmarshal pnpm v6 lockfile: %w", err)
+		}
 	}
 
 	isV5 := version < 6.0
@@ -124,10 +136,7 @@ func (p *pnpmV6LockYaml) Parse(version float64, doc *yaml.Node) ([]pnpmPackage, 
 		}
 		pkgKey := name + "@" + ver
 
-		integrity := ""
-		if value, ok := pkgInfo.Resolution["integrity"]; ok {
-			integrity = value
-		}
+		integrity := integrityFromResolution(pkgInfo.Resolution)
 
 		dependencies := make(map[string]string)
 		for depName, depVersion := range sortedIter(pkgInfo.Dependencies) {
@@ -147,7 +156,12 @@ func (p *pnpmV6LockYaml) Parse(version float64, doc *yaml.Node) ([]pnpmPackage, 
 // Parse implements the PnpmLockfileParser interface for v9+ lockfiles.
 func (p *pnpmV9LockYaml) Parse(_ float64, doc *yaml.Node) ([]pnpmPackage, error) {
 	if err := doc.Decode(p); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal pnpm v9 lockfile: %w", err)
+		var typeErr *yaml.TypeError
+		if errors.As(err, &typeErr) {
+			log.WithFields("error", err).Trace("partial pnpm v9 lockfile decode; keeping successfully decoded entries")
+		} else {
+			return nil, fmt.Errorf("failed to unmarshal pnpm v9 lockfile: %w", err)
+		}
 	}
 
 	packages := make(map[string]pnpmPackage)
@@ -162,7 +176,7 @@ func (p *pnpmV9LockYaml) Parse(_ float64, doc *yaml.Node) ([]pnpmPackage, error)
 			continue
 		}
 		pkgKey := name + "@" + ver
-		packages[pkgKey] = pnpmPackage{Name: name, Version: ver, Integrity: entry.Resolution["integrity"], Dev: entry.Dev}
+		packages[pkgKey] = pnpmPackage{Name: name, Version: ver, Integrity: integrityFromResolution(entry.Resolution), Dev: entry.Dev}
 	}
 
 	for key, snapshotInfo := range sortedIter(p.Snapshots) {
@@ -308,6 +322,21 @@ func mergePnpmPackages(into map[string]pnpmPackage, pkgs []pnpmPackage, doc int)
 		}
 		into[key] = p
 	}
+}
+
+
+// integrityFromResolution reads the integrity string from a pnpm resolution map.
+// Nested variation resolutions have no top-level integrity field; those packages
+// are still cataloged with an empty integrity rather than aborting the lockfile.
+func integrityFromResolution(resolution map[string]any) string {
+	if resolution == nil {
+		return ""
+	}
+	value, ok := resolution["integrity"].(string)
+	if !ok {
+		return ""
+	}
+	return value
 }
 
 // parseVersionField extracts the version string from a dependency entry.

--- a/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
+++ b/syft/pkg/cataloger/javascript/parse_pnpm_lock_test.go
@@ -764,6 +764,47 @@ func TestParsePnpmLock_MultiDocument(t *testing.T) {
 	pkgtest.TestFileParser(t, fixture, adapter.parsePnpmLock, expectedPkgs, expectedRelationships)
 }
 
+
+// pnpm can record a provisioned Node runtime with a nested "variations" resolution.
+// That used to abort the whole v9 decode (map[string]string cannot hold the sequence),
+// which silently dropped every other package from the SBOM (anchore/syft#5241).
+func TestParsePnpmLock_V9VariationsResolution(t *testing.T) {
+	var expectedRelationships []artifact.Relationship
+	fixture := "testdata/pnpm-v9-variations/pnpm-lock.yaml"
+
+	locationSet := file.NewLocationSet(file.NewLocation(fixture))
+
+	expectedPkgs := []pkg.Package{
+		{
+			Name:      "is-odd",
+			Version:   "3.0.1",
+			PURL:      "pkg:npm/is-odd@3.0.1",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata: pkg.PnpmLockEntry{
+				Resolution:   pkg.PnpmLockResolution{Integrity: "sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA=="},
+				Dependencies: map[string]string{},
+			},
+		},
+		{
+			Name:      "node",
+			Version:   "runtime:26.8.1",
+			PURL:      "pkg:npm/node@runtime%3A26.8.1",
+			Locations: locationSet,
+			Language:  pkg.JavaScript,
+			Type:      pkg.NpmPkg,
+			Metadata: pkg.PnpmLockEntry{
+				Resolution:   pkg.PnpmLockResolution{},
+				Dependencies: map[string]string{},
+			},
+		},
+	}
+
+	adapter := newGenericPnpmLockAdapter(CatalogerConfig{IncludeDevDependencies: true})
+	pkgtest.TestFileParser(t, fixture, adapter.parsePnpmLock, expectedPkgs, expectedRelationships)
+}
+
 // pnpmDoc renders a minimal v9 lockfile document holding a single package.
 func pnpmDoc(version, name, ver, integrity string) string {
 	doc := ""

--- a/syft/pkg/cataloger/javascript/testdata/pnpm-v9-variations/pnpm-lock.yaml
+++ b/syft/pkg/cataloger/javascript/testdata/pnpm-v9-variations/pnpm-lock.yaml
@@ -1,0 +1,46 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-odd:
+        specifier: 3.0.1
+        version: 3.0.1
+    devDependencies:
+      node:
+        specifier: runtime:^26.8.1
+        version: runtime:26.8.1
+
+packages:
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+  node@runtime:26.8.1:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin:
+              node: bin/node
+            integrity: sha256-srdmYPpN7U4LKkHuPAxlHNUuqBcOrZHrrB4UesPVVkM=
+            type: binary
+            url: https://nodejs.org/download/release/v26.8.1/node-v26.8.1-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+    version: 26.8.1
+    hasBin: true
+
+snapshots:
+
+  is-odd@3.0.1: {}
+
+  node@runtime:26.8.1: {}


### PR DESCRIPTION
## Description

pnpm can record a provisioned Node runtime (`node@runtime:…`) with a nested `variations` resolution whose `variants` field is a YAML sequence. The v9 parser typed `Resolution` as `map[string]string`, so that entry raised a `yaml.TypeError` and the whole document decode was aborted — which silently dropped every other package from the SBOM while still exiting 0.

This change:

- types `Resolution` as `map[string]any` so nested variation objects decode cleanly
- tolerates `*yaml.TypeError` in the v6/v9 parsers and keeps successfully decoded entries (with a trace log)
- adds a regression fixture covering the issue's lockfile shape

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have added unit tests that cover changed behavior
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections

## Issue references

Fixes #5241
