### PR TITLE
feat: add download location for go modules

### DIFF
--- a/syft/format/internal/spdxutil/helpers/download_location.go
+++ b/syft/format/internal/spdxutil/helpers/download_location.go
@@ -1,10 +1,13 @@
 package helpers
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
 	urilib "github.com/spdx/gordf/uri"
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
 
 	"github.com/anchore/syft/syft/pkg"
 )
@@ -12,6 +15,14 @@ import (
 const NONE = "NONE"
 const NOASSERTION = "NOASSERTION"
 const SUPPLIERORG = "Organization"
+
+// goProxy is the public Go module proxy used to construct a stable, publicly
+// resolvable download location for Go modules.
+const goProxy = "https://proxy.golang.org"
+
+// golangStdlib is the synthetic package name syft assigns to the Go standard
+// library, which is not a downloadable module.
+const golangStdlib = "stdlib"
 
 func DownloadLocation(p pkg.Package) string {
 	// 3.7: Package Download Location
@@ -37,9 +48,30 @@ func DownloadLocation(p pkg.Package) string {
 			location = metadata.Dist.URL
 		case pkg.OpamPackage:
 			location = metadata.URL
+		case pkg.GolangBinaryBuildinfoEntry, pkg.GolangModuleEntry, pkg.GolangSourceEntry:
+			location = golangProxyLocation(p.Name, p.Version)
 		}
 	}
 	return URIValue(location)
+}
+
+// golangProxyLocation builds the Go module proxy download URL for a module
+// version, or returns an empty string when the package is not a downloadable
+// module (the standard library, or a version that is not a module version such
+// as "(devel)" or a bare Go toolchain version).
+func golangProxyLocation(name, version string) string {
+	if name == golangStdlib || !semver.IsValid(version) {
+		return ""
+	}
+	escapedPath, err := module.EscapePath(name)
+	if err != nil {
+		return ""
+	}
+	escapedVersion, err := module.EscapeVersion(version)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s/@v/%s.zip", goProxy, escapedPath, escapedVersion)
 }
 
 func isURIValid(uri string) bool {

--- a/syft/format/internal/spdxutil/helpers/download_location_test.go
+++ b/syft/format/internal/spdxutil/helpers/download_location_test.go
@@ -650,6 +650,60 @@ func Test_DownloadLocation(t *testing.T) {
 			},
 			expected: "https://github.com/anchore/syft",
 		},
+		{
+			name: "go binary module resolves to the go proxy zip",
+			input: pkg.Package{
+				Name:     "github.com/spf13/cobra",
+				Version:  "v1.8.1",
+				Metadata: pkg.GolangBinaryBuildinfoEntry{},
+			},
+			expected: "https://proxy.golang.org/github.com/spf13/cobra/@v/v1.8.1.zip",
+		},
+		{
+			name: "go module path with uppercase is proxy-escaped",
+			input: pkg.Package{
+				Name:     "github.com/BurntSushi/toml",
+				Version:  "v1.4.0",
+				Metadata: pkg.GolangBinaryBuildinfoEntry{},
+			},
+			expected: "https://proxy.golang.org/github.com/!burnt!sushi/toml/@v/v1.4.0.zip",
+		},
+		{
+			name: "go module entry resolves to the go proxy zip",
+			input: pkg.Package{
+				Name:     "golang.org/x/text",
+				Version:  "v0.14.0",
+				Metadata: pkg.GolangModuleEntry{},
+			},
+			expected: "https://proxy.golang.org/golang.org/x/text/@v/v0.14.0.zip",
+		},
+		{
+			name: "go source entry resolves to the go proxy zip",
+			input: pkg.Package{
+				Name:     "github.com/foo/bar",
+				Version:  "v0.1.0",
+				Metadata: pkg.GolangSourceEntry{},
+			},
+			expected: "https://proxy.golang.org/github.com/foo/bar/@v/v0.1.0.zip",
+		},
+		{
+			name: "go standard library has no download location",
+			input: pkg.Package{
+				Name:     "stdlib",
+				Version:  "go1.22.0",
+				Metadata: pkg.GolangBinaryBuildinfoEntry{},
+			},
+			expected: NOASSERTION,
+		},
+		{
+			name: "go main module built locally has no module version",
+			input: pkg.Package{
+				Name:     "github.com/anchore/syft",
+				Version:  "(devel)",
+				Metadata: pkg.GolangBinaryBuildinfoEntry{},
+			},
+			expected: NOASSERTION,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

`DownloadLocation` in the SPDX helper populated apk, npm, composer, and opam packages but left every Go module at `NOASSERTION`. This adds a case for the Go metadata types (`GolangBinaryBuildinfoEntry`, `GolangModuleEntry`, `GolangSourceEntry`) that builds the public Go module proxy zip URL from the module path and version:

```
https://proxy.golang.org/<escaped-path>/@v/<escaped-version>.zip
```

Paths and versions are encoded with `module.EscapePath` / `module.EscapeVersion` (already available via `golang.org/x/mod`), so case-encoded module paths like `github.com/BurntSushi/toml` resolve correctly (`.../!burnt!sushi/...`).

The standard library (`stdlib`) and non-module versions such as `(devel)` or a bare Go toolchain version are skipped and remain `NOASSERTION`, since they are not fetchable from the proxy.

Refs #2087.

## Type of change

- Enhancement (non-breaking change which adds functionality)

## Tests

Added table cases to `Test_DownloadLocation` covering a normal module, uppercase-escaped path, module/source entries, stdlib, and `(devel)`. `spdxjson` and `spdxtagvalue` format suites pass unchanged.
